### PR TITLE
Bug 2013321: TuneD: workaround for high CPU utilization of [scheduler] plug-in.

### DIFF
--- a/assets/tuned/patches/040-openshift-profiles-aws.diff
+++ b/assets/tuned/patches/040-openshift-profiles-aws.diff
@@ -17,6 +17,8 @@ index af2f2bc6..9b370ea2 100644
  [scheduler]
  # see rhbz#1979352; exclude containers from aligning to house keeping CPUs
  cgroup_ps_blacklist=/kubepods\.slice/
++# workaround for rhbz#1921738
++runtime=0
 +
 +[sysfs]
 +/sys/module/nvme_core/parameters/io_timeout=4294967295


### PR DESCRIPTION
The fix for rhbz#1979352 introduced the [scheduler] plug-in as a
standard part of openshift TuneD profiles.  Unfortunately, the
[scheduler] plug-in can be very CPU intensive, especially on the
OpenShift platform.  The bug for this issue is tracked by rhbz#1921738.
Until this is fixed, work around this problem by adding "runtime=0"
[scheduler] plug-in option.