### PR TITLE
Rename cluster-node-tuning ClusterOperator

### DIFF
--- a/manifests/04-operator.yaml
+++ b/manifests/04-operator.yaml
@@ -36,7 +36,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           - name: OPERATOR_NAME
-            value: "cluster-node-tuning-operator"
+            value: "cluster-node-tuning"
           - name: RESYNC_PERIOD
             value: "600"
           - name: CLUSTER_NODE_TUNED_IMAGE

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	nodeTunedImageDefault string = "registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-node-tuned"
-	operatorNameDefault   string = "cluster-node-tuning-operator"
+	operatorNameDefault   string = "cluster-node-tuning"
 	resyncPeriodDefault   int64  = 600
 )
 


### PR DESCRIPTION
As per request from Clayton, we "need to drop “-operator” from the ClusterOperator object name."