### PR TITLE
Bug 1999608: Reload when deps of recommended profile change.

### DIFF
--- a/pkg/tuned/tuned.go
+++ b/pkg/tuned/tuned.go
@@ -50,6 +50,7 @@ const (
 	timedUpdaterInterval   = 1
 	programName            = "openshift-tuned"
 	tunedProfilesDir       = "/etc/tuned"
+	tunedConfFile          = "tuned.conf"
 	tunedActiveProfileFile = tunedProfilesDir + "/active_profile"
 	tunedRecommendDir      = tunedProfilesDir + "/recommend.d"
 	tunedRecommendFile     = tunedRecommendDir + "/50-openshift.conf"
@@ -302,9 +303,18 @@ func disableSystemTuned() {
 	}
 }
 
-// profilesExtract extracts Tuned daemon profiles to the daemon configuration directory.
-// If the data in the to be extracted recommended profile is different than the current
-// recommended profile, the function returns true.
+func profilesEqual(profileFile string, profileData string) bool {
+	content, err := ioutil.ReadFile(profileFile)
+	if err != nil {
+		content = []byte{}
+	}
+
+	return profileData == string(content)
+}
+
+// profilesExtract extracts TuneD daemon profiles to the daemon configuration directory.
+// If the data in the to-be-extracted recommended profile or the profiles being included
+// from the current recommended profile have changed, the function returns true.
 func profilesExtract(profiles []tunedv1.TunedProfile) (bool, error) {
 	var (
 		change bool
@@ -325,34 +335,34 @@ func profilesExtract(profiles []tunedv1.TunedProfile) (bool, error) {
 			continue
 		}
 		profileDir := fmt.Sprintf("%s/%s", tunedProfilesDir, *profile.Name)
-		profileFile := fmt.Sprintf("%s/%s", profileDir, "tuned.conf")
+		profileFile := fmt.Sprintf("%s/%s", profileDir, tunedConfFile)
 
 		if err := mkdir(profileDir); err != nil {
-			return change, fmt.Errorf("failed to create Tuned profile directory %q: %v", profileDir, err)
+			return change, fmt.Errorf("failed to create TuneD profile directory %q: %v", profileDir, err)
 		}
 
-		if recommendedProfile == *profile.Name {
-			// Recommended profile name matches profile of the profile currently being extracted, compare their content.
+		// Get a list of TuneD profiles names the recommended profile depends on.
+		recommendedProfileDeps := profileDepends(recommendedProfile)
+		// Add the recommended profile itself.
+		recommendedProfileDeps[recommendedProfile] = true
+		if recommendedProfileDeps[*profile.Name] {
+			// Recommended profile (dependency) name matches profile name of the profile
+			// currently being extracted, compare their content.
 			var un string
-			content, err := ioutil.ReadFile(profileFile)
-			if err != nil {
-				content = []byte{}
-			}
-
-			change = *profile.Data != string(content)
+			change = change || !profilesEqual(profileFile, *profile.Data)
 			if !change {
 				un = "un"
 			}
-			klog.Infof("recommended Tuned profile %s content %schanged", recommendedProfile, un)
+			klog.Infof("recommended TuneD profile %s content %schanged [%s]", recommendedProfile, un, *profile.Name)
 		}
 
 		f, err := os.Create(profileFile)
 		if err != nil {
-			return change, fmt.Errorf("failed to create Tuned profile file %q: %v", profileFile, err)
+			return change, fmt.Errorf("failed to create TuneD profile file %q: %v", profileFile, err)
 		}
 		defer f.Close()
 		if _, err = f.WriteString(*profile.Data); err != nil {
-			return change, fmt.Errorf("failed to write Tuned profile file %q: %v", profileFile, err)
+			return change, fmt.Errorf("failed to write TuneD profile file %q: %v", profileFile, err)
 		}
 	}
 
@@ -778,6 +788,45 @@ func (c *Controller) stalldRequested(profileName string) (*bool, error) {
 	}
 
 	return &ret, nil
+}
+
+// profileIncludes returns a slice of strings containing TuneD profile names
+// custom (/etc/tuned/<profileName>/) profile 'profileName' includes.
+func profileIncludes(profileName string) []string {
+	profileFile := fmt.Sprintf("%s/%s/%s", tunedProfilesDir, profileName, tunedConfFile)
+
+	content, err := ioutil.ReadFile(profileFile)
+	if err != nil {
+		content = []byte{}
+	}
+
+	s := string(content)
+
+	return getIniFileSectionSlice(&s, "main", "include", ",")
+}
+
+// profileDepends returns "TuneD profile name"->bool map that custom
+// (/etc/tuned/<profileName>/) profile 'profileName' depends on as keys.
+// The dependency is resolved by finding all the "parent" profiles which are
+// included by using the "include" keyword in the profile's [main] section.
+// Note: no expansion of the TuneD functions into profiles names, such as
+// "f:virt_check" is performed by this function.  Only static parsing of
+// the TuneD INI configuration files is performed.
+func profileDepends(profileName string) map[string]bool {
+	return profileDependsLoop(profileName, map[string]bool{})
+}
+
+func profileDependsLoop(profileName string, seenProfiles map[string]bool) map[string]bool {
+	profiles := profileIncludes(profileName)
+	for _, p := range profiles {
+		if seenProfiles[p] {
+			// We have already seen/processed custom profile 'p'.
+			continue
+		}
+		seenProfiles[p] = true
+		seenProfiles = profileDependsLoop(p, seenProfiles)
+	}
+	return seenProfiles
 }
 
 // Method updateTunedProfile updates a Tuned profile with information to report back

--- a/test/e2e/testing_manifests/cause_tuned_failure.yaml
+++ b/test/e2e/testing_manifests/cause_tuned_failure.yaml
@@ -7,8 +7,8 @@ spec:
   profile:
   - data: |
       [main]
-      summary=A Tuned daemon profile that does not exist
-      include=profile-does-not-exist
+      summary=A TuneD daemon profile that includes a dummy profile
+      include=openshift-dummy
     name: openshift-cause-tuned-failure
   recommend:
   - match:

--- a/test/e2e/testing_manifests/dummy.yaml
+++ b/test/e2e/testing_manifests/dummy.yaml
@@ -1,0 +1,12 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-dummy
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=A dummy profile with no settings
+    name: openshift-dummy
+  recommend: []


### PR DESCRIPTION
This change fixes operand's behavior during administrator-initiated changes of TuneD profiles that the currently recommended TuneD profile depends on.  Now, changes to any such dependent profile and changes to the recommended TuneD profile will cause TuneD daemon reload.
