### PR TITLE
Bug 1925072: Remove architecture specific gcc flags.

### DIFF
--- a/assets/tuned/stalld/Makefile
+++ b/assets/tuned/stalld/Makefile
@@ -4,8 +4,8 @@ VERSION	:=	1.7
 INSTALL	=	install
 CC	:=	gcc
 FOPTS	:=	-flto=auto -ffat-lto-objects -fexceptions -fstack-protector-strong \
-		-fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection
-MOPTS	:=	-m64 -mtune=generic
+		-fasynchronous-unwind-tables -fstack-clash-protection
+MOPTS	:=	-m64
 WOPTS	:= 	-Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
 SOPTS	:= 	-specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1
 


### PR DESCRIPTION
The `-mtune=generic` is IA32/AMD64/EM64T processor specific.  Also, with `-fcf-protection` GCC fails to build `stalld` on other architectures such as ppc64/s390x.
