### PR TITLE
Enable tuned-profiles-nfv profiles, add rtentsk plugin.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN INSTALL_PKGS=" \
     cd daemon && \
     LC_COLLATE=C cat ../patches/*.diff | patch -Np1 && \
     make rpm PYTHON=/usr/bin/python && \
-    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*,tuned-profiles-nfv*}
+    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*}
 
 FROM centos:7
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -13,7 +13,7 @@ RUN INSTALL_PKGS=" \
     cd daemon && \
     LC_COLLATE=C cat ../patches/*.diff | patch -Np1 && \
     make rpm PYTHON=/usr/bin/python && \
-    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*,tuned-profiles-nfv*}
+    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*}
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -14,7 +14,7 @@ RUN INSTALL_PKGS=" \
     cd daemon && \
     LC_COLLATE=C cat ../patches/*.diff | patch -Np1 && \
     make rpm PYTHON=/usr/bin/python3 && \
-    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*,tuned-profiles-nfv*}
+    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*}
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/

--- a/assets/tuned/patches/030-realtime-virt-host-drop_lapic_calc.diff
+++ b/assets/tuned/patches/030-realtime-virt-host-drop_lapic_calc.diff
@@ -1,0 +1,167 @@
+The LAPIC advancement improvement is minimal (3 or 4 us) and its
+calculation has shown to be problematic under certain
+scenarios (for example if qemu-kvm is not installed).
+
+Remove it.
+
+See: https://github.com/redhat-performance/tuned/pull/288
+
+diff --git a/profiles/realtime-virtual-host/find-lapictscdeadline-optimal.sh b/profiles/realtime-virtual-host/find-lapictscdeadline-optimal.sh
+deleted file mode 100755
+index 539c47e1..00000000
+--- a/profiles/realtime-virtual-host/find-lapictscdeadline-optimal.sh
++++ /dev/null
+@@ -1,30 +0,0 @@
+-#!/bin/bash
+-
+-: ${1?"Usage: $0 latency-file"}
+-
+-lines=`wc -l $1 | cut -f 1 -d " "`
+-in_range=0
+-prev_value=1
+-for i in `seq 1 $lines`; do
+-	a=`awk "NR==$i" $1 | cut -f 2 -d ":"`
+-	value=$(($a*100/$prev_value))
+-	if [ $value -ge 98 -a $value -le 102 ]; then
+-		in_range=$(($in_range + 1))
+-	else
+-		in_range=0
+-	fi
+-	if [ $in_range -ge 2 ]; then
+-		echo -n "optimal value for lapic_timer_advance_ns is: "
+-		awk "NR==$(($i - 1))" $1 | cut -f 1 -d ":"
+-		exit 0
+-	fi
+-	prev_value=$a
+-done
+-# if still decreasing, then use highest ns value
+-if [ $value -le 99 ]; then
+-	echo -n "optimal value for lapic_timer_advance_ns is: "
+-	awk "NR==$(($i - 1))" $1 | cut -f 1 -d ":"
+-	exit 0
+-fi
+-echo optimal not found
+-exit 1
+diff --git a/profiles/realtime-virtual-host/script.sh b/profiles/realtime-virtual-host/script.sh
+index edae6c59..a11dac75 100755
+--- a/profiles/realtime-virtual-host/script.sh
++++ b/profiles/realtime-virtual-host/script.sh
+@@ -2,102 +2,13 @@
+ 
+ . /usr/lib/tuned/functions
+ 
+-CACHE_VALUE_FILE=./lapic_timer_adv_ns
+-CACHE_CPU_FILE=./lapic_timer_adv_ns.cpumodel
+-KVM_LAPIC_FILE=/sys/module/kvm/parameters/lapic_timer_advance_ns
+ KTIMER_LOCKLESS_FILE=/sys/kernel/ktimer_lockless_check
+-QEMU=$(type -P qemu-kvm || echo /usr/libexec/qemu-kvm)
+-TSCDEADLINE_LATENCY="/usr/share/qemu-kvm/tscdeadline_latency.flat"
+-[ -f "$TSCDEADLINE_LATENCY" ] || TSCDEADLINE_LATENCY="/usr/share/tuned-profiles-nfv-host-bin/tscdeadline_latency.flat"
+-[ -f "$TSCDEADLINE_LATENCY" ] || TSCDEADLINE_LATENCY="/usr/share/tuned/tscdeadline_latency.flat"
+-
+-run_tsc_deadline_latency()
+-{
+-    dir=`mktemp -d`
+-
+-    for i in `seq 1000 500 7000`; do
+-        echo $i > $KVM_LAPIC_FILE
+-
+-        unixpath=`mktemp`
+-
+-        chrt -f 1 $QEMU -S -enable-kvm -device pc-testdev \
+-            -device isa-debug-exit,iobase=0xf4,iosize=0x4 \
+-            -display none -serial stdio -device pci-testdev \
+-            -kernel "$TSCDEADLINE_LATENCY"  \
+-            -cpu host,tsc-deadline=on \
+-            -mon chardev=char0,mode=readline \
+-            -chardev socket,id=char0,nowait,path=$unixpath,server | grep latency | cut -f 2 -d ":" > $dir/out &
+-
+-        sleep 1s
+-        pidofvcpu=`echo "info cpus" | ncat -U $unixpath | grep thread_id | cut -f 3 -d "=" | tr -d "\r"`
+-        taskset -p -c $1 $pidofvcpu >/dev/null
+-        echo "cont" | ncat -U $unixpath >/dev/null
+-        wait
+-
+-        if [ ! -f $dir/out ]; then
+-             die running $TSCDEADLINE_LATENCY failed
+-        fi
+-
+-        tmp=$(wc -l $dir/out | awk '{ print $1 }')
+-        if [ $tmp -eq 0 ]; then
+-            die running $TSCDEADLINE_LATENCY failed
+-        fi
+-
+-        A=0
+-        while read l; do
+-            A=$(($A+$l))
+-        done < $dir/out
+-
+-        lines=`wc -l $dir/out | cut -f 1 -d " "`
+-        ans=$(($A/$lines))
+-        echo $i: $ans
+-    done
+-}
+ 
+ start() {
+     setup_kvm_mod_low_latency
+ 
+     disable_ksm
+ 
+-    # If CPU model has changed, clean the cache
+-    if [ -f $CACHE_CPU_FILE ]; then
+-        curmodel=`cat /proc/cpuinfo | grep "model name" | cut -f 2 -d ":" | uniq`
+-        if [ -z "$curmodel" ]; then
+-            die failed to read CPU model
+-        fi
+-
+-        genmodel=`cat $CACHE_CPU_FILE`
+-
+-        if [ "$curmodel" != "$genmodel" ]; then
+-            rm -f $CACHE_VALUE_FILE
+-            rm -f $CACHE_CPU_FILE
+-        fi
+-    fi
+-
+-    # If the cache is empty, find the best lapic_timer_advance_ns value
+-    # and cache it
+-
+-    if [ ! -f $KVM_LAPIC_FILE ]; then
+-        die $KVM_LAPIC_FILE not found
+-    fi
+-
+-    if [ ! -f $CACHE_VALUE_FILE ]; then
+-        if [ -f "$TSCDEADLINE_LATENCY" ]; then
+-             tempdir=`mktemp -d`
+-             isolatedcpu=`echo "$TUNED_isolated_cores_expanded" | cut -f 1 -d ","`
+-             run_tsc_deadline_latency $isolatedcpu > $tempdir/lat.out
+-             if ! ./find-lapictscdeadline-optimal.sh $tempdir/lat.out > $tempdir/opt.out; then
+-                die could not find optimal latency
+-             fi
+-             echo `cat $tempdir/opt.out | cut -f 2 -d ":"` > $CACHE_VALUE_FILE
+-             curmodel=`cat /proc/cpuinfo | grep "model name" | cut -f 2 -d ":" | uniq`
+-             echo "$curmodel" > $CACHE_CPU_FILE
+-        fi
+-    fi
+-
+-    if [ -f $CACHE_VALUE_FILE ]; then
+-        echo `cat $CACHE_VALUE_FILE` > $KVM_LAPIC_FILE
+-    fi
+     systemctl start rt-entsk
+ 
+     if [ -f $KTIMER_LOCKLESS_FILE ]; then
+diff --git a/tuned.spec b/tuned.spec
+index a9867103..4e148fb1 100644
+--- a/tuned.spec
++++ b/tuned.spec
+@@ -201,11 +201,6 @@ Requires: %{name} = %{version}
+ Requires: %{name}-profiles-realtime = %{version}
+ Requires: tuna
+ Requires: nmap-ncat
+-%if 0%{?rhel} == 7
+-Requires: qemu-kvm-tools-rhev
+-%else
+-Recommends: tuned-profiles-nfv-host-bin
+-%endif
+ 
+ %description profiles-nfv-host
+ Additional tuned profile(s) targeted to Network Function Virtualization (NFV) host.

--- a/assets/tuned/patches/040-tuned-plugin-rtentsk.diff
+++ b/assets/tuned/patches/040-tuned-plugin-rtentsk.diff
@@ -1,0 +1,97 @@
+Add rtentsk plugin support.
+
+See: https://github.com/redhat-performance/tuned/pull/289
+
+--- a/profiles/realtime-virtual-guest/script.sh
++++ b/profiles/realtime-virtual-guest/script.sh
+@@ -5,7 +5,6 @@
+ KTIMER_LOCKLESS_FILE=/sys/kernel/ktimer_lockless_check
+ 
+ start() {
+-    systemctl start rt-entsk
+     if [ -f $KTIMER_LOCKLESS_FILE ]; then
+         echo 1 > $KTIMER_LOCKLESS_FILE
+     fi
+@@ -13,8 +12,7 @@ start() {
+ }
+ 
+ stop() {
+-    systemctl stop rt-entsk
+-    return "$?"
++    return 0
+ }
+ 
+ verify() {
+diff --git a/profiles/realtime-virtual-host/script.sh b/profiles/realtime-virtual-host/script.sh
+index a11dac75..030f2b07 100755
+--- a/profiles/realtime-virtual-host/script.sh
++++ b/profiles/realtime-virtual-host/script.sh
+@@ -9,8 +9,6 @@ start() {
+ 
+     disable_ksm
+ 
+-    systemctl start rt-entsk
+-
+     if [ -f $KTIMER_LOCKLESS_FILE ]; then
+         echo 1 > $KTIMER_LOCKLESS_FILE
+     fi
+@@ -23,7 +21,6 @@ stop() {
+         teardown_kvm_mod_low_latency
+         enable_ksm
+     fi
+-    systemctl stop rt-entsk
+     return "$?"
+ }
+ 
+diff --git a/profiles/realtime/tuned.conf b/profiles/realtime/tuned.conf
+index cd998b79..8eed36ea 100644
+--- a/profiles/realtime/tuned.conf
++++ b/profiles/realtime/tuned.conf
+@@ -58,3 +58,5 @@ script = ${i:PROFILE_DIR}/script.sh
+ 
+ [scheduler]
+ isolated_cores=${isolated_cores}
++
++[rtentsk]
+diff --git a/tuned/plugins/plugin_rtentsk.py b/tuned/plugins/plugin_rtentsk.py
+new file mode 100644
+index 00000000..22d873fb
+--- /dev/null
++++ b/tuned/plugins/plugin_rtentsk.py
+@@ -0,0 +1,36 @@
++from . import base
++from .decorators import *
++import tuned.logs
++from tuned.utils.commands import commands
++import glob
++import socket
++import time
++
++log = tuned.logs.get()
++
++class RTENTSKPlugin(base.Plugin):
++	"""
++	Plugin for avoiding interruptions due to static key IPIs due
++        to opening socket with timestamping enabled (by opening a
++        socket ourselves the static key is kept enabled).
++	"""
++
++	def _instance_init(self, instance):
++		instance._has_static_tuning = True
++		instance._has_dynamic_tuning = False
++
++		# SO_TIMESTAMP nor SOF_TIMESTAMPING_OPT_TX_SWHW is defined by
++		# the socket class
++
++		SO_TIMESTAMP = 29 # see include/uapi/asm-generic/socket.h
++		#define SO_TIMESTAMP 0x4012 # parisc!
++		SOF_TIMESTAMPING_OPT_TX_SWHW = (1<<14) # see include/uapi/linux/net_tstamp.h
++
++		s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
++		s.setsockopt(socket.SOL_SOCKET, SO_TIMESTAMP, SOF_TIMESTAMPING_OPT_TX_SWHW)
++		self.rtentsk_socket = s
++		log.info("opened SOF_TIMESTAMPING_OPT_TX_SWHW socket")
++
++	def _instance_cleanup(self, instance):
++		s = self.rtentsk_socket
++		s.close()


### PR DESCRIPTION
Thanks to the upstream tuned patch it is now possible to ship tuned-profiles-nfv profiles.

This PR adds tuned patches which enable full support of tuned-profiles-nfv.  Add `[rtentsk]` plugin support:
    https://github.com/redhat-performance/tuned/pull/289


