### PR TITLE
Bug 1948782: Revert "add 'single-node-production-edge' annotations to CVO manifests."

### DIFF
--- a/manifests/10-namespace.yaml
+++ b/manifests/10-namespace.yaml
@@ -5,7 +5,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   labels:

--- a/manifests/20-crd-profile.yaml
+++ b/manifests/20-crd-profile.yaml
@@ -5,7 +5,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: profiles.tuned.openshift.io
 spec:
   group: tuned.openshift.io

--- a/manifests/20-crd-tuned.yaml
+++ b/manifests/20-crd-tuned.yaml
@@ -5,7 +5,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: tuneds.tuned.openshift.io
 spec:
   group: tuned.openshift.io

--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -5,7 +5,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
     release.openshift.io/create-only: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"
@@ -19,7 +18,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
     service.beta.openshift.io/serving-cert-secret-name: node-tuning-operator-tls
   labels:
     name: node-tuning-operator
@@ -41,7 +39,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: prometheus-k8s
   namespace: openshift-cluster-node-tuning-operator
 rules:
@@ -63,7 +60,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: prometheus-k8s
   namespace: openshift-cluster-node-tuning-operator
 roleRef:
@@ -82,7 +78,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: node-tuning-operator
   namespace: openshift-cluster-node-tuning-operator
 spec:
@@ -104,7 +99,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     role: alert-rules
   name: node-tuning-operator

--- a/manifests/40-rbac.yaml
+++ b/manifests/40-rbac.yaml
@@ -7,7 +7,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning-operator
   namespace: openshift-cluster-node-tuning-operator
 
@@ -21,7 +20,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning-operator
 rules:
 - apiGroups: ["tuned.openshift.io"]
@@ -72,7 +70,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning-operator
 subjects:
 - kind: ServiceAccount
@@ -94,7 +91,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: tuned
   namespace: openshift-cluster-node-tuning-operator
 
@@ -108,7 +104,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning:tuned
 rules:
 - apiGroups: ["tuned.openshift.io"]
@@ -129,7 +124,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning:tuned
 roleRef:
   kind: ClusterRole

--- a/manifests/50-operator.yaml
+++ b/manifests/50-operator.yaml
@@ -5,7 +5,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: cluster-node-tuning-operator
   namespace: openshift-cluster-node-tuning-operator
 spec:

--- a/manifests/60-clusteroperator.yaml
+++ b/manifests/60-clusteroperator.yaml
@@ -5,7 +5,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/single-node-production-edge: "true"
   name: node-tuning
 spec: {}
 status:


### PR DESCRIPTION
Reverts openshift/cluster-node-tuning-operator#187