### PR TITLE
Tolerate only master/etcd taints.

### DIFF
--- a/assets/tuned/06-ds-tuned.yaml
+++ b/assets/tuned/06-ds-tuned.yaml
@@ -96,5 +96,9 @@ spec:
       securityContext: {}
       terminationGracePeriodSeconds: 30
       tolerations:
-      # tolerate all taints so that tuned is always present on all nodes
-      - operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/etcd
+        operator: Exists
+        effect: NoSchedule


### PR DESCRIPTION
NTO's tuned operand tolerates any taints.  This does not give much room for cases where NTO's operator is not welcome on certain nodes that need a very specific tuning not handled by the operator/operand.  Match MCO's MCD taints and tolerate only: `node-role.kubernetes.io/master` and `node-role.kubernetes.io/etcd`.
