### PR TITLE
Basic CR validation using openAPIV3Schema

### DIFF
--- a/manifests/02-crd.yaml
+++ b/manifests/02-crd.yaml
@@ -21,6 +21,7 @@ spec:
     served: true
     # One and only one version must be marked as the storage version.
     storage: true
+  #preserveUnknownFields: false	# Do not use "false" in k8s 1.15, recursively nested "match" sections are dropped.
   validation:
     openAPIV3Schema:
       description: 'Tuned is a collection of rules that allows cluster-wide deployment of
@@ -29,6 +30,7 @@ spec:
         the cluster in the format that the daemons understand. The responsibility for applying
         the node-level tuning then lies with the containerized tuned daemons. More info:
         https://github.com/openshift/cluster-node-tuning-operator'
+      type: object
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -48,6 +50,70 @@ spec:
           description: 'spec is the specification of the desired behavior of Tuned. More info:
             https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
           type: object
+          required:
+          - profile
+          - recommend
+          properties:
+            profile:
+              description: 'Tuned profiles.'
+              type: array
+              items:
+                description: 'A tuned profile.'
+                type: object
+                required:
+                - name
+                - data
+                properties:
+                  name:
+                    description: 'Name of the tuned profile to be used in the recommend section.'
+                    type: string
+                  data:
+                    description: 'Specification of the tuned profile to be consumed by the tuned daemon.'
+                    type: string
+            recommend:
+              description: 'Selection logic for all tuned profiles.'
+              type: array
+              items:
+                description: 'Selection logic for a single tuned profile.'
+                type: object
+                required:
+                - profile
+                - priority
+                properties:
+                  profile:
+                    description: 'Name of the tuned profile to recommend.'
+                    type: string
+                  priority:
+                    description: 'Tuned profile priority. Highest priority is 0.'
+                    type: integer
+                    format: int64
+                    minimum: 0
+                  match:
+                    description: 'Rules governing application of a tuned profile connected by logical OR operator.'
+                    type: array
+                    items:
+                      description: 'Rules governing application of a tuned profile.'
+                      type: object
+                      required:
+                      - label
+                      properties:
+                        label:
+                          description: 'Node or Pod label name.'
+                          type: string
+                        value:
+                          description: 'Node or Pod label value. If omitted, the presence of label name is enough to match.'
+                          type: string
+                        type:
+                          description: 'Match type: [node/pod]. If omitted, "node" is assumed.'
+                          type: string
+                          enum: [ 'node', 'pod' ]
+                        match:
+                          description: 'Additional rules governing application of the tuned profile connected by logical AND operator.'
+                          type: array
+                          items:
+                            # OpenAPI v3 validation schemas containing $ref are not permitted => cannot do recursive validation in 1.14
+                            # https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#validation
+                            type: object
         status:
-          description: 'Status is the current state of Tuned.  This cannot be overriden.'
+          description: 'Status is the current state of Tuned. This cannot be overriden.'
           type: object


### PR DESCRIPTION
This is necessary to enable basic custom CR formatting checks.
Outstanding issues:
  - unknown fields are not dropped from CRs
  - only one level of "match:" sections is validated due to recursive
    nature of the tuned CRD spec