### PR TITLE
Bug 1826086: node: fix the pid max variable

### DIFF
--- a/assets/tuned/default-cr-tuned.yaml
+++ b/assets/tuned/default-cr-tuned.yaml
@@ -19,7 +19,7 @@ spec:
 
       [sysctl]
       net.ipv4.ip_forward=1
-      kernel.pid_max=>4194304
+      kernel.pid_max=4194304
       net.netfilter.nf_conntrack_max=1048576
       net.ipv4.conf.all.arp_announce=2
       net.ipv4.neigh.default.gc_thresh1=8192


### PR DESCRIPTION
Fixes a long running issue where the syntax is bad for pid max