### PR TITLE
Add more RelatedObjects for the must-gather tool.

### DIFF
--- a/manifests/04-operator.yaml
+++ b/manifests/04-operator.yaml
@@ -32,9 +32,6 @@ spec:
       containers:
         - name: cluster-node-tuning-operator
           image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-node-tuning-operator
-          ports:
-          - containerPort: 60000
-            name: metrics
           command:
           - cluster-node-tuning-operator
           args:


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1717739

`openshift-must-gather inspect clusteroperator/node-tuning` now exits successfully (0) and returns all resources created by the operator.


