### PR TITLE
Bug 1960337: manifests: fix selector in node-tuning-operator ServiceMonitor

### DIFF
--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -90,7 +90,8 @@ spec:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: node-tuning-operator.openshift-cluster-node-tuning-operator.svc
   selector:
-    name: node-tuning-operator
+    matchLabels:
+      name: node-tuning-operator
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule


### PR DESCRIPTION
Invalid spec in ServiceMonitor makes CVO attempt to apply this manifest on every sync loop.