### PR TITLE
e2e tests: s/plugin/plug-in/ and TuneD renaming

### DIFF
--- a/test/e2e/basic/custom_node_labels.go
+++ b/test/e2e/basic/custom_node_labels.go
@@ -46,7 +46,7 @@ var _ = ginkgo.Describe("[basic][custom_node_labels] Node Tuning Operator custom
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/e2e/basic/custom_pod_labels.go
+++ b/test/e2e/basic/custom_pod_labels.go
@@ -46,7 +46,7 @@ var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom 
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 			node := nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err = util.GetTunedForNode(cs, &node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/e2e/basic/default_irq_smp_affinity.go
+++ b/test/e2e/basic/default_irq_smp_affinity.go
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("[basic][default_irq_smp_affinity] Node Tuning Operator 
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/e2e/basic/default_node_sysctl.go
+++ b/test/e2e/basic/default_node_sysctl.go
@@ -26,7 +26,7 @@ var _ = ginkgo.Describe("[basic][default_node_sysctl] Node Tuning Operator defau
 		gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 		node := nodes[0]
-		ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+		ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 		pod, err := util.GetTunedForNode(cs, &node)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/e2e/basic/modules.go
+++ b/test/e2e/basic/modules.go
@@ -49,7 +49,7 @@ var _ = ginkgo.Describe("[basic][modules] Node Tuning Operator load kernel modul
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/e2e/basic/netdev_set_channels.go
+++ b/test/e2e/basic/netdev_set_channels.go
@@ -16,7 +16,7 @@ import (
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
 
-// Test the tuned daemon functionality to adjust netdev queue count for physical network devices via ethtool.
+// Test the TuneD daemon functionality to adjust netdev queue count for physical network devices via ethtool.
 var _ = ginkgo.Describe("[basic][netdev_set_channels] Node Tuning Operator adjust netdev queue count", func() {
 	const (
 		profileNetdev   = "../testing_manifests/netdev_set_channels.yaml"
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("[basic][netdev_set_channels] Node Tuning Operator adjus
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.Logf("found Pod %s running on node %s", pod.Name, node.Name)

--- a/test/e2e/basic/rollback.go
+++ b/test/e2e/basic/rollback.go
@@ -14,7 +14,7 @@ import (
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
 
-// Test the functionality of the preStop container lifecycle hook -- Tuned settings rollback.
+// Test the functionality of the preStop container lifecycle hook -- TuneD settings rollback.
 var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollback", func() {
 	const (
 		profileIngress  = "../../../examples/ingress.yaml"
@@ -23,7 +23,7 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 		sysctlValDef    = "2" // default value of 'sysctlVar'
 	)
 
-	ginkgo.Context("Tuned settings rollback", func() {
+	ginkgo.Context("TuneD settings rollback", func() {
 		var (
 			pod *coreapi.Pod
 		)
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 			node := nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err = util.GetTunedForNode(cs, &node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 			pod = nil
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("waiting for a new tuned Pod to be ready on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("waiting for a new TuneD Pod to be ready on node %s", node.Name))
 			err = wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
 				pod, err = util.GetTunedForNode(cs, &node)
 				if err != nil {

--- a/test/e2e/basic/sysctl_d_override.go
+++ b/test/e2e/basic/sysctl_d_override.go
@@ -49,7 +49,7 @@ var _ = ginkgo.Describe("[basic][sysctl_d_override] Node Tuning Operator /etc/sy
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 			node := &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -66,7 +66,7 @@ var _ = ginkgo.Describe("[basic][sysctl_d_override] Node Tuning Operator /etc/sy
 			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "pod", pod.Name, "--wait")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("waiting for a new tuned Pod to be ready on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("waiting for a new TuneD Pod to be ready on node %s", node.Name))
 			err = wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
 				pod, err = util.GetTunedForNode(cs, node)
 				if err != nil {
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("[basic][sysctl_d_override] Node Tuning Operator /etc/sy
 			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "pod", pod.Name, "--wait")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By(fmt.Sprintf("waiting for a new Tuned Pod to be ready on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("waiting for a new TuneD Pod to be ready on node %s", node.Name))
 			err = wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
 				pod, err = util.GetTunedForNode(cs, node)
 				if err != nil {

--- a/test/e2e/basic/tuned_errors_and_recovery.go
+++ b/test/e2e/basic/tuned_errors_and_recovery.go
@@ -16,15 +16,15 @@ import (
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
 
-// Test the creation a Tuned Profile causing the Tuned daemon to bail out with an error message and a recovery after deleting the Profile
-var _ = ginkgo.Describe("[basic][tuned_errors_and_recovery] Cause Tuned daemon errors and recover", func() {
+// Test the creation a Tuned Profile causing the TuneD daemon to bail out with an error message and a recovery after deleting the Profile
+var _ = ginkgo.Describe("[basic][tuned_errors_and_recovery] Cause TuneD daemon errors and recover", func() {
 	const (
 		profileCauseTunedFailure   = "../testing_manifests/cause_tuned_failure.yaml"
 		profileDummy               = "../testing_manifests/dummy.yaml"
 		nodeLabelCauseTunedFailure = "tuned.openshift.io/cause-tuned-failure"
 	)
 
-	ginkgo.Context("Tuned daemon errors and recovery", func() {
+	ginkgo.Context("TuneD daemon errors and recovery", func() {
 		var (
 			node *coreapi.Node
 		)
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("[basic][tuned_errors_and_recovery] Cause Tuned daemon e
 			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileCauseTunedFailure)
 		})
 
-		ginkgo.It("Cause Tuned daemon errors on invalid profile load and recover after the profile deletion", func() {
+		ginkgo.It("Cause TuneD daemon errors on invalid profile load and recover after the profile deletion", func() {
 			const (
 				pollInterval          = 5 * time.Second
 				waitDuration          = 5 * time.Minute

--- a/test/e2e/core/cluster_version.go
+++ b/test/e2e/core/cluster_version.go
@@ -24,7 +24,7 @@ var _ = ginkgo.Describe("[core][cluster_version] Node Tuning Operator host, cont
 		gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
 		node = &nodes[0]
-		ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+		ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 		pod, err := util.GetTunedForNode(cs, node)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -33,7 +33,7 @@ var _ = ginkgo.Describe("[core][cluster_version] Node Tuning Operator host, cont
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		util.Logf("%s", out)
 
-		ginkgo.By("getting the Tuned container OS version")
+		ginkgo.By("getting the TuneD container OS version")
 		out, err = util.ExecCmdInPod(pod, "cat", "/etc/os-release")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		util.Logf("%s", out)

--- a/test/e2e/reboots/kernel_parameter_add_rm.go
+++ b/test/e2e/reboots/kernel_parameter_add_rm.go
@@ -62,7 +62,7 @@ var _ = ginkgo.Describe("[reboots][kernel_parameter_add_rm] Node Tuning Operator
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/e2e/reboots/machine_config_labels.go
+++ b/test/e2e/reboots/machine_config_labels.go
@@ -56,7 +56,7 @@ var _ = ginkgo.Describe("[reboots][machine_config_labels] Node Tuning Operator m
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/e2e/reboots/stalld.go
+++ b/test/e2e/reboots/stalld.go
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			node = &nodes[0]
-			ginkgo.By(fmt.Sprintf("getting a Tuned Pod running on node %s", node.Name))
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -62,7 +62,7 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 			_, _, err = util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelRealtime+"=")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// BZ1926903: check for the systemd/Tuned [service] plugin race
+			// BZ1926903: check for the systemd/TuneD [service] plug-in race
 			ginkgo.By(fmt.Sprintf("creating custom realtime profile %s with stalld service stopped,disabled", profileStalldOff))
 			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileStalldOff)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 			util.ExecCmdInPod(pod, "chroot", "/host", "reboot")
 			// Ignore errors; we can get "exit status 143", i.e. SIGTERM caused by the reboot
 
-			// Wait for the host to reboot and the Tuned [service] plugin to start/enable stalld service.
+			// Wait for the host to reboot and the TuneD [service] plug-in to start/enable stalld service.
 			ginkgo.By(fmt.Sprintf("checking the stalld daemon is running on node %s", node.Name))
 			out, err = util.WaitForCmdInPod(pollInterval, 20*time.Minute, pod, "pidof", "stalld")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -52,14 +52,14 @@ func GetTunedForNode(cs *framework.ClientSet, node *corev1.Node) (*corev1.Pod, e
 
 	podList, err := cs.Pods(ntoconfig.OperatorNamespace()).List(context.TODO(), listOptions)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't get a list of Tuned Pods: %v", err)
+		return nil, fmt.Errorf("couldn't get a list of TuneD Pods: %v", err)
 	}
 
 	if len(podList.Items) != 1 {
 		if len(podList.Items) == 0 {
-			return nil, fmt.Errorf("failed to find a Tuned Pod for node %s", node.Name)
+			return nil, fmt.Errorf("failed to find a TuneD Pod for node %s", node.Name)
 		}
-		return nil, fmt.Errorf("too many (%d) Tuned Pods for node %s", len(podList.Items), node.Name)
+		return nil, fmt.Errorf("too many (%d) TuneD Pods for node %s", len(podList.Items), node.Name)
 	}
 	return &podList.Items[0], nil
 }


### PR DESCRIPTION
This is a cleanup PR.  Where appropriate (e.g. not Tuned CR), references to the TuneD were fixed for e2e tests as per the upstream project.
