### PR TITLE
Bug 1925072: Updating to the latest stalld v1.7.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN INSTALL_PKGS=" \
     rpm -V $INSTALL_PKGS && \
     dnf --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
     find /root/rpms -name \*.rpm -exec basename {} .rpm \; | xargs rpm -e --justdb && \
-    cp -a /var/lib/tuned/tuned/stalld/stalld /usr/local/bin && \
+    cp -a /var/lib/tuned/tuned/stalld/{stalld,scripts/throttlectl.sh} /usr/local/bin && \
     rm -rf /var/lib/tuned/tuned && \
     touch /etc/sysctl.conf && \
     dnf clean all && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -35,7 +35,7 @@ RUN INSTALL_PKGS=" \
     rpm -V $INSTALL_PKGS && \
     yum --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
     find /root/rpms -name \*.rpm -exec basename {} .rpm \; | xargs rpm -e --justdb && \
-    cp -a /var/lib/tuned/tuned/stalld/stalld /usr/local/bin && \
+    cp -a /var/lib/tuned/tuned/stalld/{stalld,scripts/throttlectl.sh} /usr/local/bin && \
     rm -rf /var/lib/tuned/tuned && \
     touch /etc/sysctl.conf && \
     yum clean all && \

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -36,7 +36,7 @@ RUN INSTALL_PKGS=" \
     rpm -V $INSTALL_PKGS && \
     dnf --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
     find /root/rpms -name \*.rpm -exec basename {} .rpm \; | xargs rpm -e --justdb && \
-    cp -a /var/lib/tuned/tuned/stalld/stalld /usr/local/bin && \
+    cp -a /var/lib/tuned/tuned/stalld/{stalld,scripts/throttlectl.sh} /usr/local/bin && \
     rm -rf /var/lib/tuned/tuned && \
     touch /etc/sysctl.conf && \
     dnf clean all && \

--- a/assets/tuned/stalld/Makefile
+++ b/assets/tuned/stalld/Makefile
@@ -1,17 +1,23 @@
 NAME	:=	stalld
-VERSION	:=	1.0
+VERSION	:=	1.7
 
 INSTALL	=	install
 CC	:=	gcc
