### PR TITLE
Bug 1795671: Do not set owner references on tuned ServiceAccount (4.2)

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/cluster-node-tuning-operator /usr/bin/
 COPY manifests /manifests
 RUN useradd cluster-node-tuning-operator

--- a/pkg/controller/tuned/tuned_controller.go
+++ b/pkg/controller/tuned/tuned_controller.go
@@ -192,7 +192,6 @@ func (r *ReconcileTuned) syncServiceAccount(tuned *tunedv1.Tuned) error {
 
 	sa := &corev1.ServiceAccount{}
 	err = r.cache.Get(context.TODO(), types.NamespacedName{Namespace: saManifest.Namespace, Name: saManifest.Name}, sa)
-	saManifest.SetOwnerReferences(addOwnerReference(&sa.ObjectMeta, tuned))
 	if err != nil {
 		if errors.IsNotFound(err) {
 			err = r.client.Create(context.TODO(), saManifest)


### PR DESCRIPTION
Fixes bug 1795671 which causes race conditions on upgrade from 4.x -> 4.2.

This PR removes owner reference from the ServiceAccount.