### PR TITLE
Bug 1900196: Automatically restart stalld after exit.

### DIFF
--- a/pkg/tuned/host_payload.go
+++ b/pkg/tuned/host_payload.go
@@ -80,6 +80,7 @@ Environment=FG=--foreground
 Environment=PF="--pidfile /run/stalld.pid"
 
 ExecStart=/usr/bin/chrt -f 10 /usr/local/bin/stalld $CLIST $AGGR $BP $BR $BD $THRESH $LOGGING $FG $PF
+Restart=always
 User=root
 `
 


### PR DESCRIPTION
Add "Restart=always" to the stalld unit to restart the stalld service even if
it exits successfully.

Resolves rhbz#1900196.