### PR TITLE
Bug 1878602: Support for stall daemon.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,17 @@ RUN make build
 
 FROM centos:7 as tuned
 WORKDIR /root
-COPY assets/tuned /root
+COPY assets /root/assets
 RUN INSTALL_PKGS=" \
-      git rpm-build make desktop-file-utils patch \
+      gcc git rpm-build make desktop-file-utils patch \
       " && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
-    cd daemon && \
+    cd assets/tuned/daemon && \
     LC_COLLATE=C cat ../patches/*.diff | patch -Np1 && \
     make rpm PYTHON=/usr/bin/python && \
-    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*}
+    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*} && \
+    cd ../stalld && \
+    make
 
 FROM centos:7
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
@@ -23,7 +25,7 @@ ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}
 WORKDIR ${APP_ROOT}
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/openshift-tuned /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/assets ${APP_ROOT}
+COPY --from=tuned   /root/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
       socat procps-ng \
@@ -32,6 +34,8 @@ RUN INSTALL_PKGS=" \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
+    cp -a /var/lib/tuned/tuned/stalld/stalld /usr/local/bin && \
+    rm -rf /var/lib/tuned/tuned && \
     touch /etc/sysctl.conf && \
     yum clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -5,15 +5,17 @@ RUN make build
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base AS tuned
 WORKDIR /root
-COPY assets/tuned /root
+COPY assets /root/assets
 RUN INSTALL_PKGS=" \
-      git rpm-build make desktop-file-utils patch \
+      gcc git rpm-build make desktop-file-utils patch \
       " && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
-    cd daemon && \
+    cd assets/tuned/daemon && \
     LC_COLLATE=C cat ../patches/*.diff | patch -Np1 && \
     make rpm PYTHON=/usr/bin/python && \
-    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*}
+    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*} && \
+    cd ../stalld && \
+    make
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
@@ -23,7 +25,7 @@ ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}
 WORKDIR ${APP_ROOT}
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/openshift-tuned /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/assets ${APP_ROOT}
+COPY --from=tuned   /root/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
       socat procps-ng \
@@ -32,6 +34,8 @@ RUN INSTALL_PKGS=" \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
+    cp -a /var/lib/tuned/tuned/stalld/stalld /usr/local/bin && \
+    rm -rf /var/lib/tuned/tuned && \
     touch /etc/sysctl.conf && \
     yum clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -5,16 +5,18 @@ RUN make build
 
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6 AS tuned
 WORKDIR /root
-COPY assets/tuned /root
+COPY assets /root/assets
 RUN INSTALL_PKGS=" \
-      git rpm-build make desktop-file-utils patch \
+      gcc git rpm-build make desktop-file-utils patch \
       python3 python3-configobj python3-pyudev \
       " && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
-    cd daemon && \
+    cd assets/tuned/daemon && \
     LC_COLLATE=C cat ../patches/*.diff | patch -Np1 && \
     make rpm PYTHON=/usr/bin/python3 && \
-    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*}
+    rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*} && \
+    cd ../stalld && \
+    make
 
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
@@ -24,7 +26,7 @@ ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}
 WORKDIR ${APP_ROOT}
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/openshift-tuned /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/assets ${APP_ROOT}
+COPY --from=tuned   /root/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
       socat procps-ng \
@@ -33,6 +35,8 @@ RUN INSTALL_PKGS=" \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
+    cp -a /var/lib/tuned/tuned/stalld/stalld /usr/local/bin && \
+    rm -rf /var/lib/tuned/tuned && \
     touch /etc/sysctl.conf && \
     yum clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node Tuning Operator
 
-The Node Tuning Operator manages cluster node-level tuning for
+The Node Tuning Operator (NTO) manages cluster node-level tuning for
 [OpenShift](https://openshift.io/).
 
 The majority of high-performance applications require some
@@ -260,18 +260,42 @@ in the `profile:` section of the Tuned CR:
 * modules
 * mounts
 * net
+* rtentsk
 * scheduler
 * scsi_host
 * selinux
+* service
 * sysctl
 * sysfs
+* systemd
 * usb
 * video
 * vm
 
 with the exception of dynamic tuning functionality provided by some of the plug-ins.
-The following Tuned plug-ins are currently not supported:
+The following Tuned plug-ins are currently not fully supported:
 
 * bootloader
 * script
-* systemd
+
+
+## Additional tuning on fully-managed hosts
+Support for the [stall daemon](https://github.com/bristot/stalld)
+(stalld) has been added to complement tuning performed by Tuned realtime
+profiles. Currently, only hosts fully-managed by the
+[Machine Config Operator](https://github.com/openshift/machine-config-operator)
+(MCO) can benefit from this functionality. To deploy stalld on such hosts,
+the following line needs to be added to the Tuned service plugin.
+
+```
+service.stalld=start,enable
+```
+
+A host-supplied configuration file can be used to override the stalld systemd
+unit created when using the line above in the Tuned service plugin. This
+file can then be referred to by prefixing the absolute path to the overlay
+file on the host by the `/host` prefix.
+
+```
+service.stalld=start,enable,file:/host<absolute_path_to_the_overlay_file_on_the_host>
+```

--- a/assets/tuned/patches/070-service-plugin.diff
+++ b/assets/tuned/patches/070-service-plugin.diff
@@ -1,0 +1,354 @@
+The service plugin can handle sysvinit, sysv-rc, openrc, systemd.
+Syntax is the following:
+
+[service]
+service.sendmail = start,enable,file:${i:PROFILE_DIR}/tuned-sendmail.conf
+
+'start' means to start the service, 'stop' to stop, 'enable' to enable,
+'disable' to disable, file:FILE is the overlay configuration file
+that will be installed for the service. Multiple directives can be
+separated by comma ',' or semicolon ';'. If the directives are
+conflicting, the last one will be used. The internal variable
+${i:PROFILE_DIR} points to the directory from which the profile is
+loaded.
+
+The service plugin supports configuration overlays only for the systemd,
+for other init systems this directive is ignored. The configuration
+overlay files are copied to the /etc/systemd/system/SERVICE_NAME.service.d/
+directories. Upon unloading if the directory is empty, it's removed.
+
+With systemd, the 'start' directive is implemented by 'restart' in order
+to allow loading of the service configuration file overlay.
+
+With init systems other than systemd, it works only with the current runlevel.
+
+Resolves: rhbz#1869991
+
+See: https://github.com/redhat-performance/tuned/pull/293
+
+diff --git a/tuned/consts.py b/tuned/consts.py
+index 733ad513..876fe69d 100644
+--- a/tuned/consts.py
++++ b/tuned/consts.py
+@@ -49,6 +49,10 @@
+ DEF_CGROUP_MOUNT_POINT = "/sys/fs/cgroup/cpuset"
+ DEF_CGROUP_MODE = 0o770
+ 
++# service plugin configuration
++SERVICE_SYSTEMD_CFG_PATH = "/etc/systemd/system/%s.service.d"
++DEF_SERVICE_CFG_DIR_MODE = 0o755
++
+ # modules plugin configuration
+ MODULES_FILE = "/etc/modprobe.d/tuned.conf"
+ 
+diff --git a/tuned/plugins/plugin_service.py b/tuned/plugins/plugin_service.py
+new file mode 100644
+index 00000000..84a071f7
+--- /dev/null
++++ b/tuned/plugins/plugin_service.py
+@@ -0,0 +1,283 @@
++from . import base
++import collections
++import tuned.consts as consts
++from .decorators import *
++import os
++import re
++import tuned.logs
++from tuned.utils.commands import commands
++
++log = tuned.logs.get()
++cmd = commands()
++
++class Service():
++	def __init__(self, start = None, enable = None, cfg_file = None, runlevel = None):
++		self.enable = enable
++		self.start = start
++		self.cfg_file = cfg_file
++		self.runlevel = runlevel
++
++class InitHandler():
++	def runlevel_get(self):
++		(retcode, out) = cmd.execute(["runlevel"])
++		return out.split()[-1] if retcode == 0 else None
++
++	def daemon_reload(self):
++		cmd.execute(["telinit", "q"])
++
++	def cfg_install(self, name, cfg_file):
++		pass
++
++	def cfg_uninstall(self, name, cfg_file):
++		pass
++
++	def cfg_verify(self, name, cfg_file):
++		return None
++
++# no enable/disable
++class SysVBasicHandler(InitHandler):
++	def start(self, name):
++		cmd.execute(["service", name, "start"])
++
++	def stop(self, name):
++		cmd.execute(["service", name, "stop"])
++
++	def enable(self, name, runlevel):
++		raise NotImplementedError()
++
++	def disable(self, name, runlevel):
++		raise NotImplementedError()
++
++	def is_running(self, name):
++		(retcode, out) = cmd.execute(["service", name, "status"], no_errors = [0])
++		return retcode == 0
++
++	def is_enabled(self, name, runlevel):
++		raise NotImplementedError()
++
++class SysVHandler(SysVBasicHandler):
++	def enable(self, name, runlevel):
++		cmd.execute(["chkconfig", "--level", runlevel, name, "on"])
++
++	def disable(self, name, runlevel):
++		cmd.execute(["chkconfig", "--level", runlevel, name, "off"])
++
++	def is_enabled(self, name, runlevel):
++		(retcode, out) = cmd.execute(["chkconfig", "--list", name])
++		return out.split("%s:" % str(runlevel))[1][:2] == "on" if retcode == 0 else None
++
++class SysVRCHandler(SysVBasicHandler):
++	def enable(self, name, runlevel):
++		cmd.execute(["sysv-rc-conf", "--level", runlevel, name, "on"])
++
++	def disable(self, name, runlevel):
++		cmd.execute(["sysv-rc-conf", "--level", runlevel, name, "off"])
++
++	def is_enabled(self, name, runlevel):
++		(retcode, out) = cmd.execute(["sysv-rc-conf", "--list", name])
++		return out.split("%s:" % str(runlevel))[1][:2] == "on" if retcode == 0 else None
++
++class OpenRCHandler(InitHandler):
++	def runlevel_get(self):
++		(retcode, out) = cmd.execute(["rc-status", "-r"])
++		return out.strip() if retcode == 0 else None
++
++	def start(self, name):
++		cmd.execute(["rc-service", name, "start"])
++
++	def stop(self, name):
++		cmd.execute(["rc-service", name, "stop"])
++
++	def enable(self, name, runlevel):
++		cmd.execute(["rc-update", "add", name, runlevel])
++
++	def disable(self, name, runlevel):
++		cmd.execute(["rc-update", "del", name, runlevel])
++
++	def is_running(self, name):
++		(retcode, out) = cmd.execute(["rc-service", name, "status"], no_errors = [0])
++		return retcode == 0
++
++	def is_enabled(self, name, runlevel):
++		(retcode, out) = cmd.execute(["rc-update", "show", runlevel])
++		return bool(re.search(r"\b" + re.escape(name) + r"\b", out))
++
++class SystemdHandler(InitHandler):
++	# runlevel not used
++	def runlevel_get(self):
++		return ""
++
++	def start(self, name):
++		cmd.execute(["systemctl", "restart", name])
++
++	def stop(self, name):
++		cmd.execute(["systemctl", "stop", name])
++
++	def enable(self, name, runlevel):
++		cmd.execute(["systemctl", "enable", name])
++
++	def disable(self, name, runlevel):
++		cmd.execute(["systemctl", "disable", name])
++
++	def is_running(self, name):
++		(retcode, out) = cmd.execute(["systemctl", "is-active", name], no_errors = [0])
++		return retcode == 0
++
++	def is_enabled(self, name, runlevel):
++		(retcode, out) = cmd.execute(["systemctl", "is-enabled", name], no_errors = [0])
++		status = out.strip()
++		return True if status == "enabled" else False if status =="disabled" else None
++
++	def cfg_install(self, name, cfg_file):
++		log.info("installing service configuration overlay file '%s' for service '%s'" % (cfg_file, name))
++		if not os.path.exists(cfg_file):
++			log.error("Unable to find service configuration '%s'" % cfg_file)
++			return
++		dirpath = consts.SERVICE_SYSTEMD_CFG_PATH % name
++		try:
++			os.makedirs(dirpath, consts.DEF_SERVICE_CFG_DIR_MODE)
++		except OSError as e:
++			log.error("Unable to create directory '%s': %s" % (dirpath, e))
++			return
++		cmd.copy(cfg_file, dirpath)
++		self.daemon_reload()
++
++	def cfg_uninstall(self, name, cfg_file):
++		log.info("uninstalling service configuration overlay file '%s' for service '%s'" % (cfg_file, name))
++		dirpath = consts.SERVICE_SYSTEMD_CFG_PATH % name
++		path = "%s/%s" % (dirpath, os.path.basename(cfg_file))
++		cmd.unlink(path)
++		self.daemon_reload()
++		# remove the service dir if empty, do not check for errors
++		try:
++			os.rmdir(dirpath)
++		except (FileNotFoundError, OSError):
++			pass
++
++	def cfg_verify(self, name, cfg_file):
++		if cfg_file is None:
++			return None
++		path = "%s/%s" % (consts.SERVICE_SYSTEMD_CFG_PATH % name, os.path.basename(cfg_file))
++		if not os.path.exists(cfg_file):
++			log.error("Unable to find service '%s' configuration '%s'" % (name, cfg_file))
++			return False
++		if not os.path.exists(path):
++			log.error("Service '%s' configuration not installed in '%s'" % (name, path))
++			return False
++		md5sum1 = cmd.md5sum(cfg_file)
++		md5sum2 = cmd.md5sum(path)
++		return md5sum1 == md5sum2
++
++class ServicePlugin(base.Plugin):
++	"""
++	Plugin for handling sysvinit, openrc, and systemd services.
++	"""
++
++	def __init__(self, *args, **kwargs):
++		super(ServicePlugin, self).__init__(*args, **kwargs)
++		self._has_dynamic_options = True
++		self._init_handler = self._detect_init_system()
++
++	def _check_cmd(self, command):
++		(retcode, out) = cmd.execute(command, no_errors = [0])
++		return retcode == 0
++
++	def _detect_init_system(self):
++		if self._check_cmd(["systemctl", "status"]):
++			log.debug("detected systemd")
++			return SystemdHandler()
++		elif self._check_cmd(["chkconfig"]):
++			log.debug("detected generic sysvinit")
++			return SysVHandler()
++		elif self._check_cmd(["update-rc.d", "-h"]):
++			log.debug("detected sysv-rc")
++			return SysVRCHandler()
++		elif self._check_cmd(["rc-update", "-h"]):
++			log.debug("detected openrc")
++			return OpenRCHandler()
++		else:
++			raise exceptions.NotSupportedPluginException("Unable to detect your init system, disabling the plugin.")
++
++	def _parse_service_options(self, name,  val):
++		l = re.split(r"\s*[,;]\s*", val)
++		service = Service()
++		for i in l:
++			if i == "enable":
++				service.enable = True
++			elif i == "disable":
++				service.enable = False
++			elif i == "start":
++				service.start = True
++			elif i == "stop":
++				service.start = False
++			elif i[:5] == "file:":
++				service.cfg_file = i[5:]
++			else:
++				log.error("service '%s': invalid service option: '%s'" % (name, i))
++		return service
++
++	def _instance_init(self, instance):
++		instance._has_dynamic_tuning = False
++		instance._has_static_tuning = True
++
++		self._services = collections.OrderedDict([(option[8:], self._parse_service_options(option[8:], 
++			self._variables.expand(value))) for option, value in instance.options.items()
++			if option[:8] == "service." and len(option) > 8])
++		instance._services_original = {}
++
++	def _instance_cleanup(self, instance):
++		pass
++
++	def _process_service(self, name, start, enable, runlevel):
++		if start:
++			self._init_handler.start(name)
++		elif start is not None:
++			self._init_handler.stop(name)
++		if enable:
++			self._init_handler.enable(name, runlevel)
++		elif enable is not None:
++			self._init_handler.disable(name, runlevel)
++
++	def _instance_apply_static(self, instance):
++		runlevel = self._init_handler.runlevel_get()
++		if runlevel is None:
++			log.error("Cannot detect runlevel")
++			return
++		
++		for service in self._services.items():
++			is_enabled = self._init_handler.is_enabled(service[0], runlevel)
++			is_running = self._init_handler.is_running(service[0])
++			instance._services_original[service[0]] = Service(is_running, is_enabled, service[1].cfg_file, runlevel)
++			if service[1].cfg_file:
++				self._init_handler.cfg_install(service[0], service[1].cfg_file)
++			self._process_service(service[0], service[1].start, service[1].enable, runlevel)
++
++	def _instance_verify_static(self, instance, ignore_missing, devices):
++		runlevel = self._init_handler.runlevel_get()
++		if runlevel is None:
++			log.error(consts.STR_VERIFY_PROFILE_FAIL % "cannot detect runlevel")
++			return False
++
++		ret = True
++		for service in self._services.items():
++			ret_cfg_verify = self._init_handler.cfg_verify(service[0], service[1].cfg_file)
++			if ret_cfg_verify:
++				log.info(consts.STR_VERIFY_PROFILE_OK % "service '%s' configuration '%s' matches" % (service[0], service[1].cfg_file))
++			elif ret_cfg_verify is not None:
++				log.error(consts.STR_VERIFY_PROFILE_FAIL % "service '%s' configuration '%s' differs" % (service[0], service[1].cfg_file))
++				ret = False
++			else:
++				log.info(consts.STR_VERIFY_PROFILE_VALUE_MISSING % "service '%s' configuration '%s'" % (service[0], service[1].cfg_file))
++			is_enabled = self._init_handler.is_enabled(service[0], runlevel)
++			is_running = self._init_handler.is_running(service[0])
++			if self._verify_value("%s running" % service[0], service[1].start, is_running, ignore_missing) is False:
++				ret = False
++			if self._verify_value("%s enabled" % service[0], service[1].enable, is_enabled, ignore_missing) is False:
++				ret = False
++		return ret
++
++	def _instance_unapply_static(self, instance, full_rollback = False):
++		for name, value in list(instance._services_original.items()):
++			if value.cfg_file:
++				self._init_handler.cfg_uninstall(name, value.cfg_file)
++			self._process_service(name, value.start, value.enable, value.runlevel)
+diff --git a/tuned/utils/commands.py b/tuned/utils/commands.py
+index 3799feee..3f283a33 100644
+--- a/tuned/utils/commands.py
++++ b/tuned/utils/commands.py
+@@ -1,4 +1,5 @@
+ import errno
++import hashlib
+ import tuned.logs
+ import copy
+ import os
+@@ -195,6 +196,11 @@ def add_modify_option_in_file(self, f, d, add = True):
+ 
+ 		return self.write_to_file(f, data)
+ 
++	# calcualtes md5sum of file 'f'
++	def md5sum(self, f):
++		data = self.read_file(f)
++		return hashlib.md5(str(data).encode("utf-8")).hexdigest()
++
+ 	# returns machine ID or empty string "" in case of error
+ 	def get_machine_id(self, no_error = True):
+ 		return self.read_file(consts.MACHINE_ID_FILE, no_error).strip()

--- a/assets/tuned/stalld/Makefile
+++ b/assets/tuned/stalld/Makefile
@@ -1,0 +1,56 @@
+NAME	:=	stalld
+VERSION	:=	1.0
+
+INSTALL	=	install
+CC	:=	gcc
+CFLAGS	:=	-Wall -O2 -g
+LDFLAGS	:=	-ggdb
+LIBS	:=	 -lpthread
+
+DIRS	:=	src redhat man
+FILES	:=	Makefile README.md gpl-2.0.txt
+TARBALL	:=	$(NAME)-$(VERSION).tar.xz
+UPSTREAM_TARBALLS	:= fedorapeople.org:~/public_html/
+BINDIR	:=	/usr/bin
+DATADIR	:=	/usr/share
+DOCDIR	:=	$(DATADIR)/doc
+MANDIR	:=	$(DATADIR)/man
+LICDIR	:=	$(DATADIR)/licenses
+
+all: src/stalld.o
+	$(CC) -o stalld	 $(LDFLAGS) src/stalld.o $(LIBS)
+
+static: src/stalld.o
+	$(CC) -o stalld-static $(LDFLAGS) --static src/stalld.o $(LIBS)
+
+.PHONY: install
+install:
+	$(INSTALL) -m 755 -d $(DESTDIR)$(BINDIR) $(DESTDIR)$(DOCDIR)
+	$(INSTALL) stalld -m 755 $(DESTDIR)$(BINDIR)
+	$(INSTALL) README.md -m 644 $(DESTDIR)$(DOCDIR)
+	$(INSTALL) -m 755 -d $(DESTDIR)$(MANDIR)/man8
+	$(INSTALL) man/stalld.8 -m 644 $(DESTDIR)$(MANDIR)/man8
+	$(INSTALL) -m 755 -d $(DESTDIR)$(LICDIR)/$(NAME)
+	$(INSTALL) gpl-2.0.txt -m 644 $(DESTDIR)$(LICDIR)/$(NAME)
+
+.PHONY: clean tarball redhat push
+clean:
+	@test ! -f stalld || rm stalld
+	@test ! -f stalld-static || rm stalld-static
+	@test ! -f src/stalld.o || rm src/stalld.o
+	@test ! -f $(TARBALL) || rm -f $(TARBALL)
+	@make -C redhat clean
+	@rm -rf *~
+
+tarball:  clean
+	rm -rf $(NAME)-$(VERSION) && mkdir $(NAME)-$(VERSION)
+	cp -r $(DIRS) $(FILES) $(NAME)-$(VERSION)
+	tar -cvJf $(TARBALL) --exclude='*~' $(NAME)-$(VERSION)
+	rm -rf $(NAME)-$(VERSION)
+
+redhat: tarball
+	$(MAKE) -C redhat
+
+push: tarball
+	scp $(TARBALL) $(UPSTREAM_TARBALLS)
+	make -C redhat push

--- a/assets/tuned/stalld/README.md
+++ b/assets/tuned/stalld/README.md
@@ -1,0 +1,48 @@
+# stalld
+
+The stalld program (which stands for 'stall daemon') is a
+mechanism to prevent the *starvation* of operating system threads in a
+Linux system. The premise is to start up on a *housekeeping* cpu (one
+that is not used for real-application purposes) and to periodically
+monitor the state of each thread in the system, looking for a thread
+that has been on a run queue (i.e. ready to run) for a specifed length
+of time without being run. This condition is usually hit when the
+thread is on the same cpu as a high-priority cpu-intensive task and
+therefore is being given no opportunity to run.
+
+When a thread is judged to be starving, stalld changes
+that thread to use the SCHED_DEADLINE policy and gives the thread a
+small slice of time for that cpu (specified on the command line). The
+thread then runs and when that timeslice is used, the thread is then
+returned to its original scheduling policy and stalld then
+continues to monitor thread states.
+
+## Command Line Options
+
+`Usage: stalld [-l] [-v] [-k] [-s] [-f] [-h]
+          [-c cpu-list]
+          [-p time in ns] [-r time in ns]
+          [-d time in seconds] [-t time in seconds]`
+
+### Logging options
+- -l/--log_only: only log information (do not boost) [false]
+- -v/--verbose: print info to the std output [false]
+- -k/--log_kmsg: print log to the kernel buffer [false]
+- -s/--log_syslog: print log to syslog [true]
+
+### Startup options
+- -c/--cpu: list of cpus to monitor for stalled threads [all cpus]
+- -f/--foreground: run in foreground [false but true when -v]
+- -P/--pidfile: write daemon pid to specified file [no pidfile]
+
+### Boosting options
+- -p/--boost_period: SCHED_DEADLINE period [ns] that the starving task will receive [1000000000]
+- -r/--boost_runtime: SCHED_DEADLINE runtime [ns] that the starving task will receive [20000]
+- -d/--boost_duration: how long [s] the starving task will run with SCHED_DEADLINE [3]
+
+### Monitoring options
+- -t/--starving_threshold: how long [s] the starving task will wait before being boosted [60]
+- -A/--aggressive_mode: dispatch one thread per run queue, even when there is no starving
+                          threads on all CPU (uses more CPU/power). [false]
+### Miscellaneous
+- -h/--help: print this menu

--- a/assets/tuned/stalld/src/stalld.c
+++ b/assets/tuned/stalld/src/stalld.c
@@ -1,0 +1,1194 @@
+/*
+ * stalld: starvation detection and avoidance (with bounds).
+ *
+ * This program was born after Daniel and Juri started debugging once again
+ * problems caused kernel threads starving due to busy-loop sched FIFO threads.
+ *
+ * The idea is simple: after detecting a thread starving on a given CPU for a
+ * given period, this thread will receive a "bounded" chance to run, using
+ * SCHED_DEADLINE. In this way, the starving thread is able to make progress
+ * causing a bounded Operating System noise (OS Noise).
+ *
+ * SPDX-License-Identifier: GPL-2.0
+ *
+ * Copyright (C) 2020 Red Hat Inc, Daniel Bristot de Oliveira <bristot@redhat.com>
+ *
+ */
+
+#define _GNU_SOURCE
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+#include <linux/sched.h>
+
+#define BUFFER_SIZE		(1024 * 1000)
+#define MAX_WAITING_PIDS	30
+
+/*
+ * See kernel/sched/debug.c:print_task().
+ */
+struct task_info {
+	int pid;
+	int prio;
+	int ctxsw;
+	time_t since;
+	char comm[15];
+};
+
+struct cpu_info {
+	int id;
+	int nr_running;
+	int nr_rt_running;
+	int ctxsw;
+	int nr_waiting_tasks;
+	int thread_running;
+	struct task_info *starving;
+	pthread_t thread;
+};
+
+#ifdef __x86_64__
+# define __NR_sched_setattr 314
+# define __NR_sched_getattr 315
+#elif __i386__
+# define __NR_sched_setattr 351
+# define __NR_sched_getattr 352
+#elif __arm__
+# define __NR_sched_setattr 380
+# define __NR_sched_getattr 381
+#elif __aarch64__
+# define __NR_sched_setattr 274
+# define __NR_sched_getattr 275
+#elif __powerpc__
+# define __NR_sched_setattr 355
+# define __NR_sched_getattr 356
+#elif __s390x__
+# define __NR_sched_setattr 345
+# define __NR_sched_getattr 346
+#endif
+
+struct sched_attr {
+	uint32_t size;
+	uint32_t sched_policy;
+	uint64_t sched_flags;
+	int32_t sched_nice;
+	uint32_t sched_priority;
+	uint64_t sched_runtime;
+	uint64_t sched_deadline;
+	uint64_t sched_period;
+};
+
+int sched_setattr(pid_t pid, const struct sched_attr *attr,
+		  unsigned int flags) {
+	return syscall(__NR_sched_setattr, pid, attr, flags);
+}
+
+int sched_getattr(pid_t pid, struct sched_attr *attr,
+		  unsigned int size, unsigned int flags)
+{
+	return syscall (__NR_sched_getattr, pid , attr, size, flags);
+}
+
+/*
+ * logging.
+ */
+int config_verbose = 0;
+int config_write_kmesg = 0;
+int config_log_syslog = 1;
+int config_log_only = 0;
+int config_foreground = 0;
+
+/*
+ * boost parameters (time in nanoseconds).
+ */
+unsigned long config_dl_period  = 1000000000;
+unsigned long config_dl_runtime = 20000;
+
+/*
+ * control loop (time in seconds)
+ */
+long config_starving_threshold = 60;
+long config_boost_duration = 3;
+long config_aggressive = 0;
+
+#define NS_PER_SEC 1000000000
+
+/*
+ * XXX: Make it a cpu mask, lazy Daniel!
+ */
+int config_monitor_all_cpus = 1;
+char *config_monitored_cpus;
+
+
+/*
+ * print any error messages and exit
+ */
+
+void die(const char *fmt, ...)
+{
+	va_list ap;
+	int ret = errno;
+
+	if (errno)
+		perror("stalld: ");
+	else
+		ret = -1;
+
+	va_start(ap, fmt);
+	fprintf(stderr, "  ");
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+
+	fprintf(stderr, "\n");
+	exit(ret);
+}
+
+/*
+ * path to file for storing daemon pid
+ */
+char pidfile[MAXPATHLEN];
+
+void log_msg(const char *fmt, ...)
+{
+	const char *log_prefix = "stalld: ";
+	char message[1024];
+	char *log;
+	int kmesg_fd;
+	va_list ap;
+
+	log = message + strlen(log_prefix);
+
+	sprintf(message, log_prefix, strlen(log_prefix));
+
+	va_start(ap, fmt);
+	vsprintf(log, fmt, ap);
+	va_end(ap);
+
+	/*
+	 * print the entire message (including PREFIX).
+	 */
+	if (config_verbose)
+		fprintf(stderr, "%s", message);
+
+	/*
+	 * print the entire message (including PREFIX).
+	 */
+	if (config_write_kmesg) {
+		kmesg_fd = open("/dev/kmsg", O_WRONLY);
+
+		/*
+		 * Log iff possible.
+		 */
+		if (kmesg_fd) {
+			if (write(kmesg_fd, message, strlen(message)) < 0)
+				die ("write to klog failed");
+			close(kmesg_fd);
+		}
+	}
+
+	/*
+	 * print the log (syslog adds PREFIX).
+	 */
+	if (config_log_syslog)
+		syslog(LOG_INFO, "%s", log);
+
+}
+
+void write_pidfile(void)
+{
+	FILE *f = fopen(pidfile, "w");
+	if (f != NULL) {
+		fprintf(f, "%d", getpid());
+		fclose(f);
+	}
+	else
+		die("unable to open pidfile %s: %s\n", pidfile, strerror(errno));
+}
+
+
+
+/*
+ * Based on:
+ * https://github.com/pasce/daemon-skeleton-linux-c
+ */
+void deamonize(void)
+{
+	pid_t pid;
+
+	/*
+	 * Fork off the parent process.
+	 */
+	pid = fork();
+
+	/*
+	 * An error occurred.
+	 */
+	if (pid < 0)
+		die("Error while forking the deamon");
+
+	/*
+	 * Success: Let the parent terminate.
+	 */
+	if (pid > 0)
+		exit(EXIT_SUCCESS);
+
+	/*
+	 * On success: The child process becomes session leader.
+	 */
+	if (setsid() < 0)
+		die("Error while creating the deamon (setsid)");
+
+	/*
+	 * Catch, ignore and handle signals.
+	 * XXX: Implement a working signal handler.
+	 */
+	signal(SIGCHLD, SIG_IGN);
+	signal(SIGHUP, SIG_IGN);
+
+	/*
+	 * Fork off for the second time.
+	 */
+	pid = fork();
+
+	/*
+	 * An error occurred.
+	 */
+	if (pid < 0)
+		die("Error while forking the deamon (the second)");
+
+	/*
+	 * Success: Let the parent terminate.
+	 */
+	if (pid > 0)
+		exit(EXIT_SUCCESS);
+
+	/*
+	 * Set new file permissions.
+	 */
+	umask(0);
+
+	/*
+	 * Change the working directory to the root directory.
+	 */
+	if (chdir("/"))
+		die("Cannot change directory to '/'");
+}
+
+/*
+ * Set HRTICK and frinds: Based on cyclicdeadline by Steven Rostedt.
+ */
+#define _STR(x) #x
+#define STR(x) _STR(x)
+#ifndef MAXPATH
+#define MAXPATH 1024
+#endif
+static int find_mount(const char *mount, char *debugfs)
+{
+	char type[100];
+	FILE *fp;
+
+	if ((fp = fopen("/proc/mounts","r")) == NULL)
+		return 0;
+
+	while (fscanf(fp, "%*s %"
+		      STR(MAXPATH)
+		      "s %99s %*s %*d %*d\n",
+		      debugfs, type) == 2) {
+		if (strcmp(type, mount) == 0)
+			break;
+	}
+	fclose(fp);
+
+	if (strcmp(type, mount) != 0)
+		return 0;
+	return 1;
+}
+
+static const char *find_debugfs(void)
+{
+	static int debugfs_found;
+	static char debugfs[MAXPATH+1];
+
+	if (debugfs_found)
+		return debugfs;
+
+	if (!find_mount("debugfs", debugfs))
+		return "";
+
+	debugfs_found = 1;
+
+	return debugfs;
+}
+
+static int setup_hr_tick(void)
+{
+	const char *debugfs = find_debugfs();
+	char files[strlen(debugfs) + strlen("/sched_features") + 1];
+	char buf[500];
+	struct stat st;
+	static int set = 0;
+	char *p;
+	int ret;
+	int len;
+	int fd;
+
+	if (set)
+		return 1;
+
+	set = 1;
+
+	if (strlen(debugfs) == 0)
+		return 0;
+
+	sprintf(files, "%s/sched_features", debugfs);
+	ret = stat(files, &st);
+	if (ret < 0)
+		return 0;
+
+	fd = open(files, O_RDWR);
+	if (fd < 0) {
+		log_msg("could not open %s to set HRTICK: %s", files, strerror(errno));
+		return 0;
+	}
+
+	len = sizeof(buf);
+
+	ret = read(fd, buf, len);
+	if (ret < 0) {
+		perror(files);
+		close(fd);
+		return 0;
+	}
+	if (ret >= len)
+		ret = len - 1;
+	buf[ret] = 0;
+
+	ret = 1;
+
+	p = strstr(buf, "HRTICK");
+	if (p + 3 >= buf) {
+		p -= 3;
+		if (strncmp(p, "NO_HRTICK", 9) == 0) {
+			log_msg("dl_runtime is shorter than 1ms, setting HRTICK\n");
+			ret = write(fd, "HRTICK", 6);
+			if (ret != 6)
+				ret = 0;
+			else
+				ret = 1;
+		}
+	}
+
+	close(fd);
+	return ret;
+}
+
+int read_sched_debug(char *buffer, int size)
+{
+	int position = 0;
+	int retval;
+	int fd;
+
+	fd = open("/proc/sched_debug", O_RDONLY);
+
+	if (!fd)
+		goto out_error;
+
+	do {
+		retval = read(fd, &buffer[position], size - position);
+		if (read < 0)
+			goto out_close_fd;
+
+		position += retval;
+
+	} while (retval > 0 && position < size);
+
+	close(fd);
+
+	return position;
+
+out_close_fd:
+	close(fd);
+
+out_error:
+	return 0;
+}
+
+char *get_cpu_info_start(char *buffer, int cpu)
+{
+	/* 'cpu#9999,\0' */
+	char cpu_header[10];
+
+	sprintf(cpu_header, "cpu#%d,", cpu);
+
+	return strstr(buffer, cpu_header);
+}
+
+char *get_next_cpu_info_start(char *start)
+{
+	const char *next_cpu = "cpu#";
+
+	/* Skipp the current cpu definition */
+	start += 10;
+
+	return strstr(start, next_cpu);
+}
+
+char *alloc_and_fill_cpu_buffer(int cpu, char *sched_dbg, int sched_dbg_size)
+{
+	char *next_cpu_start;
+	char *cpu_buffer;
+	char *cpu_start;
+	int size = 0;
+
+	cpu_start = get_cpu_info_start(sched_dbg, cpu);
+
+	if (!cpu_start)
+		return NULL;
+
+	next_cpu_start = get_next_cpu_info_start(cpu_start);
+
+	/*
+	 * If it did not find the next CPU, it should be the
+	 * end of the file.
+	 */
+	if (!next_cpu_start)
+		next_cpu_start = sched_dbg + sched_dbg_size;
+
+	size = next_cpu_start - cpu_start;
+
+	if (size <= 0)
+		return NULL;
+
+	cpu_buffer = malloc(size);
+
+	if (!cpu_buffer)
+		return NULL;
+
+	strncpy(cpu_buffer, cpu_start, size);
+
+	cpu_buffer[size-1] = '\0';
+
+	return cpu_buffer;
+}
+
+long get_long_from_str(char *start)
+{
+	long value;
+	char *end;
+
+	errno = 0;
+	value = strtol(start, &end, 10);
+	if (errno || start == end)
+		die("Invalid ID '%s'", value);
+
+	return value;
+}
+
+long get_long_after_colon(char *start)
+{
+	/*
+	 * Find the ":"
+	 */
+	start = strstr(start, ":");
+	if (!start)
+		return -1;
+
+	/*
+	 * skip ":"
+	 */
+	start++;
+
+	return get_long_from_str(start);
+}
+
+long get_variable_long_value(char *buffer, const char *variable)
+{
+	char *start;
+	/*
+	 * Line:
+	 * '  .nr_running                    : 0'
+	 */
+
+	/*
+	 * Find the ".nr_running"
+	 */
+	start = strstr(buffer, variable);
+	if (!start)
+		return -1;
+
+	return get_long_after_colon(start);
+}
+
+/*
+ * Example:
+ * ' S           task   PID         tree-key  switches  prio     wait-time             sum-exec        sum-sleep'
+ * '-----------------------------------------------------------------------------------------------------------'
+ * ' I         rcu_gp     3        13.973264         2   100         0.000000         0.004469         0.000000 0 0 /
+ */
+int fill_waiting_task(char *buffer, struct task_info *task_info, int nr_entries)
+{
+	struct task_info *task;
+	char *start = buffer;
+	int tasks = 0;
+	int comm_size;
+	char *end;
+
+	while (tasks < nr_entries) {
+		task = &task_info[tasks];
+
+		start = strstr(start, "\n R");
+
+		if (!start)
+			break;
+
+		/*
+		 * Skip '\n R'
+		 */
+		start = &start[3];
+
+		/*
+		 * skip the spaces.
+		 */
+		while(start[0] == ' ')
+			start++;
+
+		end = start;
+
+		while(end[0] != ' ')
+			end++;
+
+		comm_size = end - start;
+
+		if (comm_size > 15)
+			die("comm_size is too large: %d\n", comm_size);
+
+		strncpy(task->comm, start, comm_size);
+
+		task->comm[comm_size] = 0;
+
+		/*
+		 * go to the end of the task comm
+		 */
+		start=end;
+
+		task->pid = strtol(start, &end, 10);
+
+		/*
+		 * skip the pid
+		 */
+		start=end;
+
+		/*
+		 * skip the tree-key
+		 */
+		while(start[0] == ' ')
+			start++;
+
+		while(start[0] != ' ')
+			start++;
+
+		task->ctxsw = strtol(start, &end, 10);
+
+		start = end;
+
+		task->prio = strtol(start, &end, 10);
+
+		task->since = time(NULL);
+
+		/*
+		 * go to the end and try to find the next occurence.
+		 */
+		start = end;
+
+		tasks++;
+	}
+
+	return tasks;
+}
+
+void print_waiting_tasks(struct cpu_info *cpu_info)
+{
+	struct task_info *task;
+	time_t now = time(NULL);
+	int i;
+
+	printf("CPU %d has %d waiting tasks\n", cpu_info->id, cpu_info->nr_waiting_tasks);
+	if (!cpu_info->nr_waiting_tasks)
+		return;
+
+	for (i = 0; i < cpu_info->nr_waiting_tasks; i++) {
+		task = &cpu_info->starving[i];
+
+		printf("%15s %9d %9d %9d %9ld\n", task->comm, task->pid, task->prio, task->ctxsw, (now - task->since));
+	}
+
+	return;
+
+}
+
+void merge_taks_info(struct task_info *old_tasks, int nr_old, struct task_info *new_tasks, int nr_new)
+{
+	struct task_info *old_task;
+	struct task_info *new_task;
+	int i;
+	int j;
+
+	for (i = 0; i < nr_old; i++) {
+		old_task = &old_tasks[i];
+
+		for (j = 0; j < nr_new; j++) {
+			new_task = &new_tasks[j];
+
+			if (old_task->pid == new_task->pid) {
+				if (old_task->ctxsw == new_task->ctxsw)
+					new_task->since = old_task->since;
+
+				break;
+			}
+		}
+	}
+}
+
+int parse_cpu_info(struct cpu_info *cpu_info, char *buffer, int buffer_size)
+{
+
+	struct task_info *old_tasks = cpu_info->starving;
+	int nr_old_tasks = cpu_info->nr_waiting_tasks;
+	int cpu = cpu_info->id;
+	char *cpu_buffer;
+
+	cpu_buffer = alloc_and_fill_cpu_buffer(cpu, buffer, buffer_size);
+	if (!cpu_buffer)
+		return -1;
+
+	cpu_info->nr_running = get_variable_long_value(cpu_buffer, ".nr_running");
+	cpu_info->nr_rt_running = get_variable_long_value(cpu_buffer, ".rt_nr_running");
+
+	cpu_info->starving = malloc(sizeof(struct task_info) * MAX_WAITING_PIDS);
+
+	cpu_info->nr_waiting_tasks = fill_waiting_task(cpu_buffer, cpu_info->starving, MAX_WAITING_PIDS);
+
+	if (old_tasks) {
+		merge_taks_info(old_tasks, nr_old_tasks, cpu_info->starving, cpu_info->nr_waiting_tasks);
+		free(old_tasks);
+	}
+
+	free(cpu_buffer);
+
+	return 0;
+}
+
+int boost_starving_task(int pid)
+{
+	int ret;
+	int flags = 0;
+	struct sched_attr new_attr;
+	struct sched_attr old_attr;
+
+	memset(&new_attr, 0, sizeof(new_attr));
+	new_attr.size = sizeof(new_attr);
+	new_attr.sched_policy   = SCHED_DEADLINE;
+	new_attr.sched_runtime  = config_dl_runtime;
+	new_attr.sched_deadline = config_dl_period;
+	new_attr.sched_period   = config_dl_period;
+
+	/*
+	 * Get the old prio, to be restored at the end of the
+	 * boosting period.
+	 */
+	ret = sched_getattr(pid, &old_attr, sizeof(old_attr), flags);
+
+	/*
+	 * Boost.
+	 */
+	ret = sched_setattr(pid, &new_attr, flags);
+	if (ret < 0) {
+	    log_msg("sched_setattr failed to boost pid %d: %s\n", pid, strerror(errno));
+	    return 1;
+	}
+
+	/*
+	 * Wait.
+	 *
+	 * XXX: We might want to check if the task suspended before the
+	 * end of the duration.
+	 */
+	sleep(config_boost_duration);
+
+	/*
+	 * Restore the old priority.
+	 */
+	ret = sched_setattr(pid, &old_attr, flags);
+
+	/*
+	 * XXX: If the proccess dies, we get an error. Deal with that
+	 * latter.
+	 * if (ret < 0)
+	 *   die("sched_setattr failed to set the normal priorities");
+	 */
+
+	return 0;
+
+}
+
+int check_starving_tasks(struct cpu_info *cpu)
+{
+	struct task_info *tasks = cpu->starving;
+	struct task_info *task;
+	int starving = 0;
+	int i;
+
+	for (i = 0; i < cpu->nr_waiting_tasks; i++) {
+		task = &tasks[i];
+
+		if ((time(NULL) - task->since) >= config_starving_threshold) {
+
+			log_msg("%s-%d starved on CPU %d for %d seconds\n",
+				task->comm, task->pid, cpu->id,
+				(time(NULL) - task->since));
+
+			starving+=1;
+
+			/*
+			 * It it is only logging, just reset the time couter
+			 * after logging.
+			 */
+			if (config_log_only) {
+				task->since = time(NULL);
+				continue;
+			}
+
+			boost_starving_task(task->pid);
+		}
+	}
+
+	return starving;
+}
+
+int check_might_starve_tasks(struct cpu_info *cpu)
+{
+	struct task_info *tasks = cpu->starving;
+	struct task_info *task;
+	int starving = 0;
+	int i;
+
+	if (cpu->thread_running)
+		die("checking a running thread!!!???");
+
+	for (i = 0; i < cpu->nr_waiting_tasks; i++) {
+		task = &tasks[i];
+
+		if ((time(NULL) - task->since) >= config_starving_threshold/2) {
+
+			log_msg("%s-%d might starve on CPU %d (waiting for %d seconds)\n",
+				task->comm, task->pid, cpu->id,
+				(time(NULL) - task->since));
+
+			starving = 1;
+		}
+	}
+
+	return starving;
+}
+
+void print_usage(void)
+{
+	int i;
+
+	char *msg[] = {
+		"stalld: starvation detection and avoidance (with bounds)",
+		"  usage: stalld [-l] [-v] [-k] [-s] [-f] [-h] \\",
+		"          [-c cpu-list] \\",
+		"          [-p time in ns] [-r time in ns] \\",
+		"          [-d time in seconds] [-t time in seconds]",
+		"",
+		"       logging options:",
+		"          -l/--log_only: only log information (do not boost)",
+		"          -v/--verbose: print info to the std output",
+		"          -k/--log_kmsg: print log to the kernel buffer",
+		"          -s/--log_syslog: print log to syslog",
+		"          -f/--foreground: run in foreground [implict when -v]",
+		"        boosting options:",
+		"          -p/--boost_period: SCHED_DEADLINE period [ns] that the starving task will receive",
+		"          -r/--boost_runtime: SCHED_DEADLINE runtime [ns] that the starving task will receive",
+		"          -d/--boost_duration: how long [s] the starving task will run with SCHED_DEADLINE",
+		"        monitoring options:",
+		"          -t/--starving_threshold: how long [s] the starving task will wait before being boosted",
+		"          -A/--aggressive_mode: dispatch one thread per run queue, even when there is no starving",
+		"                               threads on all CPU (uses more CPU/power).",
+		"	misc:",
+		"          --pidfile: write daemon pid to specified file",
+		"          -h/--help: print this menu",
+		NULL,
+	};
+
+	for(i = 0; msg[i]; i++)
+		fprintf(stderr, "%s\n", msg[i]);
+
+}
+
+void usage(const char *fmt, ...)
+{
+	va_list ap;
+
+	print_usage();
+
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+
+	fprintf(stderr, "\n");
+
+	exit(EINVAL);
+}
+
+void parse_cpu_list(char *cpulist)
+{
+	const char *p;
+	int end_cpu;
+	int nr_cpus;
+	int cpu;
+	int i;
+
+	nr_cpus = sysconf(_SC_NPROCESSORS_CONF);
+
+	config_monitored_cpus = malloc(nr_cpus * sizeof(char));
+	memset(config_monitored_cpus, 0, (nr_cpus * sizeof(char)));
+
+	for (p = cpulist; *p; ) {
+		cpu = atoi(p);
+		if (cpu < 0 || (!cpu && *p != '0') || cpu > nr_cpus)
+			goto err;
+
+		while (isdigit(*p))
+			p++;
+		if (*p == '-') {
+			p++;
+			end_cpu = atoi(p);
+			if (end_cpu < cpu || (!end_cpu && *p != '0'))
+				goto err;
+			while (isdigit(*p))
+				p++;
+		} else
+			end_cpu = cpu;
+
+		if (cpu == end_cpu) {
+			if (config_verbose)
+				printf("cpulist: adding cpu %d\n", cpu);
+			config_monitored_cpus[cpu] = 1;
+		} else {
+			for (i = cpu; i <= end_cpu; i++) {
+				if (config_verbose)
+					printf("cpulist: adding cpu %d\n", i);
+				config_monitored_cpus[i] = 1;
+			}
+		}
+
+		if (*p == ',')
+			p++;
+	}
+
+	return;
+err:
+	die("Error parsing the cpu list %s", cpulist);
+}
+
+int should_monitor(int cpu)
+{
+	if (config_monitor_all_cpus)
+		return 1;
+	if (config_monitored_cpus[cpu])
+		return 1;
+
+	return 0;
+}
+
+int parse_args(int argc, char **argv)
+{
+	int c;
+
+	/* ensure the pidfile is an empty string */
+	pidfile[0] = '\0';
+
+	while (1) {
+		static struct option long_options[] = {
+			{"cpu",			required_argument, 0, 'c'},
+			{"log_only",		no_argument,	   0, 'l'},
+			{"verbose",		no_argument,	   0, 'v'},
+			{"log_kmsg",		no_argument,	   0, 'k'},
+			{"log_syslog",		no_argument,	   0, 's'},
+			{"foreground",		no_argument,	   0, 'f'},
+			{"aggressive_mode",	no_argument,	   0, 'A'},
+			{"help",		no_argument,	   0, 'h'},
+			{"boost_period",	required_argument, 0, 'p'},
+			{"boost_runtime",	required_argument, 0, 'r'},
+			{"boost_duration",	required_argument, 0, 'd'},
+			{"starving_threshold",	required_argument, 0, 't'},
+			{"pidfile",             required_argument, 0, 'P'},
+			{0, 0, 0, 0}
+		};
+
+		/* getopt_long stores the option index here. */
+		int option_index = 0;
+
+		c = getopt_long(argc, argv, "lvkfAhsp:r:d:t:c:",
+				 long_options, &option_index);
+
+		/* Detect the end of the options. */
+		if (c == -1)
+			break;
+
+		switch (c) {
+		case 'c':
+			config_monitor_all_cpus = 0;
+			parse_cpu_list(optarg);
+			break;
+		case 'l':
+			config_log_only = 1;
+			break;
+		case 'v':
+			config_verbose = 1;
+			config_foreground = 1;
+			break;
+		case 'k':
+			config_write_kmesg = 1;
+			break;
+		case 's':
+			config_log_syslog = 1;
+			break;
+		case 'f':
+			config_foreground = 1;
+			break;
+		case 'A':
+			config_aggressive = 1;
+			break;
+		case 'p':
+			config_dl_period = get_long_from_str(optarg);
+			if (config_dl_period < 200000000)
+				usage("boost_period should be at least 200 ms");
+			if (config_dl_period > 4000000000)
+				usage("boost_period should be at most 4 s");
+			break;
+		case 'r':
+			config_dl_runtime = get_long_from_str(optarg);
+			if (config_dl_period < 200000000)
+				usage("boost_period should be at least 200 ms");
+			if (config_dl_period > 4000000000)
+				usage("boost_period should be at most 4 seconds");
+			break;
+		case 'd':
+			config_boost_duration = get_long_from_str(optarg);
+			if (config_boost_duration < 1)
+				usage("boost_duration should be at least 1 second");
+
+			if (config_boost_duration > 60)
+				usage("boost_duration should be at most 60 seconds");
+
+			break;
+		case 't':
+			config_starving_threshold = get_long_from_str(optarg);
+			if (config_starving_threshold < 1)
+				usage("starving_threshold should be at least 1 second");
+
+			if (config_starving_threshold > 3600)
+				usage("boost_duration should be at most one hour");
+
+			break;
+		case 'h':
+			print_usage();
+			exit(EXIT_SUCCESS);
+			break;
+		case 'P':
+			strncpy(pidfile, optarg, sizeof(pidfile)-1);
+			break;
+		case '?':
+			usage("Invalid option");
+			break;
+		default:
+			usage("Invalid option");
+		}
+	}
+
+	if (config_dl_period < config_dl_runtime)
+		usage("runtime is longer than the period");
+
+	if (config_dl_period > (config_boost_duration * NS_PER_SEC))
+		usage("the period is longer than the boost_duration: the boosted task might not be able to run");
+
+	if (config_boost_duration > config_starving_threshold)
+		usage("the boost duration cannot be longer than the starving threshold ");
+
+	if (config_dl_runtime < 1000000)
+		setup_hr_tick();
+
+	return(0);
+}
+
+void *cpu_main(void *data)
+{
+	struct cpu_info *cpu = data;
+	char buffer[BUFFER_SIZE];
+	int nothing_to_do = 0;
+	int retval;
+
+	while (cpu->thread_running) {
+
+		retval = read_sched_debug(buffer, BUFFER_SIZE);
+		if(!retval)
+			die("fail reading sched debug file!");
+
+		parse_cpu_info(cpu, buffer, BUFFER_SIZE);
+
+		if (config_verbose)
+			print_waiting_tasks(cpu);
+
+		if (cpu->nr_rt_running && cpu->nr_waiting_tasks) {
+			nothing_to_do = 0;
+			check_starving_tasks(cpu);
+		} else {
+			nothing_to_do++;
+		}
+
+		/*
+		 * it not in aggressive mode, give up after 10 cycles with
+		 * nothing to do.
+		 */
+		if (!config_aggressive && nothing_to_do == 10) {
+			cpu->thread_running=0;
+			pthread_exit(NULL);
+		}
+
+		sleep(1);
+	}
+
+	return NULL;
+}
+
+static const char *join_thread(pthread_t *thread)
+{
+	void *result;
+
+	pthread_join(*thread, &result);
+
+	return result;
+}
+
+int aggressive_main(struct cpu_info *cpus, int nr_cpus)
+{
+	int i;
+
+	for (i = 0; i < nr_cpus; i++) {
+		if (!should_monitor(i))
+			continue;
+
+		cpus[i].id = i;
+		cpus[i].thread_running = 1;
+		pthread_create(&cpus[i].thread, NULL, cpu_main, &cpus[i]);
+	}
+
+	for (i = 0; i < nr_cpus; i++) {
+		if (!should_monitor(i))
+			continue;
+
+		join_thread(&cpus[i].thread);
+	}
+
+	return 0;
+}
+
+int conservative_main(struct cpu_info *cpus, int nr_cpus)
+{
+	char buffer[BUFFER_SIZE];
+	pthread_attr_t dettached;
+	struct cpu_info *cpu;
+	int retval;
+	int i;
+
+	pthread_attr_setdetachstate(&dettached, PTHREAD_CREATE_DETACHED);
+
+	for (i = 0; i < nr_cpus; i++) {
+		cpus[i].id = i;
+		cpus[i].thread_running = 0;
+	}
+
+	while (1) {
+		retval = read_sched_debug(buffer, BUFFER_SIZE);
+		if(!retval)
+			die("fail reading sched debug file!");
+
+		for (i = 0; i < nr_cpus; i++) {
+			if (!should_monitor(i))
+				continue;
+
+			cpu = &cpus[i];
+
+			if (cpu->thread_running)
+				continue;
+
+			parse_cpu_info(cpu, buffer, BUFFER_SIZE);
+
+			if (config_verbose)
+				printf("\tchecking cpu %d - rt: %d - starving: %d\n", i, cpu->nr_rt_running, cpu->nr_waiting_tasks);
+
+			if (check_might_starve_tasks(cpu)) {
+				cpus[i].id = i;
+				cpus[i].thread_running = 1;
+				pthread_create(&cpus[i].thread, &dettached, cpu_main, &cpus[i]);
+			}
+		}
+
+		sleep(MAX(config_starving_threshold/20,1));
+	}
+}
+
+
+int main(int argc, char **argv)
+{
+	struct cpu_info *cpus;
+	int nr_cpus;
+
+	parse_args(argc, argv);
+
+	nr_cpus = sysconf(_SC_NPROCESSORS_CONF);
+	if (nr_cpus < 1)
+		die("Can not calculate number of CPUS\n");
+
+	cpus = malloc(sizeof(struct cpu_info) * nr_cpus);
+	if (!cpus)
+		die("Cannot allocate memory");
+
+	memset(cpus, 0, sizeof(struct cpu_info) * nr_cpus);
+
+	if (config_log_syslog)
+		openlog("stalld", 0, LOG_DAEMON);
+
+	if (!config_foreground)
+		deamonize();
+
+	if (strlen(pidfile) > 0)
+		write_pidfile();
+
+	if (config_aggressive)
+		aggressive_main(cpus, nr_cpus);
+	else
+		conservative_main(cpus, nr_cpus);
+
+	if (config_log_syslog)
+		closelog();
+
+	exit(0);
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	k8s.io/client-go v0.18.2
 	k8s.io/code-generator v0.18.0
 	k8s.io/klog v1.0.0
+	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 	sigs.k8s.io/controller-tools v0.2.2 // indirect
 )
 

