### PR TITLE
Bug 1795665: Do not set owner references on tuned ServiceAccount

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.3:base
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/cluster-node-tuning-operator /usr/bin/
 COPY manifests /manifests
 RUN useradd cluster-node-tuning-operator

--- a/pkg/controller/tuned/tuned_controller.go
+++ b/pkg/controller/tuned/tuned_controller.go
@@ -190,9 +190,6 @@ func (r *ReconcileTuned) syncServiceAccount(tuned *tunedv1.Tuned) error {
 	if err != nil {
 		return fmt.Errorf("Couldn't build tuned ServiceAccount: %v", err)
 	}
-	if err := setControllerReference(tuned, saManifest, r.scheme); err != nil {
-		return fmt.Errorf("Couldn't set owner references to ServiceAccount: %v", err)
-	}
 
 	sa := &corev1.ServiceAccount{}
 	err = r.cache.Get(context.TODO(), types.NamespacedName{Namespace: saManifest.Namespace, Name: saManifest.Name}, sa)


### PR DESCRIPTION
Fixes bug 1795665 which causes race conditions on upgrade from 4.x -> 4.3.

This PR removes owner reference from the ServiceAccount.