### PR TITLE
Updating cluster-node-tuning-operator builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6 AS tuned
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift AS tuned
 WORKDIR /root
 COPY assets /root/assets
 RUN INSTALL_PKGS=" \
@@ -18,7 +18,7 @@ RUN INSTALL_PKGS=" \
     cd ../stalld && \
     make
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
 COPY manifests /manifests
 ENV APP_ROOT=/var/lib/tuned


### PR DESCRIPTION
Updating cluster-node-tuning-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/cluster-node-tuning-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.