### PR TITLE
Retry handling of profile changes on errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ REV=$(shell git describe --long --tags --match='v*' --always --dirty)
 
 # API-related variables
 API_TYPES_DIR:=pkg/apis/tuned/v1
-API_TYPES:=$(wildcard $(API_TYPES_DIR)/types_*.go)
+API_TYPES:=$(wildcard $(API_TYPES_DIR)/*_types.go)
 API_ZZ_GENERATED:=zz_generated.deepcopy
 API_TYPES_GENERATED:=$(API_TYPES_DIR)/$(API_ZZ_GENERATED).go
 API_GO_HEADER_FILE:=pkg/apis/header.go.txt


### PR DESCRIPTION
A race condition exists between extracting tuned daemon profiles CR into
`/etc/tuned` directory and applying the pre-calculated profile CR.  If the pre-calculated
profile CR is set and processed prior to the tuned profiles being present in
`/etc/tuned` a possibility exists the calculated profile will not be set.

This change fixes the issue and corrects a `Makefile` prerequisite name.