### PR TITLE
Fix custom profiles ordering based on their priorities.

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -117,7 +117,7 @@ func (f *Factory) TunedConfigMapRecommend(tunedArray []tunedv1.Tuned) (*corev1.C
 		if aRecommendAll[i].Priority != nil && aRecommendAll[j].Priority != nil {
 			return *aRecommendAll[i].Priority < *aRecommendAll[j].Priority
 		}
-		return false
+		return aRecommendAll[i].Priority != nil // undefined priority has the lowest priority
 	})
 	i := 0
 	// Walk through the virtual "recommend:" section of all items in tunedArray sorted by priority


### PR DESCRIPTION
In cases any of the profile priorities were undefined, it was possible to have
incorrect ordering of tuned profiles in tuned-recommend ConfigMap.  This PR
fixes this issue.