### PR TITLE
Bug 2029371: controller: update MC after application by TuneD

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -598,12 +598,16 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	}
 
 	if mcLabels != nil {
-		// The Tuned daemon profile "tunedProfileName" for nodeName matched with MachineConfig
+		// The Tuned daemon profile 'tunedProfileName' for nodeName matched with MachineConfig
 		// labels set for additional machine configuration.  Sync the operator-created
 		// MachineConfig for MachineConfigPools 'pools'.
-		err := c.syncMachineConfig(getMachineConfigNameForPools(pools), mcLabels, profile.Status.Bootcmdline, profile.Status.Stalld)
-		if err != nil {
-			return fmt.Errorf("failed to update Profile %s: %v", profile.Name, err)
+		if profile.Status.TunedProfile == tunedProfileName && profileApplied(profile) {
+			// Synchronize MachineConfig only once the (calculated) TuneD profile 'tunedProfileName'
+			// has been successfully applied.
+			err := c.syncMachineConfig(getMachineConfigNameForPools(pools), mcLabels, profile.Status.Bootcmdline, profile.Status.Stalld)
+			if err != nil {
+				return fmt.Errorf("failed to update Profile %s: %v", profile.Name, err)
+			}
 		}
 	}
 	if profile.Spec.Config.TunedProfile == tunedProfileName &&

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -81,7 +81,22 @@ func (c *Controller) getOrCreateOperatorStatus() (*configv1.ClusterOperator, err
 	return co, nil
 }
 
-// profileDegraded returns true if Tuned Profiles 'profile' has not been applied
+// profileApplied returns true if Tuned Profile 'profile' has been applied.
+func profileApplied(profile *tunedv1.Profile) bool {
+	if profile == nil || profile.Spec.Config.TunedProfile != profile.Status.TunedProfile {
+		return false
+	}
+
+	for _, sc := range profile.Status.Conditions {
+		if sc.Type == tunedv1.TunedProfileApplied && sc.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+// profileDegraded returns true if Tuned Profile 'profile' has not been applied
 // or applied with errors (Degraded).
 func profileDegraded(profile *tunedv1.Profile) bool {
 	if profile == nil {


### PR DESCRIPTION
Tuned Profiles are created by NTO operator and updated by both the
operator and its operand.  The operand's updates are the source of truth
for information such as kernel command-line parameters and presence of
the stalld daemon.  The operator is informed about this via the status
field of the a Tuned Profile that corresponds to a given node.  Operator
updates are the source of truth about which TuneD profile should be
applied.

When a new cluster node is added (for example during a cluster
scale-up), a new Tuned Profile is created.  If the node is quickly added
to a MachinePool for which an NTO-managed MachineConfig already exists,
this addition will cause NTO to overwrite/update the MachineConfig with
data that is incorrectly initialized.  If the operand was too slow to
correct this update (typically during scale-ups when the operand was not
yet running), this would cause unnecessary reboots of nodes sharing the
same MachineConfigPool.

This PR fixes the behaviour above by only letting the operator update
the NTO-managed MachineConfigs once the newly requested Tuned Profile
configuration is successfully applied.

Resolves rhbz#2024682