### PR TITLE
add namespace to Tuned CR

### DIFF
--- a/manifests/03-cr.yaml
+++ b/manifests/03-cr.yaml
@@ -1,4 +1,5 @@
-apiVersion: "tuned.openshift.io/v1alpha1"
-kind: "Tuned"
+apiVersion: tuned.openshift.io/v1alpha1
+kind: Tuned
 metadata:
-  name: "default"
+  name: default
+  namespace: openshift-cluster-node-tuning-operator


### PR DESCRIPTION
fixes CVO error
```
I1022 15:33:33.401829       1 reflector.go:286] github.com/openshift/cluster-version-operator/vendor/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go:117: forcing resync
E1022 15:33:39.000690       1 sync.go:52] error running apply for (tuned.openshift.io/v1alpha1, Kind=Tuned) /default: Namespace parameter required.
I1022 15:33:41.730935       1 reflector.go:286] github.com/openshift/cluster-version-operator/pkg/generated/informers/externalversions/factory.go:118: forcing resync
I1022 15:33:43.394037       1 leaderelection.go:209] successfully renewed lease openshift-cluster-version/cluster-version-operator
I1022 15:33:47.648483       1 reflector.go:286] github.com/openshift/cluster-version-operator/vendor/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go:117: forcing resync
E1022 15:33:52.010414       1 sync.go:52] error running apply for (tuned.openshift.io/v1alpha1, Kind=Tuned) /default: Namespace parameter required.
```
@derekwaynecarr @bparees 