### PR TITLE
Bug 1718842: Operator-assisted removal of detached tuned secrets.

### DIFF
--- a/assets/tuned/06-ds-tuned.yaml
+++ b/assets/tuned/06-ds-tuned.yaml
@@ -55,6 +55,8 @@ spec:
                 fieldPath: spec.nodeName
           - name: RESYNC_PERIOD
             value: "60"
+          - name: RELEASE_VERSION
+            value: ""
       volumes:
       - hostPath:
           path: /sys

--- a/manifests/03-rbac.yaml
+++ b/manifests/03-rbac.yaml
@@ -28,7 +28,7 @@ rules:
   verbs: ["use"]
 # "" indicates the core API group
 - apiGroups: [""]
-  resources: ["configmaps","namespaces","serviceaccounts","services"]
+  resources: ["configmaps","namespaces","secrets","serviceaccounts","services"]
   verbs: ["create","get","delete","list","update","watch"]
 - apiGroups: [""]
   resources: ["nodes","pods"]

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -135,6 +136,13 @@ func (f *Factory) TunedDaemonSet() (*appsv1.DaemonSet, error) {
 	ds, err := NewDaemonSet(MustAssetReader(TunedDaemonSet))
 	imageTuned := ntoconfig.NodeTunedImage()
 	ds.Spec.Template.Spec.Containers[0].Image = imageTuned
+
+	for i := range ds.Spec.Template.Spec.Containers[0].Env {
+		if ds.Spec.Template.Spec.Containers[0].Env[i].Name == "RELEASE_VERSION" {
+			ds.Spec.Template.Spec.Containers[0].Env[i].Value = os.Getenv("RELEASE_VERSION")
+			break
+		}
+	}
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit adds support for automatic removal of detached tuned
secrets which might have accumulated in the operator namespace
prior to commit 014900fe.

Associated BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1714484