### PR TITLE
Bug 1906228: openshift-tuned and Tuned daemon signal handling fixes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=tuned   /root/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
-      socat procps-ng \
+      nmap-ncat procps-ng \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -28,7 +28,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=tuned   /root/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
-      socat procps-ng \
+      nmap-ncat procps-ng \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -29,7 +29,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=tuned   /root/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
-      socat procps-ng \
+      nmap-ncat procps-ng \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \

--- a/assets/bin/run
+++ b/assets/bin/run
@@ -17,7 +17,7 @@ start() {
 
 stop() {
   local timeout=10	# wait $timeout [s] for a reply via the socket
-  local response=$(echo stop | socat -t$timeout - UNIX-CONNECT:$openshift_tuned_socket 2>/dev/null)
+  local response=$(echo stop | nc -i$timeout -U $openshift_tuned_socket 2>/dev/null)
 
   if [ "$response" != "ok" ]; then
     # provide a failure message in the event log

--- a/assets/tuned/patches/010-terminate.diff
+++ b/assets/tuned/patches/010-terminate.diff
@@ -1,0 +1,20 @@
+Lower the threading.Event's wait() timeout.
+
+The current 3600s wait() timeout in the controller's loop is too high.  There
+are known instances of signals not being acted upon.  One known example is
+SIGTERM not being acted upon during system shutdown.  Lowering the timeout
+to 5s allows for this signal to be acted upon right after the timeout.
+
+See: https://github.com/redhat-performance/tuned/pull/319
+
+--- a/tuned/daemon/controller.py
++++ b/tuned/daemon/controller.py
+@@ -61,7 +61,7 @@ class Controller(tuned.exports.interfaces.ExportableInterface):
+ 		if daemon:
+ 			self._terminate.clear()
+ 			# we have to pass some timeout, otherwise signals will not work
+-			while not self._cmd.wait(self._terminate, 3600):
++			while not self._cmd.wait(self._terminate, 5):
+ 				pass
+ 
+ 		log.info("terminating controller")

--- a/pkg/tuned/tuned.go
+++ b/pkg/tuned/tuned.go
@@ -922,6 +922,7 @@ func (c *Controller) changeWatcher() (err error) {
 
 			if string(data) != socketCmdStop {
 				// We only support one command over the socket interface at this point
+				klog.Warningf("ignoring unsupported command received over socket: %s", string(data))
 				continue
 			}
 


### PR DESCRIPTION
Changes:
  - Reviewed openshift-tuned signal handling.  The Tuned daemon is now more "supervised" by openshift-tuned in terms of termination.
  - Replace socat with nmap-ncat.  Neither `-t<timeout>` nor `-T<timeout>` for socat seemed to be working reliably to quit trying after `<timeout>` socket inactivity.  nmap-ncat with `-i<timeout>`, on the other hand does exactly what is needed, i.e. sets an idle (read/write) timeout.
  - Be less aggressive wrt. restarting the Tuned daemon and quitting the supervisor process.  Sometimes it is actually desirable not to restart and quit (e.g. system shutdown/reboot).
  - Added an e2e test to test the functionality of the container lifecycle preStop hook (Tuned daemon profile settings rollback).
  - Added a patch for the Tuned daemon to resolve the issue with `SIGTERM`
    not being handled in time by the Tuned daemon.