### PR TITLE
controller: ignore non-linux hosts

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -556,6 +556,15 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	profileMf.ObjectMeta.OwnerReferences = getDefaultTunedRefs(tuned)
 
 	profileMf.Name = nodeName
+	nodeLabels, err := c.pc.nodeLabelsGet(nodeName)
+	if err != nil {
+		return err
+	}
+	if nodeLabels["kubernetes.io/os"] != "linux" {
+		klog.Infof("ignoring non-linux Node %s", nodeName)
+		return nil
+	}
+
 	tunedProfileName, mcLabels, pools, daemonDebug, err := c.pc.calculateProfile(nodeName)
 	if err != nil {
 		return err


### PR DESCRIPTION
Controller has a sync loop that creates Tuned Profiles for every node on
the cluster.  As TuneD supports only Linux hosts, there is no point in
creating Profiles for hosts other than Linux.