### PR TITLE
Add "core" e2e tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ $(GOBINDATA_BIN):
 	$(GO) build -o $(GOBINDATA_BIN) ./vendor/github.com/kevinburke/go-bindata/go-bindata
 
 test-e2e: $(BINDATA)
-	for d in basic reboots; do \
+	for d in core basic reboots; do \
 	  KUBERNETES_CONFIG="$(KUBECONFIG)" $(GO) test -v -timeout 40m ./test/e2e/$$d -ginkgo.v -ginkgo.noColor -ginkgo.failFast || exit; \
 	done
 

--- a/test/e2e/core/cluster_version.go
+++ b/test/e2e/core/cluster_version.go
@@ -1,0 +1,45 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	coreapi "k8s.io/api/core/v1"
+
+	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
+)
+
+// Test the core functionality by reporting host, container OS and cluster version.
+var _ = ginkgo.Describe("[core][cluster_version] Node Tuning Operator host, container OS and cluster version", func() {
+	var (
+		node *coreapi.Node
+	)
+
+	ginkgo.It("host, container OS and cluster version retrievable", func() {
+		ginkgo.By("getting a list of worker nodes")
+		nodes, err := util.GetNodesByRole(cs, "worker")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
+
+		node = &nodes[0]
+		ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+		pod, err := util.GetTunedForNode(cs, node)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.By(fmt.Sprintf("getting the host OS version on node %s", node.Name))
+		out, err := util.ExecCmdInPod(pod, "cat", "/host/etc/os-release")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		util.Logf("%s", out)
+
+		ginkgo.By("getting the Tuned container OS version")
+		out, err = util.ExecCmdInPod(pod, "cat", "/etc/os-release")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		util.Logf("%s", out)
+
+		ginkgo.By("getting the cluster version")
+		_, _, err = util.ExecAndLogCommand("oc", "get", "clusterversion", "version", "-o", "jsonpath='{.status.desired.version}'")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/test/e2e/core/operator_test.go
+++ b/test/e2e/core/operator_test.go
@@ -1,0 +1,19 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	"github.com/openshift/cluster-node-tuning-operator/test/framework"
+)
+
+var (
+	cs = framework.NewClientSet()
+)
+
+func TestNodeTuningOperator(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Node Tuning Operator e2e tests: core")
+}


### PR DESCRIPTION
The core e2e tests are checking the ability to retrieve:
  - host and container OS release
  - cluster version

This information is also useful for debugging e2e test failures in cases the developer has no access to the cluster e2e tests are running on.