--- a/manifests/02-crd-profile.yaml
+++ b/manifests/02-crd-profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: profiles.tuned.openshift.io
@@ -9,47 +9,52 @@ spec:
     listKind: ProfileList
     plural: profiles
     singular: profile
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1
     served: true
     storage: true
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      description: Profile is a specification for a Profile resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            config:
-              properties:
-                tunedProfile:
-                  description: tuned profile to apply
-                  type: string
-              required:
-              - tunedProfile
-              type: object
-          required:
-          - config
-          type: object
-        status:
-          description: ProfileStatus is the status for a Profile resource
-          properties:
-            bootcmdline:
-              description: kernel parameters calculated by tuned for the active tuned
-                profile
-              type: string
-          type: object
-      type: object
+    schema:
+      openAPIV3Schema:
+        description: Profile is a specification for a Profile resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              config:
+                properties:
+                  tunedProfile:
+                    description: tuned profile to apply
+                    type: string
+                required:
+                - tunedProfile
+                type: object
+            required:
+            - config
+            type: object
+          status:
+            description: ProfileStatus is the status for a Profile resource; the status
+              is for internal use only and its fields may be changed/removed in the
+              future.
+            properties:
+              bootcmdline:
+                description: kernel parameters calculated by tuned for the active tuned
+                  profile
+                type: string
+              stalld:
+                description: 'deploy stall daemon: https://github.com/bristot/stalld/'
+                type: boolean
+            type: object
+        type: object

