### PR TITLE
Support isolate_managed_irq in the realtime profile.

### DIFF
--- a/assets/patches/055-realtime-regex_search_ternary.diff
+++ b/assets/patches/055-realtime-regex_search_ternary.diff
@@ -1,0 +1,28 @@
+Support for the regex_search_ternary used by the realtime profile.
+
+See: https://bugzilla.redhat.com/show_bug.cgi?id=1797025
+
+--- /dev/null
++++ b/usr/lib/python2.7/site-packages/tuned/profiles/functions/function_regex_search_ternary.py
+@@ -0,0 +1,21 @@
++import re
++from . import base
++
++class regex_search_ternary(base.Function):
++	"""
++	Ternary regex operator, it takes arguments in the following form
++	STR1, REGEX, STR2, STR3
++	If REGEX matches STR1 (re.search is used), STR2 is returned,
++	otherwise STR3 is returned
++	"""
++	def __init__(self):
++		# 4 arguments
++		super(regex_search_ternary, self).__init__("regex_search_ternary", 4, 4)
++
++	def execute(self, args):
++		if not super(regex_search_ternary, self).execute(args):
++			return None
++		if re.search(args[1], args[0]):
++			return args[2]
++		else:
++			return args[3]

--- a/assets/patches/060-realtime.diff
+++ b/assets/patches/060-realtime.diff
@@ -1,16 +1,27 @@
 Backport upstream realtime profile.
 
+This patch also includes a fix to enable isolate_managed_irq to be
+defined in child profiles.
+See: https://github.com/redhat-performance/tuned/pull/260
+
 diff -Nura a/etc/tuned/realtime-variables.conf b/etc/tuned/realtime-variables.conf
---- a/etc/tuned/realtime-variables.conf	1970-01-01 01:00:00.000000000 +0100
-+++ b/etc/tuned/realtime-variables.conf	2017-05-16 14:42:40.000000000 +0200
-@@ -0,0 +1,4 @@
+--- a/etc/tuned/realtime-variables.conf
++++ b/etc/tuned/realtime-variables.conf
+@@ -0,0 +1,11 @@
 +# Examples:
 +# isolated_cores=2,4-7
 +# isolated_cores=2-23
 +#
++#
++# Uncomment the 'isolate_managed_irq=Y' bellow if you want to move kernel
++# managed IRQs out of isolated cores. Note that this requires kernel
++# support. Please only specify this parameter if you are sure that the
++# kernel supports it.
++#
++# isolate_managed_irq=Y
 diff -Nura a/usr/lib/tuned/realtime/script.sh b/usr/lib/tuned/realtime/script.sh
---- a/usr/lib/tuned/realtime/script.sh	1970-01-01 01:00:00.000000000 +0100
-+++ b/usr/lib/tuned/realtime/script.sh	2019-11-04 14:56:25.000000000 +0100
+--- a/usr/lib/tuned/realtime/script.sh
++++ b/usr/lib/tuned/realtime/script.sh
 @@ -0,0 +1,20 @@
 +#!/bin/sh
 +
@@ -33,9 +44,9 @@ diff -Nura a/usr/lib/tuned/realtime/script.sh b/usr/lib/tuned/realtime/script.sh
 +
 +process $@
 diff -Nura a/usr/lib/tuned/realtime/tuned.conf b/usr/lib/tuned/realtime/tuned.conf
---- a/usr/lib/tuned/realtime/tuned.conf	1970-01-01 01:00:00.000000000 +0100
-+++ b/usr/lib/tuned/realtime/tuned.conf	2020-01-09 11:13:10.000000000 +0100
-@@ -0,0 +1,50 @@
+--- a/usr/lib/tuned/realtime/tuned.conf
++++ b/usr/lib/tuned/realtime/tuned.conf
+@@ -0,0 +1,57 @@
 +# tuned configuration
 +#
 +# Red Hat Enterprise Linux for Real Time Documentation:
@@ -66,6 +77,13 @@ diff -Nura a/usr/lib/tuned/realtime/tuned.conf b/usr/lib/tuned/realtime/tuned.co
 +# Fail if isolated_cores contains CPUs which are not online
 +assert2=${f:assertion:isolated_cores contains online CPU(s):${isolated_cores_expanded}:${isolated_cores_online_expanded}}
 +
++# Assembly managed_irq
++# Make sure isolate_managed_irq is defined before any of the variables that
++# use it (such as managed_irq) are defined, so that child profiles can set
++# isolate_managed_irq directly in the profile (tuned.conf)
++isolate_managed_irq = ${isolate_managed_irq}
++managed_irq=${f:regex_search_ternary:${isolate_managed_irq}:\b[y,Y,1,t,T]\b:managed_irq,domain,:}
++
 +[sysctl]
 +kernel.hung_task_timeout_secs = 600
 +kernel.nmi_watchdog = 0
