### PR TITLE
Bug 1826167: Mount host's /etc/sysctl.{conf,d/} to enable sysctl override from the host.

### DIFF
--- a/assets/tuned/06-ds-tuned.yaml
+++ b/assets/tuned/06-ds-tuned.yaml
@@ -33,6 +33,14 @@ spec:
           privileged: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /etc/sysctl.d
+          name: etc
+          subPath: sysctl.d
+          readOnly: true
+        - mountPath: /etc/sysctl.conf
+          name: etc
+          subPath: sysctl.conf
+          readOnly: true
         - mountPath: /etc/tuned/recommend.d
           name: etc-tuned-recommend
         - mountPath: /var/lib/tuned/profiles-data
@@ -58,6 +66,10 @@ spec:
           - name: RELEASE_VERSION
             value: ""
       volumes:
+      - hostPath:
+          path: /etc
+          type: Directory
+        name: etc
       - hostPath:
           path: /sys
         name: sys


### PR DESCRIPTION
Cause: 
Tuned pods did not mount `/etc/sysctl.{conf,d/}` from the host.

Consequence: 
Settings provided by the host can be overriden by tuned profiles even though this is no longer the standard behaviour of tuned as shipped in RHEL 7.3.

Fix: 
Mount `/etc/sysctl.{conf,d/}` from the host in tuned pods.

Result: 
Tuned profiles no longer override the host sysctl settings in `/etc/sysctl.{conf,d/}`.