--- a/manifests/02-crd-tuned.yaml
+++ b/manifests/02-crd-tuned.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tuneds.tuned.openshift.io
@@ -9,128 +9,128 @@ spec:
     listKind: TunedList
     plural: tuneds
     singular: tuned
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1
     served: true
     storage: true
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      description: 'Tuned is a collection of rules that allows cluster-wide deployment
-        of node-level sysctls and more flexibility to add custom tuning specified
-        by user needs.  These rules are translated and passed to all containerized
-        tuned daemons running in the cluster in the format that the daemons understand.
-        The responsibility for applying the node-level tuning then lies with the containerized
-        tuned daemons. More info: https://github.com/openshift/cluster-node-tuning-operator'
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: 'spec is the specification of the desired behavior of Tuned.
-            More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
-          properties:
-            managementState:
-              description: managementState indicates whether the registry instance
-                represented by this config instance is under operator management or
-                not.  Valid values are Force, Managed, Unmanaged, and Removed.
-              pattern: ^(Managed|Unmanaged|Force|Removed)$
-              type: string
-            profile:
-              description: Tuned profiles.
-              items:
-                description: A tuned profile.
-                properties:
-                  data:
-                    description: Specification of the tuned profile to be consumed
-                      by the tuned daemon.
-                    type: string
-                  name:
-                    description: Name of the tuned profile to be used in the recommend
-                      section.
-                    type: string
-                required:
-                - data
-                - name
-                type: object
-              type: array
-            recommend:
-              description: Selection logic for all tuned profiles.
-              items:
-                description: Selection logic for a single tuned profile.
-                properties:
-                  machineConfigLabels:
-                    additionalProperties:
+    schema:
+      openAPIV3Schema:
+        description: 'Tuned is a collection of rules that allows cluster-wide deployment
+          of node-level sysctls and more flexibility to add custom tuning specified
+          by user needs.  These rules are translated and passed to all containerized
+          tuned daemons running in the cluster in the format that the daemons understand.
+          The responsibility for applying the node-level tuning then lies with the containerized
+          tuned daemons. More info: https://github.com/openshift/cluster-node-tuning-operator'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'spec is the specification of the desired behavior of Tuned.
+              More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+            properties:
+              managementState:
+                description: managementState indicates whether the registry instance
+                  represented by this config instance is under operator management or
+                  not.  Valid values are Force, Managed, Unmanaged, and Removed.
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              profile:
+                description: Tuned profiles.
+                items:
+                  description: A tuned profile.
+                  properties:
+                    data:
+                      description: Specification of the tuned profile to be consumed
+                        by the tuned daemon.
                       type: string
-                    description: MachineConfigLabels specifies the labels for a MachineConfig.
-                      The MachineConfig is created automatically to apply additional
-                      host settings (e.g. kernel boot parameters) profile 'Profile'
-                      needs and can only be applied by creating a MachineConfig. This
-                      involves finding all MachineConfigPools with machineConfigSelector
-                      matching the MachineConfigLabels and setting the profile 'Profile'
-                      on all nodes that match the MachineConfigPools' nodeSelectors.
-                    type: object
-                  match:
-                    description: Rules governing application of a tuned profile connected
-                      by logical OR operator.
-                    items:
-                      description: Rules governing application of a tuned profile.
-                      properties:
-                        label:
-                          description: Node or Pod label name.
-                          type: string
-                        match:
-                          description: 'Additional rules governing application of the tuned profile connected by logical AND operator.'
-                          type: array
-                          items:
-                            # Recursively nested "match" sections are dropped without the following.
-                            x-kubernetes-preserve-unknown-fields: true
-                            # OpenAPI v3 validation schemas containing $ref are not permitted => cannot do recursive validation in 1.14
-                            # https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#validation
-                            type: object
-                        type:
-                          description: 'Match type: [node/pod]. If omitted, "node"
-                            is assumed.'
-                          enum:
-                          - node
-                          - pod
-                          type: string
-                        value:
-                          description: Node or Pod label value. If omitted, the presence
-                            of label name is enough to match.
-                          type: string
-                      required:
-                      - label
+                    name:
+                      description: Name of the tuned profile to be used in the recommend
+                        section.
+                      type: string
+                  required:
+                  - data
+                  - name
+                  type: object
+                type: array
+              recommend:
+                description: Selection logic for all tuned profiles.
+                items:
+                  description: Selection logic for a single tuned profile.
+                  properties:
+                    machineConfigLabels:
+                      additionalProperties:
+                        type: string
+                      description: MachineConfigLabels specifies the labels for a MachineConfig.
+                        The MachineConfig is created automatically to apply additional
+                        host settings (e.g. kernel boot parameters) profile 'Profile'
+                        needs and can only be applied by creating a MachineConfig. This
+                        involves finding all MachineConfigPools with machineConfigSelector
+                        matching the MachineConfigLabels and setting the profile 'Profile'
+                        on all nodes that match the MachineConfigPools' nodeSelectors.
                       type: object
-                    type: array
-                  priority:
-                    description: Tuned profile priority. Highest priority is 0.
-                    format: int64
-                    minimum: 0
-                    type: integer
-                  profile:
-                    description: Name of the tuned profile to recommend.
-                    type: string
-                required:
-                - priority
-                - profile
-                type: object
-              type: array
-          required:
-          - profile
-          - recommend
-          type: object
-        status:
-          description: TunedStatus is the status for a Tuned resource
-          type: object
-      type: object
+                    match:
+                      description: Rules governing application of a tuned profile connected
+                        by logical OR operator.
+                      items:
+                        description: Rules governing application of a tuned profile.
+                        properties:
+                          label:
+                            description: Node or Pod label name.
+                            type: string
+                          match:
+                            description: 'Additional rules governing application of the tuned profile connected by logical AND operator.'
+                            type: array
+                            items:
+                              # Recursively nested "match" sections are dropped without the following.
+                              x-kubernetes-preserve-unknown-fields: true
+                              # OpenAPI v3 validation schemas containing $ref are not permitted => cannot do recursive validation in 1.14
+                              # https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#validation
+                              type: object
+                          type:
+                            description: 'Match type: [node/pod]. If omitted, "node"
+                              is assumed.'
+                            enum:
+                            - node
+                            - pod
+                            type: string
+                          value:
+                            description: Node or Pod label value. If omitted, the presence
+                              of label name is enough to match.
+                            type: string
+                        required:
+                        - label
+                        type: object
+                      type: array
+                    priority:
+                      description: Tuned profile priority. Highest priority is 0.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    profile:
+                      description: Name of the tuned profile to recommend.
+                      type: string
+                  required:
+                  - priority
+                  - profile
+                  type: object
+                type: array
+            required:
+            - profile
+            - recommend
+            type: object
+          status:
+            description: TunedStatus is the status for a Tuned resource
+            type: object
+        type: object

--- a/manifests/03-rbac.yaml
+++ b/manifests/03-rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 ---
 
 # Cluster role for the operator itself.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cluster-node-tuning-operator
@@ -55,7 +55,7 @@ rules:
 ---
 
 # Bind the operator cluster role to its Service Account.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-node-tuning-operator

--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -127,11 +127,15 @@ type ProfileConfig struct {
 	TunedProfile string `json:"tunedProfile"`
 }
 
