### PR TITLE
Bug 2036303: Prevent unnecessary ksm* error log messages.

### DIFF
--- a/assets/tuned/patches/050-no-ksm-errors.diff
+++ b/assets/tuned/patches/050-no-ksm-errors.diff
@@ -1,0 +1,29 @@
+Check the presence of `ksm` and `ksmtuned` units before (un)masking them.
+
+Prevents messages in the logs such as:
+2021-02-24 14:46:52,399 ERROR    tuned.plugins.plugin_script: script '/usr/lib/tuned/cpu-partitioning/script.sh' error output: 'Unit ksm.service does not exist, proceeding anyway.
+
+See: https://github.com/redhat-performance/tuned/pull/331
+
+diff --git a/profiles/functions b/profiles/functions
+index 0e1836b6..636995c6 100644
+--- a/profiles/functions
++++ b/profiles/functions
+@@ -559,6 +559,8 @@ disable_ksm()
+ 		if ! touch $KSM_MASK_FILE; then
+ 			die "failed to create $KSM_MASK_FILE"
+ 		fi
++		# Do not run any systemctl commands if $KSM_SERVICES units do not exist
++		systemctl cat -- $KSM_SERVICES &> /dev/null || return
+ 		systemctl --now --quiet mask $KSM_SERVICES
+ 		# Unmerge all shared pages
+ 		test -f $KSM_RUN_PATH && echo 2 > $KSM_RUN_PATH
+@@ -569,6 +571,8 @@ disable_ksm()
+ enable_ksm()
+ {
+ 	if [ -f $KSM_MASK_FILE ]; then
++		# Do not run any systemctl commands if $KSM_SERVICES units do not exist
++		systemctl cat -- $KSM_SERVICES &> /dev/null || return
+ 		if systemctl --quiet unmask $KSM_SERVICES; then
+ 			rm -f $KSM_MASK_FILE
+ 		fi


### PR DESCRIPTION
Adding upstream TuneD patch:
https://github.com/redhat-performance/tuned/pull/331

The patch checks the presence of `ksm` and `ksmtuned` units before (un)masking them.

The change prevents messages in the logs such as:
```
2021-02-24 14:46:52,399 ERROR    tuned.plugins.plugin_script: script '/usr/lib/tuned/cpu-partitioning/script.sh' error output: 'Unit ksm.service does not exist, proceeding anyway.
```

which caused per-node Profiles go into Degraded state.

Resolves: rhbz#2036303