### PR TITLE
Bug 1920438: Fix openshift-tuned panic on turning debugging on/off.

### DIFF
--- a/pkg/tuned/tuned.go
+++ b/pkg/tuned/tuned.go
@@ -484,7 +484,9 @@ func (c *Controller) tunedRestart() (err error) {
 	if _, err = c.tunedStop(); err != nil {
 		return err
 	}
-	c.tunedCmd = nil // Cmd.Start() cannot be used more than once
+	c.tunedCmd = nil                 // Cmd.Start() cannot be used more than once
+	c.tunedExit = make(chan bool, 1) // Once tunedStop() terminates, the tunedExit channel is closed!
+
 	if err = c.tunedReload(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes openshift-tuned panic on turning debugging on/off introduced by:
https://github.com/openshift/cluster-node-tuning-operator/pull/192