-// ProfileStatus is the status for a Profile resource
+// ProfileStatus is the status for a Profile resource; the status is for internal use only
+// and its fields may be changed/removed in the future.
 type ProfileStatus struct {
 	// kernel parameters calculated by tuned for the active tuned profile
 	// +optional
 	Bootcmdline string `json:"bootcmdline"`
+	// deploy stall daemon: https://github.com/bristot/stalld/
+	// +optional
+	Stalld bool `json:"stalld"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/tuned/host_payload.go
+++ b/pkg/tuned/host_payload.go
@@ -1,0 +1,108 @@
+package tuned
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+
+	"k8s.io/klog"
+	"k8s.io/utils/pointer"
+
+	ign3types "github.com/coreos/ignition/v2/config/v3_1/types"
+)
+
+func stalldIgnitionFile() ign3types.File {
+	const stalldPath = "/usr/local/bin/stalld"
+	mode := 0755
+
+	stalldBytes, err := ioutil.ReadFile(stalldPath)
+	if err != nil {
+		klog.Errorf("failed to read %s: %v", stalldPath, err)
+		return ign3types.File{}
+	}
+	payload := fmt.Sprintf("data:application/octet-stream;base64,%s", base64.StdEncoding.EncodeToString(stalldBytes))
+
+	return ign3types.File{
+		Node:          ign3types.Node{Path: stalldPath},
+		FileEmbedded1: ign3types.FileEmbedded1{Contents: ign3types.Resource{Source: &payload}, Mode: &mode}}
+}
+
+func stalldSystemdUnit() ign3types.Unit {
+	const unit = `[Unit]
+Description=Stall Monitor
+
+[Service]
+# List of cpus to monitor (default: all online)
+# ex: CLIST="-c 1,2,5"
+Environment=CLIST=
+
+# Aggressive mode
+# ex: AGGR=-A
+Environment=AGGR=
+
+# Period parameter for SCHED_DEADLINE in nanoseconds
+# ex: BP="-p 1000000000"
+Environment=BP="-p 1000000000"
+
+# Runtime parameter for SCHED_DEADLINE in nanoseconds
+# ex: BR="-r 20000"
+Environment=BR="-r 10000"
+
+# Duration parameter for SCHED_DEADLINE in seconds
+# ex: BD="-d 3"
+Environment=BD="-d 3"
+
+# Starving Threshold in seconds
+# this value the time the thread must be kept ready but not
+# actually run to decide that the thread is starving
+# ex: THRESH="-t 60"
+Environment=THRESH="-t 60"
+
+# Logging options
+#
+# Set logging to be some combination of:
+#     --log_only
+#     --log_kmsg
+#     --log_syslog
+#     or Nothing (default)
+# ex: LOGONLY=--log_only
+Environment=LOGGING="--log_syslog --log_kmsg"
+
+# Run in the foreground
+# ex: FG=--foreground
+# note: when using this should change the service Type to be simple
+Environment=FG=--foreground
+
+# Write a pidfile
+# ex: PF=--pidfile /run/stalld.pid
+Environment=PF="--pidfile /run/stalld.pid"
+
+ExecStart=/usr/local/bin/stalld $CLIST $AGGR $BP $BR $BD $THRESH $LOGGING $FG $PF
+User=root
+`
+
+	return ign3types.Unit{
+		Contents: pointer.StringPtr(unit),
+		Enabled:  pointer.BoolPtr(true),
+		Name:     "stalld.service"}
+}
+
+func ProvideIgnitionFiles(stalld bool) []ign3types.File {
+	files := []ign3types.File{}
+
+	if stalld {
+		files = append(files, stalldIgnitionFile())
+	}
+
+	return files
+}
+
+func ProvideSystemdUnits(stalld bool) []ign3types.Unit {
+	units := []ign3types.Unit{}
+
+	if stalld {
+		units = append(units, stalldSystemdUnit())
+	}
+
+	return units
+}

--- a/test/e2e/reboots/stalld.go
+++ b/test/e2e/reboots/stalld.go
@@ -1,0 +1,102 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	coreapi "k8s.io/api/core/v1"
+
+	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
+)
+
+// Test the installation of systemd units with the stall daemon.
+var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing systemd units and stalld", func() {
+	const (
+		profileRealtime   = "../testing_manifests/stalld.yaml"
+		mcpRealtime       = "../../../examples/realtime-mcp.yaml"
+		nodeLabelRealtime = "node-role.kubernetes.io/worker-rt"
+		procCmdline       = "/proc/cmdline"
+	)
+
+	ginkgo.Context("stalld", func() {
+		var (
+			node *coreapi.Node
+		)
+
+		// Cleanup code to roll back cluster changes done by this test even if it fails in the middle of ginkgo.It()
+		ginkgo.AfterEach(func() {
+			// This cleanup code ignores issues outlined in rhbz#1816239;
+			// this can cause a degraded MachineConfigPool
+			ginkgo.By("cluster changes rollback")
+			if node != nil {
+				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelRealtime+"-")
+			}
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileRealtime)
+			util.ExecAndLogCommand("oc", "delete", "-f", mcpRealtime)
+		})
+
+		ginkgo.It("stalld process started/stopped", func() {
+			ginkgo.By("getting a list of worker nodes")
+			nodes, err := util.GetNodesByRole(cs, "worker")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
+
+			workerMachinesOrig, err := util.GetUpdatedMachineCountForPool(cs, "worker")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			node = &nodes[0]
+			ginkgo.By(fmt.Sprintf("getting a tuned pod running on node %s", node.Name))
+			pod, err := util.GetTunedForNode(cs, node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("labelling node %s with label %s", node.Name, nodeLabelRealtime))
+			_, _, err = util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelRealtime+"=")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("creating custom realtime profile %s with stalld service", profileRealtime))
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileRealtime)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("creating custom MachineConfigPool %s", mcpRealtime))
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-f", mcpRealtime)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("waiting for worker-rt MachineConfigPool UpdatedMachineCount == 1")
+			err = util.WaitForPoolUpdatedMachineCount(cs, "worker-rt", 1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("checking the stalld daemon is running on the host")
+			out, err := util.ExecCmdInPod(pod, "pidof", "stalld")
+			util.Logf(fmt.Sprintf("stalld process running on the host with PID %s", out))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Node label needs to be removed first, and we also need to wait for the worker pool to complete the update;
+			// otherwise worker-rt MachineConfigPool deletion would cause Degraded state of the worker pool.
+			// see rhbz#1816239
+			ginkgo.By(fmt.Sprintf("removing label %s from node %s", nodeLabelRealtime, node.Name))
+			_, _, err = util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelRealtime+"-")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("deleting the custom realtime profile %s with stalld service", profileRealtime))
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileRealtime)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Wait for the worker machineCount to go to the original value when the node was not part of worker-rt pool.
+			ginkgo.By(fmt.Sprintf("waiting for worker UpdatedMachineCount == %d", workerMachinesOrig))
+			err = util.WaitForPoolUpdatedMachineCount(cs, "worker", workerMachinesOrig)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("checking the stalld daemon is not running on the host")
+			_, err = util.ExecCmdInPod(pod, "pidof", "stalld")
+			// pidof exits 1 when there is no running process found
+			gomega.Expect(err).To(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("deleting custom MachineConfigPool %s", mcpRealtime))
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-f", mcpRealtime)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+})

--- a/test/e2e/testing_manifests/stalld.yaml
+++ b/test/e2e/testing_manifests/stalld.yaml
@@ -16,9 +16,8 @@ spec:
       not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
       [bootloader]
       cmdline_ocp_realtime=+systemd.cpu_affinity=${not_isolated_cores_expanded}
-      #[service]
-      #service.stalld=start,enable
-      #service.stalld=start,enable,file:/host/etc/tuned/openshift-realtime/stalld.conf
+      [service]
+      service.stalld=start,enable
     name: openshift-realtime
 
   recommend:

--- a/vendor/github.com/ajeddeloh/go-json/README
+++ b/vendor/github.com/ajeddeloh/go-json/README
@@ -1,0 +1,10 @@
+This is a fork of go's encoding/json library. It adds the a third target for unmarshalling, json.Node.
+Unmarshalling to a Node behaves similarilarly to unmarshalling to an interface{}, except it also records
+the offsets for the start and end of the value that was unmarshalled and, if the value was part of a json
+object, it also records the offsets of the start and end of the object's key. The Value field of the Node
+will be unmarshalled to the same types as if it were an interface{}, except in the case of arrays and
+objects. In those case it will be unmarshalled to a []Node or map[string]Node instead []interface{} or
+map[string]interface{} for arrays and objects, respectively.
+
+There are two branchs, go15 and go16. go15 contains the modified go1.5 library and go16 contains the
+modified go1.6 library.

--- a/vendor/github.com/ajeddeloh/go-json/decode.go
+++ b/vendor/github.com/ajeddeloh/go-json/decode.go
@@ -1,0 +1,1226 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Represents JSON data structure using native Go types: booleans, floats,
+// strings, arrays, and maps.
+
+package json
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strconv"
+	"unicode"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// Unmarshal parses the JSON-encoded data and stores the result
+// in the value pointed to by v.
+//
+// Unmarshal uses the inverse of the encodings that
+// Marshal uses, allocating maps, slices, and pointers as necessary,
+// with the following additional rules:
+//
+// To unmarshal JSON into a pointer, Unmarshal first handles the case of
+// the JSON being the JSON literal null.  In that case, Unmarshal sets
+// the pointer to nil.  Otherwise, Unmarshal unmarshals the JSON into
+// the value pointed at by the pointer.  If the pointer is nil, Unmarshal
+// allocates a new value for it to point to.
+//
+// To unmarshal JSON into a struct, Unmarshal matches incoming object
+// keys to the keys used by Marshal (either the struct field name or its tag),
+// preferring an exact match but also accepting a case-insensitive match.
+//
+// To unmarshal JSON into an interface value,
+// Unmarshal stores one of these in the interface value:
+//
+//	bool, for JSON booleans
+//	float64, for JSON numbers
+//	string, for JSON strings
+//	[]interface{}, for JSON arrays
+//	map[string]interface{}, for JSON objects
+//	nil for JSON null
+//
+// To unmarshal a JSON array into a slice, Unmarshal resets the slice to nil
+// and then appends each element to the slice.
+//
+// To unmarshal a JSON object into a map, Unmarshal replaces the map
+// with an empty map and then adds key-value pairs from the object to
+// the map.
+//
+// If a JSON value is not appropriate for a given target type,
+// or if a JSON number overflows the target type, Unmarshal
+// skips that field and completes the unmarshalling as best it can.
+// If no more serious errors are encountered, Unmarshal returns
+// an UnmarshalTypeError describing the earliest such error.
+//
+// The JSON null value unmarshals into an interface, map, pointer, or slice
+// by setting that Go value to nil. Because null is often used in JSON to mean
+// ``not present,'' unmarshaling a JSON null into any other Go type has no effect
+// on the value and produces no error.
+//
+// When unmarshaling quoted strings, invalid UTF-8 or
+// invalid UTF-16 surrogate pairs are not treated as an error.
+// Instead, they are replaced by the Unicode replacement
+// character U+FFFD.
+//
+func Unmarshal(data []byte, v interface{}) error {
+	// Check for well-formedness.
+	// Avoids filling out half a data structure
+	// before discovering a JSON syntax error.
+	var d decodeState
+	err := checkValid(data, &d.scan)
+	if err != nil {
+		return err
+	}
+
+	d.init(data)
+	return d.unmarshal(v)
+}
+
+// Unmarshaler is the interface implemented by objects
+// that can unmarshal a JSON description of themselves.
+// The input can be assumed to be a valid encoding of
+// a JSON value. UnmarshalJSON must copy the JSON data
+// if it wishes to retain the data after returning.
+type Unmarshaler interface {
+	UnmarshalJSON([]byte) error
+}
+
+// An UnmarshalTypeError describes a JSON value that was
+// not appropriate for a value of a specific Go type.
+type UnmarshalTypeError struct {
+	Value  string       // description of JSON value - "bool", "array", "number -5"
+	Type   reflect.Type // type of Go value it could not be assigned to
+	Offset int64        // error occurred after reading Offset bytes
+}
+
+func (e *UnmarshalTypeError) Error() string {
+	return "json: cannot unmarshal " + e.Value + " into Go value of type " + e.Type.String()
+}
+
+// An UnmarshalFieldError describes a JSON object key that
+// led to an unexported (and therefore unwritable) struct field.
+// (No longer used; kept for compatibility.)
+type UnmarshalFieldError struct {
+	Key   string
+	Type  reflect.Type
+	Field reflect.StructField
+}
+
+func (e *UnmarshalFieldError) Error() string {
+	return "json: cannot unmarshal object key " + strconv.Quote(e.Key) + " into unexported field " + e.Field.Name + " of type " + e.Type.String()
+}
+
+// An InvalidUnmarshalError describes an invalid argument passed to Unmarshal.
+// (The argument to Unmarshal must be a non-nil pointer.)
+type InvalidUnmarshalError struct {
+	Type reflect.Type
+}
+
+type Node struct {
+	Start    int
+	End      int
+	KeyStart int // Only value if a member of a struct
+	KeyEnd   int
+	Value    interface{}
+}
+
+func (e *InvalidUnmarshalError) Error() string {
+	if e.Type == nil {
+		return "json: Unmarshal(nil)"
+	}
+
+	if e.Type.Kind() != reflect.Ptr {
+		return "json: Unmarshal(non-pointer " + e.Type.String() + ")"
+	}
+	return "json: Unmarshal(nil " + e.Type.String() + ")"
+}
+
+func (d *decodeState) unmarshal(v interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(runtime.Error); ok {
+				panic(r)
+			}
+			err = r.(error)
+		}
+	}()
+
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return &InvalidUnmarshalError{reflect.TypeOf(v)}
+	}
+
+	d.scan.reset()
+	// We decode rv not rv.Elem because the Unmarshaler interface
+	// test must be applied at the top level of the value.
+	d.value(rv)
+	return d.savedError
+}
+
+// A Number represents a JSON number literal.
+type Number string
+
+// String returns the literal text of the number.
+func (n Number) String() string { return string(n) }
+
+// Float64 returns the number as a float64.
+func (n Number) Float64() (float64, error) {
+	return strconv.ParseFloat(string(n), 64)
+}
+
+// Int64 returns the number as an int64.
+func (n Number) Int64() (int64, error) {
+	return strconv.ParseInt(string(n), 10, 64)
+}
+
+// decodeState represents the state while decoding a JSON value.
+type decodeState struct {
+	data       []byte
+	off        int // read offset in data
+	scan       scanner
+	nextscan   scanner // for calls to nextValue
+	savedError error
+	useNumber  bool
+}
+
+// errPhase is used for errors that should not happen unless
+// there is a bug in the JSON decoder or something is editing
+// the data slice while the decoder executes.
+var errPhase = errors.New("JSON decoder out of sync - data changing underfoot?")
+
+func (d *decodeState) init(data []byte) *decodeState {
+	d.data = data
+	d.off = 0
+	d.savedError = nil
+	return d
+}
+
+// error aborts the decoding by panicking with err.
+func (d *decodeState) error(err error) {
+	panic(err)
+}
+
+// saveError saves the first err it is called with,
+// for reporting at the end of the unmarshal.
+func (d *decodeState) saveError(err error) {
+	if d.savedError == nil {
+		d.savedError = err
+	}
+}
+
+// next cuts off and returns the next full JSON value in d.data[d.off:].
+// The next value is known to be an object or array, not a literal.
+func (d *decodeState) next() []byte {
+	c := d.data[d.off]
+	item, rest, err := nextValue(d.data[d.off:], &d.nextscan)
+	if err != nil {
+		d.error(err)
+	}
+	d.off = len(d.data) - len(rest)
+
+	// Our scanner has seen the opening brace/bracket
+	// and thinks we're still in the middle of the object.
+	// invent a closing brace/bracket to get it out.
+	if c == '{' {
+		d.scan.step(&d.scan, '}')
+	} else {
+		d.scan.step(&d.scan, ']')
+	}
+
+	return item
+}
+
+// scanWhile processes bytes in d.data[d.off:] until it
+// receives a scan code not equal to op.
+// It updates d.off and returns the new scan code.
+func (d *decodeState) scanWhile(op int) int {
+	var newOp int
+	for {
+		if d.off >= len(d.data) {
+			newOp = d.scan.eof()
+			d.off = len(d.data) + 1 // mark processed EOF with len+1
+		} else {
+			c := int(d.data[d.off])
+			d.off++
+			newOp = d.scan.step(&d.scan, c)
+		}
+		if newOp != op {
+			break
+		}
+	}
+	return newOp
+}
+
+// value decodes a JSON value from d.data[d.off:] into the value.
+// it updates d.off to point past the decoded value.
+func (d *decodeState) value(v reflect.Value) {
+	if !v.IsValid() {
+		_, rest, err := nextValue(d.data[d.off:], &d.nextscan)
+		if err != nil {
+			d.error(err)
+		}
+		d.off = len(d.data) - len(rest)
+
+		// d.scan thinks we're still at the beginning of the item.
+		// Feed in an empty string - the shortest, simplest value -
+		// so that it knows we got to the end of the value.
+		if d.scan.redo {
+			// rewind.
+			d.scan.redo = false
+			d.scan.step = stateBeginValue
+		}
+		d.scan.step(&d.scan, '"')
+		d.scan.step(&d.scan, '"')
+
+		n := len(d.scan.parseState)
+		if n > 0 && d.scan.parseState[n-1] == parseObjectKey {
+			// d.scan thinks we just read an object key; finish the object
+			d.scan.step(&d.scan, ':')
+			d.scan.step(&d.scan, '"')
+			d.scan.step(&d.scan, '"')
+			d.scan.step(&d.scan, '}')
+		}
+
+		return
+	}
+
+	switch op := d.scanWhile(scanSkipSpace); op {
+	default:
+		d.error(errPhase)
+
+	case scanBeginArray:
+		d.array(v)
+
+	case scanBeginObject:
+		d.object(v)
+
+	case scanBeginLiteral:
+		d.literal(v)
+	}
+}
+
+type unquotedValue struct{}
+
+// valueQuoted is like value but decodes a
+// quoted string literal or literal null into an interface value.
+// If it finds anything other than a quoted string literal or null,
+// valueQuoted returns unquotedValue{}.
+func (d *decodeState) valueQuoted() interface{} {
+	switch op := d.scanWhile(scanSkipSpace); op {
+	default:
+		d.error(errPhase)
+
+	case scanBeginArray:
+		d.array(reflect.Value{})
+
+	case scanBeginObject:
+		d.object(reflect.Value{})
+
+	case scanBeginLiteral:
+		switch v := d.literalInterface().(type) {
+		case nil, string:
+			return v
+		}
+	}
+	return unquotedValue{}
+}
+
+// indirect walks down v allocating pointers as needed,
+// until it gets to a non-pointer.
+// if it encounters an Unmarshaler, indirect stops and returns that.
+// if decodingNull is true, indirect stops at the last pointer so it can be set to nil.
+func (d *decodeState) indirect(v reflect.Value, decodingNull bool) (Unmarshaler, encoding.TextUnmarshaler, reflect.Value) {
+	// If v is a named type and is addressable,
+	// start with its address, so that if the type has pointer methods,
+	// we find them.
+	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() {
+		v = v.Addr()
+	}
+	for {
+		// Load value from interface, but only if the result will be
+		// usefully addressable.
+		if v.Kind() == reflect.Interface && !v.IsNil() {
+			e := v.Elem()
+			if e.Kind() == reflect.Ptr && !e.IsNil() && (!decodingNull || e.Elem().Kind() == reflect.Ptr) {
+				v = e
+				continue
+			}
+		}
+
+		if v.Kind() != reflect.Ptr {
+			break
+		}
+
+		if v.Elem().Kind() != reflect.Ptr && decodingNull && v.CanSet() {
+			break
+		}
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		if v.Type().NumMethod() > 0 {
+			if u, ok := v.Interface().(Unmarshaler); ok {
+				return u, nil, reflect.Value{}
+			}
+			if u, ok := v.Interface().(encoding.TextUnmarshaler); ok {
+				return nil, u, reflect.Value{}
+			}
+		}
+		v = v.Elem()
+	}
+	return nil, nil, v
+}
+
+// array consumes an array from d.data[d.off-1:], decoding into the value v.
+// the first byte of the array ('[') has been read already.
+func (d *decodeState) array(v reflect.Value) {
+	// Check for unmarshaler.
+	u, ut, pv := d.indirect(v, false)
+	if u != nil {
+		d.off--
+		err := u.UnmarshalJSON(d.next())
+		if err != nil {
+			d.error(err)
+		}
+		return
+	}
+	if ut != nil {
+		d.saveError(&UnmarshalTypeError{"array", v.Type(), int64(d.off)})
+		d.off--
+		d.next()
+		return
+	}
+
+	v = pv
+
+	// Check type of target.
+	switch v.Kind() {
+	case reflect.Interface:
+		if v.NumMethod() == 0 {
+			// Decoding into nil interface?  Switch to non-reflect code.
+			v.Set(reflect.ValueOf(d.arrayInterface()))
+			return
+		}
+		// Otherwise it's invalid.
+		fallthrough
+	default:
+		if v.Type() == reflect.TypeOf(Node{}) {
+			// Decoding to Node? Switch to that code
+			v.Set(reflect.ValueOf(d.arrayNode()))
+			return
+		}
+		d.saveError(&UnmarshalTypeError{"array", v.Type(), int64(d.off)})
+		d.off--
+		d.next()
+		return
+	case reflect.Array:
+	case reflect.Slice:
+		break
+	}
+
+	i := 0
+	for {
+		// Look ahead for ] - can only happen on first iteration.
+		op := d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+
+		// Back up so d.value can have the byte we just read.
+		d.off--
+		d.scan.undo(op)
+
+		// Get element of array, growing if necessary.
+		if v.Kind() == reflect.Slice {
+			// Grow slice if necessary
+			if i >= v.Cap() {
+				newcap := v.Cap() + v.Cap()/2
+				if newcap < 4 {
+					newcap = 4
+				}
+				newv := reflect.MakeSlice(v.Type(), v.Len(), newcap)
+				reflect.Copy(newv, v)
+				v.Set(newv)
+			}
+			if i >= v.Len() {
+				v.SetLen(i + 1)
+			}
+		}
+
+		if i < v.Len() {
+			// Decode into element.
+			d.value(v.Index(i))
+		} else {
+			// Ran out of fixed array: skip.
+			d.value(reflect.Value{})
+		}
+		i++
+
+		// Next token must be , or ].
+		op = d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+		if op != scanArrayValue {
+			d.error(errPhase)
+		}
+	}
+
+	if i < v.Len() {
+		if v.Kind() == reflect.Array {
+			// Array.  Zero the rest.
+			z := reflect.Zero(v.Type().Elem())
+			for ; i < v.Len(); i++ {
+				v.Index(i).Set(z)
+			}
+		} else {
+			v.SetLen(i)
+		}
+	}
+	if i == 0 && v.Kind() == reflect.Slice {
+		v.Set(reflect.MakeSlice(v.Type(), 0, 0))
+	}
+}
+
+var nullLiteral = []byte("null")
+
+// object consumes an object from d.data[d.off-1:], decoding into the value v.
+// the first byte ('{') of the object has been read already.
+func (d *decodeState) object(v reflect.Value) {
+	// Check for unmarshaler.
+	u, ut, pv := d.indirect(v, false)
+	if u != nil {
+		d.off--
+		err := u.UnmarshalJSON(d.next())
+		if err != nil {
+			d.error(err)
+		}
+		return
+	}
+	if ut != nil {
+		d.saveError(&UnmarshalTypeError{"object", v.Type(), int64(d.off)})
+		d.off--
+		d.next() // skip over { } in input
+		return
+	}
+	v = pv
+
+	// Decoding into nil interface?  Switch to non-reflect code.
+	if v.Kind() == reflect.Interface && v.NumMethod() == 0 {
+		v.Set(reflect.ValueOf(d.objectInterface()))
+		return
+	} else if v.Type() == reflect.TypeOf(Node{}) {
+		// Decoding to Node? Switch to that code
+		v.Set(reflect.ValueOf(d.objectNode()))
+		return
+	}
+
+	// Check type of target: struct or map[string]T
+	switch v.Kind() {
+	case reflect.Map:
+		// map must have string kind
+		t := v.Type()
+		if t.Key().Kind() != reflect.String {
+			d.saveError(&UnmarshalTypeError{"object", v.Type(), int64(d.off)})
+			d.off--
+			d.next() // skip over { } in input
+			return
+		}
+		if v.IsNil() {
+			v.Set(reflect.MakeMap(t))
+		}
+	case reflect.Struct:
+
+	default:
+		d.saveError(&UnmarshalTypeError{"object", v.Type(), int64(d.off)})
+		d.off--
+		d.next() // skip over { } in input
+		return
+	}
+
+	var mapElem reflect.Value
+
+	for {
+		// Read opening " of string key or closing }.
+		op := d.scanWhile(scanSkipSpace)
+		if op == scanEndObject {
+			// closing } - can only happen on first iteration.
+			break
+		}
+		if op != scanBeginLiteral {
+			d.error(errPhase)
+		}
+
+		// Read key.
+		start := d.off - 1
+		op = d.scanWhile(scanContinue)
+		item := d.data[start : d.off-1]
+		key, ok := unquoteBytes(item)
+		if !ok {
+			d.error(errPhase)
+		}
+
+		// Figure out field corresponding to key.
+		var subv reflect.Value
+		destring := false // whether the value is wrapped in a string to be decoded first
+
+		if v.Kind() == reflect.Map {
+			elemType := v.Type().Elem()
+			if !mapElem.IsValid() {
+				mapElem = reflect.New(elemType).Elem()
+			} else {
+				mapElem.Set(reflect.Zero(elemType))
+			}
+			subv = mapElem
+		} else {
+			var f *field
+			fields := cachedTypeFields(v.Type())
+			for i := range fields {
+				ff := &fields[i]
+				if bytes.Equal(ff.nameBytes, key) {
+					f = ff
+					break
+				}
+				if f == nil && ff.equalFold(ff.nameBytes, key) {
+					f = ff
+				}
+			}
+			if f != nil {
+				subv = v
+				destring = f.quoted
+				for _, i := range f.index {
+					if subv.Kind() == reflect.Ptr {
+						if subv.IsNil() {
+							subv.Set(reflect.New(subv.Type().Elem()))
+						}
+						subv = subv.Elem()
+					}
+					subv = subv.Field(i)
+				}
+			}
+		}
+
+		// Read : before value.
+		if op == scanSkipSpace {
+			op = d.scanWhile(scanSkipSpace)
+		}
+		if op != scanObjectKey {
+			d.error(errPhase)
+		}
+
+		// Read value.
+		if destring {
+			switch qv := d.valueQuoted().(type) {
+			case nil:
+				d.literalStore(nullLiteral, subv, false)
+			case string:
+				d.literalStore([]byte(qv), subv, true)
+			default:
+				d.saveError(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal unquoted value into %v", subv.Type()))
+			}
+		} else {
+			d.value(subv)
+		}
+
+		// Write value back to map;
+		// if using struct, subv points into struct already.
+		if v.Kind() == reflect.Map {
+			kv := reflect.ValueOf(key).Convert(v.Type().Key())
+			v.SetMapIndex(kv, subv)
+		}
+
+		// Next token must be , or }.
+		op = d.scanWhile(scanSkipSpace)
+		if op == scanEndObject {
+			break
+		}
+		if op != scanObjectValue {
+			d.error(errPhase)
+		}
+	}
+}
+
+// literal consumes a literal from d.data[d.off-1:], decoding into the value v.
+// The first byte of the literal has been read already
+// (that's how the caller knows it's a literal).
+func (d *decodeState) literal(v reflect.Value) {
+	// All bytes inside literal return scanContinue op code.
+	start := d.off - 1
+	op := d.scanWhile(scanContinue)
+
+	// Scan read one byte too far; back up.
+	d.off--
+	d.scan.undo(op)
+
+	d.literalStore(d.data[start:d.off], v, false)
+}
+
+// convertNumber converts the number literal s to a float64 or a Number
+// depending on the setting of d.useNumber.
+func (d *decodeState) convertNumber(s string) (interface{}, error) {
+	if d.useNumber {
+		return Number(s), nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil, &UnmarshalTypeError{"number " + s, reflect.TypeOf(0.0), int64(d.off)}
+	}
+	return f, nil
+}
+
+var numberType = reflect.TypeOf(Number(""))
+
+// literalStore decodes a literal stored in item into v.
+//
+// fromQuoted indicates whether this literal came from unwrapping a
+// string from the ",string" struct tag option. this is used only to
+// produce more helpful error messages.
+func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool) {
+	// Check for unmarshaler.
+	if len(item) == 0 {
+		//Empty string given
+		d.saveError(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+		return
+	}
+	wantptr := item[0] == 'n' // null
+	u, ut, pv := d.indirect(v, wantptr)
+	if u != nil {
+		err := u.UnmarshalJSON(item)
+		if err != nil {
+			d.error(err)
+		}
+		return
+	}
+	if ut != nil {
+		if item[0] != '"' {
+			if fromQuoted {
+				d.saveError(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+			} else {
+				d.saveError(&UnmarshalTypeError{"string", v.Type(), int64(d.off)})
+			}
+			return
+		}
+		s, ok := unquoteBytes(item)
+		if !ok {
+			if fromQuoted {
+				d.error(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+			} else {
+				d.error(errPhase)
+			}
+		}
+		err := ut.UnmarshalText(s)
+		if err != nil {
+			d.error(err)
+		}
+		return
+	}
+
+	v = pv
+
+	switch c := item[0]; c {
+	case 'n': // null
+		switch v.Kind() {
+		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+			v.Set(reflect.Zero(v.Type()))
+			// otherwise, ignore null for primitives/string
+		}
+	case 't', 'f': // true, false
+		value := c == 't'
+		switch v.Kind() {
+		default:
+			if fromQuoted {
+				d.saveError(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+			} else {
+				d.saveError(&UnmarshalTypeError{"bool", v.Type(), int64(d.off)})
+			}
+		case reflect.Bool:
+			v.SetBool(value)
+		case reflect.Interface:
+			if v.NumMethod() == 0 {
+				v.Set(reflect.ValueOf(value))
+			} else {
+				d.saveError(&UnmarshalTypeError{"bool", v.Type(), int64(d.off)})
+			}
+		}
+
+	case '"': // string
+		s, ok := unquoteBytes(item)
+		if !ok {
+			if fromQuoted {
+				d.error(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+			} else {
+				d.error(errPhase)
+			}
+		}
+		switch v.Kind() {
+		default:
+			d.saveError(&UnmarshalTypeError{"string", v.Type(), int64(d.off)})
+		case reflect.Slice:
+			if v.Type().Elem().Kind() != reflect.Uint8 {
+				d.saveError(&UnmarshalTypeError{"string", v.Type(), int64(d.off)})
+				break
+			}
+			b := make([]byte, base64.StdEncoding.DecodedLen(len(s)))
+			n, err := base64.StdEncoding.Decode(b, s)
+			if err != nil {
+				d.saveError(err)
+				break
+			}
+			v.Set(reflect.ValueOf(b[0:n]))
+		case reflect.String:
+			v.SetString(string(s))
+		case reflect.Interface:
+			if v.NumMethod() == 0 {
+				v.Set(reflect.ValueOf(string(s)))
+			} else {
+				d.saveError(&UnmarshalTypeError{"string", v.Type(), int64(d.off)})
+			}
+		}
+
+	default: // number
+		if c != '-' && (c < '0' || c > '9') {
+			if fromQuoted {
+				d.error(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+			} else {
+				d.error(errPhase)
+			}
+		}
+		s := string(item)
+		switch v.Kind() {
+		default:
+			if v.Kind() == reflect.String && v.Type() == numberType {
+				v.SetString(s)
+				break
+			}
+			if fromQuoted {
+				d.error(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
+			} else {
+				d.error(&UnmarshalTypeError{"number", v.Type(), int64(d.off)})
+			}
+		case reflect.Interface:
+			n, err := d.convertNumber(s)
+			if err != nil {
+				d.saveError(err)
+				break
+			}
+			if v.NumMethod() != 0 {
+				d.saveError(&UnmarshalTypeError{"number", v.Type(), int64(d.off)})
+				break
+			}
+			v.Set(reflect.ValueOf(n))
+
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			n, err := strconv.ParseInt(s, 10, 64)
+			if err != nil || v.OverflowInt(n) {
+				d.saveError(&UnmarshalTypeError{"number " + s, v.Type(), int64(d.off)})
+				break
+			}
+			v.SetInt(n)
+
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			n, err := strconv.ParseUint(s, 10, 64)
+			if err != nil || v.OverflowUint(n) {
+				d.saveError(&UnmarshalTypeError{"number " + s, v.Type(), int64(d.off)})
+				break
+			}
+			v.SetUint(n)
+
+		case reflect.Float32, reflect.Float64:
+			n, err := strconv.ParseFloat(s, v.Type().Bits())
+			if err != nil || v.OverflowFloat(n) {
+				d.saveError(&UnmarshalTypeError{"number " + s, v.Type(), int64(d.off)})
+				break
+			}
+			v.SetFloat(n)
+		}
+	}
+}
+
+// The xxxInterface routines build up a value to be stored
+// in an empty interface.  They are not strictly necessary,
+// but they avoid the weight of reflection in this common case.
+
+// valueInterface is like value but returns interface{}
+func (d *decodeState) valueInterface() interface{} {
+	switch d.scanWhile(scanSkipSpace) {
+	default:
+		d.error(errPhase)
+		panic("unreachable")
+	case scanBeginArray:
+		return d.arrayInterface()
+	case scanBeginObject:
+		return d.objectInterface()
+	case scanBeginLiteral:
+		return d.literalInterface()
+	}
+}
+
+// valueNode is like valueInterface but returns a wrapped version that
+// contains metadata about where it decoded from
+func (d *decodeState) valueNode() Node {
+	switch d.scanWhile(scanSkipSpace) {
+	default:
+		d.error(errPhase)
+		panic("unreachable")
+	case scanBeginArray:
+		return d.arrayNode()
+	case scanBeginObject:
+		return d.objectNode()
+	case scanBeginLiteral:
+		return d.literalNode()
+	}
+}
+
+// arrayInterface is like array but returns []interface{}.
+func (d *decodeState) arrayInterface() []interface{} {
+	var v = make([]interface{}, 0)
+	for {
+		// Look ahead for ] - can only happen on first iteration.
+		op := d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+
+		// Back up so d.value can have the byte we just read.
+		d.off--
+		d.scan.undo(op)
+
+		v = append(v, d.valueInterface())
+
+		// Next token must be , or ].
+		op = d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+		if op != scanArrayValue {
+			d.error(errPhase)
+		}
+	}
+	return v
+}
+
+// arrayNode is like arrayInterface but returns Node.
+func (d *decodeState) arrayNode() Node {
+	var v = make([]Node, 0)
+	node := Node{
+		Start: d.off,
+		Value: v,
+	}
+	for {
+		// Look ahead for ] - can only happen on first iteration.
+		op := d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+
+		// Back up so d.value can have the byte we just read.
+		d.off--
+		d.scan.undo(op)
+
+		v = append(v, d.valueNode())
+
+		// Next token must be , or ].
+		op = d.scanWhile(scanSkipSpace)
+		if op == scanEndArray {
+			break
+		}
+		if op != scanArrayValue {
+			d.error(errPhase)
+		}
+	}
+	node.Value = v
+	node.End = d.off - 1
+	return node
+}
+
+// objectInterface is like object but returns map[string]interface{}.
+func (d *decodeState) objectInterface() map[string]interface{} {
+	m := make(map[string]interface{})
+	for {
+		// Read opening " of string key or closing }.
+		op := d.scanWhile(scanSkipSpace)
+		if op == scanEndObject {
+			// closing } - can only happen on first iteration.
+			break
+		}
+		if op != scanBeginLiteral {
+			d.error(errPhase)
+		}
+
+		// Read string key.
+		start := d.off - 1
+		op = d.scanWhile(scanContinue)
+		item := d.data[start : d.off-1]
+		key, ok := unquote(item)
+		if !ok {
+			d.error(errPhase)
+		}
+
+		// Read : before value.
+		if op == scanSkipSpace {
+			op = d.scanWhile(scanSkipSpace)
+		}
+		if op != scanObjectKey {
+			d.error(errPhase)
+		}
+
+		// Read value.
+		m[key] = d.valueInterface()
+
+		// Next token must be , or }.
+		op = d.scanWhile(scanSkipSpace)
+		if op == scanEndObject {
+			break
+		}
+		if op != scanObjectValue {
+			d.error(errPhase)
+		}
+	}
+	return m
+}
+
+// objectNode is like object but returns Node.
+func (d *decodeState) objectNode() Node {
+	m := make(map[string]Node)
+	node := Node{
+		Start: d.off,
+	}
+	for {
+		// Read opening " of string key or closing }.
+		op := d.scanWhile(scanSkipSpace)
+		if op == scanEndObject {
+			// closing } - can only happen on first iteration.
+			break
+		}
+		if op != scanBeginLiteral {
+			d.error(errPhase)
+		}
+
+		// Read string key.
+		start := d.off - 1
+		op = d.scanWhile(scanContinue)
+		item := d.data[start : d.off-1]
+		keyEnd := d.off - 1
+		key, ok := unquote(item)
+		if !ok {
+			d.error(errPhase)
+		}
+
+		// Read : before value.
+		if op == scanSkipSpace {
+			op = d.scanWhile(scanSkipSpace)
+		}
+		if op != scanObjectKey {
+			d.error(errPhase)
+		}
+
+		// Read value.
+		val := d.valueNode()
+		val.KeyStart = start
+		val.KeyEnd = keyEnd
+		m[key] = val
+
+		// Next token must be , or }.
+		op = d.scanWhile(scanSkipSpace)
+		if op == scanEndObject {
+			break
+		}
+		if op != scanObjectValue {
+			d.error(errPhase)
+		}
+	}
+	node.Value = m
+	node.End = d.off - 1
+	return node
+}
+
+// literalInterface is like literal but returns an interface value.
+func (d *decodeState) literalInterface() interface{} {
+	// All bytes inside literal return scanContinue op code.
+	start := d.off - 1
+	op := d.scanWhile(scanContinue)
+
+	// Scan read one byte too far; back up.
+	d.off--
+	d.scan.undo(op)
+	item := d.data[start:d.off]
+
+	switch c := item[0]; c {
+	case 'n': // null
+		return nil
+
+	case 't', 'f': // true, false
+		return c == 't'
+
+	case '"': // string
+		s, ok := unquote(item)
+		if !ok {
+			d.error(errPhase)
+		}
+		return s
+
+	default: // number
+		if c != '-' && (c < '0' || c > '9') {
+			d.error(errPhase)
+		}
+		n, err := d.convertNumber(string(item))
+		if err != nil {
+			d.saveError(err)
+		}
+		return n
+	}
+}
+
+func (d *decodeState) literalNode() Node {
+	start := d.off - 1
+	// Can just use the interface version since this has no children
+	node := Node{
+		Start: start,
+		Value: d.literalInterface(),
+	}
+	node.End = d.off - 1
+	return node
+}
+
+// getu4 decodes \uXXXX from the beginning of s, returning the hex value,
+// or it returns -1.
+func getu4(s []byte) rune {
+	if len(s) < 6 || s[0] != '\\' || s[1] != 'u' {
+		return -1
+	}
+	r, err := strconv.ParseUint(string(s[2:6]), 16, 64)
+	if err != nil {
+		return -1
+	}
+	return rune(r)
+}
+
+// unquote converts a quoted JSON string literal s into an actual string t.
+// The rules are different than for Go, so cannot use strconv.Unquote.
+func unquote(s []byte) (t string, ok bool) {
+	s, ok = unquoteBytes(s)
+	t = string(s)
+	return
+}
+
+func unquoteBytes(s []byte) (t []byte, ok bool) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return
+	}
+	s = s[1 : len(s)-1]
+
+	// Check for unusual characters. If there are none,
+	// then no unquoting is needed, so return a slice of the
+	// original bytes.
+	r := 0
+	for r < len(s) {
+		c := s[r]
+		if c == '\\' || c == '"' || c < ' ' {
+			break
+		}
+		if c < utf8.RuneSelf {
+			r++
+			continue
+		}
+		rr, size := utf8.DecodeRune(s[r:])
+		if rr == utf8.RuneError && size == 1 {
+			break
+		}
+		r += size
+	}
+	if r == len(s) {
+		return s, true
+	}
+
+	b := make([]byte, len(s)+2*utf8.UTFMax)
+	w := copy(b, s[0:r])
+	for r < len(s) {
+		// Out of room?  Can only happen if s is full of
+		// malformed UTF-8 and we're replacing each
+		// byte with RuneError.
+		if w >= len(b)-2*utf8.UTFMax {
+			nb := make([]byte, (len(b)+utf8.UTFMax)*2)
+			copy(nb, b[0:w])
+			b = nb
+		}
+		switch c := s[r]; {
+		case c == '\\':
+			r++
+			if r >= len(s) {
+				return
+			}
+			switch s[r] {
+			default:
+				return
+			case '"', '\\', '/', '\'':
+				b[w] = s[r]
+				r++
+				w++
+			case 'b':
+				b[w] = '\b'
+				r++
+				w++
+			case 'f':
+				b[w] = '\f'
+				r++
+				w++
+			case 'n':
+				b[w] = '\n'
+				r++
+				w++
+			case 'r':
+				b[w] = '\r'
+				r++
+				w++
+			case 't':
+				b[w] = '\t'
+				r++
+				w++
+			case 'u':
+				r--
+				rr := getu4(s[r:])
+				if rr < 0 {
+					return
+				}
+				r += 6
+				if utf16.IsSurrogate(rr) {
+					rr1 := getu4(s[r:])
+					if dec := utf16.DecodeRune(rr, rr1); dec != unicode.ReplacementChar {
+						// A valid pair; consume.
+						r += 6
+						w += utf8.EncodeRune(b[w:], dec)
+						break
+					}
+					// Invalid surrogate; fall back to replacement rune.
+					rr = unicode.ReplacementChar
+				}
+				w += utf8.EncodeRune(b[w:], rr)
+			}
+
+		// Quote, control characters are invalid.
+		case c == '"', c < ' ':
+			return
+
+		// ASCII
+		case c < utf8.RuneSelf:
+			b[w] = c
+			r++
+			w++
+
+		// Coerce to well-formed UTF-8.
+		default:
+			rr, size := utf8.DecodeRune(s[r:])
+			r += size
+			w += utf8.EncodeRune(b[w:], rr)
+		}
+	}
+	return b[0:w], true
+}

--- a/vendor/github.com/ajeddeloh/go-json/encode.go
+++ b/vendor/github.com/ajeddeloh/go-json/encode.go
@@ -1,0 +1,1194 @@
+// Copyright 2010 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package json implements encoding and decoding of JSON objects as defined in
+// RFC 4627. The mapping between JSON objects and Go values is described
+// in the documentation for the Marshal and Unmarshal functions.
+//
+// See "JSON and Go" for an introduction to this package:
+// https://golang.org/doc/articles/json_and_go.html
+package json
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/base64"
+	"math"
+	"reflect"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Marshal returns the JSON encoding of v.
+//
+// Marshal traverses the value v recursively.
+// If an encountered value implements the Marshaler interface
+// and is not a nil pointer, Marshal calls its MarshalJSON method
+// to produce JSON.  The nil pointer exception is not strictly necessary
+// but mimics a similar, necessary exception in the behavior of
+// UnmarshalJSON.
+//
+// Otherwise, Marshal uses the following type-dependent default encodings:
+//
+// Boolean values encode as JSON booleans.
+//
+// Floating point, integer, and Number values encode as JSON numbers.
+//
+// String values encode as JSON strings coerced to valid UTF-8,
+// replacing invalid bytes with the Unicode replacement rune.
+// The angle brackets "<" and ">" are escaped to "\u003c" and "\u003e"
+// to keep some browsers from misinterpreting JSON output as HTML.
+// Ampersand "&" is also escaped to "\u0026" for the same reason.
+//
+// Array and slice values encode as JSON arrays, except that
+// []byte encodes as a base64-encoded string, and a nil slice
+// encodes as the null JSON object.
+//
+// Struct values encode as JSON objects. Each exported struct field
+// becomes a member of the object unless
+//   - the field's tag is "-", or
+//   - the field is empty and its tag specifies the "omitempty" option.
+// The empty values are false, 0, any
+// nil pointer or interface value, and any array, slice, map, or string of
+// length zero. The object's default key string is the struct field name
+// but can be specified in the struct field's tag value. The "json" key in
+// the struct field's tag value is the key name, followed by an optional comma
+// and options. Examples:
+//
+//   // Field is ignored by this package.
+//   Field int `json:"-"`
+//
+//   // Field appears in JSON as key "myName".
+//   Field int `json:"myName"`
+//
+//   // Field appears in JSON as key "myName" and
+//   // the field is omitted from the object if its value is empty,
+//   // as defined above.
+//   Field int `json:"myName,omitempty"`
+//
+//   // Field appears in JSON as key "Field" (the default), but
+//   // the field is skipped if empty.
+//   // Note the leading comma.
+//   Field int `json:",omitempty"`
+//
+// The "string" option signals that a field is stored as JSON inside a
+// JSON-encoded string. It applies only to fields of string, floating point,
+// integer, or boolean types. This extra level of encoding is sometimes used
+// when communicating with JavaScript programs:
+//
+//    Int64String int64 `json:",string"`
+//
+// The key name will be used if it's a non-empty string consisting of
+// only Unicode letters, digits, dollar signs, percent signs, hyphens,
+// underscores and slashes.
+//
+// Anonymous struct fields are usually marshaled as if their inner exported fields
+// were fields in the outer struct, subject to the usual Go visibility rules amended
+// as described in the next paragraph.
+// An anonymous struct field with a name given in its JSON tag is treated as
+// having that name, rather than being anonymous.
+// An anonymous struct field of interface type is treated the same as having
+// that type as its name, rather than being anonymous.
+//
+// The Go visibility rules for struct fields are amended for JSON when
+// deciding which field to marshal or unmarshal. If there are
+// multiple fields at the same level, and that level is the least
+// nested (and would therefore be the nesting level selected by the
+// usual Go rules), the following extra rules apply:
+//
+// 1) Of those fields, if any are JSON-tagged, only tagged fields are considered,
+// even if there are multiple untagged fields that would otherwise conflict.
+// 2) If there is exactly one field (tagged or not according to the first rule), that is selected.
+// 3) Otherwise there are multiple fields, and all are ignored; no error occurs.
+//
+// Handling of anonymous struct fields is new in Go 1.1.
+// Prior to Go 1.1, anonymous struct fields were ignored. To force ignoring of
+// an anonymous struct field in both current and earlier versions, give the field
+// a JSON tag of "-".
+//
+// Map values encode as JSON objects.
+// The map's key type must be string; the map keys are used as JSON object
+// keys, subject to the UTF-8 coercion described for string values above.
+//
+// Pointer values encode as the value pointed to.
+// A nil pointer encodes as the null JSON object.
+//
+// Interface values encode as the value contained in the interface.
+// A nil interface value encodes as the null JSON object.
+//
+// Channel, complex, and function values cannot be encoded in JSON.
+// Attempting to encode such a value causes Marshal to return
+// an UnsupportedTypeError.
+//
+// JSON cannot represent cyclic data structures and Marshal does not
+// handle them.  Passing cyclic structures to Marshal will result in
+// an infinite recursion.
+//
+func Marshal(v interface{}) ([]byte, error) {
+	e := &encodeState{}
+	err := e.marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return e.Bytes(), nil
+}
+
+// MarshalIndent is like Marshal but applies Indent to format the output.
+func MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	b, err := Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	err = Indent(&buf, b, prefix, indent)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// HTMLEscape appends to dst the JSON-encoded src with <, >, &, U+2028 and U+2029
+// characters inside string literals changed to \u003c, \u003e, \u0026, \u2028, \u2029
+// so that the JSON will be safe to embed inside HTML <script> tags.
+// For historical reasons, web browsers don't honor standard HTML
+// escaping within <script> tags, so an alternative JSON encoding must
+// be used.
+func HTMLEscape(dst *bytes.Buffer, src []byte) {
+	// The characters can only appear in string literals,
+	// so just scan the string one byte at a time.
+	start := 0
+	for i, c := range src {
+		if c == '<' || c == '>' || c == '&' {
+			if start < i {
+				dst.Write(src[start:i])
+			}
+			dst.WriteString(`\u00`)
+			dst.WriteByte(hex[c>>4])
+			dst.WriteByte(hex[c&0xF])
+			start = i + 1
+		}
+		// Convert U+2028 and U+2029 (E2 80 A8 and E2 80 A9).
+		if c == 0xE2 && i+2 < len(src) && src[i+1] == 0x80 && src[i+2]&^1 == 0xA8 {
+			if start < i {
+				dst.Write(src[start:i])
+			}
+			dst.WriteString(`\u202`)
+			dst.WriteByte(hex[src[i+2]&0xF])
+			start = i + 3
+		}
+	}
+	if start < len(src) {
+		dst.Write(src[start:])
+	}
+}
+
+// Marshaler is the interface implemented by objects that
+// can marshal themselves into valid JSON.
+type Marshaler interface {
+	MarshalJSON() ([]byte, error)
+}
+
+// An UnsupportedTypeError is returned by Marshal when attempting
+// to encode an unsupported value type.
+type UnsupportedTypeError struct {
+	Type reflect.Type
+}
+
+func (e *UnsupportedTypeError) Error() string {
+	return "json: unsupported type: " + e.Type.String()
+}
+
+type UnsupportedValueError struct {
+	Value reflect.Value
+	Str   string
+}
+
+func (e *UnsupportedValueError) Error() string {
+	return "json: unsupported value: " + e.Str
+}
+
+// Before Go 1.2, an InvalidUTF8Error was returned by Marshal when
+// attempting to encode a string value with invalid UTF-8 sequences.
+// As of Go 1.2, Marshal instead coerces the string to valid UTF-8 by
+// replacing invalid bytes with the Unicode replacement rune U+FFFD.
+// This error is no longer generated but is kept for backwards compatibility
+// with programs that might mention it.
+type InvalidUTF8Error struct {
+	S string // the whole string value that caused the error
+}
+
+func (e *InvalidUTF8Error) Error() string {
+	return "json: invalid UTF-8 in string: " + strconv.Quote(e.S)
+}
+
+type MarshalerError struct {
+	Type reflect.Type
+	Err  error
+}
+
+func (e *MarshalerError) Error() string {
+	return "json: error calling MarshalJSON for type " + e.Type.String() + ": " + e.Err.Error()
+}
+
+var hex = "0123456789abcdef"
+
+// An encodeState encodes JSON into a bytes.Buffer.
+type encodeState struct {
+	bytes.Buffer // accumulated output
+	scratch      [64]byte
+}
+
+var encodeStatePool sync.Pool
+
+func newEncodeState() *encodeState {
+	if v := encodeStatePool.Get(); v != nil {
+		e := v.(*encodeState)
+		e.Reset()
+		return e
+	}
+	return new(encodeState)
+}
+
+func (e *encodeState) marshal(v interface{}) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(runtime.Error); ok {
+				panic(r)
+			}
+			if s, ok := r.(string); ok {
+				panic(s)
+			}
+			err = r.(error)
+		}
+	}()
+	e.reflectValue(reflect.ValueOf(v))
+	return nil
+}
+
+func (e *encodeState) error(err error) {
+	panic(err)
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func (e *encodeState) reflectValue(v reflect.Value) {
+	valueEncoder(v)(e, v, false)
+}
+
+type encoderFunc func(e *encodeState, v reflect.Value, quoted bool)
+
+var encoderCache struct {
+	sync.RWMutex
+	m map[reflect.Type]encoderFunc
+}
+
+func valueEncoder(v reflect.Value) encoderFunc {
+	if !v.IsValid() {
+		return invalidValueEncoder
+	}
+	return typeEncoder(v.Type())
+}
+
+func typeEncoder(t reflect.Type) encoderFunc {
+	encoderCache.RLock()
+	f := encoderCache.m[t]
+	encoderCache.RUnlock()
+	if f != nil {
+		return f
+	}
+
+	// To deal with recursive types, populate the map with an
+	// indirect func before we build it. This type waits on the
+	// real func (f) to be ready and then calls it.  This indirect
+	// func is only used for recursive types.
+	encoderCache.Lock()
+	if encoderCache.m == nil {
+		encoderCache.m = make(map[reflect.Type]encoderFunc)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	encoderCache.m[t] = func(e *encodeState, v reflect.Value, quoted bool) {
+		wg.Wait()
+		f(e, v, quoted)
+	}
+	encoderCache.Unlock()
+
+	// Compute fields without lock.
+	// Might duplicate effort but won't hold other computations back.
+	f = newTypeEncoder(t, true)
+	wg.Done()
+	encoderCache.Lock()
+	encoderCache.m[t] = f
+	encoderCache.Unlock()
+	return f
+}
+
+var (
+	marshalerType     = reflect.TypeOf(new(Marshaler)).Elem()
+	textMarshalerType = reflect.TypeOf(new(encoding.TextMarshaler)).Elem()
+)
+
+// newTypeEncoder constructs an encoderFunc for a type.
+// The returned encoder only checks CanAddr when allowAddr is true.
+func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
+	if t.Implements(marshalerType) {
+		return marshalerEncoder
+	}
+	if t.Kind() != reflect.Ptr && allowAddr {
+		if reflect.PtrTo(t).Implements(marshalerType) {
+			return newCondAddrEncoder(addrMarshalerEncoder, newTypeEncoder(t, false))
+		}
+	}
+
+	if t.Implements(textMarshalerType) {
+		return textMarshalerEncoder
+	}
+	if t.Kind() != reflect.Ptr && allowAddr {
+		if reflect.PtrTo(t).Implements(textMarshalerType) {
+			return newCondAddrEncoder(addrTextMarshalerEncoder, newTypeEncoder(t, false))
+		}
+	}
+
+	switch t.Kind() {
+	case reflect.Bool:
+		return boolEncoder
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return intEncoder
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return uintEncoder
+	case reflect.Float32:
+		return float32Encoder
+	case reflect.Float64:
+		return float64Encoder
+	case reflect.String:
+		return stringEncoder
+	case reflect.Interface:
+		return interfaceEncoder
+	case reflect.Struct:
+		return newStructEncoder(t)
+	case reflect.Map:
+		return newMapEncoder(t)
+	case reflect.Slice:
+		return newSliceEncoder(t)
+	case reflect.Array:
+		return newArrayEncoder(t)
+	case reflect.Ptr:
+		return newPtrEncoder(t)
+	default:
+		return unsupportedTypeEncoder
+	}
+}
+
+func invalidValueEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	e.WriteString("null")
+}
+
+func marshalerEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		e.WriteString("null")
+		return
+	}
+	m := v.Interface().(Marshaler)
+	b, err := m.MarshalJSON()
+	if err == nil {
+		// copy JSON into buffer, checking validity.
+		err = compact(&e.Buffer, b, true)
+	}
+	if err != nil {
+		e.error(&MarshalerError{v.Type(), err})
+	}
+}
+
+func addrMarshalerEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	va := v.Addr()
+	if va.IsNil() {
+		e.WriteString("null")
+		return
+	}
+	m := va.Interface().(Marshaler)
+	b, err := m.MarshalJSON()
+	if err == nil {
+		// copy JSON into buffer, checking validity.
+		err = compact(&e.Buffer, b, true)
+	}
+	if err != nil {
+		e.error(&MarshalerError{v.Type(), err})
+	}
+}
+
+func textMarshalerEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		e.WriteString("null")
+		return
+	}
+	m := v.Interface().(encoding.TextMarshaler)
+	b, err := m.MarshalText()
+	if err == nil {
+		_, err = e.stringBytes(b)
+	}
+	if err != nil {
+		e.error(&MarshalerError{v.Type(), err})
+	}
+}
+
+func addrTextMarshalerEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	va := v.Addr()
+	if va.IsNil() {
+		e.WriteString("null")
+		return
+	}
+	m := va.Interface().(encoding.TextMarshaler)
+	b, err := m.MarshalText()
+	if err == nil {
+		_, err = e.stringBytes(b)
+	}
+	if err != nil {
+		e.error(&MarshalerError{v.Type(), err})
+	}
+}
+
+func boolEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	if quoted {
+		e.WriteByte('"')
+	}
+	if v.Bool() {
+		e.WriteString("true")
+	} else {
+		e.WriteString("false")
+	}
+	if quoted {
+		e.WriteByte('"')
+	}
+}
+
+func intEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	b := strconv.AppendInt(e.scratch[:0], v.Int(), 10)
+	if quoted {
+		e.WriteByte('"')
+	}
+	e.Write(b)
+	if quoted {
+		e.WriteByte('"')
+	}
+}
+
+func uintEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	b := strconv.AppendUint(e.scratch[:0], v.Uint(), 10)
+	if quoted {
+		e.WriteByte('"')
+	}
+	e.Write(b)
+	if quoted {
+		e.WriteByte('"')
+	}
+}
+
+type floatEncoder int // number of bits
+
+func (bits floatEncoder) encode(e *encodeState, v reflect.Value, quoted bool) {
+	f := v.Float()
+	if math.IsInf(f, 0) || math.IsNaN(f) {
+		e.error(&UnsupportedValueError{v, strconv.FormatFloat(f, 'g', -1, int(bits))})
+	}
+	b := strconv.AppendFloat(e.scratch[:0], f, 'g', -1, int(bits))
+	if quoted {
+		e.WriteByte('"')
+	}
+	e.Write(b)
+	if quoted {
+		e.WriteByte('"')
+	}
+}
+
+var (
+	float32Encoder = (floatEncoder(32)).encode
+	float64Encoder = (floatEncoder(64)).encode
+)
+
+func stringEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	if v.Type() == numberType {
+		numStr := v.String()
+		if numStr == "" {
+			numStr = "0" // Number's zero-val
+		}
+		e.WriteString(numStr)
+		return
+	}
+	if quoted {
+		sb, err := Marshal(v.String())
+		if err != nil {
+			e.error(err)
+		}
+		e.string(string(sb))
+	} else {
+		e.string(v.String())
+	}
+}
+
+func interfaceEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	if v.IsNil() {
+		e.WriteString("null")
+		return
+	}
+	e.reflectValue(v.Elem())
+}
+
+func unsupportedTypeEncoder(e *encodeState, v reflect.Value, quoted bool) {
+	e.error(&UnsupportedTypeError{v.Type()})
+}
+
+type structEncoder struct {
+	fields    []field
+	fieldEncs []encoderFunc
+}
+
+func (se *structEncoder) encode(e *encodeState, v reflect.Value, quoted bool) {
+	e.WriteByte('{')
+	first := true
+	for i, f := range se.fields {
+		fv := fieldByIndex(v, f.index)
+		if !fv.IsValid() || f.omitEmpty && isEmptyValue(fv) {
+			continue
+		}
+		if first {
+			first = false
+		} else {
+			e.WriteByte(',')
+		}
+		e.string(f.name)
+		e.WriteByte(':')
+		se.fieldEncs[i](e, fv, f.quoted)
+	}
+	e.WriteByte('}')
+}
+
+func newStructEncoder(t reflect.Type) encoderFunc {
+	fields := cachedTypeFields(t)
+	se := &structEncoder{
+		fields:    fields,
+		fieldEncs: make([]encoderFunc, len(fields)),
+	}
+	for i, f := range fields {
+		se.fieldEncs[i] = typeEncoder(typeByIndex(t, f.index))
+	}
+	return se.encode
+}
+
+type mapEncoder struct {
+	elemEnc encoderFunc
+}
+
+func (me *mapEncoder) encode(e *encodeState, v reflect.Value, _ bool) {
+	if v.IsNil() {
+		e.WriteString("null")
+		return
+	}
+	e.WriteByte('{')
+	var sv stringValues = v.MapKeys()
+	sort.Sort(sv)
+	for i, k := range sv {
+		if i > 0 {
+			e.WriteByte(',')
+		}
+		e.string(k.String())
+		e.WriteByte(':')
+		me.elemEnc(e, v.MapIndex(k), false)
+	}
+	e.WriteByte('}')
+}
+
+func newMapEncoder(t reflect.Type) encoderFunc {
+	if t.Key().Kind() != reflect.String {
+		return unsupportedTypeEncoder
+	}
+	me := &mapEncoder{typeEncoder(t.Elem())}
+	return me.encode
+}
+
+func encodeByteSlice(e *encodeState, v reflect.Value, _ bool) {
+	if v.IsNil() {
+		e.WriteString("null")
+		return
+	}
+	s := v.Bytes()
+	e.WriteByte('"')
+	if len(s) < 1024 {
+		// for small buffers, using Encode directly is much faster.
+		dst := make([]byte, base64.StdEncoding.EncodedLen(len(s)))
+		base64.StdEncoding.Encode(dst, s)
+		e.Write(dst)
+	} else {
+		// for large buffers, avoid unnecessary extra temporary
+		// buffer space.
+		enc := base64.NewEncoder(base64.StdEncoding, e)
+		enc.Write(s)
+		enc.Close()
+	}
+	e.WriteByte('"')
+}
+
+// sliceEncoder just wraps an arrayEncoder, checking to make sure the value isn't nil.
+type sliceEncoder struct {
+	arrayEnc encoderFunc
+}
+
+func (se *sliceEncoder) encode(e *encodeState, v reflect.Value, _ bool) {
+	if v.IsNil() {
+		e.WriteString("null")
+		return
+	}
+	se.arrayEnc(e, v, false)
+}
+
+func newSliceEncoder(t reflect.Type) encoderFunc {
+	// Byte slices get special treatment; arrays don't.
+	if t.Elem().Kind() == reflect.Uint8 {
+		return encodeByteSlice
+	}
+	enc := &sliceEncoder{newArrayEncoder(t)}
+	return enc.encode
+}
+
+type arrayEncoder struct {
+	elemEnc encoderFunc
+}
+
+func (ae *arrayEncoder) encode(e *encodeState, v reflect.Value, _ bool) {
+	e.WriteByte('[')
+	n := v.Len()
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			e.WriteByte(',')
+		}
+		ae.elemEnc(e, v.Index(i), false)
+	}
+	e.WriteByte(']')
+}
+
+func newArrayEncoder(t reflect.Type) encoderFunc {
+	enc := &arrayEncoder{typeEncoder(t.Elem())}
+	return enc.encode
+}
+
+type ptrEncoder struct {
+	elemEnc encoderFunc
+}
+
+func (pe *ptrEncoder) encode(e *encodeState, v reflect.Value, quoted bool) {
+	if v.IsNil() {
+		e.WriteString("null")
+		return
+	}
+	pe.elemEnc(e, v.Elem(), quoted)
+}
+
+func newPtrEncoder(t reflect.Type) encoderFunc {
+	enc := &ptrEncoder{typeEncoder(t.Elem())}
+	return enc.encode
+}
+
+type condAddrEncoder struct {
+	canAddrEnc, elseEnc encoderFunc
+}
+
+func (ce *condAddrEncoder) encode(e *encodeState, v reflect.Value, quoted bool) {
+	if v.CanAddr() {
+		ce.canAddrEnc(e, v, quoted)
+	} else {
+		ce.elseEnc(e, v, quoted)
+	}
+}
+
+// newCondAddrEncoder returns an encoder that checks whether its value
+// CanAddr and delegates to canAddrEnc if so, else to elseEnc.
+func newCondAddrEncoder(canAddrEnc, elseEnc encoderFunc) encoderFunc {
+	enc := &condAddrEncoder{canAddrEnc: canAddrEnc, elseEnc: elseEnc}
+	return enc.encode
+}
+
+func isValidTag(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case strings.ContainsRune("!#$%&()*+-./:<=>?@[]^_{|}~ ", c):
+			// Backslash and quote chars are reserved, but
+			// otherwise any punctuation chars are allowed
+			// in a tag name.
+		default:
+			if !unicode.IsLetter(c) && !unicode.IsDigit(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func fieldByIndex(v reflect.Value, index []int) reflect.Value {
+	for _, i := range index {
+		if v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				return reflect.Value{}
+			}
+			v = v.Elem()
+		}
+		v = v.Field(i)
+	}
+	return v
+}
+
+func typeByIndex(t reflect.Type, index []int) reflect.Type {
+	for _, i := range index {
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+		t = t.Field(i).Type
+	}
+	return t
+}
+
+// stringValues is a slice of reflect.Value holding *reflect.StringValue.
+// It implements the methods to sort by string.
+type stringValues []reflect.Value
+
+func (sv stringValues) Len() int           { return len(sv) }
+func (sv stringValues) Swap(i, j int)      { sv[i], sv[j] = sv[j], sv[i] }
+func (sv stringValues) Less(i, j int) bool { return sv.get(i) < sv.get(j) }
+func (sv stringValues) get(i int) string   { return sv[i].String() }
+
+// NOTE: keep in sync with stringBytes below.
+func (e *encodeState) string(s string) (int, error) {
+	len0 := e.Len()
+	e.WriteByte('"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if 0x20 <= b && b != '\\' && b != '"' && b != '<' && b != '>' && b != '&' {
+				i++
+				continue
+			}
+			if start < i {
+				e.WriteString(s[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				e.WriteByte('\\')
+				e.WriteByte(b)
+			case '\n':
+				e.WriteByte('\\')
+				e.WriteByte('n')
+			case '\r':
+				e.WriteByte('\\')
+				e.WriteByte('r')
+			case '\t':
+				e.WriteByte('\\')
+				e.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \n and \r,
+				// as well as <, > and &. The latter are escaped because they
+				// can lead to security holes when user-controlled strings
+				// are rendered into JSON and served to some browsers.
+				e.WriteString(`\u00`)
+				e.WriteByte(hex[b>>4])
+				e.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				e.WriteString(s[start:i])
+			}
+			e.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				e.WriteString(s[start:i])
+			}
+			e.WriteString(`\u202`)
+			e.WriteByte(hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		e.WriteString(s[start:])
+	}
+	e.WriteByte('"')
+	return e.Len() - len0, nil
+}
+
+// NOTE: keep in sync with string above.
+func (e *encodeState) stringBytes(s []byte) (int, error) {
+	len0 := e.Len()
+	e.WriteByte('"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if 0x20 <= b && b != '\\' && b != '"' && b != '<' && b != '>' && b != '&' {
+				i++
+				continue
+			}
+			if start < i {
+				e.Write(s[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				e.WriteByte('\\')
+				e.WriteByte(b)
+			case '\n':
+				e.WriteByte('\\')
+				e.WriteByte('n')
+			case '\r':
+				e.WriteByte('\\')
+				e.WriteByte('r')
+			case '\t':
+				e.WriteByte('\\')
+				e.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \n and \r,
+				// as well as <, >, and &. The latter are escaped because they
+				// can lead to security holes when user-controlled strings
+				// are rendered into JSON and served to some browsers.
+				e.WriteString(`\u00`)
+				e.WriteByte(hex[b>>4])
+				e.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRune(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				e.Write(s[start:i])
+			}
+			e.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				e.Write(s[start:i])
+			}
+			e.WriteString(`\u202`)
+			e.WriteByte(hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		e.Write(s[start:])
+	}
+	e.WriteByte('"')
+	return e.Len() - len0, nil
+}
+
+// A field represents a single field found in a struct.
+type field struct {
+	name      string
+	nameBytes []byte                 // []byte(name)
+	equalFold func(s, t []byte) bool // bytes.EqualFold or equivalent
+
+	tag       bool
+	index     []int
+	typ       reflect.Type
+	omitEmpty bool
+	quoted    bool
+}
+
+func fillField(f field) field {
+	f.nameBytes = []byte(f.name)
+	f.equalFold = foldFunc(f.nameBytes)
+	return f
+}
+
+// byName sorts field by name, breaking ties with depth,
+// then breaking ties with "name came from json tag", then
+// breaking ties with index sequence.
+type byName []field
+
+func (x byName) Len() int { return len(x) }
+
+func (x byName) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byName) Less(i, j int) bool {
+	if x[i].name != x[j].name {
+		return x[i].name < x[j].name
+	}
+	if len(x[i].index) != len(x[j].index) {
+		return len(x[i].index) < len(x[j].index)
+	}
+	if x[i].tag != x[j].tag {
+		return x[i].tag
+	}
+	return byIndex(x).Less(i, j)
+}
+
+// byIndex sorts field by index sequence.
+type byIndex []field
+
+func (x byIndex) Len() int { return len(x) }
+
+func (x byIndex) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byIndex) Less(i, j int) bool {
+	for k, xik := range x[i].index {
+		if k >= len(x[j].index) {
+			return false
+		}
+		if xik != x[j].index[k] {
+			return xik < x[j].index[k]
+		}
+	}
+	return len(x[i].index) < len(x[j].index)
+}
+
+// typeFields returns a list of fields that JSON should recognize for the given type.
+// The algorithm is breadth-first search over the set of structs to include - the top struct
+// and then any reachable anonymous structs.
+func typeFields(t reflect.Type) []field {
+	// Anonymous fields to explore at the current level and the next.
+	current := []field{}
+	next := []field{{typ: t}}
+
+	// Count of queued names for current level and the next.
+	count := map[reflect.Type]int{}
+	nextCount := map[reflect.Type]int{}
+
+	// Types already visited at an earlier level.
+	visited := map[reflect.Type]bool{}
+
+	// Fields found.
+	var fields []field
+
+	for len(next) > 0 {
+		current, next = next, current[:0]
+		count, nextCount = nextCount, map[reflect.Type]int{}
+
+		for _, f := range current {
+			if visited[f.typ] {
+				continue
+			}
+			visited[f.typ] = true
+
+			// Scan f.typ for fields to include.
+			for i := 0; i < f.typ.NumField(); i++ {
+				sf := f.typ.Field(i)
+				if sf.PkgPath != "" { // unexported
+					continue
+				}
+				tag := sf.Tag.Get("json")
+				if tag == "-" {
+					continue
+				}
+				name, opts := parseTag(tag)
+				if !isValidTag(name) {
+					name = ""
+				}
+				index := make([]int, len(f.index)+1)
+				copy(index, f.index)
+				index[len(f.index)] = i
+
+				ft := sf.Type
+				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
+					// Follow pointer.
+					ft = ft.Elem()
+				}
+
+				// Only strings, floats, integers, and booleans can be quoted.
+				quoted := false
+				if opts.Contains("string") {
+					switch ft.Kind() {
+					case reflect.Bool,
+						reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+						reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+						reflect.Float32, reflect.Float64,
+						reflect.String:
+						quoted = true
+					}
+				}
+
+				// Record found field and index sequence.
+				if name != "" || !sf.Anonymous || ft.Kind() != reflect.Struct {
+					tagged := name != ""
+					if name == "" {
+						name = sf.Name
+					}
+					fields = append(fields, fillField(field{
+						name:      name,
+						tag:       tagged,
+						index:     index,
+						typ:       ft,
+						omitEmpty: opts.Contains("omitempty"),
+						quoted:    quoted,
+					}))
+					if count[f.typ] > 1 {
+						// If there were multiple instances, add a second,
+						// so that the annihilation code will see a duplicate.
+						// It only cares about the distinction between 1 or 2,
+						// so don't bother generating any more copies.
+						fields = append(fields, fields[len(fields)-1])
+					}
+					continue
+				}
+
+				// Record new anonymous struct to explore in next round.
+				nextCount[ft]++
+				if nextCount[ft] == 1 {
+					next = append(next, fillField(field{name: ft.Name(), index: index, typ: ft}))
+				}
+			}
+		}
+	}
+
+	sort.Sort(byName(fields))
+
+	// Delete all fields that are hidden by the Go rules for embedded fields,
+	// except that fields with JSON tags are promoted.
+
+	// The fields are sorted in primary order of name, secondary order
+	// of field index length. Loop over names; for each name, delete
+	// hidden fields by choosing the one dominant field that survives.
+	out := fields[:0]
+	for advance, i := 0, 0; i < len(fields); i += advance {
+		// One iteration per name.
+		// Find the sequence of fields with the name of this first field.
+		fi := fields[i]
+		name := fi.name
+		for advance = 1; i+advance < len(fields); advance++ {
+			fj := fields[i+advance]
+			if fj.name != name {
+				break
+			}
+		}
+		if advance == 1 { // Only one field with this name
+			out = append(out, fi)
+			continue
+		}
+		dominant, ok := dominantField(fields[i : i+advance])
+		if ok {
+			out = append(out, dominant)
+		}
+	}
+
+	fields = out
+	sort.Sort(byIndex(fields))
+
+	return fields
+}
+
+// dominantField looks through the fields, all of which are known to
+// have the same name, to find the single field that dominates the
+// others using Go's embedding rules, modified by the presence of
+// JSON tags. If there are multiple top-level fields, the boolean
+// will be false: This condition is an error in Go and we skip all
+// the fields.
+func dominantField(fields []field) (field, bool) {
+	// The fields are sorted in increasing index-length order. The winner
+	// must therefore be one with the shortest index length. Drop all
+	// longer entries, which is easy: just truncate the slice.
+	length := len(fields[0].index)
+	tagged := -1 // Index of first tagged field.
+	for i, f := range fields {
+		if len(f.index) > length {
+			fields = fields[:i]
+			break
+		}
+		if f.tag {
+			if tagged >= 0 {
+				// Multiple tagged fields at the same level: conflict.
+				// Return no field.
+				return field{}, false
+			}
+			tagged = i
+		}
+	}
+	if tagged >= 0 {
+		return fields[tagged], true
+	}
+	// All remaining fields have the same length. If there's more than one,
+	// we have a conflict (two fields named "X" at the same level) and we
+	// return no field.
+	if len(fields) > 1 {
+		return field{}, false
+	}
+	return fields[0], true
+}
+
+var fieldCache struct {
+	sync.RWMutex
+	m map[reflect.Type][]field
+}
+
+// cachedTypeFields is like typeFields but uses a cache to avoid repeated work.
+func cachedTypeFields(t reflect.Type) []field {
+	fieldCache.RLock()
+	f := fieldCache.m[t]
+	fieldCache.RUnlock()
+	if f != nil {
+		return f
+	}
+
+	// Compute fields without lock.
+	// Might duplicate effort but won't hold other computations back.
+	f = typeFields(t)
+	if f == nil {
+		f = []field{}
+	}
+
+	fieldCache.Lock()
+	if fieldCache.m == nil {
+		fieldCache.m = map[reflect.Type][]field{}
+	}
+	fieldCache.m[t] = f
+	fieldCache.Unlock()
+	return f
+}

--- a/vendor/github.com/ajeddeloh/go-json/fold.go
+++ b/vendor/github.com/ajeddeloh/go-json/fold.go
@@ -1,0 +1,143 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package json
+
+import (
+	"bytes"
+	"unicode/utf8"
+)
+
+const (
+	caseMask     = ^byte(0x20) // Mask to ignore case in ASCII.
+	kelvin       = '\u212a'
+	smallLongEss = '\u017f'
+)
+
+// foldFunc returns one of four different case folding equivalence
+// functions, from most general (and slow) to fastest:
+//
+// 1) bytes.EqualFold, if the key s contains any non-ASCII UTF-8
+// 2) equalFoldRight, if s contains special folding ASCII ('k', 'K', 's', 'S')
+// 3) asciiEqualFold, no special, but includes non-letters (including _)
+// 4) simpleLetterEqualFold, no specials, no non-letters.
+//
+// The letters S and K are special because they map to 3 runes, not just 2:
+//  * S maps to s and to U+017F 'ſ' Latin small letter long s
+//  * k maps to K and to U+212A 'K' Kelvin sign
+// See https://play.golang.org/p/tTxjOc0OGo
+//
+// The returned function is specialized for matching against s and
+// should only be given s. It's not curried for performance reasons.
+func foldFunc(s []byte) func(s, t []byte) bool {
+	nonLetter := false
+	special := false // special letter
+	for _, b := range s {
+		if b >= utf8.RuneSelf {
+			return bytes.EqualFold
+		}
+		upper := b & caseMask
+		if upper < 'A' || upper > 'Z' {
+			nonLetter = true
+		} else if upper == 'K' || upper == 'S' {
+			// See above for why these letters are special.
+			special = true
+		}
+	}
+	if special {
+		return equalFoldRight
+	}
+	if nonLetter {
+		return asciiEqualFold
+	}
+	return simpleLetterEqualFold
+}
+
+// equalFoldRight is a specialization of bytes.EqualFold when s is
+// known to be all ASCII (including punctuation), but contains an 's',
+// 'S', 'k', or 'K', requiring a Unicode fold on the bytes in t.
+// See comments on foldFunc.
+func equalFoldRight(s, t []byte) bool {
+	for _, sb := range s {
+		if len(t) == 0 {
+			return false
+		}
+		tb := t[0]
+		if tb < utf8.RuneSelf {
+			if sb != tb {
+				sbUpper := sb & caseMask
+				if 'A' <= sbUpper && sbUpper <= 'Z' {
+					if sbUpper != tb&caseMask {
+						return false
+					}
+				} else {
+					return false
+				}
+			}
+			t = t[1:]
+			continue
+		}
+		// sb is ASCII and t is not. t must be either kelvin
+		// sign or long s; sb must be s, S, k, or K.
+		tr, size := utf8.DecodeRune(t)
+		switch sb {
+		case 's', 'S':
+			if tr != smallLongEss {
+				return false
+			}
+		case 'k', 'K':
+			if tr != kelvin {
+				return false
+			}
+		default:
+			return false
+		}
+		t = t[size:]
+
+	}
+	if len(t) > 0 {
+		return false
+	}
+	return true
+}
+
+// asciiEqualFold is a specialization of bytes.EqualFold for use when
+// s is all ASCII (but may contain non-letters) and contains no
+// special-folding letters.
+// See comments on foldFunc.
+func asciiEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, sb := range s {
+		tb := t[i]
+		if sb == tb {
+			continue
+		}
+		if ('a' <= sb && sb <= 'z') || ('A' <= sb && sb <= 'Z') {
+			if sb&caseMask != tb&caseMask {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+// simpleLetterEqualFold is a specialization of bytes.EqualFold for
+// use when s is all ASCII letters (no underscores, etc) and also
+// doesn't contain 'k', 'K', 's', or 'S'.
+// See comments on foldFunc.
+func simpleLetterEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, b := range s {
+		if b&caseMask != t[i]&caseMask {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/ajeddeloh/go-json/indent.go
+++ b/vendor/github.com/ajeddeloh/go-json/indent.go
@@ -1,0 +1,137 @@
+// Copyright 2010 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package json
+
+import "bytes"
+
+// Compact appends to dst the JSON-encoded src with
+// insignificant space characters elided.
+func Compact(dst *bytes.Buffer, src []byte) error {
+	return compact(dst, src, false)
+}
+
+func compact(dst *bytes.Buffer, src []byte, escape bool) error {
+	origLen := dst.Len()
+	var scan scanner
+	scan.reset()
+	start := 0
+	for i, c := range src {
+		if escape && (c == '<' || c == '>' || c == '&') {
+			if start < i {
+				dst.Write(src[start:i])
+			}
+			dst.WriteString(`\u00`)
+			dst.WriteByte(hex[c>>4])
+			dst.WriteByte(hex[c&0xF])
+			start = i + 1
+		}
+		// Convert U+2028 and U+2029 (E2 80 A8 and E2 80 A9).
+		if c == 0xE2 && i+2 < len(src) && src[i+1] == 0x80 && src[i+2]&^1 == 0xA8 {
+			if start < i {
+				dst.Write(src[start:i])
+			}
+			dst.WriteString(`\u202`)
+			dst.WriteByte(hex[src[i+2]&0xF])
+			start = i + 3
+		}
+		v := scan.step(&scan, int(c))
+		if v >= scanSkipSpace {
+			if v == scanError {
+				break
+			}
+			if start < i {
+				dst.Write(src[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if scan.eof() == scanError {
+		dst.Truncate(origLen)
+		return scan.err
+	}
+	if start < len(src) {
+		dst.Write(src[start:])
+	}
+	return nil
+}
+
+func newline(dst *bytes.Buffer, prefix, indent string, depth int) {
+	dst.WriteByte('\n')
+	dst.WriteString(prefix)
+	for i := 0; i < depth; i++ {
+		dst.WriteString(indent)
+	}
+}
+
+// Indent appends to dst an indented form of the JSON-encoded src.
+// Each element in a JSON object or array begins on a new,
+// indented line beginning with prefix followed by one or more
+// copies of indent according to the indentation nesting.
+// The data appended to dst does not begin with the prefix nor
+// any indentation, and has no trailing newline, to make it
+// easier to embed inside other formatted JSON data.
+func Indent(dst *bytes.Buffer, src []byte, prefix, indent string) error {
+	origLen := dst.Len()
+	var scan scanner
+	scan.reset()
+	needIndent := false
+	depth := 0
+	for _, c := range src {
+		scan.bytes++
+		v := scan.step(&scan, int(c))
+		if v == scanSkipSpace {
+			continue
+		}
+		if v == scanError {
+			break
+		}
+		if needIndent && v != scanEndObject && v != scanEndArray {
+			needIndent = false
+			depth++
+			newline(dst, prefix, indent, depth)
+		}
+
+		// Emit semantically uninteresting bytes
+		// (in particular, punctuation in strings) unmodified.
+		if v == scanContinue {
+			dst.WriteByte(c)
+			continue
+		}
+
+		// Add spacing around real punctuation.
+		switch c {
+		case '{', '[':
+			// delay indent so that empty object and array are formatted as {} and [].
+			needIndent = true
+			dst.WriteByte(c)
+
+		case ',':
+			dst.WriteByte(c)
+			newline(dst, prefix, indent, depth)
+
+		case ':':
+			dst.WriteByte(c)
+			dst.WriteByte(' ')
+
+		case '}', ']':
+			if needIndent {
+				// suppress indent in empty object/array
+				needIndent = false
+			} else {
+				depth--
+				newline(dst, prefix, indent, depth)
+			}
+			dst.WriteByte(c)
+
+		default:
+			dst.WriteByte(c)
+		}
+	}
+	if scan.eof() == scanError {
+		dst.Truncate(origLen)
+		return scan.err
+	}
+	return nil
+}

--- a/vendor/github.com/ajeddeloh/go-json/scanner.go
+++ b/vendor/github.com/ajeddeloh/go-json/scanner.go
@@ -1,0 +1,630 @@
+// Copyright 2010 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package json
+
+// JSON value parser state machine.
+// Just about at the limit of what is reasonable to write by hand.
+// Some parts are a bit tedious, but overall it nicely factors out the
+// otherwise common code from the multiple scanning functions
+// in this package (Compact, Indent, checkValid, nextValue, etc).
+//
+// This file starts with two simple examples using the scanner
+// before diving into the scanner itself.
+
+import "strconv"
+
+// checkValid verifies that data is valid JSON-encoded data.
+// scan is passed in for use by checkValid to avoid an allocation.
+func checkValid(data []byte, scan *scanner) error {
+	scan.reset()
+	for _, c := range data {
+		scan.bytes++
+		if scan.step(scan, int(c)) == scanError {
+			return scan.err
+		}
+	}
+	if scan.eof() == scanError {
+		return scan.err
+	}
+	return nil
+}
+
+// nextValue splits data after the next whole JSON value,
+// returning that value and the bytes that follow it as separate slices.
+// scan is passed in for use by nextValue to avoid an allocation.
+func nextValue(data []byte, scan *scanner) (value, rest []byte, err error) {
+	scan.reset()
+	for i, c := range data {
+		v := scan.step(scan, int(c))
+		if v >= scanEndObject {
+			switch v {
+			// probe the scanner with a space to determine whether we will
+			// get scanEnd on the next character. Otherwise, if the next character
+			// is not a space, scanEndTop allocates a needless error.
+			case scanEndObject, scanEndArray:
+				if scan.step(scan, ' ') == scanEnd {
+					return data[:i+1], data[i+1:], nil
+				}
+			case scanError:
+				return nil, nil, scan.err
+			case scanEnd:
+				return data[0:i], data[i:], nil
+			}
+		}
+	}
+	if scan.eof() == scanError {
+		return nil, nil, scan.err
+	}
+	return data, nil, nil
+}
+
+// A SyntaxError is a description of a JSON syntax error.
+type SyntaxError struct {
+	msg    string // description of error
+	Offset int64  // error occurred after reading Offset bytes
+}
+
+func (e *SyntaxError) Error() string { return e.msg }
+
+// A scanner is a JSON scanning state machine.
+// Callers call scan.reset() and then pass bytes in one at a time
+// by calling scan.step(&scan, c) for each byte.
+// The return value, referred to as an opcode, tells the
+// caller about significant parsing events like beginning
+// and ending literals, objects, and arrays, so that the
+// caller can follow along if it wishes.
+// The return value scanEnd indicates that a single top-level
+// JSON value has been completed, *before* the byte that
+// just got passed in.  (The indication must be delayed in order
+// to recognize the end of numbers: is 123 a whole value or
+// the beginning of 12345e+6?).
+type scanner struct {
+	// The step is a func to be called to execute the next transition.
+	// Also tried using an integer constant and a single func
+	// with a switch, but using the func directly was 10% faster
+	// on a 64-bit Mac Mini, and it's nicer to read.
+	step func(*scanner, int) int
+
+	// Reached end of top-level value.
+	endTop bool
+
+	// Stack of what we're in the middle of - array values, object keys, object values.
+	parseState []int
+
+	// Error that happened, if any.
+	err error
+
+	// 1-byte redo (see undo method)
+	redo      bool
+	redoCode  int
+	redoState func(*scanner, int) int
+
+	// total bytes consumed, updated by decoder.Decode
+	bytes int64
+}
+
+// These values are returned by the state transition functions
+// assigned to scanner.state and the method scanner.eof.
+// They give details about the current state of the scan that
+// callers might be interested to know about.
+// It is okay to ignore the return value of any particular
+// call to scanner.state: if one call returns scanError,
+// every subsequent call will return scanError too.
+const (
+	// Continue.
+	scanContinue     = iota // uninteresting byte
+	scanBeginLiteral        // end implied by next result != scanContinue
+	scanBeginObject         // begin object
+	scanObjectKey           // just finished object key (string)
+	scanObjectValue         // just finished non-last object value
+	scanEndObject           // end object (implies scanObjectValue if possible)
+	scanBeginArray          // begin array
+	scanArrayValue          // just finished array value
+	scanEndArray            // end array (implies scanArrayValue if possible)
+	scanSkipSpace           // space byte; can skip; known to be last "continue" result
+
+	// Stop.
+	scanEnd   // top-level value ended *before* this byte; known to be first "stop" result
+	scanError // hit an error, scanner.err.
+)
+
+// These values are stored in the parseState stack.
+// They give the current state of a composite value
+// being scanned.  If the parser is inside a nested value
+// the parseState describes the nested state, outermost at entry 0.
+const (
+	parseObjectKey   = iota // parsing object key (before colon)
+	parseObjectValue        // parsing object value (after colon)
+	parseArrayValue         // parsing array value
+)
+
+// reset prepares the scanner for use.
+// It must be called before calling s.step.
+func (s *scanner) reset() {
+	s.step = stateBeginValue
+	s.parseState = s.parseState[0:0]
+	s.err = nil
+	s.redo = false
+	s.endTop = false
+}
+
+// eof tells the scanner that the end of input has been reached.
+// It returns a scan status just as s.step does.
+func (s *scanner) eof() int {
+	if s.err != nil {
+		return scanError
+	}
+	if s.endTop {
+		return scanEnd
+	}
+	s.step(s, ' ')
+	if s.endTop {
+		return scanEnd
+	}
+	if s.err == nil {
+		s.err = &SyntaxError{"unexpected end of JSON input", s.bytes}
+	}
+	return scanError
+}
+
+// pushParseState pushes a new parse state p onto the parse stack.
+func (s *scanner) pushParseState(p int) {
+	s.parseState = append(s.parseState, p)
+}
+
+// popParseState pops a parse state (already obtained) off the stack
+// and updates s.step accordingly.
+func (s *scanner) popParseState() {
+	n := len(s.parseState) - 1
+	s.parseState = s.parseState[0:n]
+	s.redo = false
+	if n == 0 {
+		s.step = stateEndTop
+		s.endTop = true
+	} else {
+		s.step = stateEndValue
+	}
+}
+
+func isSpace(c rune) bool {
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
+}
+
+// stateBeginValueOrEmpty is the state after reading `[`.
+func stateBeginValueOrEmpty(s *scanner, c int) int {
+	if c <= ' ' && isSpace(rune(c)) {
+		return scanSkipSpace
+	}
+	if c == ']' {
+		return stateEndValue(s, c)
+	}
+	return stateBeginValue(s, c)
+}
+
+// stateBeginValue is the state at the beginning of the input.
+func stateBeginValue(s *scanner, c int) int {
+	if c <= ' ' && isSpace(rune(c)) {
+		return scanSkipSpace
+	}
+	switch c {
+	case '{':
+		s.step = stateBeginStringOrEmpty
+		s.pushParseState(parseObjectKey)
+		return scanBeginObject
+	case '[':
+		s.step = stateBeginValueOrEmpty
+		s.pushParseState(parseArrayValue)
+		return scanBeginArray
+	case '"':
+		s.step = stateInString
+		return scanBeginLiteral
+	case '-':
+		s.step = stateNeg
+		return scanBeginLiteral
+	case '0': // beginning of 0.123
+		s.step = state0
+		return scanBeginLiteral
+	case 't': // beginning of true
+		s.step = stateT
+		return scanBeginLiteral
+	case 'f': // beginning of false
+		s.step = stateF
+		return scanBeginLiteral
+	case 'n': // beginning of null
+		s.step = stateN
+		return scanBeginLiteral
+	}
+	if '1' <= c && c <= '9' { // beginning of 1234.5
+		s.step = state1
+		return scanBeginLiteral
+	}
+	return s.error(c, "looking for beginning of value")
+}
+
+// stateBeginStringOrEmpty is the state after reading `{`.
+func stateBeginStringOrEmpty(s *scanner, c int) int {
+	if c <= ' ' && isSpace(rune(c)) {
+		return scanSkipSpace
+	}
+	if c == '}' {
+		n := len(s.parseState)
+		s.parseState[n-1] = parseObjectValue
+		return stateEndValue(s, c)
+	}
+	return stateBeginString(s, c)
+}
+
+// stateBeginString is the state after reading `{"key": value,`.
+func stateBeginString(s *scanner, c int) int {
+	if c <= ' ' && isSpace(rune(c)) {
+		return scanSkipSpace
+	}
+	if c == '"' {
+		s.step = stateInString
+		return scanBeginLiteral
+	}
+	return s.error(c, "looking for beginning of object key string")
+}
+
+// stateEndValue is the state after completing a value,
+// such as after reading `{}` or `true` or `["x"`.
+func stateEndValue(s *scanner, c int) int {
+	n := len(s.parseState)
+	if n == 0 {
+		// Completed top-level before the current byte.
+		s.step = stateEndTop
+		s.endTop = true
+		return stateEndTop(s, c)
+	}
+	if c <= ' ' && isSpace(rune(c)) {
+		s.step = stateEndValue
+		return scanSkipSpace
+	}
+	ps := s.parseState[n-1]
+	switch ps {
+	case parseObjectKey:
+		if c == ':' {
+			s.parseState[n-1] = parseObjectValue
+			s.step = stateBeginValue
+			return scanObjectKey
+		}
+		return s.error(c, "after object key")
+	case parseObjectValue:
+		if c == ',' {
+			s.parseState[n-1] = parseObjectKey
+			s.step = stateBeginString
+			return scanObjectValue
+		}
+		if c == '}' {
+			s.popParseState()
+			return scanEndObject
+		}
+		return s.error(c, "after object key:value pair")
+	case parseArrayValue:
+		if c == ',' {
+			s.step = stateBeginValue
+			return scanArrayValue
+		}
+		if c == ']' {
+			s.popParseState()
+			return scanEndArray
+		}
+		return s.error(c, "after array element")
+	}
+	return s.error(c, "")
+}
+
+// stateEndTop is the state after finishing the top-level value,
+// such as after reading `{}` or `[1,2,3]`.
+// Only space characters should be seen now.
+func stateEndTop(s *scanner, c int) int {
+	if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
+		// Complain about non-space byte on next call.
+		s.error(c, "after top-level value")
+	}
+	return scanEnd
+}
+
+// stateInString is the state after reading `"`.
+func stateInString(s *scanner, c int) int {
+	if c == '"' {
+		s.step = stateEndValue
+		return scanContinue
+	}
+	if c == '\\' {
+		s.step = stateInStringEsc
+		return scanContinue
+	}
+	if c < 0x20 {
+		return s.error(c, "in string literal")
+	}
+	return scanContinue
+}
+
+// stateInStringEsc is the state after reading `"\` during a quoted string.
+func stateInStringEsc(s *scanner, c int) int {
+	switch c {
+	case 'b', 'f', 'n', 'r', 't', '\\', '/', '"':
+		s.step = stateInString
+		return scanContinue
+	}
+	if c == 'u' {
+		s.step = stateInStringEscU
+		return scanContinue
+	}
+	return s.error(c, "in string escape code")
+}
+
+// stateInStringEscU is the state after reading `"\u` during a quoted string.
+func stateInStringEscU(s *scanner, c int) int {
+	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
+		s.step = stateInStringEscU1
+		return scanContinue
+	}
+	// numbers
+	return s.error(c, "in \\u hexadecimal character escape")
+}
+
+// stateInStringEscU1 is the state after reading `"\u1` during a quoted string.
+func stateInStringEscU1(s *scanner, c int) int {
+	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
+		s.step = stateInStringEscU12
+		return scanContinue
+	}
+	// numbers
+	return s.error(c, "in \\u hexadecimal character escape")
+}
+
+// stateInStringEscU12 is the state after reading `"\u12` during a quoted string.
+func stateInStringEscU12(s *scanner, c int) int {
+	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
+		s.step = stateInStringEscU123
+		return scanContinue
+	}
+	// numbers
+	return s.error(c, "in \\u hexadecimal character escape")
+}
+
+// stateInStringEscU123 is the state after reading `"\u123` during a quoted string.
+func stateInStringEscU123(s *scanner, c int) int {
+	if '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F' {
+		s.step = stateInString
+		return scanContinue
+	}
+	// numbers
+	return s.error(c, "in \\u hexadecimal character escape")
+}
+
+// stateNeg is the state after reading `-` during a number.
+func stateNeg(s *scanner, c int) int {
+	if c == '0' {
+		s.step = state0
+		return scanContinue
+	}
+	if '1' <= c && c <= '9' {
+		s.step = state1
+		return scanContinue
+	}
+	return s.error(c, "in numeric literal")
+}
+
+// state1 is the state after reading a non-zero integer during a number,
+// such as after reading `1` or `100` but not `0`.
+func state1(s *scanner, c int) int {
+	if '0' <= c && c <= '9' {
+		s.step = state1
+		return scanContinue
+	}
+	return state0(s, c)
+}
+
+// state0 is the state after reading `0` during a number.
+func state0(s *scanner, c int) int {
+	if c == '.' {
+		s.step = stateDot
+		return scanContinue
+	}
+	if c == 'e' || c == 'E' {
+		s.step = stateE
+		return scanContinue
+	}
+	return stateEndValue(s, c)
+}
+
+// stateDot is the state after reading the integer and decimal point in a number,
+// such as after reading `1.`.
+func stateDot(s *scanner, c int) int {
+	if '0' <= c && c <= '9' {
+		s.step = stateDot0
+		return scanContinue
+	}
+	return s.error(c, "after decimal point in numeric literal")
+}
+
+// stateDot0 is the state after reading the integer, decimal point, and subsequent
+// digits of a number, such as after reading `3.14`.
+func stateDot0(s *scanner, c int) int {
+	if '0' <= c && c <= '9' {
+		s.step = stateDot0
+		return scanContinue
+	}
+	if c == 'e' || c == 'E' {
+		s.step = stateE
+		return scanContinue
+	}
+	return stateEndValue(s, c)
+}
+
+// stateE is the state after reading the mantissa and e in a number,
+// such as after reading `314e` or `0.314e`.
+func stateE(s *scanner, c int) int {
+	if c == '+' {
+		s.step = stateESign
+		return scanContinue
+	}
+	if c == '-' {
+		s.step = stateESign
+		return scanContinue
+	}
+	return stateESign(s, c)
+}
+
+// stateESign is the state after reading the mantissa, e, and sign in a number,
+// such as after reading `314e-` or `0.314e+`.
+func stateESign(s *scanner, c int) int {
+	if '0' <= c && c <= '9' {
+		s.step = stateE0
+		return scanContinue
+	}
+	return s.error(c, "in exponent of numeric literal")
+}
+
+// stateE0 is the state after reading the mantissa, e, optional sign,
+// and at least one digit of the exponent in a number,
+// such as after reading `314e-2` or `0.314e+1` or `3.14e0`.
+func stateE0(s *scanner, c int) int {
+	if '0' <= c && c <= '9' {
+		s.step = stateE0
+		return scanContinue
+	}
+	return stateEndValue(s, c)
+}
+
+// stateT is the state after reading `t`.
+func stateT(s *scanner, c int) int {
+	if c == 'r' {
+		s.step = stateTr
+		return scanContinue
+	}
+	return s.error(c, "in literal true (expecting 'r')")
+}
+
+// stateTr is the state after reading `tr`.
+func stateTr(s *scanner, c int) int {
+	if c == 'u' {
+		s.step = stateTru
+		return scanContinue
+	}
+	return s.error(c, "in literal true (expecting 'u')")
+}
+
+// stateTru is the state after reading `tru`.
+func stateTru(s *scanner, c int) int {
+	if c == 'e' {
+		s.step = stateEndValue
+		return scanContinue
+	}
+	return s.error(c, "in literal true (expecting 'e')")
+}
+
+// stateF is the state after reading `f`.
+func stateF(s *scanner, c int) int {
+	if c == 'a' {
+		s.step = stateFa
+		return scanContinue
+	}
+	return s.error(c, "in literal false (expecting 'a')")
+}
+
+// stateFa is the state after reading `fa`.
+func stateFa(s *scanner, c int) int {
+	if c == 'l' {
+		s.step = stateFal
+		return scanContinue
+	}
+	return s.error(c, "in literal false (expecting 'l')")
+}
+
+// stateFal is the state after reading `fal`.
+func stateFal(s *scanner, c int) int {
+	if c == 's' {
+		s.step = stateFals
+		return scanContinue
+	}
+	return s.error(c, "in literal false (expecting 's')")
+}
+
+// stateFals is the state after reading `fals`.
+func stateFals(s *scanner, c int) int {
+	if c == 'e' {
+		s.step = stateEndValue
+		return scanContinue
+	}
+	return s.error(c, "in literal false (expecting 'e')")
+}
+
+// stateN is the state after reading `n`.
+func stateN(s *scanner, c int) int {
+	if c == 'u' {
+		s.step = stateNu
+		return scanContinue
+	}
+	return s.error(c, "in literal null (expecting 'u')")
+}
+
+// stateNu is the state after reading `nu`.
+func stateNu(s *scanner, c int) int {
+	if c == 'l' {
+		s.step = stateNul
+		return scanContinue
+	}
+	return s.error(c, "in literal null (expecting 'l')")
+}
+
+// stateNul is the state after reading `nul`.
+func stateNul(s *scanner, c int) int {
+	if c == 'l' {
+		s.step = stateEndValue
+		return scanContinue
+	}
+	return s.error(c, "in literal null (expecting 'l')")
+}
+
+// stateError is the state after reaching a syntax error,
+// such as after reading `[1}` or `5.1.2`.
+func stateError(s *scanner, c int) int {
+	return scanError
+}
+
+// error records an error and switches to the error state.
+func (s *scanner) error(c int, context string) int {
+	s.step = stateError
+	s.err = &SyntaxError{"invalid character " + quoteChar(c) + " " + context, s.bytes}
+	return scanError
+}
+
+// quoteChar formats c as a quoted character literal
+func quoteChar(c int) string {
+	// special cases - different from quoted strings
+	if c == '\'' {
+		return `'\''`
+	}
+	if c == '"' {
+		return `'"'`
+	}
+
+	// use quoted string with different quotation marks
+	s := strconv.Quote(string(c))
+	return "'" + s[1:len(s)-1] + "'"
+}
+
+// undo causes the scanner to return scanCode from the next state transition.
+// This gives callers a simple 1-byte undo mechanism.
+func (s *scanner) undo(scanCode int) {
+	if s.redo {
+		panic("json: invalid use of scanner")
+	}
+	s.redoCode = scanCode
+	s.redoState = s.step
+	s.step = stateRedo
+	s.redo = true
+}
+
+// stateRedo helps implement the scanner's 1-byte undo.
+func stateRedo(s *scanner, c int) int {
+	s.redo = false
+	s.step = s.redoState
+	return s.redoCode
+}

--- a/vendor/github.com/ajeddeloh/go-json/stream.go
+++ b/vendor/github.com/ajeddeloh/go-json/stream.go
@@ -1,0 +1,480 @@
+// Copyright 2010 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package json
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+// A Decoder reads and decodes JSON objects from an input stream.
+type Decoder struct {
+	r     io.Reader
+	buf   []byte
+	d     decodeState
+	scanp int // start of unread data in buf
+	scan  scanner
+	err   error
+
+	tokenState int
+	tokenStack []int
+}
+
+// NewDecoder returns a new decoder that reads from r.
+//
+// The decoder introduces its own buffering and may
+// read data from r beyond the JSON values requested.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{r: r}
+}
+
+// UseNumber causes the Decoder to unmarshal a number into an interface{} as a
+// Number instead of as a float64.
+func (dec *Decoder) UseNumber() { dec.d.useNumber = true }
+
+// Decode reads the next JSON-encoded value from its
+// input and stores it in the value pointed to by v.
+//
+// See the documentation for Unmarshal for details about
+// the conversion of JSON into a Go value.
+func (dec *Decoder) Decode(v interface{}) error {
+	if dec.err != nil {
+		return dec.err
+	}
+
+	if err := dec.tokenPrepareForDecode(); err != nil {
+		return err
+	}
+
+	if !dec.tokenValueAllowed() {
+		return &SyntaxError{msg: "not at beginning of value"}
+	}
+
+	// Read whole value into buffer.
+	n, err := dec.readValue()
+	if err != nil {
+		return err
+	}
+	dec.d.init(dec.buf[dec.scanp : dec.scanp+n])
+	dec.scanp += n
+
+	// Don't save err from unmarshal into dec.err:
+	// the connection is still usable since we read a complete JSON
+	// object from it before the error happened.
+	err = dec.d.unmarshal(v)
+
+	// fixup token streaming state
+	dec.tokenValueEnd()
+
+	return err
+}
+
+// Buffered returns a reader of the data remaining in the Decoder's
+// buffer. The reader is valid until the next call to Decode.
+func (dec *Decoder) Buffered() io.Reader {
+	return bytes.NewReader(dec.buf[dec.scanp:])
+}
+
+// readValue reads a JSON value into dec.buf.
+// It returns the length of the encoding.
+func (dec *Decoder) readValue() (int, error) {
+	dec.scan.reset()
+
+	scanp := dec.scanp
+	var err error
+Input:
+	for {
+		// Look in the buffer for a new value.
+		for i, c := range dec.buf[scanp:] {
+			dec.scan.bytes++
+			v := dec.scan.step(&dec.scan, int(c))
+			if v == scanEnd {
+				scanp += i
+				break Input
+			}
+			// scanEnd is delayed one byte.
+			// We might block trying to get that byte from src,
+			// so instead invent a space byte.
+			if (v == scanEndObject || v == scanEndArray) && dec.scan.step(&dec.scan, ' ') == scanEnd {
+				scanp += i + 1
+				break Input
+			}
+			if v == scanError {
+				dec.err = dec.scan.err
+				return 0, dec.scan.err
+			}
+		}
+		scanp = len(dec.buf)
+
+		// Did the last read have an error?
+		// Delayed until now to allow buffer scan.
+		if err != nil {
+			if err == io.EOF {
+				if dec.scan.step(&dec.scan, ' ') == scanEnd {
+					break Input
+				}
+				if nonSpace(dec.buf) {
+					err = io.ErrUnexpectedEOF
+				}
+			}
+			dec.err = err
+			return 0, err
+		}
+
+		n := scanp - dec.scanp
+		err = dec.refill()
+		scanp = dec.scanp + n
+	}
+	return scanp - dec.scanp, nil
+}
+
+func (dec *Decoder) refill() error {
+	// Make room to read more into the buffer.
+	// First slide down data already consumed.
+	if dec.scanp > 0 {
+		n := copy(dec.buf, dec.buf[dec.scanp:])
+		dec.buf = dec.buf[:n]
+		dec.scanp = 0
+	}
+
+	// Grow buffer if not large enough.
+	const minRead = 512
+	if cap(dec.buf)-len(dec.buf) < minRead {
+		newBuf := make([]byte, len(dec.buf), 2*cap(dec.buf)+minRead)
+		copy(newBuf, dec.buf)
+		dec.buf = newBuf
+	}
+
+	// Read.  Delay error for next iteration (after scan).
+	n, err := dec.r.Read(dec.buf[len(dec.buf):cap(dec.buf)])
+	dec.buf = dec.buf[0 : len(dec.buf)+n]
+
+	return err
+}
+
+func nonSpace(b []byte) bool {
+	for _, c := range b {
+		if !isSpace(rune(c)) {
+			return true
+		}
+	}
+	return false
+}
+
+// An Encoder writes JSON objects to an output stream.
+type Encoder struct {
+	w   io.Writer
+	err error
+}
+
+// NewEncoder returns a new encoder that writes to w.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w: w}
+}
+
+// Encode writes the JSON encoding of v to the stream,
+// followed by a newline character.
+//
+// See the documentation for Marshal for details about the
+// conversion of Go values to JSON.
+func (enc *Encoder) Encode(v interface{}) error {
+	if enc.err != nil {
+		return enc.err
+	}
+	e := newEncodeState()
+	err := e.marshal(v)
+	if err != nil {
+		return err
+	}
+
+	// Terminate each value with a newline.
+	// This makes the output look a little nicer
+	// when debugging, and some kind of space
+	// is required if the encoded value was a number,
+	// so that the reader knows there aren't more
+	// digits coming.
+	e.WriteByte('\n')
+
+	if _, err = enc.w.Write(e.Bytes()); err != nil {
+		enc.err = err
+	}
+	encodeStatePool.Put(e)
+	return err
+}
+
+// RawMessage is a raw encoded JSON object.
+// It implements Marshaler and Unmarshaler and can
+// be used to delay JSON decoding or precompute a JSON encoding.
+type RawMessage []byte
+
+// MarshalJSON returns *m as the JSON encoding of m.
+func (m *RawMessage) MarshalJSON() ([]byte, error) {
+	return *m, nil
+}
+
+// UnmarshalJSON sets *m to a copy of data.
+func (m *RawMessage) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("json.RawMessage: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}
+
+var _ Marshaler = (*RawMessage)(nil)
+var _ Unmarshaler = (*RawMessage)(nil)
+
+// A Token holds a value of one of these types:
+//
+//	Delim, for the four JSON delimiters [ ] { }
+//	bool, for JSON booleans
+//	float64, for JSON numbers
+//	Number, for JSON numbers
+//	string, for JSON string literals
+//	nil, for JSON null
+//
+type Token interface{}
+
+const (
+	tokenTopValue = iota
+	tokenArrayStart
+	tokenArrayValue
+	tokenArrayComma
+	tokenObjectStart
+	tokenObjectKey
+	tokenObjectColon
+	tokenObjectValue
+	tokenObjectComma
+)
+
+// advance tokenstate from a separator state to a value state
+func (dec *Decoder) tokenPrepareForDecode() error {
+	// Note: Not calling peek before switch, to avoid
+	// putting peek into the standard Decode path.
+	// peek is only called when using the Token API.
+	switch dec.tokenState {
+	case tokenArrayComma:
+		c, err := dec.peek()
+		if err != nil {
+			return err
+		}
+		if c != ',' {
+			return &SyntaxError{"expected comma after array element", 0}
+		}
+		dec.scanp++
+		dec.tokenState = tokenArrayValue
+	case tokenObjectColon:
+		c, err := dec.peek()
+		if err != nil {
+			return err
+		}
+		if c != ':' {
+			return &SyntaxError{"expected colon after object key", 0}
+		}
+		dec.scanp++
+		dec.tokenState = tokenObjectValue
+	}
+	return nil
+}
+
+func (dec *Decoder) tokenValueAllowed() bool {
+	switch dec.tokenState {
+	case tokenTopValue, tokenArrayStart, tokenArrayValue, tokenObjectValue:
+		return true
+	}
+	return false
+}
+
+func (dec *Decoder) tokenValueEnd() {
+	switch dec.tokenState {
+	case tokenArrayStart, tokenArrayValue:
+		dec.tokenState = tokenArrayComma
+	case tokenObjectValue:
+		dec.tokenState = tokenObjectComma
+	}
+}
+
+// A Delim is a JSON array or object delimiter, one of [ ] { or }.
+type Delim rune
+
+func (d Delim) String() string {
+	return string(d)
+}
+
+// Token returns the next JSON token in the input stream.
+// At the end of the input stream, Token returns nil, io.EOF.
+//
+// Token guarantees that the delimiters [ ] { } it returns are
+// properly nested and matched: if Token encounters an unexpected
+// delimiter in the input, it will return an error.
+//
+// The input stream consists of basic JSON values—bool, string,
+// number, and null—along with delimiters [ ] { } of type Delim
+// to mark the start and end of arrays and objects.
+// Commas and colons are elided.
+func (dec *Decoder) Token() (Token, error) {
+	for {
+		c, err := dec.peek()
+		if err != nil {
+			return nil, err
+		}
+		switch c {
+		case '[':
+			if !dec.tokenValueAllowed() {
+				return dec.tokenError(c)
+			}
+			dec.scanp++
+			dec.tokenStack = append(dec.tokenStack, dec.tokenState)
+			dec.tokenState = tokenArrayStart
+			return Delim('['), nil
+
+		case ']':
+			if dec.tokenState != tokenArrayStart && dec.tokenState != tokenArrayComma {
+				return dec.tokenError(c)
+			}
+			dec.scanp++
+			dec.tokenState = dec.tokenStack[len(dec.tokenStack)-1]
+			dec.tokenStack = dec.tokenStack[:len(dec.tokenStack)-1]
+			dec.tokenValueEnd()
+			return Delim(']'), nil
+
+		case '{':
+			if !dec.tokenValueAllowed() {
+				return dec.tokenError(c)
+			}
+			dec.scanp++
+			dec.tokenStack = append(dec.tokenStack, dec.tokenState)
+			dec.tokenState = tokenObjectStart
+			return Delim('{'), nil
+
+		case '}':
+			if dec.tokenState != tokenObjectStart && dec.tokenState != tokenObjectComma {
+				return dec.tokenError(c)
+			}
+			dec.scanp++
+			dec.tokenState = dec.tokenStack[len(dec.tokenStack)-1]
+			dec.tokenStack = dec.tokenStack[:len(dec.tokenStack)-1]
+			dec.tokenValueEnd()
+			return Delim('}'), nil
+
+		case ':':
+			if dec.tokenState != tokenObjectColon {
+				return dec.tokenError(c)
+			}
+			dec.scanp++
+			dec.tokenState = tokenObjectValue
+			continue
+
+		case ',':
+			if dec.tokenState == tokenArrayComma {
+				dec.scanp++
+				dec.tokenState = tokenArrayValue
+				continue
+			}
+			if dec.tokenState == tokenObjectComma {
+				dec.scanp++
+				dec.tokenState = tokenObjectKey
+				continue
+			}
+			return dec.tokenError(c)
+
+		case '"':
+			if dec.tokenState == tokenObjectStart || dec.tokenState == tokenObjectKey {
+				var x string
+				old := dec.tokenState
+				dec.tokenState = tokenTopValue
+				err := dec.Decode(&x)
+				dec.tokenState = old
+				if err != nil {
+					clearOffset(err)
+					return nil, err
+				}
+				dec.tokenState = tokenObjectColon
+				return x, nil
+			}
+			fallthrough
+
+		default:
+			if !dec.tokenValueAllowed() {
+				return dec.tokenError(c)
+			}
+			var x interface{}
+			if err := dec.Decode(&x); err != nil {
+				clearOffset(err)
+				return nil, err
+			}
+			return x, nil
+		}
+	}
+}
+
+func clearOffset(err error) {
+	if s, ok := err.(*SyntaxError); ok {
+		s.Offset = 0
+	}
+}
+
+func (dec *Decoder) tokenError(c byte) (Token, error) {
+	var context string
+	switch dec.tokenState {
+	case tokenTopValue:
+		context = " looking for beginning of value"
+	case tokenArrayStart, tokenArrayValue, tokenObjectValue:
+		context = " looking for beginning of value"
+	case tokenArrayComma:
+		context = " after array element"
+	case tokenObjectKey:
+		context = " looking for beginning of object key string"
+	case tokenObjectColon:
+		context = " after object key"
+	case tokenObjectComma:
+		context = " after object key:value pair"
+	}
+	return nil, &SyntaxError{"invalid character " + quoteChar(int(c)) + " " + context, 0}
+}
+
+// More reports whether there is another element in the
+// current array or object being parsed.
+func (dec *Decoder) More() bool {
+	c, err := dec.peek()
+	return err == nil && c != ']' && c != '}'
+}
+
+func (dec *Decoder) peek() (byte, error) {
+	var err error
+	for {
+		for i := dec.scanp; i < len(dec.buf); i++ {
+			c := dec.buf[i]
+			if isSpace(rune(c)) {
+				continue
+			}
+			dec.scanp = i
+			return c, nil
+		}
+		// buffer has been scanned, now report any error
+		if err != nil {
+			return 0, err
+		}
+		err = dec.refill()
+	}
+}
+
+/*
+TODO
+
+// EncodeToken writes the given JSON token to the stream.
+// It returns an error if the delimiters [ ] { } are not properly used.
+//
+// EncodeToken does not call Flush, because usually it is part of
+// a larger operation such as Encode, and those will call Flush when finished.
+// Callers that create an Encoder and then invoke EncodeToken directly,
+// without using Encode, need to call Flush when finished to ensure that
+// the JSON is written to the underlying writer.
+func (e *Encoder) EncodeToken(t Token) error  {
+	...
+}
+
+*/

--- a/vendor/github.com/ajeddeloh/go-json/tags.go
+++ b/vendor/github.com/ajeddeloh/go-json/tags.go
@@ -1,0 +1,44 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package json
+
+import (
+	"strings"
+)
+
+// tagOptions is the string following a comma in a struct field's "json"
+// tag, or the empty string. It does not include the leading comma.
+type tagOptions string
+
+// parseTag splits a struct field's json tag into its name and
+// comma-separated options.
+func parseTag(tag string) (string, tagOptions) {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tagOptions(tag[idx+1:])
+	}
+	return tag, tagOptions("")
+}
+
+// Contains reports whether a comma-separated list of options
+// contains a particular substr flag. substr must be surrounded by a
+// string boundary or commas.
+func (o tagOptions) Contains(optionName string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var next string
+		i := strings.Index(s, ",")
+		if i >= 0 {
+			s, next = s[:i], s[i+1:]
+		}
+		if s == optionName {
+			return true
+		}
+		s = next
+	}
+	return false
+}

