### PR TITLE
Bug 1851214: use lowercase plurals in resource property of relatedObjects

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -44,9 +44,11 @@ func (c *Controller) syncOperatorStatus() error {
 		}
 	}
 	co.Status.RelatedObjects = []configv1.ObjectReference{
+		// The `resource` property of `relatedObjects` stanza should be the lowercase, plural value like `daemonsets`.
+		// See BZ1851214
 		{Group: "", Resource: "namespaces", Name: tunedMf.Namespace},
-		{Group: "tuned.openshift.io", Resource: tunedMf.Kind, Name: tunedMf.Name, Namespace: tunedMf.Namespace},
-		{Group: "apps", Resource: dsMf.Kind, Name: dsMf.Name, Namespace: dsMf.Namespace},
+		{Group: "tuned.openshift.io", Resource: "tuneds", Name: tunedMf.Name, Namespace: tunedMf.Namespace},
+		{Group: "apps", Resource: "daemonsets", Name: dsMf.Name, Namespace: dsMf.Namespace},
 	}
 
 	if clusteroperator.ConditionsEqual(oldConditions, co.Status.Conditions) {


### PR DESCRIPTION
The `resource` property of the `relatedObjects` stanza in the ClusterOperator object needs lowercase plurals.

