### PR TITLE
Bug 1907936: Switch to nto_profile_calculated_total.

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -4,10 +4,10 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
 const (
-	podLabelsUsedQuery = "nto_pod_labels_used_info"
-	profileSetQuery    = "nto_profile_set_total"
-	buildInfoQuery     = "nto_build_info"
-	degradedInfoQuery  = "nto_degraded_info"
+	podLabelsUsedQuery     = "nto_pod_labels_used_info"
+	profileCalculatedQuery = "nto_profile_calculated_total"
+	buildInfoQuery         = "nto_build_info"
+	degradedInfoQuery      = "nto_degraded_info"
 
 	// MetricsPort is the IP port supplied to the HTTP server used for Prometheus,
 	// and matches what is specified in the corresponding Service and ServiceMonitor.
@@ -22,10 +22,10 @@ var (
 			Help: "Is the Pod label functionality turned on (1) or off (0)?",
 		},
 	)
-	profileSet = prometheus.NewCounterVec(
+	profileCalculated = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: profileSetQuery,
-			Help: "The number of times a Tuned profile was set for a given node.",
+			Name: profileCalculatedQuery,
+			Help: "The number of times a Tuned profile was calculated for a given node.",
 		},
 		[]string{"node", "profile"},
 	)
@@ -47,7 +47,7 @@ var (
 func init() {
 	registry.MustRegister(
 		podLabelsUsed,
-		profileSet,
+		profileCalculated,
 		buildInfo,
 		degradedState,
 	)

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -58,10 +58,10 @@ func PodLabelsUsed(enable bool) {
 	podLabelsUsed.Set(0)
 }
 
-// ProfileSet keeps track of the number of times a given Tuned profile
-// resource was set for node 'nodeName'.
-func ProfileSet(nodeName, profileName string) {
-	profileSet.With(map[string]string{"node": nodeName, "profile": profileName}).Inc()
+// ProfileCalculated keeps track of the number of times a given Tuned profile
+// resource was calculated for node 'nodeName'.
+func ProfileCalculated(nodeName, profileName string) {
+	profileCalculated.With(map[string]string{"node": nodeName, "profile": profileName}).Inc()
 }
 
 // RegisterVersion exposes the Operator build version.

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -512,6 +512,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	if err != nil {
 		return err
 	}
+	metrics.ProfileCalculated(profileMf.Name, tunedProfileName)
 
 	profile, err := c.listers.TunedProfiles.Get(profileMf.Name)
 	if err != nil {
@@ -534,7 +535,6 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 			}
 			// Profile created successfully
 			klog.Infof("created profile %s [%s]", profileMf.Name, tunedProfileName)
-			metrics.ProfileSet(profileMf.Name, tunedProfileName)
 			return nil
 		}
 
@@ -565,7 +565,6 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 		return fmt.Errorf("failed to update Profile %s: %v", profile.Name, err)
 	}
 	klog.Infof("updated profile %s [%s]", profile.Name, tunedProfileName)
-	metrics.ProfileSet(nodeName, tunedProfileName)
 
 	return nil
 }


### PR DESCRIPTION
Previously, the metric `nto_profile_set_total` was used to indicate the number of times a profile was "set" for a particular node.  This was inaccurate, mostly due to the lack of reporting a profile applied on a given node.  Change to metric name and the code to report the metric accurately.