--- a/vendor/github.com/coreos/ignition/v2/config/merge/merge.go
+++ b/vendor/github.com/coreos/ignition/v2/config/merge/merge.go
@@ -1,0 +1,229 @@
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merge
+
+import (
+	"reflect"
+
+	"github.com/coreos/ignition/v2/config/util"
+)
+
+// Rules of Config Merging:
+// 1) Parent and child configs must be the same version/type
+// 2) Only valid configs can be merged
+// 3) It is possible to merge two valid configs and get an invalid config
+// 3) For structs:
+//   a) Members that are structs get merged recursively (i.e. ignition.storage)
+//   b) Members that are primitives get replaced by the child's member (e.g. ignition.storage.files[i].path)
+//   c) Members that are pointers only get replaced by the child's value if the child's value is non-nil (e.g. ignition.config.replace.source)
+//   d) List merging of a list with IgnoreDuplicates: append the lists (e.g. ignition.storage.files[i].append)
+//   e) List merging of a list not merged with other lists: merge any entries with the same Key() and append the others (e.g. ignition.storage.filesystems by path)
+//   f) List merging of a list merged with other lists: (e.g. ignition.storage.{files,links,directories} by path)
+//      - merge entries with the same Key() that are in the same list
+//      - remove entries from the parent with the same Key() that are not in the same list
+//      - append entries that are unique to the child
+
+// appendToSlice is a helper that appends to a slice without returning a new one.
+// panics if len >= cap
+func appendToSlice(s, v reflect.Value) {
+	s.SetLen(s.Len() + 1)
+	s.Index(s.Len() - 1).Set(v)
+}
+
+type handleKey struct {
+	handle string
+	key    string
+}
+
+// structInfo holds information about a struct being processed and has helper methods for querying that
+// information in a way that is more clear what the intent is.
+type structInfo struct {
+	// set of field names to not do duplicate merging on
+	ignoreDups map[string]struct{}
+
+	// map from field names to a handle indicating all those with the same handle should have duplication
+	// checking done across all fields that share that handle
+	mergedKeys map[string]string
+
+	// map from each handle + key() value to what list it came from
+	keysToValues map[handleKey]reflect.Value
+
+	// map from each handle + key() to the list it came from
+	keysToLists map[handleKey]string
+}
+
+// returns if this field should not do duplicate checking/merging
+func (s structInfo) ignoreField(name string) bool {
+	_, ignore := s.ignoreDups[name]
+	return ignore
+}
+
+// getChildEntryByKey takes the name of a field (not handle) in the parent and a key and looks that entry
+// up in the child. It will look up across all slices that share the same handle. It return the value and
+// name of the field in the child it was found in. The bool indicates whether it was found.
+func (s structInfo) getChildEntryByKey(fieldName, key string) (reflect.Value, string, bool) {
+	handle := fieldName
+	if tmp, ok := s.mergedKeys[fieldName]; ok {
+		handle = tmp
+	}
+
+	hkey := handleKey{
+		handle: handle,
+		key:    key,
+	}
+	if v, ok := s.keysToValues[hkey]; ok {
+		return v, s.keysToLists[hkey], true
+	}
+	return reflect.Value{}, "", false
+}
+
+func newStructInfo(parent, child reflect.Value) structInfo {
+	ignoreDups := map[string]struct{}{}
+	if ignorer, ok := parent.Interface().(util.IgnoresDups); ok {
+		ignoreDups = ignorer.IgnoreDuplicates()
+	}
+
+	mergedKeys := map[string]string{}
+	if merger, ok := parent.Interface().(util.MergesKeys); ok {
+		mergedKeys = merger.MergedKeys()
+	}
+
+	keysToValues := map[handleKey]reflect.Value{}
+	keysToLists := map[handleKey]string{}
+	for i := 0; i < child.NumField(); i++ {
+		field := child.Field(i)
+		if field.Kind() != reflect.Slice {
+			continue
+		}
+
+		fieldName := child.Type().Field(i).Name
+		if _, ok := ignoreDups[fieldName]; ok {
+			continue
+		}
+
+		handle := fieldName
+		if tmp, ok := mergedKeys[handle]; ok {
+			handle = tmp
+		}
+
+		for j := 0; j < field.Len(); j++ {
+			v := field.Index(j)
+			hkey := handleKey{
+				handle: handle,
+				key:    util.CallKey(v),
+			}
+			keysToValues[hkey] = v
+			keysToLists[hkey] = fieldName
+		}
+	}
+
+	return structInfo{
+		ignoreDups:   ignoreDups,
+		mergedKeys:   mergedKeys,
+		keysToValues: keysToValues,
+		keysToLists:  keysToLists,
+	}
+}
+
+// MergeStruct is intended for use by config/vX_Y/ packages only. They should expose their own Merge() that is properly
+// typed. Use that one instead.
+// parent and child MUST be the same type
+func MergeStruct(parent, child reflect.Value) reflect.Value {
+	// use New() so it's settable, addr-able, etc
+	result := reflect.New(parent.Type()).Elem()
+	info := newStructInfo(parent, child)
+
+	for i := 0; i < parent.NumField(); i++ {
+		fieldName := parent.Type().Field(i).Name
+		parentField := parent.Field(i)
+		childField := child.Field(i)
+		resultField := result.Field(i)
+
+		kind := parentField.Kind()
+		switch {
+		case util.IsPrimitive(kind):
+			resultField.Set(childField)
+		case kind == reflect.Ptr && childField.IsNil():
+			resultField.Set(parentField)
+		case kind == reflect.Ptr && !childField.IsNil():
+			resultField.Set(childField)
+		case kind == reflect.Struct:
+			resultField.Set(MergeStruct(parentField, childField))
+		case kind == reflect.Slice && info.ignoreField(fieldName):
+			if parentField.Len()+childField.Len() == 0 {
+				continue
+			}
+			resultField.Set(reflect.AppendSlice(parentField, childField))
+		case kind == reflect.Slice && !info.ignoreField(fieldName):
+			// ooph, this is a doosey
+			maxlen := parentField.Len() + childField.Len()
+			if maxlen == 0 {
+				continue
+			}
+			resultField.Set(reflect.MakeSlice(parentField.Type(), 0, parentField.Len()+childField.Len()))
+			parentKeys := getKeySet(parentField)
+
+			for i := 0; i < parentField.Len(); i++ {
+				parentItem := parentField.Index(i)
+				key := util.CallKey(parentItem)
+
+				if childItem, childList, ok := info.getChildEntryByKey(fieldName, key); ok {
+					if childList == fieldName {
+						// case 1: in child config in same list
+						if childItem.Kind() == reflect.Struct {
+							// If HTTP header Value is nil, it means that we should remove the
+							// parent header from the result.
+							if fieldName == "HTTPHeaders" && childItem.FieldByName("Value").IsNil() {
+								continue
+							}
+							appendToSlice(resultField, MergeStruct(parentItem, childItem))
+						} else if util.IsPrimitive(childItem.Kind()) {
+							appendToSlice(resultField, childItem)
+						} else {
+							panic("List of pointers or slices or something else weird")
+						}
+					} else {
+						// case 2: in child config in different list. Do nothing since it'll be handled iterating over that list
+					}
+				} else {
+					// case 3: not in child config, append it
+					appendToSlice(resultField, parentItem)
+				}
+			}
+			for i := 0; i < childField.Len(); i++ {
+				childItem := childField.Index(i)
+				key := util.CallKey(childItem)
+				if _, alreadyMerged := parentKeys[key]; !alreadyMerged {
+					// We only check the parentMap for this field. If the parent had a matching entry in a differnt field
+					// then it would be skipped as case 2 above
+					appendToSlice(resultField, childItem)
+				}
+			}
+		default:
+			panic("unreachable code reached")
+		}
+	}
+
+	return result
+}
+
+// getKeySet takes a value of a slice and returns the set of all the Key() values in that slice
+func getKeySet(list reflect.Value) map[string]struct{} {
+	m := map[string]struct{}{}
+	for i := 0; i < list.Len(); i++ {
+		m[util.CallKey(list.Index(i))] = struct{}{}
+	}
+	return m
+}

