### PR TITLE
Set maxUnavailable on ds/tuned to 10%

### DIFF
--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -11,7 +11,7 @@ spec:
       openshift-app: tuned
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 10%
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
This daemonset isn't critical for ensuring availability so allow up to
10% to be updated at once

On a 250 node cluster we're seeing about 5 pods per minute
upgrading from 4.5.4 to 4.5.5 which isn't horrible, but we can surely
upgrade more than one at a time.