### PR TITLE
Bug 2037036: grub2-editenv: no errors when using [bootloader] plug-in

### DIFF
--- a/assets/bin/grub2-editenv
+++ b/assets/bin/grub2-editenv
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# This is a workaround to prevent TuneD running in the container from reporting
+# ERROR    tuned.utils.commands: Executing grub2-editenv error: [Errno 2] No such file or directory: 'grub2-editenv': 'grub2-editenv'
+# message while keeping the [bootloader] plug-in working.  Note that every ERROR message
+# emitted by TuneD will result in Tuned Profile going into Degraded status, so we want
+# to limit unnecessary ERROR reporting.


### PR DESCRIPTION
Workaround for `TuneD` running in the container not to emit
```
ERROR    tuned.utils.commands: Executing grub2-editenv error: [Errno 2] No such file or directory: 'grub2-editenv': 'grub2-editenv'
```
message while keeping the `[bootloader]` plug-in functional.