### PR TITLE
Add initial support for bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ are supported when using [custom profiles](#custom-tuning-specification) defined
 in the `profile:` section of the Tuned CR:
 
 * audio
+* bootloader
 * cpu
 * disk
 * eeepc_she

--- a/assets/tuned/06-ds-tuned.yaml
+++ b/assets/tuned/06-ds-tuned.yaml
@@ -48,6 +48,16 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
+        - mountPath: /etc/grub.d
+          name: etc-grub
+        - mountPath: /etc/default/grub
+          name: etc-default-grub
+        - mountPath: /boot/grub2
+          name: boot-grub2
+        - mountPath: /etc/grub2.cfg
+          name: boot-grub2-cfg
+        - mountPath: /etc/grub2-efi.cfg
+          name: boot-grub2-cfg
         env:
           - name: OCP_NODE_NAME
             valueFrom:
@@ -70,6 +80,19 @@ spec:
       - hostPath:
           path: /lib/modules
         name: lib-modules
+      - hostPath:
+          path: /boot/grub2
+        name: boot-grub2
+      - hostPath:
+          path: /boot/grub2/grub.cfg
+          type: File
+        name: boot-grub2-cfg
+      - hostPath:
+          path: /etc/grub.d
+        name: etc-grub
+      - hostPath:
+          path: /etc/default/grub
+        name: etc-default-grub
       - configMap:
           items:
           - key: tuned-ocp-recommend


### PR DESCRIPTION
Add support for bootloader in tuned. It needs mounting some extra directories for bootloader to be executed. It is not using the functionality yet, as this will be provided on another comit, but it can be tested using a profile that includes [bootloader] section.

Partially resolves #72 