### PR TITLE
[WIP] Pin kernel-tools to test GCP disruptive tests upgrade theory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM centos:8 as tuned
 WORKDIR /root
 COPY assets /root/assets
 RUN INSTALL_PKGS=" \
-      gcc git rpm-build make desktop-file-utils patch dnf-plugins-core \
+      gcc git rpm-build make desktop-file-utils patch dnf-plugins-core kernel-tools-libs-4.18.0-305.3.1.el8_4.x86_64 kernel-tools-4.18.0-305.3.1.el8_4.x86_64 python3-perf-4.18.0-305.3.1.el8_4.x86_64 \
       " && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     cd assets/tuned/daemon && \
@@ -29,7 +29,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=tuned   /root/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
-      nmap-ncat procps-ng \
+      nmap-ncat procps-ng kernel-tools-libs-4.18.0-305.3.1.el8_4.x86_64 kernel-tools-4.18.0-305.3.1.el8_4.x86_64 python3-perf-4.18.0-305.3.1.el8_4.x86_64 \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -7,7 +7,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.9 AS tuned
 WORKDIR /root
 COPY assets /root/assets
 RUN INSTALL_PKGS=" \
-      gcc git rpm-build make desktop-file-utils patch dnf-plugins-core \
+      gcc git rpm-build make desktop-file-utils patch dnf-plugins-core kernel-tools-libs-4.18.0-305.3.1.el8_4.x86_64 kernel-tools-4.18.0-305.3.1.el8_4.x86_64 python3-perf-4.18.0-305.3.1.el8_4.x86_64 \
       " && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     cd assets/tuned/daemon && \
@@ -29,7 +29,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=tuned   /root/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
-      nmap-ncat procps-ng \
+      nmap-ncat procps-ng kernel-tools-libs-4.18.0-305.3.1.el8_4.x86_64 kernel-tools-4.18.0-305.3.1.el8_4.x86_64 python3-perf-4.18.0-305.3.1.el8_4.x86_64 \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \


### PR DESCRIPTION
I've been trying to dig into each of the things that changed around the
time we see the disruption, and there's not a lot, but there's also
nothing obvious.  The main change that Clayton pointed to was `stalld`
bump but that team came back and said it's not even used by default (and
confirmed by looking at logs).

However, that change caused the cluster-node-tuning-operator container
image to be rebuilt, and it pulled in an updated kernel-tools package.

```
< kernel-tools-4.18.0-305.3.1.el8_4.x86_64
< kernel-tools-libs-4.18.0-305.3.1.el8_4.x86_64
---
> kernel-tools-4.18.0-305.7.1.el8_4.x86_64
> kernel-tools-libs-4.18.0-305.7.1.el8_4.x86_64
```

This change pins the kernel tools to the older version, as a way to
test what's happening. There's not a lot more avenues to explore for
why our upgrades are failing this way.