### PR TITLE
Add nto_custom_profiles:count metric via PrometheusRule

### DIFF
--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -127,3 +127,5 @@ spec:
       for: 2h
       labels:
         severity: warning
+    - expr: count(nto_profile_calculated_total{profile!~"openshift-node",profile!~"openshift-control-plane",profile!~"openshift"})
+      record: nto_custom_profiles:count


### PR DESCRIPTION
This PR adds a metric to count the number of custom Profiles in the cluster. Put another way, it counts the number of nodes that are using a TuneD profile other than `openshift-node`, `openshift-control-plane`. and `openshift`. 

We can get this information from the existing `nto_profile_calculated_total` metric using the query:
`count(nto_profile_calculated_total{profile!~"openshift-node",profile!~"openshift-control-plane",profile!~"openshift"})`

I was hoping to add this query directly to the telemetry rules, but it seems telemetry requires that metrics be specified by name only, so using this full query is not possible. Fortunately we can add a "new metric" just by using a PrometheusRule. 

Once we get this added the PR to the cluster-monitoring-operator will be quite simple to add this metric to telemetry.