### PR TITLE
build-machinery-go: bump to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/api v0.0.0-20210805075156-d8fab4513288
-	github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3
+	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20210730113412-1811c1b3fc0e
 	github.com/openshift/library-go v0.0.0-20210811133500-5e31383de2a7
 	github.com/openshift/machine-config-operator v0.0.1-0.20210514234214-c415ce6aed25

--- a/go.sum
+++ b/go.sum
@@ -561,6 +561,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mo
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3 h1:hYMLjavR8LrcCva788SxDqYjRc1k2w0LNGi7eX9vY5Y=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3 h1:65oBhJYHzYK5VL0gF1eiYY37lLzyLZ47b9y5Kib1nf8=
+github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49/go.mod h1:9/jG4I6sh+5QublJpZZ4Zs/P4/QCXMsQQ/K/058bSB8=
 github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47/go.mod h1:u7NRAjtYVAKokiI9LouzTv4mhds8P4S1TwdVAfbjKSk=
 github.com/openshift/client-go v0.0.0-20210730113412-1811c1b3fc0e h1:vhwzeXUxLd6JZlWZ+miBzTEpmVctHyHNq9z43ScYxWI=

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -16,7 +16,7 @@ GOFMT ?=gofmt
 GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
-go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
+go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+(.[0-9]+)?).*/\1/')
 GO_REQUIRED_MIN_VERSION ?=1.15.2
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
@@ -1,3 +1,7 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	imagebuilder.mk \
+)
+
 # IMAGE_BUILD_EXTRA_FLAGS lets you add extra flags for imagebuilder
 # e.g. to mount secrets and repo information into base image like:
 # make images IMAGE_BUILD_EXTRA_FLAGS='-mount ~/projects/origin-repos/4.2/:/etc/yum.repos.d/'

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/kustomize.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/kustomize.mk
@@ -12,8 +12,13 @@ ensure-kustomize:
 ifeq "" "$(wildcard $(KUSTOMIZE))"
 	$(info Installing kustomize into '$(KUSTOMIZE)')
 	mkdir -p '$(kustomize_dir)'
+	@# install_kustomize.sh lays down the binary as `kustomize`, and will
+	@# also fail if a file of that name already exists. Remove it for
+	@# backward compatibility (older b-m-gs used the raw file name).
+	rm -f $(kustomize_dir)/kustomize
 	@# NOTE: Pinning script to a tag rather than `master` for security reasons
 	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v$(KUSTOMIZE_VERSION)/hack/install_kustomize.sh"  | bash -s $(KUSTOMIZE_VERSION) $(kustomize_dir)
+	mv $(kustomize_dir)/kustomize $(KUSTOMIZE)
 else
 	$(info Using existing kustomize from "$(KUSTOMIZE)")
 endif

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
@@ -6,7 +6,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 	../../lib/tmp.mk \
 )
 
-YAML_PATCH_VERSION ?=v0.0.10
+YAML_PATCH_VERSION ?=v0.0.11
 YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch-$(YAML_PATCH_VERSION)
 yaml_patch_dir :=$(dir $(YAML_PATCH))
 
@@ -15,7 +15,7 @@ ensure-yaml-patch:
 ifeq "" "$(wildcard $(YAML_PATCH))"
 	$(info Installing yaml-patch into '$(YAML_PATCH)')
 	mkdir -p '$(yaml_patch_dir)'
-	curl -s -f -L https://github.com/krishicks/yaml-patch/releases/download/$(YAML_PATCH_VERSION)/yaml_patch_$(GOHOSTOS) -o '$(YAML_PATCH)'
+	curl -s -f -L https://github.com/pivotal-cf/yaml-patch/releases/download/$(YAML_PATCH_VERSION)/yaml_patch_$(GOHOSTOS) -o '$(YAML_PATCH)'
 	chmod +x '$(YAML_PATCH)';
 else
 	$(info Using existing yaml-patch from "$(YAML_PATCH)")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -181,7 +181,7 @@ github.com/onsi/gomega/types
 ## explicit; go 1.16
 github.com/openshift/api/config/v1
 github.com/openshift/api/operator/v1
-# github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3
+# github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 ## explicit; go 1.13
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
The current version of build-machinery-go fixes the problems with
yaml-patch missing github repository.