### PR TITLE
Bug 2013678: TuneD: workaround for high CPU utilization of [scheduler] plug-in.

### DIFF
--- a/assets/tuned/manifests/default-cr-tuned.yaml
+++ b/assets/tuned/manifests/default-cr-tuned.yaml
@@ -37,6 +37,8 @@ spec:
       [scheduler]
       # see rhbz#1998120; exclude containers from aligning to house keeping CPUs
       cgroup_ps_blacklist=/kubepods\.slice/
+      # workaround for rhbz#1921738
+      runtime=0
 
   - name: "openshift-control-plane"
     data: |


### PR DESCRIPTION
The fix for rhbz#1979352 introduced the [scheduler] plug-in as a
standard part of openshift TuneD profiles.  Unfortunately, the
[scheduler] plug-in can be very CPU intensive, especially on the
OpenShift platform.  The bug for this issue is tracked by rhbz#1921738.
Until this is fixed, work around this problem by adding "runtime=0"
[scheduler] plug-in option.

Other changes:
  - Address a race in the stalld e2e test.  The race was sometimes causing
    the TuneD daemon re-enable and start stalld service after it was
    intentionally stopped by the test itself using systemctl.