### PR TITLE
Bug 2026387: Handle certificate rotation in pkg/metrics/server.go

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -52,3 +52,34 @@ func init() {
 		degradedState,
 	)
 }
+
+// PodLabelsUsed indicates whether the deprecated Pod label matching functionality
+// is turned on.
+func PodLabelsUsed(enable bool) {
+	if enable {
+		podLabelsUsed.Set(1)
+		return
+	}
+	podLabelsUsed.Set(0)
+}
+
+// ProfileCalculated keeps track of the number of times a given Tuned profile
+// resource was calculated for node 'nodeName'.
+func ProfileCalculated(nodeName, profileName string) {
+	profileCalculated.With(map[string]string{"node": nodeName, "profile": profileName}).Inc()
+}
+
+// RegisterVersion exposes the Operator build version.
+func RegisterVersion(version string) {
+	buildInfo.WithLabelValues(version).Set(1)
+}
+
+// Degraded sets the metric that indicates whether the operator is in degraded
+// mode or not.
+func Degraded(deg bool) {
+	if deg {
+		degradedState.Set(1)
+		return
+	}
+	degradedState.Set(0)
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -1,25 +1,32 @@
 package metrics
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"gopkg.in/fsnotify.v1"
 
 	"k8s.io/klog/v2"
 )
 
 const (
-	tlsCRT = "/etc/secrets/tls.crt"
-	tlsKey = "/etc/secrets/tls.key"
+	tlsSecretDir = "/etc/secrets"
+	tlsCert      = tlsSecretDir + "/tls.crt"
+	tlsKey       = tlsSecretDir + "/tls.key"
 )
 
