### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/10-namespace.yaml
+++ b/manifests/10-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/20-crd-profile.yaml
+++ b/manifests/20-crd-profile.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: profiles.tuned.openshift.io
 spec:
   group: tuned.openshift.io

--- a/manifests/20-crd-tuned.yaml
+++ b/manifests/20-crd-tuned.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: tuneds.tuned.openshift.io
 spec:
   group: tuned.openshift.io

--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
     release.openshift.io/create-only: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"
@@ -18,6 +19,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
     service.beta.openshift.io/serving-cert-secret-name: node-tuning-operator-tls
   labels:
     name: node-tuning-operator
@@ -39,6 +41,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: prometheus-k8s
   namespace: openshift-cluster-node-tuning-operator
 rules:
@@ -60,6 +63,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: prometheus-k8s
   namespace: openshift-cluster-node-tuning-operator
 roleRef:
@@ -78,6 +82,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: node-tuning-operator
   namespace: openshift-cluster-node-tuning-operator
 spec:
@@ -99,6 +104,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     role: alert-rules
   name: node-tuning-operator

--- a/manifests/40-rbac.yaml
+++ b/manifests/40-rbac.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning-operator
   namespace: openshift-cluster-node-tuning-operator
 
@@ -20,6 +21,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning-operator
 rules:
 - apiGroups: ["tuned.openshift.io"]
@@ -70,6 +72,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning-operator
 subjects:
 - kind: ServiceAccount
@@ -91,6 +94,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: tuned
   namespace: openshift-cluster-node-tuning-operator
 
@@ -104,6 +108,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning:tuned
 rules:
 - apiGroups: ["tuned.openshift.io"]
@@ -124,6 +129,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning:tuned
 roleRef:
   kind: ClusterRole

--- a/manifests/50-operator.yaml
+++ b/manifests/50-operator.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning-operator
   namespace: openshift-cluster-node-tuning-operator
 spec:

--- a/manifests/60-clusteroperator.yaml
+++ b/manifests/60-clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: node-tuning
 spec: {}
 status:


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.