### PR TITLE
Add Cloud provider specific profiles support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN INSTALL_PKGS=" \
     find /root/rpms -name \*.rpm -exec basename {} .rpm \; | xargs rpm -e --justdb && \
     cp -a /var/lib/tuned/tuned/stalld/{stalld,scripts/throttlectl.sh} /usr/local/bin && \
     rm -rf /var/lib/tuned/tuned && \
-    touch /etc/sysctl.conf && \
+    touch /etc/sysctl.conf $APP_ROOT/provider && \
     dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \
     useradd -r -u 499 cluster-node-tuning-operator

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -38,7 +38,7 @@ RUN INSTALL_PKGS=" \
     rpm -V $INSTALL_PKGS && \
     cp -a /var/lib/tuned/tuned/stalld/{stalld,scripts/throttlectl.sh} /usr/local/bin && \
     rm -rf /var/lib/tuned/tuned && \
-    touch /etc/sysctl.conf && \
+    touch /etc/sysctl.conf $APP_ROOT/provider && \
     dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \
     useradd -r -u 499 cluster-node-tuning-operator

--- a/assets/tuned/manifests/default-cr-tuned.yaml
+++ b/assets/tuned/manifests/default-cr-tuned.yaml
@@ -4,6 +4,12 @@ metadata:
   name: default
   namespace: openshift-cluster-node-tuning-operator
 spec:
+  profile:
+  - name: "openshift"
+    data: |
+      [main]
+      summary=Optimize systems running OpenShift (provider specific parent profile)
+      include=-provider-${f:exec:cat:/var/lib/tuned/provider},openshift
   recommend:
   - profile: "openshift-control-plane"
     priority: 30

--- a/assets/tuned/patches/040-cloud-profiles.diff
+++ b/assets/tuned/patches/040-cloud-profiles.diff
@@ -1,0 +1,19 @@
+Fix improper parsing of include directive
+
+Resolves rhbz#2017924
+
+See: https://github.com/redhat-performance/tuned/pull/401
+
+diff --git a/tuned/profiles/loader.py b/tuned/profiles/loader.py
+index 31037182..1407b5cc 100644
+--- a/tuned/profiles/loader.py
++++ b/tuned/profiles/loader.py
+@@ -90,7 +90,7 @@ def _load_profile(self, profile_names, profiles, processed_files):
+ 			config = self._load_config_data(filename)
+ 			profile = self._profile_factory.create(name, config)
+ 			if "include" in profile.options:
+-				include_names = re.split(r"\b\s*[,;]\s*", self._variables.expand(profile.options.pop("include")))
++				include_names = re.split(r"[,;\s]+", self._variables.expand(profile.options.pop("include")).strip())
+ 				self._load_profile(include_names, profiles, processed_files)
+ 
+ 			profiles.append(profile)

--- a/manifests/20-profile.crd.yaml
+++ b/manifests/20-profile.crd.yaml
@@ -58,6 +58,9 @@ spec:
                     debug:
                       description: option to debug Tuned daemon execution
                       type: boolean
+                    providerName:
+                      description: 'Name of the cloud provider as taken from the Node providerID: <ProviderName>://<ProviderSpecificNodeID>'
+                      type: string
                     tunedProfile:
                       description: Tuned profile to apply
                       type: string

--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -140,6 +140,9 @@ type ProfileConfig struct {
 	// option to debug Tuned daemon execution
 	// +optional
 	Debug bool `json:"debug"`
+	// Name of the cloud provider as taken from the Node providerID: <ProviderName>://<ProviderSpecificNodeID>
+	// +optional
+	ProviderName string `json:"providerName,omitempty"`
 }
 
 // ProfileStatus is the status for a Profile resource; the status is for internal use only

--- a/pkg/generated/clientset/versioned/clientset.go
+++ b/pkg/generated/clientset/versioned/clientset.go
@@ -4,6 +4,7 @@ package versioned
 
 import (
 	"fmt"
+	"net/http"
 
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned/typed/tuned/v1"
 	discovery "k8s.io/client-go/discovery"
@@ -39,7 +40,25 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 // If config's RateLimiter is not set and QPS and Burst are acceptable,
 // NewForConfig will generate a rate-limiter in configShallowCopy.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	configShallowCopy := *c
+
+	// share the transport between all clients
+	httpClient, err := rest.HTTPClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewForConfigAndClient(&configShallowCopy, httpClient)
+}
+
+// NewForConfigAndClient creates a new Clientset for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+// If config's RateLimiter is not set and QPS and Burst are acceptable,
+// NewForConfigAndClient will generate a rate-limiter in configShallowCopy.
+func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
@@ -47,14 +66,15 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
 	var cs Clientset
 	var err error
-	cs.tunedV1, err = tunedv1.NewForConfig(&configShallowCopy)
+	cs.tunedV1, err = tunedv1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
+	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -64,11 +84,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.tunedV1 = tunedv1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/pkg/generated/clientset/versioned/typed/tuned/v1/fake/fake_profile.go
+++ b/pkg/generated/clientset/versioned/typed/tuned/v1/fake/fake_profile.go
@@ -101,7 +101,7 @@ func (c *FakeProfiles) UpdateStatus(ctx context.Context, profile *tunedv1.Profil
 // Delete takes name of the profile and deletes it. Returns an error if one occurs.
 func (c *FakeProfiles) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(profilesResource, c.ns, name), &tunedv1.Profile{})
+		Invokes(testing.NewDeleteActionWithOptions(profilesResource, c.ns, name, opts), &tunedv1.Profile{})
 
 	return err
 }

