### PR TITLE
Rename workload annotations

### DIFF
--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         openshift-app: tuned
     spec:

--- a/manifests/50-operator.yaml
+++ b/manifests/50-operator.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-node-tuning-operator
     spec:


### PR DESCRIPTION
As per openshift/enhancements#739, the workload annotations names are changing.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged
