### PR TITLE
add namespace to manifests

### DIFF
--- a/manifests/04-rbac.yaml
+++ b/manifests/04-rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cluster-node-tuning-operator
+  namespace: openshift-cluster-node-tuning-operator
 
 ---
 

--- a/manifests/05-operator.yaml
+++ b/manifests/05-operator.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cluster-node-tuning-operator
+  namespace: openshift-cluster-node-tuning-operator
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Current error in the CVO trying to apply
```
E1023 14:22:17.230519       1 sync.go:52] error running apply for (/v1, Kind=ServiceAccount) /cluster-node-tuning-operator: an empty namespace may not be set when a resource name is provided
```
@bparees @wking 

Testing this now to make sure we don't just fall through to another error after this one