### PR TITLE
Change the priorities of example and e2e test profiles.

### DIFF
--- a/examples/cpu-partitioning.yaml
+++ b/examples/cpu-partitioning.yaml
@@ -18,5 +18,5 @@ spec:
   recommend:
   - match:
     - label: node-role.kubernetes.io/worker-rt
-    priority: 30
+    priority: 20
     profile: openshift-cpu-partitioning

--- a/examples/elasticsearch.yaml
+++ b/examples/elasticsearch.yaml
@@ -16,5 +16,5 @@ spec:
   - match:
     - label: tuned.openshift.io/elasticsearch
       type: pod
-    priority: 30
+    priority: 20
     profile: openshift-elasticsearch

--- a/examples/hugepages.yaml
+++ b/examples/hugepages.yaml
@@ -17,5 +17,5 @@ spec:
   recommend:
   - match:
     - label: tuned.openshift.io/hugepages
-    priority: 30
+    priority: 20
     profile: openshift-hugepages

--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -17,5 +17,5 @@ spec:
   - match:
     - label: tuned.openshift.io/ingress
       type: pod
-    priority: 30
+    priority: 20
     profile: openshift-ingress

--- a/examples/realtime-mc.yaml
+++ b/examples/realtime-mc.yaml
@@ -24,5 +24,5 @@ spec:
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: "worker-rt"
-    priority: 30
+    priority: 20
     profile: openshift-realtime

--- a/examples/realtime.yaml
+++ b/examples/realtime.yaml
@@ -17,5 +17,5 @@ spec:
   recommend:
   - match:
     - label: node-role.kubernetes.io/worker-rt
-    priority: 30
+    priority: 20
     profile: openshift-realtime

--- a/test/e2e/testing_manifests/kernel_parameter_add_rm-child.yaml
+++ b/test/e2e/testing_manifests/kernel_parameter_add_rm-child.yaml
@@ -17,5 +17,5 @@ spec:
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: "worker-rt"
-    priority: 20
+    priority: 10
     profile: openshift-kernel-parameter-remove-child

--- a/test/e2e/testing_manifests/kernel_parameter_add_rm-parent.yaml
+++ b/test/e2e/testing_manifests/kernel_parameter_add_rm-parent.yaml
@@ -16,5 +16,5 @@ spec:
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: "worker-rt"
-    priority: 30
+    priority: 20
     profile: openshift-kernel-parameter-remove-parent

--- a/test/e2e/testing_manifests/stalld.yaml
+++ b/test/e2e/testing_manifests/stalld.yaml
@@ -23,5 +23,5 @@ spec:
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: "worker-rt"
-    priority: 30
+    priority: 20
     profile: openshift-realtime


### PR DESCRIPTION
The default Tuned CR ships with two profiles with priority 30 and 40.  While the application of profiles with the same priority is now deterministic, using the same priority (30) in the examples and e2e tests is not a good idea.  Increase the priority of these profiles by lowering the priority number to 20 (and 10 where needed).
