### PR TITLE
RBAC: tighten the rules and remove unnecessary listers.

### DIFF
--- a/manifests/40-rbac.yaml
+++ b/manifests/40-rbac.yaml
@@ -22,40 +22,45 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   name: cluster-node-tuning-operator
 rules:
+# We own (the right to perform anything with) tuned.openshift.io
 - apiGroups: ["tuned.openshift.io"]
   resources: ["*"]
   verbs: ["*"]
+# The operator oversees tuned daemonset.  It even needs to be able
+# to delete it when the operator is put into "Removed" state.
 - apiGroups: ["apps"]
   resources: ["daemonsets"]
-  verbs: ["create","get","delete","list","update","watch"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterroles","clusterrolebindings"]
   verbs: ["create","get","delete","list","update","watch"]
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
   verbs: ["use"]
+# ConfigMaps manipulation is needed by the leader election code.
 # "" indicates the core API group
 - apiGroups: [""]
-  resources: ["configmaps","namespaces","secrets","serviceaccounts","services"]
+  resources: ["configmaps"]
   verbs: ["create","get","delete","list","update","watch"]
+# The pod-matching functionality will likely be deprecated in the
+# future.  When it is, remove "pods" below.
 - apiGroups: [""]
   resources: ["nodes","pods"]
   verbs: ["get","list","watch"]
+# Necessary for the implementation of metrics.
 - apiGroups: [""]
   resources: ["nodes/metrics","nodes/specs"]
   verbs: ["get"]
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create","patch"]
+# Needed by every CVO-managed operator.
 - apiGroups: ["config.openshift.io"]
   resources: ["clusteroperators"]
   verbs: ["create","get","list","watch"]
+# Needed by every CVO-managed operator.
 - apiGroups: ["config.openshift.io"]
   resources: ["clusteroperators/status"]
   verbs: ["update"]
+# Needed by the core operator functionality.
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigs"]
   verbs: ["create","get","delete","list","update","watch"]
+# Needed by the core operator functionality.
 - apiGroups: ["machineconfiguration.openshift.io"]
   resources: ["machineconfigpools"]
   verbs: ["get","list","watch"]

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -3,7 +3,6 @@ package client
 import (
 	kappslisters "k8s.io/client-go/listers/apps/v1"
 	kcorelisters "k8s.io/client-go/listers/core/v1"
-	krbaclisters "k8s.io/client-go/listers/rbac/v1"
 
 	configlisters "github.com/openshift/client-go/config/listers/config/v1"
 
@@ -12,16 +11,12 @@ import (
 )
 
 type Listers struct {
-	DaemonSets          kappslisters.DaemonSetNamespaceLister
-	Pods                kcorelisters.PodLister
-	Nodes               kcorelisters.NodeLister
-	Secrets             kcorelisters.SecretNamespaceLister
-	ServiceAccounts     kcorelisters.ServiceAccountNamespaceLister
-	ClusterRoles        krbaclisters.ClusterRoleLister
-	ClusterRoleBindings krbaclisters.ClusterRoleBindingLister
-	ClusterOperators    configlisters.ClusterOperatorLister
-	TunedResources      ntolisters.TunedNamespaceLister
-	TunedProfiles       ntolisters.ProfileNamespaceLister
-	MachineConfigs      mcfglisters.MachineConfigLister
-	MachineConfigPools  mcfglisters.MachineConfigPoolLister
+	DaemonSets         kappslisters.DaemonSetNamespaceLister
+	Pods               kcorelisters.PodLister
+	Nodes              kcorelisters.NodeLister
+	ClusterOperators   configlisters.ClusterOperatorLister
+	TunedResources     ntolisters.TunedNamespaceLister
+	TunedProfiles      ntolisters.ProfileNamespaceLister
+	MachineConfigs     mcfglisters.MachineConfigLister
+	MachineConfigPools mcfglisters.MachineConfigPoolLister
 }


### PR DESCRIPTION
This PR tightenes the RBAC rules for the operator and removes
unnecessary listers.  This is a cleanup that should have been performed
when we switched from operator-sdk and after some RBAC rules stopped
being necessary to clean up the accumulated secrets (see rhbz#1714484).