### PR TITLE
Add additionalPrinterColumns to profiles CRD.

### DIFF
--- a/manifests/20-crd-profile.yaml
+++ b/manifests/20-crd-profile.yaml
@@ -17,7 +17,20 @@ spec:
   preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.config.tunedProfile
+      name: Tuned
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Applied")].status
+      name: Applied
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     served: true
     storage: true
     schema:

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -566,6 +566,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	profile = profile.DeepCopy() // never update the objects from cache
 	profile.Spec.Config.TunedProfile = tunedProfileName
 	profile.Spec.Config.Debug = daemonDebug
+	profile.Status.Conditions = tunedpkg.InitializeStatusConditions()
 
 	klog.V(2).Infof("syncProfile(): updating Profile %s [%s]", profile.Name, tunedProfileName)
 	_, err = c.clients.Tuned.TunedV1().Profiles(ntoconfig.OperatorNamespace()).Update(context.TODO(), profile, metav1.UpdateOptions{})

--- a/pkg/tuned/tuned.go
+++ b/pkg/tuned/tuned.go
@@ -649,6 +649,12 @@ func (c *Controller) timedUpdater() (err error) {
 			reload = true
 		} else {
 			klog.Infof("active and recommended profile (%s) match; profile change will not trigger profile reload", activeProfile)
+			// We do not need to reload the tuned daemon, however, someone may have tampered with the k8s Profile for this node.
+			// Make sure it is up-to-date.
+			if err = c.updateTunedProfile(); err != nil {
+				klog.Error(err.Error())
+				return nil // retry later
+			}
 		}
 		c.change.profile = false
 	}


### PR DESCRIPTION
Changes:
  - add additionalPrinterColumns Tuned, Applied and Degraded
    to profiles.tuned.openshift.io; this will help with quick
    identification which Tuned profile is applied on which node
    and what is the status of the application.
  - fix an issue with profile status not being synced when
    manually changed or removed
  - always initialize TunedProfile's status conditions after NTO
    calculates new Tuned profile to be applied or we know Tuned
    daemon will be necessary in situations such as toggling Tuned
    daemon's debugging.