### PR TITLE
Bug 2016988: openshift profile: fix malformed patch

### DIFF
--- a/assets/tuned/patches/040-openshift-profiles-aws.diff
+++ b/assets/tuned/patches/040-openshift-profiles-aws.diff
@@ -13,7 +13,7 @@ diff --git a/assets/tuned/daemon/profiles/openshift/tuned.conf b/assets/tuned/da
 index af2f2bc6..9b370ea2 100644
 --- a/profiles/openshift/tuned.conf
 +++ b/profiles/openshift/tuned.conf
-@@ -28,3 +28,7 @@ vm.max_map_count=262144
+@@ -28,3 +28,9 @@
  [scheduler]
  # see rhbz#1979352; exclude containers from aligning to house keeping CPUs
  cgroup_ps_blacklist=/kubepods\.slice/


### PR DESCRIPTION
AWS Nitro instances need special tuning for NVME devices, see:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes

```
[sysfs]
/sys/module/nvme_core/parameters/io_timeout=4294967295
/sys/module/nvme_core/parameters/max_retries=10
```

This change fixes the malformed patch for the openshift profile.

This tuning will be moved to Cloud Provider specific profiles once the
functionality in NTO is implemented.