### PR TITLE
Bug 2038406: Add nto_custom_profile:count metric via PrometheusRule

### DIFF
--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -127,3 +127,5 @@ spec:
       for: 2h
       labels:
         severity: warning
+    - expr: count(nto_profile_calculated_total{profile!~"openshift-node",profile!~"openshift-control-plane",profile!~"openshift"})
+      record: nto_custom_profiles:count


### PR DESCRIPTION
To help prioritize future features for NTO, we want to better understand how it is being used. One way we can do this is by sending metrics through telemetry to see how often NTO is being used to manage custom TuneD profiles on nodes. This is available on 4.10 but not older versions