### PR TITLE
Bug 1973154: Switch back to NTO-shipped stalld.

### DIFF
--- a/pkg/tuned/tuned.go
+++ b/pkg/tuned/tuned.go
@@ -70,7 +70,7 @@ const (
 	// If useSystemStalld is set to true, use the OS-shipped stalld; otherwise, use the
 	// NTO-shipped version.  The aim here is to switch back to the legacy code easily just
 	// by setting this constant to false.
-	useSystemStalld = true
+	useSystemStalld = false
 )
 
 // Types


### PR DESCRIPTION
RHCOS-shipped stalld units do not ship with chrt changing the SCHED_FIFO scheduling policy for stalld causing starvation of the boosting threads.  Until this is fixed in RHCOS, use the NTO-provided stalld.