### PR TITLE
Bug 1992560: monitoring: comply with OpenShift alerting guidelines

### DIFF
--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -110,7 +110,10 @@ spec:
     rules:
     - alert: NTOPodsNotReady
       annotations:
-        message: Pod {{ $labels.pod }} on node {{ $labels.node }} is not ready.
+        description: |
+          Pod {{ $labels.pod }} is not ready.
+          Review the "Event" objects in "openshift-cluster-node-tuning-operator" namespace for further details.
+        summary: Pod {{ $labels.pod }} is not ready.
       expr: |
         kube_pod_status_ready{namespace='openshift-cluster-node-tuning-operator', condition='true'} == 0
       for: 30m
@@ -118,8 +121,8 @@ spec:
         severity: warning
     - alert: NTODegraded
       annotations:
-        message: |
-          The Node Tuning Operator is degraded. Review the "node-tuning" ClusterOperator object for further details.
+        description: The Node Tuning Operator is degraded. Review the "node-tuning" ClusterOperator object for further details.
+        summary: The Node Tuning Operator is degraded.
       expr: nto_degraded_info == 1
       for: 2h
       labels:


### PR DESCRIPTION
Adding more verbose description to alerts and moving
message -> summary based on OpenShift alerting guidelines:
https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#documentation-required

Removing {{ $labels.node }} as it produced empty output in alerts
and is redundant anyway.

Resolves: rhbz#1992560