### PR TITLE
add image refs to allow release rendering

### DIFF
--- a/manifests/05-operator.yaml
+++ b/manifests/05-operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: cluster-node-tuning-operator
       containers:
         - name: cluster-node-tuning-operator
-          image: CLUSTER_NODE_TUNING_OPERATOR_IMAGE
+          image: registry.svc.ci.openshift.org/openshift/origin-v4.0:openshift-tuned
           ports:
           - containerPort: 60000
             name: metrics

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: cluster-node-tuning-operator
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:openshift-tuned


### PR DESCRIPTION
@derekwaynecarr @bparees 
`cluster-node-tuning-operator` is in the 4.0 release image stream
```
$ release-image-stream.sh cluster-node-tuning-operator
Image Name:	sha256:ceb2f2719a4d11e8adf8e27bcb7d6e178c4a8fa04a7ec54b92cab93725b723c5
Image Created:	3 days ago
		io.openshift.build.commit.id=f8011e1e5160364e4aec9b111e40ea1a9c830ef3
```
but there is currently no `image-references` file that allows the operator deployment to be rendered by the `oc adm release new` command.

The PR adds it.