### PR TITLE
Add preliminary support for the cpu-partitioning profile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,10 @@ RUN INSTALL_PKGS=" \
       tuned tuna tuned-profiles-cpu-partitioning patch socat \
       " && \
     ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n hdparm kernel-tools ; fi) && \
+    mkdir -p /etc/grub.d/ /boot && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS $ARCH_DEP_PKGS && \
     rpm -V $INSTALL_PKGS $ARCH_DEP_PKGS && \
-    (LC_COLLATE=C cat patches/*.diff | patch -Np1 -d /usr/lib/python*/site-packages/tuned/ || :) && \
+    (LC_COLLATE=C cat patches/*.diff | patch -Np1 -d / || :) && \
     touch /etc/sysctl.conf && \
     yum -y remove patch && \
     yum clean all && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -16,9 +16,10 @@ RUN INSTALL_PKGS=" \
       tuned tuna tuned-profiles-cpu-partitioning patch socat \
       " && \
     ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n hdparm kernel-tools ; fi) && \
+    mkdir -p /etc/grub.d/ /boot && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS $ARCH_DEP_PKGS && \
     rpm -V $INSTALL_PKGS $ARCH_DEP_PKGS && \
-    (LC_COLLATE=C cat patches/*.diff | patch -Np1 -d /usr/lib/python*/site-packages/tuned/ || :) && \
+    (LC_COLLATE=C cat patches/*.diff | patch -Np1 -d / || :) && \
     touch /etc/sysctl.conf && \
     yum -y remove patch && \
     yum clean all && \

--- a/assets/patches/010-reapply_sysctl.diff
+++ b/assets/patches/010-reapply_sysctl.diff
@@ -20,8 +20,8 @@ See: https://github.com/redhat-performance/tuned/pull/226
 
 diff --git a/tuned/plugins/plugin_sysctl.py b/tuned/plugins/plugin_sysctl.py
 index b298bfa8..ee7596d5 100644
---- a/plugins/plugin_sysctl.py
-+++ b/plugins/plugin_sysctl.py
+--- a/usr/lib/python2.7/site-packages/tuned/plugins/plugin_sysctl.py
++++ b/usr/lib/python2.7/site-packages/tuned/plugins/plugin_sysctl.py
 @@ -12,10 +12,7 @@
  
  DEPRECATED_SYSCTL_OPTIONS = [ "base_reachable_time", "retrans_time" ]

--- a/assets/patches/020-fix_sighup_hang.diff
+++ b/assets/patches/020-fix_sighup_hang.diff
@@ -6,8 +6,8 @@ See: https://github.com/redhat-performance/tuned/pull/225
 
 diff --git a/tuned/daemon/controller.py b/tuned/daemon/controller.py
 index 5e1e9ba2..18e0bb61 100644
---- a/daemon/controller.py
-+++ b/daemon/controller.py
+--- a/usr/lib/python2.7/site-packages/tuned/daemon/controller.py
++++ b/usr/lib/python2.7/site-packages/tuned/daemon/controller.py
 @@ -132,14 +132,16 @@ def stop(self, caller = None):
  	def reload(self, caller = None):
  		if caller == "":

--- a/assets/patches/030-variable-expansion.diff
+++ b/assets/patches/030-variable-expansion.diff
@@ -1,0 +1,33 @@
+Workaround for a child profile variable expansion in parent's
+[variables] section.
+
+Resolves rhbz#1781664
+
+See: https://github.com/redhat-performance/tuned/pull/239
+
+diff --git a/profiles/cpu-partitioning/tuned.conf b/profiles/cpu-partitioning/tuned.conf
+index 1821b74e..56977500 100644
+--- a/usr/lib/tuned/cpu-partitioning/tuned.conf
++++ b/usr/lib/tuned/cpu-partitioning/tuned.conf
+@@ -10,6 +10,10 @@ include=network-latency
+ include=/etc/tuned/cpu-partitioning-variables.conf
+ 
+ isolated_cores_assert_check = \\${isolated_cores}
++# Make sure isolated_cores is defined before any of the variables that
++# use it (such as assert1) are defined, so that child profiles can set
++# isolated_cores directly in the profile (tuned.conf)
++isolated_cores = ${isolated_cores}
+ # Fail if isolated_cores are not set
+ assert1=${f:assertion_non_equal:isolated_cores are set:${isolated_cores}:${isolated_cores_assert_check}}
+ 
+@@ -22,6 +26,10 @@ not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+ isolated_cores_online_expanded=${f:cpulist_online:${isolated_cores}}
+ not_isolated_cores_online_expanded=${f:cpulist_online:${not_isolated_cores_expanded}}
+ not_isolated_cpumask=${f:cpulist2hex:${not_isolated_cores_expanded}}
++# Make sure no_balance_cores is defined before
++# no_balance_cores_expanded is defined, so that child profiles can set
++# no_balance_cores directly in the profile (tuned.conf)
++no_balance_cores=${no_balance_cores}
+ no_balance_cores_expanded=${f:cpulist_unpack:${no_balance_cores}}
+ 
+ # Fail if isolated_cores contains CPUs which are not online

--- a/assets/patches/040-profile-inheritance.diff
+++ b/assets/patches/040-profile-inheritance.diff
@@ -1,0 +1,28 @@
+Enable multiple profile inheritance.
+
+[main]
+include=profile1;profile2
+
+Also comma "," can be used instead of the semicolon ";".
+No escaping is done, so it's assumed there will be no comma or semicolon
+in the profile name.
+
+Signed-off-by: Jaroslav Skarvada <jskarvad@redhat.com>
+
+See: https://github.com/redhat-performance/tuned/commit/feb6e8b6f4fd3c1b1595fc52c8b0868a2460a819
+
+diff --git a/tuned/profiles/loader.py b/tuned/profiles/loader.py
+index df7bd9e4..e844472f 100644
+--- a/usr/lib/python2.7/site-packages/tuned/profiles/loader.py
++++ b/usr/lib/python2.7/site-packages/tuned/profiles/loader.py
+@@ -78,8 +78,8 @@ def _load_profile(self, profile_names, profiles, processed_files):
+ 			config = self._load_config_data(filename)
+ 			profile = self._profile_factory.create(name, config)
+ 			if "include" in profile.options:
+-				include_name = self._variables.expand(profile.options.pop("include"))
+-				self._load_profile([include_name], profiles, processed_files)
++				include_names = re.split(r"\b\s*[,;]\s*", self._variables.expand(profile.options.pop("include")))
++				self._load_profile(include_names, profiles, processed_files)
+ 
+ 			profiles.append(profile)
+ 

--- a/assets/tuned/ds-tuned.yaml
+++ b/assets/tuned/ds-tuned.yaml
@@ -39,6 +39,15 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/tuned/profiles-data
           name: var-lib-tuned-profiles-data
+        - mountPath: /etc/modprobe.d
+          name: etc
+          subPath: modprobe.d
+        - mountPath: /etc/sysconfig
+          name: etc
+          subPath: sysconfig
+        - mountPath: /etc/systemd
+          name: etc
+          subPath: systemd
         - mountPath: /sys
           name: sys
         - mountPath: /var/run/dbus
@@ -50,6 +59,8 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
+        - name: host
+          mountPath: /host
         env:
           - name: WATCH_NAMESPACE
             valueFrom:
@@ -67,6 +78,10 @@ spec:
             value: ""
       volumes:
       - hostPath:
+          path: /etc
+          type: Directory
+        name: etc
+      - hostPath:
           path: /sys
           type: Directory
         name: sys
@@ -82,6 +97,10 @@ spec:
           path: /lib/modules
           type: Directory
         name: lib-modules
+      - name: host
+        hostPath:
+          path: /
+          type: Directory
       - configMap:
           defaultMode: 0644
           items:

--- a/examples/cpu-partitioning.yaml
+++ b/examples/cpu-partitioning.yaml
@@ -1,0 +1,22 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-cpu-partitioning
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Configuration for cpu-partitioning
+      include=openshift-node,cpu-partitioning
+      [variables]
+      # {isolated,no_balance}_cores take a list of ranges; e.g. isolated_cores=2,4-7
+      isolated_cores=1
+      no_balance_cores=1
+    name: openshift-cpu-partitioning
+
+  recommend:
+  - match:
+    - label: node-role.kubernetes.io/worker-rt
+    priority: 30
+    profile: openshift-cpu-partitioning


### PR DESCRIPTION
Changes:
  - allow patches to modify tuned profiles too (see rhbz#1781664)
  - mount host directories to allow:
    * persistent changes to /etc/sysconfig/irqbalance
    * tuned to populate /etc/modprobe.d directory with module
      options (see kvm.rt.tuned.conf)
    * persistent changes to host's /etc/systemd/system.conf
      by tuned setting CPUAffinity
  - create /etc/grub.d/, /boot to make tuned's [bootloader] plugin
    pass and generate /etc/tuned/bootcmdline
  - include tuned patch for rhbz#1781664 (variable expansion)
  - include tuned patch to enable multiple profile inheritance
    (tuned 2.13 feature)
  - include an example custom openshift-cpu-partitioning profile

Note that the [bootloader] plugin does not do any host modifications,
however, the variables in /etc/tuned/bootcmdline should be set
correctly.