### PR TITLE
Add more related objects to ClusterOperator.

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -293,7 +293,8 @@ func getRelatedObjects() []configv1.ObjectReference {
 		// The `resource` property of `relatedObjects` stanza should be the lowercase, plural value like `daemonsets`.
 		// See BZ1851214
 		{Group: "", Resource: "namespaces", Name: tunedMf.Namespace},
-		{Group: "tuned.openshift.io", Resource: "tuneds", Name: tunedMf.Name, Namespace: tunedMf.Namespace},
+		{Group: "tuned.openshift.io", Resource: "profiles", Name: "", Namespace: tunedMf.Namespace},
+		{Group: "tuned.openshift.io", Resource: "tuneds", Name: "", Namespace: tunedMf.Namespace},
 		{Group: "apps", Resource: "daemonsets", Name: dsMf.Name, Namespace: dsMf.Namespace},
 	}
 }


### PR DESCRIPTION
Add all objects from the "tuned.openshift.io" API group.  All Profiles
and Tuneds will now be collected during `oc adm must-gather`.