### PR TITLE
Tolerate all taints so that tuned is always present on all nodes.

### DIFF
--- a/assets/tuned/06-cm-tuned-recommend.yaml
+++ b/assets/tuned/06-cm-tuned-recommend.yaml
@@ -6,14 +6,14 @@ metadata:
 data:
   tuned-ocp-recommend: |
     [openshift-control-plane,master]
-    /var/lib/tuned/ocp-node-labels.cfg=.*node-role.kubernetes.io/master=true
+    /var/lib/tuned/ocp-node-labels.cfg=.*node-role.kubernetes.io/master=
 
     # No such label exists, TODO
     [openshift-node-es,node-es]
-    /var/lib/tuned/ocp-node-labels.cfg=.*node-role.kubernetes.io/elasticsearch=true
+    /var/lib/tuned/ocp-node-labels.cfg=.*node-role.kubernetes.io/elasticsearch=
 
     [openshift-control-plane,node]
-    /var/lib/tuned/ocp-node-labels.cfg=.*node-role.kubernetes.io/infra=true
+    /var/lib/tuned/ocp-node-labels.cfg=.*node-role.kubernetes.io/infra=
 
     [openshift-node]
     /var/lib/tuned/ocp-node-labels.cfg=.*

--- a/assets/tuned/07-ds-tuned.yaml
+++ b/assets/tuned/07-ds-tuned.yaml
@@ -77,3 +77,6 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
+      tolerations:
+      # tolerate all taints so that tuned is always present on all nodes
+      - operator: Exists


### PR DESCRIPTION
Current tectonic 4.0 installer also uses node labels with empty values.  Adjust ConfigMaps.