--- a/vendor/github.com/coreos/ignition/v2/config/v3_1/config.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_1/config.go
@@ -1,0 +1,67 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3_1
+
+import (
+	"reflect"
+
+	"github.com/coreos/ignition/v2/config/merge"
+	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/ignition/v2/config/v3_1/types"
+	"github.com/coreos/ignition/v2/config/validate"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/coreos/vcontext/report"
+)
+
+func Merge(parent, child types.Config) types.Config {
+	vParent := reflect.ValueOf(parent)
+	vChild := reflect.ValueOf(child)
+
+	vRes := merge.MergeStruct(vParent, vChild)
+	res := vRes.Interface().(types.Config)
+	return res
+}
+
+// Parse parses the raw config into a types.Config struct and generates a report of any
+// errors, warnings, info, and deprecations it encountered
+func Parse(rawConfig []byte) (types.Config, report.Report, error) {
+	if isEmpty(rawConfig) {
+		return types.Config{}, report.Report{}, errors.ErrEmpty
+	}
+
+	var config types.Config
+	if rpt, err := util.HandleParseErrors(rawConfig, &config); err != nil {
+		return types.Config{}, rpt, err
+	}
+
+	version, err := semver.NewVersion(config.Ignition.Version)
+
+	if err != nil || *version != types.MaxVersion {
+		return types.Config{}, report.Report{}, errors.ErrUnknownVersion
+	}
+
+	rpt := validate.ValidateWithContext(config, rawConfig)
+	if rpt.IsFatal() {
+		return types.Config{}, rpt, errors.ErrInvalid
+	}
+
+	return config, rpt, nil
+}
+
+func isEmpty(userdata []byte) bool {
+	return len(userdata) == 0
+}

