### PR TITLE
Improve TuneD error reporting and set CO status Progressing when applying new profiles

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -313,7 +313,7 @@ func (c *Controller) sync(key wqKey) error {
 		if err != nil {
 			return fmt.Errorf("failed to sync DaemonSet: %v", err)
 		}
-		err = c.syncOperatorStatus(cr, nil)
+		err = c.syncOperatorStatus(cr)
 		if err != nil {
 			return fmt.Errorf("failed to sync OperatorStatus: %v", err)
 		}
@@ -393,7 +393,7 @@ out:
 	if err != nil {
 		lastErr = fmt.Errorf("failed to disable Pod informer: %v", err)
 	}
-	err = c.syncOperatorStatus(cr, nil)
+	err = c.syncOperatorStatus(cr)
 	if err != nil {
 		lastErr = fmt.Errorf("failed to synchronize Operator status: %v", err)
 	}
@@ -599,7 +599,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 
 	// Profiles carry status conditions based on which OperatorStatus is also
 	// calculated.
-	err = c.syncOperatorStatus(tuned, profile)
+	err = c.syncOperatorStatus(tuned)
 	if err != nil {
 		return fmt.Errorf("failed to sync OperatorStatus: %v", err)
 	}


### PR DESCRIPTION
This PR implements the changes to Profile and ClusterOperator status discussed in [this document]:(https://docs.google.com/document/d/1mhRsDTK91TUiE5O_G610g8QpTjTFc7GAkEiwZLdjXBE/edit?usp=sharing)

- When TuneD reports errors or warnings, add last log line containing " ERROR " or " WARNING " to the Profile degraded status condition Message.
- When the containerized TuneD daemon times out waiting for a profile to be applied, set the Profile status to Degraded.
- (second commit) When the operator is waiting for a profile to be applied, set the ClusterOperator status to Progressing False True. If the Profile is in a Degraded state, set Progressing = False as this means that the Profile either reported errors while applying, or there was a timeout waiting for the profile to be applied.