### PR TITLE
E2e test cleanup.

### DIFF
--- a/manifests/50-operator.yaml
+++ b/manifests/50-operator.yaml
@@ -67,10 +67,11 @@ spec:
               cpu: 10m
               memory: 20Mi
           volumeMounts:
-            - name: trusted-ca
-              mountPath: /var/run/configmaps/trusted-ca/
+            # Certificates and keys for node-tuning-operator.openshift-cluster-node-tuning-operator.svc
             - name: node-tuning-operator-tls
               mountPath: /etc/secrets
+            - name: trusted-ca
+              mountPath: /var/run/configmaps/trusted-ca/
       volumes:
         - name: node-tuning-operator-tls
           secret:

--- a/test/e2e/basic/available.go
+++ b/test/e2e/basic/available.go
@@ -18,11 +18,16 @@ import (
 )
 
 var _ = ginkgo.Describe("[basic][available] Node Tuning Operator availability", func() {
+	const (
+		pollInterval = 5 * time.Second
+		waitDuration = 5 * time.Minute
+	)
+
 	var explain string
 
 	ginkgo.It(fmt.Sprintf("clusteroperator/%s available", tunedv1.TunedClusterOperatorResourceName), func() {
 		ginkgo.By(fmt.Sprintf("wait for clusteroperator/%s available", tunedv1.TunedClusterOperatorResourceName))
-		err := wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+		err := wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
 			co, err := cs.ClusterOperators().Get(context.TODO(), tunedv1.TunedClusterOperatorResourceName, metav1.GetOptions{})
 			if err != nil {
 				explain = err.Error()
@@ -42,7 +47,7 @@ var _ = ginkgo.Describe("[basic][available] Node Tuning Operator availability", 
 
 	ginkgo.It(fmt.Sprintf("tuned/%s exists", tunedv1.TunedDefaultResourceName), func() {
 		ginkgo.By(fmt.Sprintf("wait for tuned/%s existence", tunedv1.TunedDefaultResourceName))
-		err := wait.PollImmediate(1*time.Second, 5*time.Minute, func() (bool, error) {
+		err := wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
 			_, err := cs.Tuneds(ntoconfig.OperatorNamespace()).Get(context.TODO(), tunedv1.TunedDefaultResourceName, metav1.GetOptions{})
 			if err != nil {
 				explain = err.Error()

--- a/test/e2e/basic/custom_node_labels.go
+++ b/test/e2e/basic/custom_node_labels.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -35,18 +36,22 @@ var _ = ginkgo.Describe("[basic][custom_node_labels] Node Tuning Operator custom
 		})
 
 		ginkgo.It(fmt.Sprintf("%s set", sysctlVar), func() {
+			const (
+				pollInterval = 5 * time.Second
+				waitDuration = 5 * time.Minute
+			)
 			ginkgo.By("getting a list of worker nodes")
 			nodes, err := util.GetNodesByRole(cs, "worker")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a tuned pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("getting the current value of %s in pod %s", sysctlVar, pod.Name))
-			valOrig, err := util.GetSysctl(sysctlVar, pod)
+			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))
+			valOrig, err := util.WaitForSysctlInPod(pollInterval, waitDuration, pod, sysctlVar)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("labelling node %s with label %s", node.Name, nodeLabelHugepages))
@@ -58,15 +63,15 @@ var _ = ginkgo.Describe("[basic][custom_node_labels] Node Tuning Operator custom
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("ensuring the custom worker node profile was set")
-			err = util.EnsureSysctl(pod, sysctlVar, "16")
+			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, "16")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom hugepages profile %s", profileHugepages))
 			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("ensuring the original %s value (%s) is set in pod %s", sysctlVar, valOrig, pod.Name))
-			err = util.EnsureSysctl(pod, sysctlVar, valOrig)
+			ginkgo.By(fmt.Sprintf("ensuring the original %s value (%s) is set in Pod %s", sysctlVar, valOrig, pod.Name))
+			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, valOrig)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("removing label %s from node %s", nodeLabelHugepages, node.Name))

--- a/test/e2e/basic/custom_pod_labels.go
+++ b/test/e2e/basic/custom_pod_labels.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -13,14 +14,14 @@ import (
 )
 
 // Test the application (and rollback) of a custom profile via pod labelling.
-var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom profile, pod labels", func() {
+var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom profile, Pod labels", func() {
 	const (
 		profileIngress  = "../../../examples/ingress.yaml"
 		podLabelIngress = "tuned.openshift.io/ingress"
 		sysctlVar       = "net.ipv4.tcp_tw_reuse"
 	)
 
-	ginkgo.Context("custom profile: pod labels", func() {
+	ginkgo.Context("custom profile: Pod labels", func() {
 		var (
 			pod *coreapi.Pod
 		)
@@ -35,18 +36,22 @@ var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom 
 		})
 
 		ginkgo.It(fmt.Sprintf("%s set", sysctlVar), func() {
+			const (
+				pollInterval = 5 * time.Second
+				waitDuration = 5 * time.Minute
+			)
 			ginkgo.By("getting a list of worker nodes")
 			nodes, err := util.GetNodesByRole(cs, "worker")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 			node := nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a tuned pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
 			pod, err = util.GetTunedForNode(cs, &node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("getting the current value of %s in pod %s", sysctlVar, pod.Name))
-			valOrig, err := util.GetSysctl(sysctlVar, pod)
+			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))
+			valOrig, err := util.WaitForSysctlInPod(pollInterval, waitDuration, pod, sysctlVar)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("labelling pod %s with label %s", pod.Name, podLabelIngress))
@@ -58,15 +63,15 @@ var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("ensuring the custom worker node profile was set")
-			err = util.EnsureSysctl(pod, sysctlVar, "1")
+			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, "1")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("removing label %s from pod %s", podLabelIngress, pod.Name))
+			ginkgo.By(fmt.Sprintf("removing label %s from Pod %s", podLabelIngress, pod.Name))
 			_, _, err = util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.OperatorNamespace(), pod.Name, podLabelIngress+"-")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("ensuring the original %s value (%s) is set in pod %s", sysctlVar, valOrig, pod.Name))
-			err = util.EnsureSysctl(pod, sysctlVar, valOrig)
+			ginkgo.By(fmt.Sprintf("ensuring the original %s value (%s) is set in Pod %s", sysctlVar, valOrig, pod.Name))
+			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, valOrig)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom ingress profile %s", profileIngress))

--- a/test/e2e/basic/modules.go
+++ b/test/e2e/basic/modules.go
@@ -37,7 +37,12 @@ var _ = ginkgo.Describe("[basic][modules] Node Tuning Operator load kernel modul
 		})
 
 		ginkgo.It(fmt.Sprintf("modules: %s loaded", moduleName), func() {
+			const (
+				pollInterval = 5 * time.Second
+				waitDuration = 5 * time.Minute
+			)
 			cmdGrepModule := []string{"grep", fmt.Sprintf("^%s ", moduleName), procModules}
+
 			ginkgo.By("getting a list of worker nodes")
 			nodes, err := util.GetNodesByRole(cs, "worker")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -64,7 +69,7 @@ var _ = ginkgo.Describe("[basic][modules] Node Tuning Operator load kernel modul
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the %s module is loaded", moduleName))
-			_, err = util.PollExecCmdInPod(5*time.Second, 5*time.Minute, pod, cmdGrepModule...)
+			_, err = util.WaitForCmdInPod(pollInterval, waitDuration, pod, cmdGrepModule...)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting profile %s", profileModules))

--- a/test/e2e/reboots/machine_config_labels.go
+++ b/test/e2e/reboots/machine_config_labels.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -10,7 +11,6 @@ import (
 	coreapi "k8s.io/api/core/v1"
 
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
-	nutil "github.com/openshift/cluster-node-tuning-operator/pkg/util"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
 
@@ -41,6 +41,12 @@ var _ = ginkgo.Describe("[reboots][machine_config_labels] Node Tuning Operator m
 		})
 
 		ginkgo.It("kernel parameters set", func() {
+			const (
+				pollInterval = 5 * time.Second
+				waitDuration = 5 * time.Minute
+			)
+			cmdCatCmdline := []string{"cat", procCmdline}
+
 			ginkgo.By("getting a list of worker nodes")
 			nodes, err := util.GetNodesByRole(cs, "worker")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -50,12 +56,12 @@ var _ = ginkgo.Describe("[reboots][machine_config_labels] Node Tuning Operator m
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a tuned pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("getting the current %s value in pod %s", procCmdline, pod.Name))
-			cmdlineOrig, err := util.GetFileInPod(pod, procCmdline)
+			ginkgo.By(fmt.Sprintf("getting the current %s value in Pod %s", procCmdline, pod.Name))
+			cmdlineOrig, err := util.WaitForCmdInPod(pollInterval, waitDuration, pod, cmdCatCmdline...)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.Logf(fmt.Sprintf("%s has %s: %s", pod.Name, procCmdline, cmdlineOrig))
 
@@ -75,8 +81,8 @@ var _ = ginkgo.Describe("[reboots][machine_config_labels] Node Tuning Operator m
 			err = util.WaitForPoolUpdatedMachineCount(cs, "worker-rt", 1)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("getting the current %s value in pod %s", procCmdline, pod.Name))
-			cmdlineNew, err := util.GetFileInPod(pod, procCmdline)
+			ginkgo.By(fmt.Sprintf("getting the current %s value in Pod %s", procCmdline, pod.Name))
+			cmdlineNew, err := util.WaitForCmdInPod(pollInterval, waitDuration, pod, cmdCatCmdline...)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.Logf("%s has %s: %s", pod.Name, procCmdline, cmdlineNew)
 
@@ -101,14 +107,6 @@ var _ = ginkgo.Describe("[reboots][machine_config_labels] Node Tuning Operator m
 			ginkgo.By(fmt.Sprintf("waiting for worker UpdatedMachineCount == %d", workerMachinesOrig))
 			err = util.WaitForPoolUpdatedMachineCount(cs, "worker", workerMachinesOrig)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			ginkgo.By(fmt.Sprintf("getting the current %s value in pod %s", procCmdline, pod.Name))
-			cmdlineNew, err = util.GetFileInPod(pod, procCmdline)
-			util.Logf("%s has %s: %s", pod.Name, procCmdline, cmdlineNew)
-
-			ginkgo.By("ensuring the original kernel command line was restored")
-			gomega.Expect(nutil.KernelArgumentsEqual(cmdlineOrig, cmdlineNew, "ostree")).To(gomega.BeTrue(),
-				"kernel parameters as retrieved from %s after profile rollback do not match", procCmdline)
 
 			ginkgo.By(fmt.Sprintf("deleting custom MachineConfigPool %s", mcpRealtime))
 			_, _, err = util.ExecAndLogCommand("oc", "delete", "-f", mcpRealtime)

--- a/test/e2e/reboots/stalld.go
+++ b/test/e2e/reboots/stalld.go
@@ -47,7 +47,7 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a tuned pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
Changes:
  - removing code duplication in `test/e2e/util/util.go`
  - documentation for functions in `test/e2e/util/util.go`
  - more expressive function names where `poll.Wait()` is used
  - more flexibility in terms of specifying the interval and
    timeout for `poll.Wait()`
  - for two e2e tests involving reboots removed a check for the
    original kernel command line parameters as the reboots can now
    cause changes not only to "ostree", but also to "root",
    "rhcos.root", "rw";  this would be difficult to maintain in the
    future
  - adhere more to k8s naming conventions ([Pp]od, ...)