### PR TITLE
CVO managed operator should deploy to masters

### DIFF
--- a/manifests/04-operator.yaml
+++ b/manifests/04-operator.yaml
@@ -14,6 +14,10 @@ spec:
         name: cluster-node-tuning-operator
     spec:
       serviceAccountName: cluster-node-tuning-operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - operator: Exists      
       containers:
         - name: cluster-node-tuning-operator
           image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-node-tuning-operator
@@ -23,6 +27,9 @@ spec:
           command:
           - cluster-node-tuning-operator
           imagePullPolicy: Always
+          resources:
+            requests:
+              memory: 20Mi
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
An operator deployed by the CVO should run on the master.
Applied a minimal memory request.