### PR TITLE
Bug 2020518: tuned: add timeout and restarts

### DIFF
--- a/pkg/tuned/tuned.go
+++ b/pkg/tuned/tuned.go
@@ -58,6 +58,16 @@ const (
 	// a couple of seconds should be more than enough for Tuned daemon to gracefully stop;
 	// be generous and give it 10s
 	tunedGracefulExitWait = time.Second * time.Duration(10)
+	// TuneD profile application typically takes ~0.5s and should never take more than ~5s.
+	// However, there were cases where TuneD daemon got stuck during application of a profile.
+	// Experience shows that subsequent restarts of TuneD can resolve this in certain situations,
+	// but not in others -- an extreme example is a TuneD profile including a profile that does
+	// not exist.  TuneD itself has no mechanism for restarting a profile application that takes
+	// too long.  The tunedTimeout below is time to wait for "profile applied/reload failed" from
+	// TuneD logs before restarting TuneD and thus retrying the profile application.  Keep this
+	// reasonably low to workaround system/TuneD issues as soon as possible, but not too low
+	// to increase the system load by retrying profile applications that can never succeed.
+	tunedInitialTimeout   = 60 // timeout in seconds
 	openshiftTunedRunDir  = "/run/" + programName
 	openshiftTunedPidFile = openshiftTunedRunDir + "/" + programName + ".pid"
 	openshiftTunedSocket  = "/var/lib/tuned/openshift-tuned.sock"
@@ -113,11 +123,15 @@ type Controller struct {
 		debug bool
 		// bit/set representaton of Profile status conditions to report back via API
 		status Bits
+		// stopping is true while the controller tries to stop the TuneD daemon.
+		stopping bool
 	}
 
-	tunedCmd  *exec.Cmd       // external command (tuned) being prepared or run
-	tunedExit chan bool       // bi-directional channel to signal and register Tuned daemon exit
-	stopCh    <-chan struct{} // receive-only channel to stop the openshift-tuned controller
+	tunedCmd     *exec.Cmd       // external command (tuned) being prepared or run
+	tunedExit    chan bool       // bi-directional channel to signal and register Tuned daemon exit
+	stopCh       <-chan struct{} // receive-only channel to stop the openshift-tuned controller
+	tunedTicker  *time.Ticker    // ticker that fires if TuneD daemon fails to report "profile XYZ applied" within tunedTimeout
+	tunedTimeout int             // timeout for TuneD daemon to report "profile applied/reload failed" [s]
 }
 
 type wqKey struct {
@@ -169,13 +183,15 @@ func newController(stopCh <-chan struct{}) (*Controller, error) {
 	listers := &ntoclient.Listers{}
 	clients := &ntoclient.Clients{}
 	controller := &Controller{
-		kubeconfig: kubeconfig,
-		workqueue:  workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		listers:    listers,
-		clients:    clients,
-		tunedExit:  make(chan bool, 1),
-		stopCh:     stopCh,
+		kubeconfig:  kubeconfig,
+		workqueue:   workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		listers:     listers,
+		clients:     clients,
+		tunedExit:   make(chan bool, 1),
+		stopCh:      stopCh,
+		tunedTicker: time.NewTicker(tunedInitialTimeout),
 	}
+	controller.tunedTicker.Stop() // The ticker will be started/reset when TuneD starts.
 
 	return controller, nil
 }
@@ -417,6 +433,7 @@ func (c *Controller) tunedRun() {
 
 			if profileApplied {
 				c.daemon.status |= scApplied
+				c.tunedTicker.Stop() // profile successfully applied, stop the TuneD watcher
 			}
 
 			if strings.Index(l, " WARNING ") >= 0 {
@@ -454,9 +471,14 @@ func (c *Controller) tunedRun() {
 
 // tunedStop tries to gracefully stop the Tuned daemon process by sending it SIGTERM.
 // If the Tuned daemon does not respond by terminating within tunedGracefulExitWait
-// duration, SIGKILL is sent.  This method returns an indication whether the Tuned
-// daemon exitted gracefully (true) or SIGTERM had to be sent (false).
+// duration, SIGKILL is sent.  This method returns an indication whether the TuneD
+// daemon exitted gracefully (true) or SIGKILL had to be sent (false).
 func (c *Controller) tunedStop() (bool, error) {
+	c.daemon.stopping = true
+	defer func() {
+		c.daemon.stopping = false
+	}()
+
 	if c.tunedCmd == nil {
 		// Looks like there has been a termination signal prior to starting tuned
 		return false, nil
@@ -477,6 +499,7 @@ func (c *Controller) tunedStop() (bool, error) {
 		// within tunedGracefulExitWait
 		klog.V(1).Infof("sending SIGKILL to PID %d", c.tunedCmd.Process.Pid)
 		c.tunedCmd.Process.Signal(syscall.SIGKILL)
+		<-c.tunedExit
 		return false, nil
 	}
 	klog.V(1).Infof("Tuned process terminated gracefully")
@@ -484,9 +507,19 @@ func (c *Controller) tunedStop() (bool, error) {
 	return true, nil
 }
 
-func (c *Controller) tunedReload() error {
+func (c *Controller) tunedReload(timeoutInitiated bool) error {
+	c.daemon.reloading = true
+	c.daemon.status = 0 // clear the set out of which Profile status conditions are created
+	tunedTimeout := time.Second * time.Duration(tunedInitialTimeout)
+	if c.tunedTicker == nil {
+		// This should never happen as the ticker is initialized at controller creation time.
+		c.tunedTicker = time.NewTicker(tunedTimeout)
+	} else {
+		c.tunedTicker.Reset(tunedTimeout)
+	}
+
 	if c.tunedCmd == nil {
-		// Tuned hasn't been started by openshift-tuned, start it
+		// TuneD hasn't been started by openshift-tuned, start it
 		c.tunedCmd = c.tunedCreateCmd()
 		go c.tunedRun()
 		return nil
@@ -497,7 +530,6 @@ func (c *Controller) tunedReload() error {
 	if c.tunedCmd.Process != nil {
 		klog.Infof("sending HUP to PID %d", c.tunedCmd.Process.Pid)
 		err := c.tunedCmd.Process.Signal(syscall.SIGHUP)
-		c.daemon.reloading = true
 		if err != nil {
 			return fmt.Errorf("error sending SIGHUP to PID %d: %v\n", c.tunedCmd.Process.Pid, err)
 		}
@@ -509,14 +541,14 @@ func (c *Controller) tunedReload() error {
 	return nil
 }
 
-func (c *Controller) tunedRestart() (err error) {
+func (c *Controller) tunedRestart(timeoutInitiated bool) (err error) {
 	if _, err = c.tunedStop(); err != nil {
 		return err
 	}
 	c.tunedCmd = nil                 // Cmd.Start() cannot be used more than once
 	c.tunedExit = make(chan bool, 1) // Once tunedStop() terminates, the tunedExit channel is closed!
 
-	if err = c.tunedReload(); err != nil {
+	if err = c.tunedReload(timeoutInitiated); err != nil {
 		return err
 	}
 	return nil
@@ -597,7 +629,7 @@ func (c *Controller) timedUpdater() (err error) {
 		// Complete restart of the Tuned daemon needed.
 		c.change.daemon = false
 		c.change.profile = false
-		return c.tunedRestart()
+		return c.tunedRestart(false)
 	}
 
 	if c.change.bootcmdline || c.daemon.reloaded {
@@ -658,7 +690,7 @@ func (c *Controller) timedUpdater() (err error) {
 	}
 
 	if reload {
-		err = c.tunedReload()
+		err = c.tunedReload(false)
 	}
 	return err
 }
@@ -777,11 +809,6 @@ func (c *Controller) updateTunedProfile() (err error) {
 		bootcmdline     string
 		stalldRequested *bool
 	)
-
-	if c.daemon.reloading {
-		// This should not be necessary, but keep this here as a reminder.
-		return fmt.Errorf("updateTunedProfile(): called while the Tuned daemon was reloading")
-	}
 
 	if bootcmdline, err = getBootcmdline(); err != nil {
 		// This should never happen unless something is seriously wrong (e.g. Tuned
@@ -1024,8 +1051,30 @@ func (c *Controller) changeWatcher() (err error) {
 		case err := <-wFs.Errors:
 			return fmt.Errorf("error watching filesystem: %v", err)
 
+		case <-c.tunedTicker.C:
+			klog.Errorf("timeout (%d) to apply TuneD profile; restarting TuneD daemon", tunedInitialTimeout)
+			err := c.tunedRestart(true)
+			if err != nil {
+				return err
+			}
+			// TuneD profile application is failing, make this visible in "oc get profile" output.
+			if err = c.updateTunedProfile(); err != nil {
+				klog.Error(err.Error())
+			}
+
 		case <-tickerUpdate.C:
 			klog.V(2).Infof("tickerUpdate.C")
+
+			if c.daemon.stopping {
+				// We have decided to stop TuneD.  Apart from showing the logs it is
+				// now unnecessary/undesirable to perform any of the following actions.
+				// The undesirability comes from extra processing which will come if
+				// TuneD manages to "get unstuck" during this phase before it receives
+				// SIGKILL (note the time window between SIGTERM/SIGKILL).
+				klog.Infof("c.daemon.stopping...")
+				continue
+			}
+
 			if c.daemon.reloading {
 				// Do not reload the Tuned daemon unless it finished reloading
 				continue
@@ -1102,6 +1151,7 @@ func retryLoop(c *Controller) (err error) {
 }
 
 func Run(stopCh <-chan struct{}, boolVersion *bool, version string) {
+	klog.Infof("starting %s %s", programName, version)
 	parseCmdOpts()
 
 	if *boolVersion {


### PR DESCRIPTION
TuneD profile application typically takes ~0.5s and should never take
more than ~5s.  However, there were cases where TuneD daemon got stuck
during application of a profile.  Experience shows that subsequent
restarts of TuneD can resolve this in certain situations.  TuneD itself,
however, has no mechanism for restarting a profile application that is
taking too long.

This change implements full restarts for TuneD daemon.

Other changes:
  - tunedStop() is now fully synchronous.  Previously, when TuneD
    refused to terminate within 10s, SIGKILL was sent without waiting
    for TuneD process to terminate.

Also see: rhbz#2013940