@@ -79,7 +97,7 @@ diff -Nura a/usr/lib/tuned/realtime/tuned.conf b/usr/lib/tuned/realtime/tuned.co
 +/sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1
 +
 +[bootloader]
-+cmdline_realtime=+isolcpus=${isolated_cores} intel_pstate=disable nosoftlockup tsc=nowatchdog
++cmdline_realtime=+isolcpus=${managed_irq}${isolated_cores} intel_pstate=disable nosoftlockup tsc=nowatchdog
 +
 +[script]
 +script = ${i:PROFILE_DIR}/script.sh

--- a/assets/patches/070-irqbalance-restart.diff
+++ b/assets/patches/070-irqbalance-restart.diff
@@ -2,16 +2,20 @@ Backport upstream fix to restart irqbalance for cpu-partitioning and realtime pr
 
 See: https://github.com/redhat-performance/tuned/pull/243
 
+Do not try to patch these functions, redefine them.
 diff -Nura a/usr/lib/tuned/functions b/usr/lib/tuned/functions
---- a/usr/lib/tuned/functions	2020-01-30 17:42:19.734070120 +0100
-+++ b/usr/lib/tuned/functions	2019-11-04 14:56:25.914002552 +0100
-@@ -473,6 +473,19 @@
- 	mv -Z $RSYSLOG_SAVE $RSYSLOG_CFG || mv $RSYSLOG_SAVE $RSYSLOG_CFG
- }
+--- a/usr/lib/tuned/functions
++++ b/usr/lib/tuned/functions
+@@ -621,3 +621,18 @@
  
+ 	exit $RETVAL
+ }
++
 +irqbalance_banned_cpus_clear() {
-+    sed -i '/^IRQBALANCE_BANNED_CPUS=/d' /etc/sysconfig/irqbalance && \
-+        test ${1:-restart} = restart && systemctl try-restart irqbalance
++    sed -i '/^IRQBALANCE_BANNED_CPUS=/d' /etc/sysconfig/irqbalance || return
++    if [ ${1:-restart} = restart ]; then
++        systemctl try-restart irqbalance
++    fi
 +}
 +
 +irqbalance_banned_cpus_setup() {
@@ -21,7 +25,3 @@ diff -Nura a/usr/lib/tuned/functions b/usr/lib/tuned/functions
 +    fi
 +    systemctl try-restart irqbalance
 +}
-+
- #
- # HARDWARE SPECIFIC tuning
- #

--- a/assets/patches/080-cpu-partitioning-upstream.diff
+++ b/assets/patches/080-cpu-partitioning-upstream.diff
@@ -3,8 +3,8 @@ Backport upstream change to use irqbalance_banned_cpus_(clear|setup) functions.
 See: https://github.com/redhat-performance/tuned/commit/4a8e64994eb978ada0c7e23702e96c82352cc222
 
 diff -Nura a/usr/lib/tuned/cpu-partitioning/script.sh b/usr/lib/tuned/cpu-partitioning/script.sh
---- a/usr/lib/tuned/cpu-partitioning/script.sh	2020-02-06 11:53:05.703480404 +0100
-+++ b/usr/lib/tuned/cpu-partitioning//script.sh	2019-08-05 11:29:07.019961531 +0200
+--- a/usr/lib/tuned/cpu-partitioning/script.sh
++++ b/usr/lib/tuned/cpu-partitioning/script.sh
 @@ -39,8 +39,7 @@
      mkdir -p "${TUNED_tmpdir}/usr/lib/dracut/hooks/pre-udev"
      cp /etc/systemd/system.conf "${TUNED_tmpdir}/etc/systemd/"

--- a/examples/realtime-mc.yaml
+++ b/examples/realtime-mc.yaml
@@ -12,6 +12,7 @@ spec:
       [variables]
       # isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7
       isolated_cores=1
+      #isolate_managed_irq=Y
       not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
       [bootloader]
       cmdline_ocp_realtime=+systemd.cpu_affinity=${not_isolated_cores_expanded}

--- a/pkg/tuned/tuned.go
+++ b/pkg/tuned/tuned.go
@@ -262,8 +262,8 @@ func disableSystemTuned() {
 }
 
 // profilesExtract extracts tuned daemon profiles to the daemon configuration directory.
-// If the data in the to be extracted active profile is different than the current active
-// profile, the function returns true.
+// If the data in the to be extracted recommended profile is different than the current
+// recommended profile, the function returns true.
 func profilesExtract(profiles []tunedv1.TunedProfile) (bool, error) {
 	var (
 		change bool


### PR DESCRIPTION
This PR supports the new isolate_managed_irq functionality in the upstream realtime profile and prepares ground for tuned-2.11.0-9.el7.noarch
