### PR TITLE
Increase operand's memory request and allow settings rollback.

### DIFF
--- a/assets/tuned/06-ds-tuned.yaml
+++ b/assets/tuned/06-ds-tuned.yaml
@@ -17,14 +17,17 @@ spec:
       serviceAccountName: tuned
       automountServiceAccountToken: true
       containers:
-      - command:
-        - /var/lib/tuned/bin/run
+      - command: ["/var/lib/tuned/bin/run","start"]
         resources:
           requests:
             cpu: 10m
-            memory: 20Mi
+            memory: 50Mi
         image: ${CLUSTER_NODE_TUNED_IMAGE}
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/var/lib/tuned/bin/run","stop"]
         name: tuned
         securityContext:
           privileged: true


### PR DESCRIPTION
This commit increases memory requests for the tuned daemon
to a more realistic 50Mi and adds a preStop hook to fascilitate
operand's settings rollback at pod termination.

This PR needs to be merged prior to merging https://github.com/openshift/openshift-tuned/pull/17.
