### PR TITLE
Bug 1887088: image-references: no longer require cluster-node-tuned

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,7 +6,3 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-node-tuning-operator
-  - name: cluster-node-tuned
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-node-tuned


### PR DESCRIPTION
Per https://issues.redhat.com/browse/ART-2044 the tuned container is obsolete. However it is still referred to in cluster-node-tuning-operator (and thus the CVO) as cluster-node-tuned. This blocks forming a nightly.