### PR TITLE
Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/10-namespace.yaml
+++ b/manifests/10-namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/20-crd-profile.yaml
+++ b/manifests/20-crd-profile.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: profiles.tuned.openshift.io
 spec:
   group: tuned.openshift.io

--- a/manifests/20-crd-tuned.yaml
+++ b/manifests/20-crd-tuned.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: tuneds.tuned.openshift.io
 spec:
   group: tuned.openshift.io

--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"
@@ -16,6 +17,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: node-tuning-operator-tls
   labels:
     name: node-tuning-operator
@@ -36,6 +38,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: prometheus-k8s
   namespace: openshift-cluster-node-tuning-operator
 rules:
@@ -56,6 +59,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: prometheus-k8s
   namespace: openshift-cluster-node-tuning-operator
 roleRef:
@@ -73,6 +77,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: node-tuning-operator
   namespace: openshift-cluster-node-tuning-operator
 spec:
@@ -93,6 +98,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     role: alert-rules
   name: node-tuning-operator

--- a/manifests/40-rbac.yaml
+++ b/manifests/40-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: cluster-node-tuning-operator
   namespace: openshift-cluster-node-tuning-operator
 
@@ -18,6 +19,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: cluster-node-tuning-operator
 rules:
 - apiGroups: ["tuned.openshift.io"]
@@ -67,6 +69,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: cluster-node-tuning-operator
 subjects:
 - kind: ServiceAccount
@@ -87,6 +90,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: tuned
   namespace: openshift-cluster-node-tuning-operator
 
@@ -99,6 +103,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: cluster-node-tuning:tuned
 rules:
 - apiGroups: ["tuned.openshift.io"]
@@ -118,6 +123,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: cluster-node-tuning:tuned
 roleRef:
   kind: ClusterRole

--- a/manifests/50-operator.yaml
+++ b/manifests/50-operator.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: cluster-node-tuning-operator
   namespace: openshift-cluster-node-tuning-operator
 spec:

--- a/manifests/60-clusteroperator.yaml
+++ b/manifests/60-clusteroperator.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: node-tuning
 spec: {}
 status:


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all cluster-node-tuning-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.