### PR TITLE
Bug 1974277: Fix conditional order for setting net device param.

### DIFF
--- a/assets/tuned/patches/050-net-device-conditional-order.diff
+++ b/assets/tuned/patches/050-net-device-conditional-order.diff
@@ -1,0 +1,21 @@
+Fix conditional order for setting net device param
+
+The conditional for setting a net device parameter has
+a faulty order where it can potentially try to first cast a string to int
+in a wrong manner and only then check if the value is a specific integer value.
+
+See: https://github.com/redhat-performance/tuned/pull/360
+
+diff --git a/tuned/plugins/plugin_net.py b/tuned/plugins/plugin_net.py
+index 55a3d32b..1f4fabbc 100644
+--- a/tuned/plugins/plugin_net.py
++++ b/tuned/plugins/plugin_net.py
+@@ -397,7 +397,7 @@ def _set_device_parameters(self, context, value, device, sim,
+ 		if dev_params:
+ 			self._check_device_support(context, d, device, dev_params)
+ 			# replace the channel parameters based on the device support
+-			if context == "channels" and (int(dev_params[next(iter(d))]) == 0 or str(dev_params[next(iter(d))]) == 'n/a'):
++			if context == "channels" and str(dev_params[next(iter(d))]) in ["n/a", "0"]:
+ 				d = self._replace_channels_parameters(context, self._cmd.dict2list(d), dev_params)
+ 
+ 		if not sim and len(d) != 0:


### PR DESCRIPTION
The conditional for setting a net device parameter in TuneD has a wrong order where it can potentially try to first cast a string to int in a wrong manner and only then check if the value is a specific integer value.

Upstream TuneD fix: https://github.com/redhat-performance/tuned/pull/360

Resolves rhbz#1974277.