-// RunServer starts the metrics server.
-func RunServer(port int, stopCh <-chan struct{}) {
+func buildServer(port int) *http.Server {
 	if port <= 0 {
 		klog.Error("invalid port for metric server")
-		return
+		return nil
 	}
 
 	handler := promhttp.HandlerFor(
@@ -37,44 +44,136 @@ func RunServer(port int, stopCh <-chan struct{}) {
 		Handler: router,
 	}
 
-	go func() {
-		if err := srv.ListenAndServeTLS(tlsCRT, tlsKey); err != nil {
-			klog.Errorf("error starting metrics server: %v", err)
+	return srv
+}
+
+func startServer(srv *http.Server) {
+	klog.Infof("starting metrics server")
+	if err := srv.ListenAndServeTLS(tlsCert, tlsKey); err != nil && err != http.ErrServerClosed {
+		klog.Errorf("error from metrics server: %v", err)
+	}
+}
+
+func stopServer(srv *http.Server) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	klog.Infof("stopping metrics server")
+	if err := srv.Shutdown(ctx); err != nil {
+		klog.Errorf("error or timeout stopping metrics listener: %v", err)
+	}
+}
+
+// RunServer starts the server, and watches the tlsCert and tlsKey for certificate changes.
+func RunServer(port int, stopCh <-chan struct{}) {
+	srv := buildServer(port)
+	if srv == nil {
+		return
+	}
+
+	go startServer(srv)
+
+	// Set up and start the file watcher.
+	watcher, err := fsnotify.NewWatcher()
+	if watcher == nil || err != nil {
+		klog.Errorf("failed to create file watcher, cert/key rotation will be disabled  %v", err)
+	} else {
+		defer watcher.Close()
+		if err := watcher.Add(tlsSecretDir); err != nil {
+			klog.Errorf("failed to add %v to watcher, cert/key rotation will be disabled: %v", tlsSecretDir, err)
 		}
-	}()
-	<-stopCh
-	if err := srv.Shutdown(context.Background()); err != nil && err != http.ErrServerClosed {
-		klog.Errorf("error stopping metrics listener: %v", err)
+	}
+
+	origCertChecksum := checksumFile(tlsCert)
+	origKeyChecksum := checksumFile(tlsKey)
+
+	for {
+		select {
+		case <-stopCh:
+			stopServer(srv)
+			return
+		case event := <-watcher.Events:
+			klog.V(2).Infof("event from filewatcher on file: %v, event: %v", event.Name, event.Op)
+
+			if event.Op == fsnotify.Chmod || event.Op == fsnotify.Remove {
+				continue
+			}
+
+			if certsChanged(origCertChecksum, origKeyChecksum) {
+				// Update file checksums with latest files.
+				origCertChecksum = checksumFile(tlsCert)
+				origKeyChecksum = checksumFile(tlsKey)
+
+				// restart server
+				klog.Infof("restarting metrics server to rotate certificates")
+				stopServer(srv)
+				srv = buildServer(port)
+				go startServer(srv)
+			}
+		case err = <-watcher.Errors:
+			klog.Warningf("error from metrics server certificate file watcher: %v", err)
+		}
 	}
 }
 
-// PodLabelsUsed indicates whether the deprecated Pod label matching functionality
-// is turned on.
-func PodLabelsUsed(enable bool) {
-	if enable {
-		podLabelsUsed.Set(1)
-		return
+// Determine if the certificates have changed and need to be updated.
+// Returns true if both files have changed AND neither is an empty file.
+func certsChanged(origCertChecksum []byte, origKeyChecksum []byte) bool {
+	// Check if both files exist.
+	certNotEmpty, err := fileExistsAndNotEmpty(tlsCert)
+	if err != nil {
+		klog.Warningf("error checking if changed TLS cert file empty/exists: %v", err)
+		return false
 	}
-	podLabelsUsed.Set(0)
-}
-
-// ProfileCalculated keeps track of the number of times a given Tuned profile
-// resource was calculated for node 'nodeName'.
-func ProfileCalculated(nodeName, profileName string) {
-	profileCalculated.With(map[string]string{"node": nodeName, "profile": profileName}).Inc()
-}
-
-// RegisterVersion exposes the Operator build version.
-func RegisterVersion(version string) {
-	buildInfo.WithLabelValues(version).Set(1)
-}
-
-// Degraded sets the metric that indicates whether the operator is in degraded
-// mode or not.
-func Degraded(deg bool) {
-	if deg {
-		degradedState.Set(1)
-		return
+	keyNotEmpty, err := fileExistsAndNotEmpty(tlsKey)
+	if err != nil {
+		klog.Warningf("error checking if changed TLS key file empty/exists: %v", err)
+		return false
 	}
-	degradedState.Set(0)
+
+	if !certNotEmpty || !keyNotEmpty {
+		// One of the files is missing despite some file event.
+		klog.V(1).Infof("certificate or key is missing or empty, certificates will not be rotated")
+		return false
+	}
+	currentCertChecksum := checksumFile(tlsCert)
+	currentKeyChecksum := checksumFile(tlsKey)
+
+	klog.V(2).Infof("certificate checksums before: %x, %x. checksums after: %x, %x", origCertChecksum, origKeyChecksum, currentCertChecksum, currentKeyChecksum)
+	// Check if the non-empty certificate/key files have actually changed.
+	if !bytes.Equal(origCertChecksum, currentCertChecksum) && !bytes.Equal(origKeyChecksum, currentKeyChecksum) {
+		klog.Infof("cert and key changed, need to restart the server.")
+		return true
+	}
+
+	return false
+}
+
+// Compute the sha256 checksum for file 'fName'.
+func checksumFile(fName string) []byte {
+	file, err := os.Open(fName)
+	if err != nil {
+		klog.Infof("failed to open file %v for checksum: %v", fName, err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+
+	if _, err = io.Copy(hash, file); err != nil {
+		klog.Infof("failed to compute checksum for file %v: %v", fName, err)
+	}
+
+	return hash.Sum(nil)
+}
+
+// Check if a file exists and has file.Size() not equal to 0.
+// Returns any error returned by os.Stat other than os.ErrNotExist.
+func fileExistsAndNotEmpty(fName string) (bool, error) {
+	if fi, err := os.Stat(fName); err == nil {
+		return (fi.Size() != 0), nil
+	} else if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else {
+		// Some other error, file may not exist.
+		return false, err
+	}
 }

--- a/test/e2e/basic/metrics_cert_rotation.go
+++ b/test/e2e/basic/metrics_cert_rotation.go
@@ -1,0 +1,110 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
+	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("[basic][metrics] Node Tuning Operator certificate rotation", func() {
+	ginkgo.Context("TLS certificate rotation", func() {
+		ginkgo.It("delete certificate Secret and check that the server restarts with latest certificate", func() {
+			const (
+				pollInterval = 5 * time.Second
+				waitDuration = 5 * time.Minute
+			)
+
+			// Delete the existing secret to force certificate rotation.
+			ginkgo.By("deleting node-tuning-operator-tls Secret to trigger certificate rotation")
+			err := rotateTLSCertSecret()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Delete the existing secret again to force certificate rotation.
+			// This is done twice to test whether the file watcher in the metrics server
+			// will continue to watch the new certificates for changes after a rotation.
+			ginkgo.By("deleting node-tuning-operator-tls Secret a second time")
+			err = rotateTLSCertSecret()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("getting a list of worker nodes")
+			nodes, err := util.GetNodesByRole(cs, "worker")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
+
+			node := &nodes[0]
+			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
+			tunedPod, err := util.GetTunedForNode(cs, node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("getting cluster-node-tuning-operator Pod")
+			operatorPod, err := util.GetNodeTuningOperatorPod(cs)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("checking if server TLS certificate matches TLS certificate in Secret")
+			err = wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
+				tlsSecret, err := cs.Secrets(ntoconfig.OperatorNamespace()).Get(context.TODO(), "node-tuning-operator-tls", metav1.GetOptions{})
+				if err != nil {
+					util.Logf("error getting secret/node-tuning-operator-tls. May not exist yet. Err: %v", err)
+					return false, nil
+				}
+				secretCertContents := string(tlsSecret.Data["tls.crt"])
+
+				operatorPodIP := operatorPod.Status.PodIP
+				opensslCmd := "/host/usr/bin/openssl s_client -connect " + operatorPodIP + ":60000 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'"
+
+				serverCertContents, err := util.ExecCmdInPod(tunedPod, "/bin/bash", "-c", opensslCmd)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+				if len(serverCertContents) > 0 && strings.Contains(secretCertContents, serverCertContents) {
+					return true, nil
+				}
+				return false, nil
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		})
+	})
+})
+
+// Deletes the secret/node-tuning-operator-tls and
+// waits up to 2 minutes for it to be recreated with the new certificate.
+func rotateTLSCertSecret() error {
+	// Get original Secret.
+	tlsSecret, err := cs.Secrets(ntoconfig.OperatorNamespace()).Get(context.TODO(), "node-tuning-operator-tls", metav1.GetOptions{})
+	if err != nil {
+		util.Logf("Error getting secret/node-tuning-operator-tls. May not exist yet. Err: %v", err)
+		return err
+	}
+	origCertContents := string(tlsSecret.Data["tls.crt"])
+
+	_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "secret/node-tuning-operator-tls")
+	if err != nil {
+		util.Logf("Error deleting secret/node-tuning-operator/tls")
+		return err
+	}
+
+	// Wait for new certificate to be injected into the Secret.
+	err = wait.PollImmediate(2*time.Second, 2*time.Minute, func() (bool, error) {
+		tlsSecret, err = cs.Secrets(ntoconfig.OperatorNamespace()).Get(context.TODO(), "node-tuning-operator-tls", metav1.GetOptions{})
+		if err != nil {
+			util.Logf("Error getting secret/node-tuning-operator-tls. May not exist yet. Err: %v", err)
+			return false, nil
+		}
+		latestCertContents := string(tlsSecret.Data["tls.crt"])
+		if len(latestCertContents) > 0 && latestCertContents != origCertContents {
+			//Secret has been updated.
+			return true, nil
+		}
+		return false, nil
+	})
+	return err
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -64,6 +64,26 @@ func GetTunedForNode(cs *framework.ClientSet, node *corev1.Node) (*corev1.Pod, e
 	return &podList.Items[0], nil
 }
 
+// GetNodeTuningOperator returns the node tuning operator Pod.
+// If more than one operator Pod is running will return the first Pod found.
+func GetNodeTuningOperatorPod(cs *framework.ClientSet) (*corev1.Pod, error) {
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{"name": "cluster-node-tuning-operator"}).String(),
+	}
+
+	podList, err := cs.Pods(ntoconfig.OperatorNamespace()).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't list potential NTO operator Pods: %v", err)
+	}
+
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("failed to find the cluster-node-tuning-operator Pods")
+	}
+
+	// Return the first operator pod if multiple are running
+	return &podList.Items[0], nil
+}
+
 // execCommand executes command 'name' with arguments 'args' and optionally
 // ('log') logs the output.  Returns captured standard output, standard error
 // and the error returned.


### PR DESCRIPTION
This  PR is intended to solve RHBZ#2026387. 

With this change, a file watcher is added to the metrics server using the fsnotify package, to watch for changes to the TLS certificate for the metrics endpoint. I took some inspiration from https://github.com/openshift/cluster-ingress-operator/pull/334/. Instead of restarting the operator when the certificate changes as is done in that PR, the server will be shut down and restarted.

These changes have been tested by editing the node-tuning-operator-tls secret (comments can be added to the certificate / key by putting them outside of the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`   lines) and by deleting the secret altogether which results in a new key pair being created.

After some review, I will do more testing using the same NTP process described in the BZ to "expire" the certificate.

@jmencak PTAL

Signed-off-by: David Gray <dagray@redhat.com>