### PR TITLE
Use net.ipv4.conf.all.arp_announce=2 in the openshift profile.

### DIFF
--- a/assets/tuned/default-cr-tuned.yaml
+++ b/assets/tuned/default-cr-tuned.yaml
@@ -21,6 +21,7 @@ spec:
       net.ipv4.ip_forward=1
       kernel.pid_max=>4194304
       net.netfilter.nf_conntrack_max=1048576
+      net.ipv4.conf.all.arp_announce=2
       net.ipv4.neigh.default.gc_thresh1=8192
       net.ipv4.neigh.default.gc_thresh2=32768
       net.ipv4.neigh.default.gc_thresh3=65536


### PR DESCRIPTION
Adapting a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1758552 from OCP 3.11.