### PR TITLE
Bug 1926903: Instantiate the stalld systemd unit as disabled.

### DIFF
--- a/assets/tuned/patches/030-service-enable-disable.diff
+++ b/assets/tuned/patches/030-service-enable-disable.diff
@@ -1,0 +1,20 @@
+Using the service plugin to enable/disable a service might results in
+conflicts with MCO taking care of enablement/disablement of a systemd units.
+This might potentially results in block upgrades once proper checking and
+error reporting is in place in future MCO versions.
+
+--- a/tuned/plugins/plugin_service.py
++++ b/tuned/plugins/plugin_service.py
+@@ -114,10 +114,10 @@ class SystemdHandler(InitHandler):
+ 		cmd.execute(["systemctl", "stop", name])
+ 
+ 	def enable(self, name, runlevel):
+-		cmd.execute(["systemctl", "enable", name])
++		log.warn("service plugin enablement is not supported")
+ 
+ 	def disable(self, name, runlevel):
+-		cmd.execute(["systemctl", "disable", name])
++		log.warn("service plugin disablement is not supported")
+ 
+ 	def is_running(self, name):
+ 		(retcode, out) = cmd.execute(["systemctl", "is-active", name], no_errors = [0])

--- a/pkg/tuned/host_payload.go
+++ b/pkg/tuned/host_payload.go
@@ -85,7 +85,7 @@ User=root
 
 	return ign3types.Unit{
 		Contents: pointer.StringPtr(unit),
-		Enabled:  pointer.BoolPtr(true),
+		Enabled:  pointer.BoolPtr(false),
 		Name:     "stalld.service"}
 }
 

--- a/test/e2e/testing_manifests/stalld-disable.yaml
+++ b/test/e2e/testing_manifests/stalld-disable.yaml
@@ -1,0 +1,27 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-realtime
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift realtime profile
+      include=openshift-node,realtime
+      [variables]
+      # isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7
+      isolated_cores=1
+      #isolate_managed_irq=Y
+      not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+      [bootloader]
+      cmdline_ocp_realtime=+systemd.cpu_affinity=${not_isolated_cores_expanded}
+      [service]
+      service.stalld=stop,disable
+    name: openshift-realtime
+
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: "worker-rt"
+    priority: 20
+    profile: openshift-realtime

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -114,8 +114,8 @@ func ExecCmdInPod(pod *corev1.Pod, cmd ...string) (string, error) {
 // did not match non-nil 'valExp' by the time duration 'duration' elapsed.
 func waitForCmdOutputInPod(interval, duration time.Duration, pod *corev1.Pod, valExp *string, trim bool, cmd ...string) (string, error) {
 	var (
-		val          string
-		err, explain error
+		val, sTrimmed string
+		err, explain  error
 	)
 	err = wait.PollImmediate(interval, duration, func() (bool, error) {
 		val, err = ExecCmdInPod(pod, cmd...)
@@ -132,11 +132,18 @@ func waitForCmdOutputInPod(interval, duration time.Duration, pod *corev1.Pod, va
 		}
 		return true, nil
 	})
+	sTrimmed = " "
+	if trim {
+		sTrimmed = "(leading/trailing whitespace trimmed) "
+	}
 	if valExp != nil && val != *valExp {
-		return val, fmt.Errorf("command %s outputs (leading/trailing whitespace trimmed) %s in Pod %s, expected %s: %v", cmd, val, pod.Name, *valExp, explain)
+		return val, fmt.Errorf("command %s outputs %s %sin Pod %s, expected %s: %v", cmd, val, sTrimmed, pod.Name, *valExp, explain)
+	}
+	if err != nil {
+		return val, fmt.Errorf("command %s outputs %s %sin Pod %s: %v", cmd, val, sTrimmed, pod.Name, explain)
 	}
 
-	return val, err
+	return val, nil
 }
 
 // WaitForCmdInPod runs command with arguments 'cmd' in Pod 'pod' at an interval


### PR DESCRIPTION
Leave the start/enablement of the stalld daemon entirely up to the Tuned `[service]` plugin.  This resolves the race between systemd starting the stall daemon and the Tuned `[service]` plugin running too early.

Other changes:
  - Improving e2e tests for the stalld functionality.
  - Better logging for e2e tests failures.

Resolves rhbz#1926903.