### PR TITLE
Remove "tuned-profiles" ConfigMap.

### DIFF
--- a/assets/tuned/cm-tuned-profiles.yaml
+++ b/assets/tuned/cm-tuned-profiles.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: tuned-profiles
-  namespace: openshift-cluster-node-tuning-operator
-data:
-  tuned-profiles-data: ""

--- a/examples/elasticsearch.yaml
+++ b/examples/elasticsearch.yaml
@@ -1,0 +1,20 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: elasticsearch
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Optimize systems running ES on OpenShift nodes
+      include=openshift-node
+      [sysctl]
+      vm.max_map_count=262144
+    name: openshift-node-elasticsearch
+  recommend:
+  - match:
+    - label: tuned.openshift.io/elasticsearch
+      type: pod
+    priority: 30
+    profile: openshift-node-elasticsearch

--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -8,11 +8,16 @@ const (
 	// TunedDefaultResourceName is the name of the Node Tuning Operator's default custom tuned resource
 	TunedDefaultResourceName = "default"
 
+	// TunedRenderedResourceName is the name of the Node Tuning Operator's tuned resource combined out of
+	// all the other custom tuned resources
+	TunedRenderedResourceName = "rendered"
+
 	// TunedClusterOperatorResourceName is the name of the clusteroperator resource
 	// that reflects the node tuning operator status.
 	TunedClusterOperatorResourceName = "node-tuning"
 )
 
+/////////////////////////////////////////////////////////////////////////////////
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -88,6 +93,7 @@ type TunedList struct {
 	Items           []Tuned `json:"items"`
 }
 
+/////////////////////////////////////////////////////////////////////////////////
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -15,7 +15,6 @@ type Listers struct {
 	Pods                kcorelisters.PodLister
 	Nodes               kcorelisters.NodeLister
 	Secrets             kcorelisters.SecretNamespaceLister
-	ConfigMaps          kcorelisters.ConfigMapNamespaceLister
 	ServiceAccounts     kcorelisters.ServiceAccountNamespaceLister
 	ClusterRoles        krbaclisters.ClusterRoleLister
 	ClusterRoleBindings krbaclisters.ClusterRoleBindingLister

--- a/pkg/operator/bootstrap.go
+++ b/pkg/operator/bootstrap.go
@@ -24,8 +24,7 @@ func (c *Controller) Bootstrap() error {
 		return nil
 	}
 
-	// If no registry resource exists,
-	// let's create one with sane defaults
+	// If no tuned resource exists, create one with sane defaults.
 	klog.Infof("creating default Tuned custom resource")
 	cr = ntomf.TunedCustomResource()
 


### PR DESCRIPTION
For faster operator to operand change propagation, remove the last ConfigMap
used by the NTO's operand.  An associated operand's PR will use a "rendered"
Tuned resource to get informed about the default and all custom tuned profile
changes.

Elasticsearch e2e custom profile test was added, replacing the original
"ingress" one.  E2e tests were improved to include removal of custom profiles
at different test stages.