### PR TITLE
Bug 1895919: Add a weak dependency on kmod to tuned.

### DIFF
--- a/assets/tuned/patches/090-kmod-weak-dependency.diff
+++ b/assets/tuned/patches/090-kmod-weak-dependency.diff
@@ -1,0 +1,16 @@
+Fixes issue #304 with modprobe being missed by the [modules] plugin.
+
+See: https://github.com/redhat-performance/tuned/pull/305
+
+diff --git a/tuned.spec b/tuned.spec
+index f28e7b58..2a3fc6bf 100644
+--- a/tuned.spec
++++ b/tuned.spec
+@@ -88,6 +88,7 @@ Requires: util-linux, dbus, polkit
+ Recommends: hdparm
+ Recommends: kernel-tools
+ Recommends: python-dmidecode
++Recommends: kmod
+ %endif
+ %if 0%{?rhel} > 7
+ Requires: python3-syspurpose

--- a/test/e2e/basic/modules.go
+++ b/test/e2e/basic/modules.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	coreapi "k8s.io/api/core/v1"
+
+	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
+	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
+)
+
+// Test loading a kernel module by applying a custom profile via node labelling.
+var _ = ginkgo.Describe("[basic][modules] Node Tuning Operator load kernel module", func() {
+	const (
+		profileModules   = "../testing_manifests/tuned_modules_load.yaml"
+		nodeLabelModules = "tuned.openshift.io/module-load"
+		procModules      = "/proc/modules"
+		moduleName       = "joydev"
+	)
+
+	ginkgo.Context("module loading", func() {
+		var (
+			node *coreapi.Node
+		)
+
+		// Cleanup code to roll back cluster changes done by this test even if it fails in the middle of ginkgo.It()
+		ginkgo.AfterEach(func() {
+			ginkgo.By("cluster changes rollback")
+			if node != nil {
+				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelModules+"-")
+			}
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileModules)
+		})
+
+		ginkgo.It(fmt.Sprintf("modules: %s loaded", moduleName), func() {
+			cmdGrepModule := []string{"grep", fmt.Sprintf("^%s ", moduleName), procModules}
+			ginkgo.By("getting a list of worker nodes")
+			nodes, err := util.GetNodesByRole(cs, "worker")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
+
+			node = &nodes[0]
+			ginkgo.By(fmt.Sprintf("getting a tuned Pod running on node %s", node.Name))
+			pod, err := util.GetTunedForNode(cs, node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("labelling node %s with label %s", node.Name, nodeLabelModules))
+			_, _, err = util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelModules+"=")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("trying to remove the %s module if loaded", moduleName))
+			_, err = util.ExecCmdInPod(pod, "rmmod", moduleName)
+
+			ginkgo.By(fmt.Sprintf("ensuring the %s module is not loaded", moduleName))
+			_, err = util.ExecCmdInPod(pod, cmdGrepModule...)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("creating profile %s", profileModules))
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileModules)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("ensuring the %s module is loaded", moduleName))
+			_, err = util.PollExecCmdInPod(5*time.Second, 5*time.Minute, pod, cmdGrepModule...)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("deleting profile %s", profileModules))
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileModules)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("removing label %s from node %s", nodeLabelModules, node.Name))
+			_, _, err = util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelModules+"-")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+})

--- a/test/e2e/reboots/stalld.go
+++ b/test/e2e/reboots/stalld.go
@@ -18,7 +18,6 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 		profileRealtime   = "../testing_manifests/stalld.yaml"
 		mcpRealtime       = "../../../examples/realtime-mcp.yaml"
 		nodeLabelRealtime = "node-role.kubernetes.io/worker-rt"
-		procCmdline       = "/proc/cmdline"
 	)
 
 	ginkgo.Context("stalld", func() {

--- a/test/e2e/testing_manifests/tuned_modules_load.yaml
+++ b/test/e2e/testing_manifests/tuned_modules_load.yaml
@@ -1,0 +1,19 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-module-load
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=An OpenShift profile to load 'joydev' module
+      include=openshift-node
+      [modules]
+      joydev=+r
+    name: openshift-module-load
+  recommend:
+  - match:
+    - label: tuned.openshift.io/module-load
+    priority: 20
+    profile: openshift-module-load


### PR DESCRIPTION
This fixes an issue in the tuned daemon with a missing
dependency on the kmod package.  The `[modules]` plugin uses
modprobe from the kmod package to load kernel modules.

Other changes:
  - Added e2e tests to test this functionality for the loop kernel
    module.
  - Reused PollExecCmdInPod() for GetFileInPod()
  - Removed an unused constant from stalld.go e2e test.