### PR TITLE
Set fs.inotify.max_user_instances=8192 in openshift-node profile.

### DIFF
--- a/assets/tuned/default-cr-tuned.yaml
+++ b/assets/tuned/default-cr-tuned.yaml
@@ -64,6 +64,7 @@ spec:
       [sysctl]
       net.ipv4.tcp_fastopen=3
       fs.inotify.max_user_watches=65536
+      fs.inotify.max_user_instances=8192
 
   - name: "openshift-control-plane-es"
     data: |


### PR DESCRIPTION
This addition closes a gap by missing the second inotify tuning
that was present in OCP 3.x.  See:
https://github.com/openshift/openshift-ansible/pull/9204