--- a/vendor/github.com/coreos/ignition/v2/config/validate/validate.go
+++ b/vendor/github.com/coreos/ignition/v2/config/validate/validate.go
@@ -1,0 +1,118 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/util"
+
+	"github.com/coreos/vcontext/json"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/coreos/vcontext/tree"
+	"github.com/coreos/vcontext/validate"
+)
+
+func ValidateDups(v reflect.Value, c path.ContextPath) (r report.Report) {
+	if v.Kind() != reflect.Struct {
+		return
+	}
+	dupsLists := map[string]map[string]struct{}{}
+	ignoreDups := map[string]struct{}{}
+	if i, ok := v.Interface().(util.IgnoresDups); ok {
+		ignoreDups = i.IgnoreDuplicates()
+	}
+	mergedKeys := map[string]string{}
+	if m, ok := v.Interface().(util.MergesKeys); ok {
+		mergedKeys = m.MergedKeys()
+	}
+
+	fields := validate.GetFields(v)
+	for _, field := range fields {
+		if field.Type.Kind() != reflect.Slice {
+			continue
+		}
+		if _, ignored := ignoreDups[field.Name]; ignored {
+			continue
+		}
+		dupListName := field.Name
+		if mergedName, ok := mergedKeys[field.Name]; ok {
+			dupListName = mergedName
+		}
+		dupList := dupsLists[dupListName]
+		if dupList == nil {
+			dupsLists[dupListName] = make(map[string]struct{}, field.Value.Len())
+			dupList = dupsLists[dupListName]
+		}
+		for i := 0; i < field.Value.Len(); i++ {
+			key := util.CallKey(field.Value.Index(i))
+			if _, isDup := dupList[key]; isDup {
+				r.AddOnError(c.Append(validate.FieldName(field, c.Tag), i), errors.ErrDuplicate)
+			}
+			dupList[key] = struct{}{}
+		}
+	}
+	return
+}
+
+func ValidateUnusedKeys(v reflect.Value, c path.ContextPath, root tree.Node) (r report.Report) {
+	if v.Kind() != reflect.Struct {
+		return
+	}
+	node, err := root.Get(c)
+	if err != nil {
+		// not every node will have corresponding json
+		return
+	}
+
+	mapNode, ok := node.(tree.MapNode)
+	if !ok {
+		// Something is wrong, we won't be able to report unused keys here, so just warn about it and stop trying
+		r.AddOnWarn(c, fmt.Errorf("context tree does not match content tree at %s. Line and column reporting may be inconsistent. Unused keys may not be reported.", c.String()))
+		return
+	}
+
+	fields := validate.GetFields(v)
+	fieldMap := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		fieldMap[validate.FieldName(field, c.Tag)] = struct{}{}
+	}
+	for key := range mapNode.Keys {
+		if _, ok := fieldMap[key]; !ok {
+			r.AddOnWarn(c.Append(tree.Key(key)), fmt.Errorf("Unused key %s", key))
+		}
+	}
+	return
+}
+
+func ValidateWithContext(cfg interface{}, raw []byte) report.Report {
+	r := validate.Validate(cfg, "json")
+	r.Merge(validate.ValidateCustom(cfg, "json", ValidateDups))
+	if raw == nil {
+		return r
+	}
+
+	if cxt, err := json.UnmarshalToContext(raw); err == nil {
+		unusedKeyCheck := func(v reflect.Value, c path.ContextPath) report.Report {
+			return ValidateUnusedKeys(v, c, cxt)
+		}
+		r.Merge(validate.ValidateCustom(cfg, "json", unusedKeyCheck))
+		r.Correlate(cxt)
+	}
+	return r
+}

