### PR TITLE
Bug 1872080: Updating Dockerfile.rhel8 baseimages to mach ocp-build-data config.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
-      socat \
+      socat procps-ng \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -26,7 +26,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
-      socat \
+      socat procps-ng \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base AS tuned
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6 AS tuned
 WORKDIR /root
 COPY assets/tuned /root
 RUN INSTALL_PKGS=" \
@@ -27,7 +27,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
-      socat \
+      socat procps-ng \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -85,7 +85,7 @@ func GetSysctl(sysctlVar string, pod *corev1.Pod) (string, error) {
 		out, err = exec.Command("oc", "rsh", "-n", ntoconfig.OperatorNamespace(), pod.Name,
 			"sysctl", "-n", sysctlVar).CombinedOutput()
 		if err != nil {
-			explain = fmt.Sprintf("failed to query sysctl %s on %s", sysctlVar, pod.Name)
+			explain = fmt.Sprintf("out=%s; err=%s", string(out), err.Error())
 			return false, nil
 		}
 		val = strings.TrimSpace(string(out))


### PR DESCRIPTION
Apart from `Dockerfile.rhel8` updates to match `ocp-build-data` config, adding procps-ng as a dependency for e2e tests and better error reporting when sysctls during e2e tests fail to be applied.

Obsoleting: https://github.com/openshift/cluster-node-tuning-operator/pull/150
