### PR TITLE
Switch the upstream Dockerfile to CentOS 8.

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -7,12 +7,12 @@ FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7 AS tune
 WORKDIR /root
 COPY assets /root/assets
 RUN INSTALL_PKGS=" \
-      gcc git rpm-build make desktop-file-utils patch \
-      python3 python3-configobj python3-pyudev \
+      gcc git rpm-build make desktop-file-utils patch dnf-plugins-core \
       " && \
-    yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
+    dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     cd assets/tuned/daemon && \
     LC_COLLATE=C cat ../patches/*.diff | patch -Np1 && \
+    dnf build-dep tuned.spec -y && \
     make rpm PYTHON=/usr/bin/python3 && \
     rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*} && \
     cd ../stalld && \
@@ -32,14 +32,14 @@ RUN INSTALL_PKGS=" \
       socat procps-ng \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
-    yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
+    dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
+    dnf --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
     find /root/rpms -name \*.rpm -exec basename {} .rpm \; | xargs rpm -e --justdb && \
     cp -a /var/lib/tuned/tuned/stalld/stalld /usr/local/bin && \
     rm -rf /var/lib/tuned/tuned && \
     touch /etc/sysctl.conf && \
-    yum clean all && \
+    dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \
     useradd -r -u 499 cluster-node-tuning-operator
 ENTRYPOINT ["/usr/bin/cluster-node-tuning-operator"]


### PR DESCRIPTION
Other changes: cleanup of the `Dockerfile.rhel8` to rely on the Tuned daemon rpm dependency spec file.