--- a/vendor/github.com/coreos/vcontext/json/json.go
+++ b/vendor/github.com/coreos/vcontext/json/json.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package json
+
+import (
+	"github.com/coreos/vcontext/tree"
+	// todo: rewrite this dep
+	json "github.com/ajeddeloh/go-json"
+)
+
+func UnmarshalToContext(raw []byte) (tree.Node, error) {
+	var ast json.Node
+	if err := json.Unmarshal(raw, &ast); err != nil {
+		return nil, err
+	}
+	node := fromJsonNode(ast)
+	tree.FixLineColumn(node, raw)
+	return node, nil
+}
+
+func fromJsonNode(n json.Node) tree.Node {
+	m := tree.MarkerFromIndices(int64(n.Start), int64(n.End))
+
+	switch v := n.Value.(type) {
+	case map[string]json.Node:
+		ret := tree.MapNode{
+			Marker:   m,
+			Children: make(map[string]tree.Node, len(v)),
+			Keys:     make(map[string]tree.Leaf, len(v)),
+		}
+		for key, child := range v {
+			ret.Children[key] = fromJsonNode(child)
+			ret.Keys[key] = tree.Leaf{
+				Marker: tree.MarkerFromIndices(int64(child.KeyStart), int64(child.KeyEnd)),
+			}
+		}
+		return ret
+	case []json.Node:
+		ret := tree.SliceNode{
+			Marker:   m,
+			Children: make([]tree.Node, 0, len(v)),
+		}
+		for _, child := range v {
+			ret.Children = append(ret.Children, fromJsonNode(child))
+		}
+		return ret
+	default:
+		return tree.Leaf{
+			Marker: m,
+		}
+	}
+}

--- a/vendor/github.com/coreos/vcontext/validate/validate.go
+++ b/vendor/github.com/coreos/vcontext/validate/validate.go
@@ -1,0 +1,149 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package validate
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+type CustomValidator func(v reflect.Value, c path.ContextPath) report.Report
+
+// validator is the interface the DefaultValidator function uses when validating types.
+// Most users should implement this interface on types they want to validate.
+type validator interface {
+	Validate(path.ContextPath) report.Report
+}
+
+// DefaultValidator checks if the type implements the validator interface and calls the
+// validate function if it does, returning the report.
+func DefaultValidator(v reflect.Value, c path.ContextPath) report.Report {
+	// first check if this object has Validate(context) defined, but only on value
+	// recievers. Both pointer and value receivers satisfy a value receiver interface
+	// so ensure we're not a pointer too.
+	if obj, ok := v.Interface().(validator); ok && v.Kind() != reflect.Ptr {
+		return obj.Validate(c)
+	}
+	return report.Report{}
+}
+
+// ValidateCustom validates thing using the custom validation function supplied. Most users will not need this
+// and should use Validate() instead.
+func ValidateCustom(thing interface{}, tag string, customValidator CustomValidator) report.Report {
+	if thing == nil {
+		return report.Report{}
+	}
+	v := reflect.ValueOf(thing)
+	ctx := path.ContextPath{Tag: tag}
+	return validate(ctx, v, customValidator)
+}
+
+// Validate walks the structs, slices, and pointers in thing and calls any Validate(path.ContextPath) report.Report
+// functions defined on the types, aggregating the results.
+func Validate(thing interface{}, tag string) report.Report {
+	return ValidateCustom(thing, tag, DefaultValidator)
+}
+
+func validate(context path.ContextPath, v reflect.Value, validateFunc CustomValidator) (r report.Report) {
+	if !v.IsValid() {
+		return
+	}
+	if v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return
+		} else {
+			v = makeConcrete(v)
+		}
+	}
+
+	r.Merge(validateFunc(v, context))
+
+	switch v.Kind() {
+	case reflect.Struct:
+		r.Merge(validateStruct(context, v, validateFunc))
+	case reflect.Slice:
+		r.Merge(validateSlice(context, v, validateFunc))
+	case reflect.Ptr:
+		if !v.IsNil() {
+			r.Merge(validate(context, v.Elem(), validateFunc))
+		}
+	}
+
+	return
+}
+
+// StructField is an extension of go's reflect.StructField that also includes the value.
+type StructField struct {
+	reflect.StructField
+	Value reflect.Value
+}
+
+// makeConcrete takes a value and if it is a value of an interface returns the
+// value of the actual underlying type implementing that interface. If the value
+// is already concrete, it returns the same value.
+func makeConcrete(v reflect.Value) reflect.Value {
+	return reflect.ValueOf(v.Interface())
+}
+
+// GetFields takes a value of a struct and flattens all embedded structs in it.
+// If any fields are interfaces, it "dereferences" the interface to its underlying type.
+func GetFields(v reflect.Value) []StructField {
+	ret := []StructField{}
+	if v.Kind() != reflect.Struct {
+		return ret
+	}
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Type().Field(i)
+		if !field.Anonymous {
+			ret = append(ret, StructField{
+				StructField: field,
+				Value:       v.Field(i),
+			})
+		} else {
+			concrete := makeConcrete(v.Field(i))
+			ret = append(ret, GetFields(concrete)...)
+		}
+	}
+	return ret
+}
+
+func FieldName(s StructField, tag string) string {
+	if tag == "" {
+		return s.Name
+	}
+	tag = s.Tag.Get(tag)
+	return strings.Split(tag, ",")[0]
+}
+
+func validateStruct(context path.ContextPath, v reflect.Value, f CustomValidator) (r report.Report) {
+	fields := GetFields(v)
+	for _, field := range fields {
+		fieldContext := context.Append(FieldName(field, context.Tag))
+		r.Merge(validate(fieldContext, field.Value, f))
+	}
+	return
+}
+
+func validateSlice(context path.ContextPath, v reflect.Value, f CustomValidator) (r report.Report) {
+	for i := 0; i < v.Len(); i++ {
+		childContext := context.Append(i)
+		r.Merge(validate(childContext, v.Index(i), f))
+	}
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,19 +2,26 @@
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
+# github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083
+github.com/ajeddeloh/go-json
 # github.com/coreos/go-semver v0.3.0
 github.com/coreos/go-semver/semver
 # github.com/coreos/go-systemd/v22 v22.0.0
 github.com/coreos/go-systemd/v22/unit
 # github.com/coreos/ignition/v2 v2.4.1
+github.com/coreos/ignition/v2/config/merge
 github.com/coreos/ignition/v2/config/shared/errors
 github.com/coreos/ignition/v2/config/shared/validations
 github.com/coreos/ignition/v2/config/util
+github.com/coreos/ignition/v2/config/v3_1
 github.com/coreos/ignition/v2/config/v3_1/types
+github.com/coreos/ignition/v2/config/validate
 # github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068
+github.com/coreos/vcontext/json
 github.com/coreos/vcontext/path
 github.com/coreos/vcontext/report
 github.com/coreos/vcontext/tree
+github.com/coreos/vcontext/validate
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/emicklei/go-restful v2.10.0+incompatible
@@ -131,7 +138,6 @@ github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.opens
 github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned
 github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/scheme
 github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1
-github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1/fake
 github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions
 github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions/internalinterfaces
 github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions/machineconfiguration.openshift.io


### PR DESCRIPTION
This PR adds support for the stalld program to prevent the _starvation_ of
operating system threads in a Linux system.

Changes:
  - support for `[service]` Tuned plugin
  - support the installation of stalld binary and systemd units on hosts fully-managed by the [Machine Config Operator](https://github.com/openshift/machine-config-operator) (MCO).

Example usage:

```
$ oc label node <node-name> node-role.kubernetes.io/worker-rt=

$ oc create -f- <<EOF
apiVersion: tuned.openshift.io/v1
kind: Tuned
metadata:
  name: openshift-realtime
  namespace: openshift-cluster-node-tuning-operator
spec:
  profile:
  - data: |
      [main]
      summary=Custom OpenShift realtime profile
      include=openshift-node,realtime
      [service]
      service.stalld=start,enable
    name: openshift-realtime

  recommend:
  - machineConfigLabels:
      machineconfiguration.openshift.io/role: "worker-rt"
    priority: 30
    profile: openshift-realtime
EOF

$ oc create -f examples/realtime-mcp.yaml
```

A host-supplied configuration file can be used to override the `stalld` systemd unit.  This file can then be referred to by prefixing the absolute path to the file on the host by the `/host` prefix.  For example:

```
      [service]
      service.stalld=start,enable,file:/host/etc/tuned/openshift-realtime/stalld.conf
```

Note that the file needs to be created on the host by other means, for example, by using a MachineConfig. One of the uses of the drop-in file is to supply environment variables to the stalld unit.  For example, the drop-in file may contain:
```
[Service]
Environment=CLIST=
Environment=AGGR=
Environment=BP="-p 1000000000"
Environment=BR="-r 10000"
Environment=BD="-d 3"
Environment=THRESH="-t 60"
Environment=LOGGING="--log_syslog --log_kmsg"
Environment=FG=--foreground
Environment=PF="--pidfile /run/stalld.pid"
```