### PR TITLE
status: report cluster operator version from payload

### DIFF
--- a/manifests/04-operator.yaml
+++ b/manifests/04-operator.yaml
@@ -29,6 +29,8 @@ spec:
           args:
           - "-v=1"
           env:
+          - name: RELEASE_VERSION
+            value: "0.0.1-snapshot"
           - name: WATCH_NAMESPACE
             valueFrom:
               fieldRef:

--- a/manifests/05-clusteroperator.yaml
+++ b/manifests/05-clusteroperator.yaml
@@ -3,3 +3,7 @@ kind: ClusterOperator
 metadata:
   name: node-tuning
 spec: {}
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"


### PR DESCRIPTION
Every operator shall report a version with name=operator whose value is equal to the RELEASE_VERSION provided by the cluster version operator.

will be enforced via https://github.com/openshift/origin/pull/22156