### PR TITLE
Bug 1801797: Pod-label support optimizations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ overwritten by the operator.  For custom tuning, create your own tuned CRs.
 Newly created CRs will be combined with the default CR and custom tuning
 applied to OpenShift nodes based on node/pod labels and profile priorities.
 
+While in certain situations the support for pod labels can be a convenient
+way of automatically delivering required tuning, this practice is discouraged
+and strongly advised against especially in large-scale clusters.  The default
+tuned CR ships without pod label matching.  If a custom profile is created
+with pod label matching the functionality will be enabled at that time.
+
 
 ## Custom tuning specification
 

--- a/assets/tuned/default-cr-tuned.yaml
+++ b/assets/tuned/default-cr-tuned.yaml
@@ -28,6 +28,7 @@ spec:
       net.ipv6.neigh.default.gc_thresh1=8192
       net.ipv6.neigh.default.gc_thresh2=32768
       net.ipv6.neigh.default.gc_thresh3=65536
+      vm.max_map_count=262144
 
       [sysfs]
       /sys/module/nvme_core/parameters/io_timeout=4294967295
@@ -66,40 +67,7 @@ spec:
       fs.inotify.max_user_watches=65536
       fs.inotify.max_user_instances=8192
 
-  - name: "openshift-control-plane-es"
-    data: |
-      [main]
-      summary=Optimize systems running ES on OpenShift control-plane
-      include=openshift-control-plane
-
-      [sysctl]
-      vm.max_map_count=262144
-
-  - name: "openshift-node-es"
-    data: |
-      [main]
-      summary=Optimize systems running ES on OpenShift nodes
-      include=openshift-node
-
-      [sysctl]
-      vm.max_map_count=262144
-
   recommend:
-  - profile: "openshift-control-plane-es"
-    priority: 10
-    match:
-    - label: "tuned.openshift.io/elasticsearch"
-      type: "pod"
-      match:
-      - label: "node-role.kubernetes.io/master"
-      - label: "node-role.kubernetes.io/infra"
-
-  - profile: "openshift-node-es"
-    priority: 20
-    match:
-    - label: "tuned.openshift.io/elasticsearch"
-      type: "pod"
-
   - profile: "openshift-control-plane"
     priority: 30
     match:


### PR DESCRIPTION
Changes:
  - Remove leftover profiles on node deletions.
  - On clusters with many thousands of pods, the operator can take large
    amounts of memory.  Also, clusters with a lot of "pod churn" (pods
    started/deleted, pod labels changed, ...) can show CPU utilization spikes
    on a node the operator runs.  Disable pod support by default.  While pod
    support is automatically re-enabled when a custom CR with pod label match
    is detected, it is discouraged to use this feature especially in
    large-scale clusters.
  - A pod label matching fix for pods with the same labels as other pods running 
    on the same node.
  - More consistent logging.
