### PR TITLE
Bug 1998120: Add a cgroup blacklisting rule to parent openshift profile.

### DIFF
--- a/assets/tuned/manifests/default-cr-tuned.yaml
+++ b/assets/tuned/manifests/default-cr-tuned.yaml
@@ -34,6 +34,10 @@ spec:
       /sys/module/nvme_core/parameters/io_timeout=4294967295
       /sys/module/nvme_core/parameters/max_retries=10
 
+      [scheduler]
+      # see rhbz#1998120; exclude containers from aligning to house keeping CPUs
+      cgroup_ps_blacklist=/kubepods\.slice/
+
   - name: "openshift-control-plane"
     data: |
       [main]


### PR DESCRIPTION
Add a cgroup blacklisting rule to parent openshift profile to prevent the `[scheduler]` plug-in from handling containers; see rhbz#1998120.