### PR TITLE
Add management workload annotations

### DIFF
--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -15,6 +15,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         openshift-app: tuned
     spec:

--- a/manifests/10-namespace.yaml
+++ b/manifests/10-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/single-node-production-edge: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-cluster-node-tuning-operator

--- a/manifests/50-operator.yaml
+++ b/manifests/50-operator.yaml
@@ -15,6 +15,8 @@ spec:
       name: cluster-node-tuning-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-node-tuning-operator
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>