### PR TITLE
openshift-tuned: TuneD built-in function support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ endif
 vet: $(BINDATA)
 	$(GO) vet ./...
 
-test:
+test-unit: $(BINDATA)
 	$(GO) test ./cmd/... ./pkg/... -coverprofile cover.out
 
 clean:

--- a/pkg/tuned/tuned_parser_test.go
+++ b/pkg/tuned/tuned_parser_test.go
@@ -1,0 +1,69 @@
+package tuned
+
+import (
+	"testing"
+)
+
+func TestBuiltinExpansion(t *testing.T) {
+	var tests = []struct {
+		input          string
+		expectedOutput string
+	}{
+		// Basic expansion.
+		{
+			input:          "provider_cloudX",
+			expectedOutput: "provider_cloudX",
+		},
+		{
+			input:          "provider_${f:exec:printf:cloudX}",
+			expectedOutput: "provider_cloudX",
+		},
+		{
+			input:          "provider_$cloudX",
+			expectedOutput: "provider_$cloudX",
+		},
+		{
+			input:          "provider_${f:exec:printf:cloudX}_$$_${}cl'oudX${f:",
+			expectedOutput: "provider_cloudX_$$_${}cl'oudX${f:",
+		},
+		// Deeper nesting in functions and its arguments.
+		{
+			input:          "provider_${f:${f:exec:printf:exec}:printf:cloudX}",
+			expectedOutput: "provider_cloudX",
+		},
+		{
+			input:          "provider_${f:${f:${f:exec:printf:exec}:printf:exec}:printf:cloudX}",
+			expectedOutput: "provider_cloudX",
+		},
+		{
+			input:          "provider_${f:exec:${f:exec:printf:printf}:cloudX}",
+			expectedOutput: "provider_cloudX",
+		},
+		{
+			input:          "provider_${f:exec:${f:exec:printf:print}f:cloudX}",
+			expectedOutput: "provider_cloudX",
+		},
+		{
+			input:          "provider_${f:exec:${f:${f:exec:printf:exec}:printf:printf}:cloudX}",
+			expectedOutput: "provider_cloudX",
+		},
+		{
+			input:          "provider_${f:exec:printf:cl${f:exec:printf:o}udX}",
+			expectedOutput: "provider_cloudX",
+		},
+	}
+
+	for i, tc := range tests {
+		actual := expandTuneDBuiltin(tc.input)
+
+		if actual != tc.expectedOutput {
+			t.Errorf(
+				"failed test case %d:\n\t  in: %s\n\twant: %s\n\thave: %s",
+				i+1,
+				tc.input,
+				tc.expectedOutput,
+				actual,
+			)
+		}
+	}
+}

--- a/test/e2e/basic/tuned_builtin_expand.go
+++ b/test/e2e/basic/tuned_builtin_expand.go
@@ -1,0 +1,92 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	coreapi "k8s.io/api/core/v1"
+
+	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
+	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
+)
+
+// Test the application (and rollback) of a custom profile via node labelling.
+var _ = ginkgo.Describe("[basic][tuned_builtin_expand] Node Tuning Operator custom profile, TuneD built-in expansion", func() {
+	const (
+		profileHugepages       = "../../../examples/hugepages.yaml"
+		profileBuiltinExpand   = "../testing_manifests/tuned_builtin_expand.yaml"
+		nodeLabelBuiltinExpand = "tuned.openshift.io/tuned-built-in"
+		sysctlVar              = "vm.nr_hugepages"
+	)
+
+	ginkgo.Context("custom profile: built-in expansion", func() {
+		var (
+			node *coreapi.Node
+		)
+
+		// Cleanup code to roll back cluster changes done by this test even if it fails in the middle of ginkgo.It()
+		ginkgo.AfterEach(func() {
+			ginkgo.By("cluster changes rollback")
+			if node != nil {
+				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelBuiltinExpand+"-")
+			}
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileBuiltinExpand)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
+		})
+
+		ginkgo.It(fmt.Sprintf("%s set", sysctlVar), func() {
+			const (
+				pollInterval = 5 * time.Second
+				waitDuration = 5 * time.Minute
+			)
+			ginkgo.By("getting a list of worker nodes")
+			nodes, err := util.GetNodesByRole(cs, "worker")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
+
+			node = &nodes[0]
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
+			pod, err := util.GetTunedForNode(cs, node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))
+			valOrig, err := util.WaitForSysctlInPod(pollInterval, waitDuration, pod, sysctlVar)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("labelling node %s with label %s", node.Name, nodeLabelBuiltinExpand))
+			_, _, err = util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelBuiltinExpand+"=")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("creating the custom profile %s", profileHugepages))
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("creating the custom profile %s", profileBuiltinExpand))
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileBuiltinExpand)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("ensuring the custom worker node profile was set")
+			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, "16")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("deleting the custom profile %s", profileBuiltinExpand))
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileBuiltinExpand)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("deleting the custom profile %s", profileHugepages))
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("ensuring the original %s value (%s) is set in Pod %s", sysctlVar, valOrig, pod.Name))
+			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, valOrig)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By(fmt.Sprintf("removing label %s from node %s", nodeLabelBuiltinExpand, node.Name))
+			_, _, err = util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelBuiltinExpand+"-")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+})

--- a/test/e2e/testing_manifests/tuned_builtin_expand.yaml
+++ b/test/e2e/testing_manifests/tuned_builtin_expand.yaml
@@ -1,0 +1,17 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-tuned-builtin
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=An OpenShift profile to test TuneD built-in function expansion
+      include=openshift-node,openshift-${f:exec:echo:-n:huge}pages
+    name: openshift-tuned-builtin
+  recommend:
+  - match:
+    - label: tuned.openshift.io/tuned-built-in
+    priority: 20
+    profile: openshift-tuned-builtin


### PR DESCRIPTION
Implemented a very basic and (yet) incomplete parser of TuneD built-in functions in the form `${f:function(:argN)*}`.  Supported built-ins are now `${f:virt_check:profile-a:profile-b}` and `${f:exec(:argN)}`.  These are being expanded only in the TuneD "include" statements to discover whether the TuneD process needs to be reloaded due to a custom profile change that uses these built-ins.

Other changes:
  - minor refactoring to lift TuneD profile parser specific code
    from the operand
  - fixed/renamed the target for unit tests, use `make test-unit`