### PR TITLE
Add docs for reapply_sysctl TuneD functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ containerized TuneD daemons running in the cluster in the format
 that the daemons understand. The daemons run on all nodes in the
 cluster, one per node.
 
-Node-level settings applied by the containerized TuneD daemon are rolled back
-on an event that triggers a profile change or when the containerized TuneD
-daemon is terminated gracefully by receiving and handling a termination signal.
+The containerized TuneD daemon will roll-back the custom node-level settings when a profile is changed or when the container receives a termination signal.
 
 ## Deploying the Node Tuning Operator
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ containerized TuneD daemons running in the cluster in the format
 that the daemons understand. The daemons run on all nodes in the
 cluster, one per node.
 
-The containerized TuneD daemon will roll-back the custom node-level settings when a profile is changed or when the container receives a termination signal.
+When a profile is changed, the containerized TuneD daemon will roll back
+any changes to node-level settings before applying the new profile. The
+containerized TuneD daemon handles termination signals by rolling back any
+node-level settings it has applied before gracefully shutting down.
+
 
 ## Deploying the Node Tuning Operator
 

--- a/manifests/20-profile.crd.yaml
+++ b/manifests/20-profile.crd.yaml
@@ -66,7 +66,7 @@ spec:
                       type: object
                       properties:
                         reapply_sysctl:
-                          description: 'turn reapply_sysctl functionality on/off for the TuneD daemon: true/false (default is false)'
+                          description: 'turn reapply_sysctl functionality on/off for the TuneD daemon: true/false'
                           type: boolean
                     tunedProfile:
                       description: TuneD profile to apply

--- a/manifests/20-tuned.crd.yaml
+++ b/manifests/20-tuned.crd.yaml
@@ -127,7 +127,7 @@ spec:
                           properties:
                             reapply_sysctl:
                               description: 'turn reapply_sysctl functionality on/off
-                                for the TuneD daemon: true/false (default is false)'
+                                for the TuneD daemon: true/false'
                               type: boolean
                           type: object
                       type: object

--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -110,7 +110,7 @@ type OperandConfig struct {
 
 // Global configuration for the TuneD daemon as defined in tuned-main.conf
 type TuneDConfig struct {
-	// turn reapply_sysctl functionality on/off for the TuneD daemon: true/false (default is false)
+	// turn reapply_sysctl functionality on/off for the TuneD daemon: true/false
 	// +optional
 	ReapplySysctl *bool `json:"reapply_sysctl"`
 }


### PR DESCRIPTION
Other changes: 
  - Fixes a statement in the API about `reapply_sysctl=false` by default.   It is actually true by default, but it is subject to the `TuneD` daemon defaults in tuned-main.conf file.
  - `s/Tuned/TuneD/` where appropriate.
