### PR TITLE
Tuned daemon fixes.

### DIFF
--- a/assets/tuned/patches/050-tuned-2.14.0-amd-performance-regression-fix.diff
+++ b/assets/tuned/patches/050-tuned-2.14.0-amd-performance-regression-fix.diff
@@ -1,0 +1,30 @@
+From f511ad5d48f4f2ae3b2616463bc3a17bae5bdb90 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jaroslav=20=C5=A0karvada?= <jskarvad@redhat.com>
+Date: Tue, 30 Jun 2020 15:39:18 +0200
+Subject: [PATCH] throughput-performance: fix performance regression on AMD
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It turned out that disablement of the numa_balancing could result in
+upto 20% performance drop on some loads.
+
+Related: rhbz#1746957
+
+Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>
+---
+ profiles/throughput-performance/tuned.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/profiles/throughput-performance/tuned.conf b/profiles/throughput-performance/tuned.conf
+index f1a6f1a..3cc6fd1 100644
+--- a/profiles/throughput-performance/tuned.conf
++++ b/profiles/throughput-performance/tuned.conf
+@@ -85,4 +85,3 @@ type=sysctl
+ uname_regex=x86_64
+ cpuinfo_regex=${amd_cpuinfo_regex}
+ kernel.sched_migration_cost_ns=5000000
+-kernel.numa_balancing=0
+-- 
+2.25.4
+

--- a/assets/tuned/patches/060-tuned-2.14.0-scheduler-isolated-cores-cgroups-fix.diff
+++ b/assets/tuned/patches/060-tuned-2.14.0-scheduler-isolated-cores-cgroups-fix.diff
@@ -1,0 +1,55 @@
+From daf02c380515b42db06d9f743070af5ab248a414 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jaroslav=20=C5=A0karvada?= <jskarvad@redhat.com>
+Date: Fri, 3 Jul 2020 12:17:03 +0200
+Subject: [PATCH] scheduler: fix isolated_cores to work with cgroups
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It seems cpuset.cpus needs to be initialized before writing to tasks.
+
+Related: rhbz#1784648
+
+Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>
+---
+ tuned/plugins/plugin_scheduler.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/tuned/plugins/plugin_scheduler.py b/tuned/plugins/plugin_scheduler.py
+index 745ee4a..9ad9f54 100644
+--- a/tuned/plugins/plugin_scheduler.py
++++ b/tuned/plugins/plugin_scheduler.py
+@@ -106,6 +106,7 @@ class SchedulerPlugin(base.Plugin):
+ 		# calculated by isolated_cores setter
+ 		self._affinity = None
+ 
++		self._cgroup_affinity_initialized = False
+ 		self._cgroup = None
+ 		self._cgroups = collections.OrderedDict([(self._sanitize_cgroup_path(option[7:]), self._variables.expand(affinity))
+ 			for option, affinity in instance.options.items() if option[:7] == "cgroup." and len(option) > 7])
+@@ -478,11 +479,14 @@ class SchedulerPlugin(base.Plugin):
+ 			log.error("Unable to set affinity '%s' for cgroup '%s'" % (affinity, cgroup))
+ 
+ 	def _cgroup_set_affinity(self):
++		if self._cgroup_affinity_initialized:
++			return
+ 		log.debug("Setting cgroups affinities")
+ 		if self._affinity is not None and self._cgroup is not None and not self._cgroup in self._cgroups:
+ 			self._cgroup_set_affinity_one(self._cgroup, self._affinity, backup = True)
+ 		for cg in self._cgroups.items():
+ 			self._cgroup_set_affinity_one(cg[0], cg[1], backup = True)
++		self._cgroup_affinity_initialized = True
+ 
+ 	def _cgroup_restore_affinity(self):
+ 		log.debug("Restoring cgroups affinities")
+@@ -920,6 +924,7 @@ class SchedulerPlugin(base.Plugin):
+ 			return self._verify_all_irq_affinity(affinity, ignore_missing)
+ 		elif enabling:
+ 			if self._cgroup:
++				self._cgroup_set_affinity()
+ 				ps_affinity = "cgroup.%s" % self._cgroup
+ 			else:
+ 				ps_affinity = affinity
+-- 
+2.25.4
+


### PR DESCRIPTION
This PR adds two fixes that resolve rhbz#1746957 and rhbz#1784648 on top of tuned 2.14.  The same fixes that ship with the Tuned daemon in RHEL 8.3.