### PR TITLE
Bug 2017427: tuned: add timeout and restarts

### DIFF
--- a/pkg/tuned/tuned.go
+++ b/pkg/tuned/tuned.go
@@ -565,7 +565,7 @@ func (c *Controller) tunedReload(timeoutInitiated bool) error {
 	}
 
 	if c.tunedCmd == nil {
-		// Tuned hasn't been started by openshift-tuned, start it.
+		// TuneD hasn't been started by openshift-tuned, start it.
 		c.tunedCmd = c.tunedCreateCmd()
 		go c.tunedRun()
 		return nil


### PR DESCRIPTION
TuneD profile application typically takes ~0.5s and should never take
more than ~5s.  However, there were cases where TuneD daemon got stuck
during application of a profile.  Experience shows that subsequent
restarts of TuneD can resolve this in certain situations.  TuneD itself,
however, has no mechanism for restarting a profile application that is
taking too long.

This change implements full restarts for TuneD daemon with exponential
backoff.

Other changes:
  - tunedStop() is now fully synchronous.  Previously, when TuneD
    refused to terminate within 10s, SIGKILL was sent without waiting
    for TuneD process to terminate.
  - no TuneD log processing is done when stopping TuneD.

Also see: rhbz#2013940
