### PR TITLE
TuneD: udev: explicitly sort udev properties

### DIFF
--- a/assets/tuned/patches/040-explicitly_sort_udev_properties.diff
+++ b/assets/tuned/patches/040-explicitly_sort_udev_properties.diff
@@ -1,0 +1,21 @@
+udev: explicitly sort udev properties
+
+Although udev properties are sorted by libudev, according
+to libudev/systemd upstream this behavior cannot be relied
+upon. Sort them explicitly for consistent behavior.
+
+Resolves: rhbz#1939970
+
+See: https://github.com/redhat-performance/tuned/pull/333
+
+--- a/tuned/hardware/device_matcher_udev.py
++++ a/tuned/hardware/device_matcher_udev.py
+@@ -18,7 +18,7 @@ def match(self, regex, device):
+ 		except AttributeError:
+ 			items = device.items()
+ 
+-		for key, val in list(items):
++		for key, val in sorted(list(items)):
+ 			properties += key + '=' + val + '\n'
+ 
+ 		return re.search(regex, properties, re.MULTILINE) is not None


### PR DESCRIPTION
Although udev properties are sorted by libudev, according
to libudev/systemd upstream this behavior cannot be relied
upon. Sort them explicitly for consistent behavior.

See upstream TuneD patch:
https://github.com/redhat-performance/tuned/pull/333