### PR TITLE
Bug 1998247: Reload when deps of recommended profile change.

### DIFF
--- a/test/e2e/testing_manifests/cause_tuned_failure.yaml
+++ b/test/e2e/testing_manifests/cause_tuned_failure.yaml
@@ -7,8 +7,8 @@ spec:
   profile:
   - data: |
       [main]
-      summary=A Tuned daemon profile that does not exist
-      include=profile-does-not-exist
+      summary=A TuneD daemon profile that includes a dummy profile
+      include=openshift-dummy
     name: openshift-cause-tuned-failure
   recommend:
   - match:

--- a/test/e2e/testing_manifests/dummy.yaml
+++ b/test/e2e/testing_manifests/dummy.yaml
@@ -1,0 +1,12 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-dummy
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=A dummy profile with no settings
+    name: openshift-dummy
+  recommend: []


### PR DESCRIPTION
This change fixes operand's behavior during administrator-initiated changes of TuneD profiles that the currently recommended TuneD profile depends on.  Now, changes to any such dependent profile and changes to the recommended TuneD profile will cause TuneD daemon reload.

Resolves rhbz#1998247.