-CFLAGS	:=	-Wall -O2 -g
+FOPTS	:=	-flto=auto -ffat-lto-objects -fexceptions -fstack-protector-strong \
+		-fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection
+MOPTS	:=	-m64 -mtune=generic
+WOPTS	:= 	-Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
+SOPTS	:= 	-specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1
+
+CFLAGS	:=	-O2 -g -DVERSION=\"$(VERSION)\" $(FOPTS) $(MOPTS) $(WOPTS) $(SOPTS)
 LDFLAGS	:=	-ggdb
 LIBS	:=	 -lpthread
 
 SRC	:=	$(wildcard src/*.c)
 HDR	:=	$(wildcard src/*.h)
 OBJ	:=	$(SRC:.c=.o)
-DIRS	:=	src redhat man
-FILES	:=	Makefile README.md gpl-2.0.txt
+DIRS	:=	src redhat man tests scripts
+FILES	:=	Makefile README.md gpl-2.0.txt scripts/throttlectl.sh
 TARBALL	:=	$(NAME)-$(VERSION).tar.xz
 UPSTREAM_TARBALLS	:= fedorapeople.org:~/public_html/
 BINDIR	:=	/usr/bin
@@ -31,7 +37,6 @@ static: $(OBJ)
 	$(CC) -o stalld-static $(LDFLAGS) --static $(OBJ) $(LIBS)
 
 tests:
-	make -C tests
 
 .PHONY: install
 install:
@@ -50,9 +55,9 @@ clean:
 	@test ! -f stalld-static || rm stalld-static
 	@test ! -f src/stalld.o || rm src/stalld.o
 	@test ! -f $(TARBALL) || rm -f $(TARBALL)
-	@make -C redhat clean
+	@make -C redhat VERSION=$(VERSION) clean
 	@make -C tests clean
-	@rm -rf *~ $(OBJ)
+	@rm -rf *~ $(OBJ) *.tar.xz
 
 tarball:  clean
 	rm -rf $(NAME)-$(VERSION) && mkdir $(NAME)-$(VERSION)
@@ -61,8 +66,8 @@ tarball:  clean
 	rm -rf $(NAME)-$(VERSION)
 
 redhat: tarball
-	$(MAKE) -C redhat
+	$(MAKE) -C redhat VERSION=$(VERSION)
 
 push: tarball
 	scp $(TARBALL) $(UPSTREAM_TARBALLS)
-	make -C redhat push
+	make -C redhat VERSION=$(VERSION) push

--- a/assets/tuned/stalld/README.md
+++ b/assets/tuned/stalld/README.md
@@ -52,3 +52,10 @@ option.
                           threads on all CPU (uses more CPU/power). [false]
 ### Miscellaneous
 - -h/--help: print this menu
+
+## Repositories
+The repository at https://gitlab.com/rt-linux-tools/stalld is the main
+repository, where the development takes place.
+
+The repository at https://git.kernel.org/pub/scm/utils/stalld/stalld.git is the
+distribution repository, where distros can pick the latest released version.

--- a/assets/tuned/stalld/scripts/throttlectl.sh
+++ b/assets/tuned/stalld/scripts/throttlectl.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/bash
+
+# This script is called to either turn off or turn on RT throttling
+# The 'off' argument causes the current values of the throttling
+# parameters from /proc/sys/kernel/sched_rt_{period,runtime}_us to
+# be saved and then rt throttling to be disabled.
+# The 'on' argument causes the previously saved values to be restored
+# or if those are not found the defaults are re-applied.
+
+path=/proc/sys/kernel
+cmd=$1
+savefile=/tmp/rtthrottle
+defperiod=1000000
+defruntime=950000
+case ${cmd} in
+    # turn off RT throttling and save previous values
+    off)
+	runtime=$(cat $path/sched_rt_runtime_us)
+	period=$(cat $path/sched_rt_period_us)
+	echo "period=$period" > $savefile
+	echo "runtime=$runtime" >> $savefile
+	# don't do anything if it's already disabled
+	if [[ "${runtime}" != "-1" ]]; then
+	    echo -1 > $path/sched_rt_runtime_us
+	fi
+	# verify that we really turned it off
+	if [[ "$(cat $path/sched_rt_runtime_us)" != "-1" ]]; then
+	    logger -t stalld "failed to turn off RT throttling"
+	    exit -1
+	fi
+	logger -t stalld "Disabled RT throttling"
+	;;
+
+    # turn on RT throttling and restore previous values
+    on)
+	if [[ -f $savefile ]]; then
+	    period=$(awk -F= '/^period/ {print $2}' $savefile)
+	    runtime=$(awk -F= '/^runtime/ {print $2}' $savefile)
+	    rm -f $savefile
+	else
+	    period=$defperiod
+	    runtime=$defruntime
+	fi
+	echo $period > $path/sched_rt_period_us
+	echo $runtime > $path/sched_rt_runtime_us
+	logger -t stalld "Restored RT throttling"
+    ;;
+    show)
+	echo "Period:  $(cat $path/sched_rt_period_us)"
+	echo "Runtime: $(cat $path/sched_rt_runtime_us)"
+	;;
+    *)
+	echo "usage: $0 on|off"
+	exit 0
+	;;
+esac

--- a/assets/tuned/stalld/src/stalld.h
+++ b/assets/tuned/stalld/src/stalld.h
@@ -9,16 +9,17 @@
 #ifndef __STALLD_H__
 #define __STALLD_H__
 
-#define BUFFER_SIZE		(100*1024)
+#define BUFFER_SIZE		(10*_SC_PAGE_SIZE)
 #define MAX_WAITING_PIDS	30
 
+#define COMM_SIZE		15
 /* informnation about running tasks on a cpu */
 struct task_info {
        int pid;
        int prio;
        int ctxsw;
        time_t since;
-       char comm[15];
+       char comm[COMM_SIZE+1];
 };
 
 /* information about cpus */
@@ -92,13 +93,13 @@ static inline void normalize_timespec(struct timespec *ts)
 
 void die(const char *fmt, ...);
 void warn(const char *fmt, ...);
+void info(const char *fmt, ...);
 void log_msg(const char *fmt, ...);
 
 long get_long_from_str(char *start);
 long get_long_after_colon(char *start);
 long get_variable_long_value(char *buffer, const char *variable);
 
-int turn_off_rt_throttling(void);
 int setup_signal_handling(void);
 void deamonize(void);
 int setup_hr_tick(void);
@@ -106,12 +107,14 @@ int should_monitor(int cpu);
 void usage(const char *fmt, ...);
 void write_pidfile(void);
 int parse_args(int argc, char **argv);
+int rt_throttling_is_off(void);
+int turn_off_rt_throttling(void);
 
 /*
- * shared variables 
+ * shared variables
  */
 extern int running;
-
+extern const char *version;
 extern int config_verbose;
 extern int config_write_kmesg;
 extern int config_log_syslog;
@@ -126,5 +129,6 @@ extern long config_boost_duration;
 extern long config_aggressive;
 extern int config_monitor_all_cpus;
 extern char *config_monitored_cpus;
+extern int config_systemd;
 extern char pidfile[];
 #endif /* __STALLD_H__ */

--- a/assets/tuned/stalld/src/throttling.c
+++ b/assets/tuned/stalld/src/throttling.c
@@ -36,6 +36,7 @@ static long rt_runtime_us = 0;
 
 static void restore_rt_throttling(int status, void *arg)
 {
+	int retval;
 	if (rt_runtime_us != -1) {
 		int fd = open(RT_RUNTIME_PATH, O_WRONLY);
 		char buffer[80];
@@ -43,7 +44,10 @@ static void restore_rt_throttling(int status, void *arg)
 		if (fd < 0)
 			die("restore_rt_throttling: failed to open %s\n", RT_RUNTIME_PATH);
 		sprintf(buffer, "%ld", rt_runtime_us);
-		write(fd, buffer, strlen(buffer));
+		retval = write(fd, buffer, strlen(buffer));
+		if (retval < 0)
+			warn("restore_rt_throttling: error restoring rt throttling");
+
 		close(fd);
 		log_msg("RT Throttling runtime restored to %d\n", rt_runtime_us);
 	}
@@ -81,5 +85,32 @@ int turn_off_rt_throttling(void)
 	close(fd);
 	on_exit(restore_rt_throttling, NULL);
 	log_msg("RT Throttling disabled\n");
+	return 0;
+}
+
+
+int rt_throttling_is_off(void)
+{
+	int ret;
+	const char *runtime = "/proc/sys/kernel/sched_rt_runtime_us";
+	int fd = open(runtime, O_RDONLY);
+	char buffer[80];
+
+	if (fd < 0)
+		die("unable to open %s to check throttling status: %s\n", runtime, strerror(errno));
+
+	ret = read(fd, buffer, sizeof(buffer));
+	if (ret <= 0)
+		die ("unable to read %s to get runtime status: %s\n", runtime, strerror(errno));
+	close(fd);
+
+	if (ret < sizeof(buffer))
+	    buffer[ret] = '\0';
+
+	if (buffer[ret-1] == '\n')
+		buffer[ret-1] = '\0';
+
+	if (strcmp(buffer, "-1") == 0)
+		return 1;
 	return 0;
 }


### PR DESCRIPTION
Changes:
  - updated https://gitlab.com/rt-linux-tools/stalld.git to v1.7.0
    (9ed8ff901c378a1e17041411e78d14b0fa9ed64e)
  - included throttlectl.sh from the repo above to disable/enable
    RT throttling reliably.  The disable of RT throttling was moved
    into the script to run before stalld is started and the enabling
    of it to be run in the script after the stalld service is stopped.