### PR TITLE
Add component field to OWNERS file.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,3 +9,4 @@ reviewers:
   - sjug
   - zvonkok
   - dagrayvid
+component: "Node Tuning Operator"


### PR DESCRIPTION
The "component:" field is now required for all OpenShift GitHub repositories
which contribute directly to the product (i.e. they contain a Dockerfile or
.spec file which ART consumes).