--- a/pkg/generated/clientset/versioned/typed/tuned/v1/fake/fake_tuned.go
+++ b/pkg/generated/clientset/versioned/typed/tuned/v1/fake/fake_tuned.go
@@ -101,7 +101,7 @@ func (c *FakeTuneds) UpdateStatus(ctx context.Context, tuned *tunedv1.Tuned, opt
 // Delete takes name of the tuned and deletes it. Returns an error if one occurs.
 func (c *FakeTuneds) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(tunedsResource, c.ns, name), &tunedv1.Tuned{})
+		Invokes(testing.NewDeleteActionWithOptions(tunedsResource, c.ns, name, opts), &tunedv1.Tuned{})
 
 	return err
 }

--- a/pkg/generated/clientset/versioned/typed/tuned/v1/tuned_client.go
+++ b/pkg/generated/clientset/versioned/typed/tuned/v1/tuned_client.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"net/http"
+
 	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
@@ -28,12 +30,28 @@ func (c *TunedV1Client) Tuneds(namespace string) TunedInterface {
 }
 
 // NewForConfig creates a new TunedV1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*TunedV1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new TunedV1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*TunedV1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tuned/tuned_parser_test.go
+++ b/pkg/tuned/tuned_parser_test.go
@@ -11,45 +11,45 @@ func TestBuiltinExpansion(t *testing.T) {
 	}{
 		// Basic expansion.
 		{
-			input:          "provider_cloudX",
-			expectedOutput: "provider_cloudX",
+			input:          "provider-cloudX",
+			expectedOutput: "provider-cloudX",
 		},
 		{
-			input:          "provider_${f:exec:printf:cloudX}",
-			expectedOutput: "provider_cloudX",
+			input:          "provider-${f:exec:printf:cloudX}",
+			expectedOutput: "provider-cloudX",
 		},
 		{
-			input:          "provider_$cloudX",
-			expectedOutput: "provider_$cloudX",
+			input:          "provider-$cloudX",
+			expectedOutput: "provider-$cloudX",
 		},
 		{
-			input:          "provider_${f:exec:printf:cloudX}_$$_${}cl'oudX${f:",
-			expectedOutput: "provider_cloudX_$$_${}cl'oudX${f:",
+			input:          "provider-${f:exec:printf:cloudX}_$$_${}cl'oudX${f:",
+			expectedOutput: "provider-cloudX_$$_${}cl'oudX${f:",
 		},
 		// Deeper nesting in functions and its arguments.
 		{
-			input:          "provider_${f:${f:exec:printf:exec}:printf:cloudX}",
-			expectedOutput: "provider_cloudX",
+			input:          "provider-${f:${f:exec:printf:exec}:printf:cloudX}",
+			expectedOutput: "provider-cloudX",
 		},
 		{
-			input:          "provider_${f:${f:${f:exec:printf:exec}:printf:exec}:printf:cloudX}",
-			expectedOutput: "provider_cloudX",
+			input:          "provider-${f:${f:${f:exec:printf:exec}:printf:exec}:printf:cloudX}",
+			expectedOutput: "provider-cloudX",
 		},
 		{
-			input:          "provider_${f:exec:${f:exec:printf:printf}:cloudX}",
-			expectedOutput: "provider_cloudX",
+			input:          "provider-${f:exec:${f:exec:printf:printf}:cloudX}",
+			expectedOutput: "provider-cloudX",
 		},
 		{
-			input:          "provider_${f:exec:${f:exec:printf:print}f:cloudX}",
-			expectedOutput: "provider_cloudX",
+			input:          "provider-${f:exec:${f:exec:printf:print}f:cloudX}",
+			expectedOutput: "provider-cloudX",
 		},
 		{
-			input:          "provider_${f:exec:${f:${f:exec:printf:exec}:printf:printf}:cloudX}",
-			expectedOutput: "provider_cloudX",
+			input:          "provider-${f:exec:${f:${f:exec:printf:exec}:printf:printf}:cloudX}",
+			expectedOutput: "provider-cloudX",
 		},
 		{
-			input:          "provider_${f:exec:printf:cl${f:exec:printf:o}udX}",
-			expectedOutput: "provider_cloudX",
+			input:          "provider-${f:exec:printf:cl${f:exec:printf:o}udX}",
+			expectedOutput: "provider-cloudX",
 		},
 	}
 

--- a/pkg/util/provider_id.go
+++ b/pkg/util/provider_id.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"strings"
+)
+
+// GetProviderName returns ProviderName part of 'providerID' in the format:
+// <ProviderName>://<ProviderSpecificNodeID>
+func GetProviderName(providerID string) string {
+	i := strings.Index(providerID, "://")
+	if i < 0 {
+		// ProviderName/ProviderSpecificNodeID separator not found, return the whole providerID
+		return providerID
+	}
+	return providerID[:i]
+}


### PR DESCRIPTION
Add support for Cloud provider specific tuning.  This functionality
takes advantage of the node `spec.providerID` values in the form of:
`<cloud-provider>://<cloud-provider-specific-id>` and writes file
`/var/lib/tuned/provider` with value `<cloud-provider>` in openshift-tuned
containers.

The default openshift profile has been adjusted to take advantage of
this functionality by using conditional profile loading.  At this point,
there are no Cloud provider specific profiles shipped.  However, it is
already possible to create custom profiles that will be applied to all
cluster nodes if profile with name `provider-<cloud-provider>` is
created by cluster administrator.