### PR TITLE
Address e2e test races

### DIFF
--- a/test/e2e/basic/custom_node_labels.go
+++ b/test/e2e/basic/custom_node_labels.go
@@ -9,6 +9,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
@@ -48,6 +49,11 @@ var _ = ginkgo.Describe("[basic][custom_node_labels] Node Tuning Operator custom
 			node = &nodes[0]
 			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Expect the default worker node profile applied prior to getting any current values.
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))

--- a/test/e2e/basic/custom_pod_labels.go
+++ b/test/e2e/basic/custom_pod_labels.go
@@ -9,6 +9,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
@@ -48,6 +49,11 @@ var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom 
 			node := nodes[0]
 			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err = util.GetTunedForNode(cs, &node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Expect the default worker node profile applied prior to getting any current values.
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))

--- a/test/e2e/basic/default_irq_smp_affinity.go
+++ b/test/e2e/basic/default_irq_smp_affinity.go
@@ -11,6 +11,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
@@ -63,6 +64,11 @@ var _ = ginkgo.Describe("[basic][default_irq_smp_affinity] Node Tuning Operator 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			nCPUs = strings.TrimSpace(nCPUs)
 			cpus, err := strconv.ParseUint(nCPUs, 10, 0)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Expect the default worker node profile applied prior to getting any current values.
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the original value of %s", procIrqDefaultSmpAffinity))

--- a/test/e2e/basic/default_node_sysctl.go
+++ b/test/e2e/basic/default_node_sysctl.go
@@ -7,6 +7,9 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
+	coreapi "k8s.io/api/core/v1"
+
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
 
@@ -28,6 +31,11 @@ var _ = ginkgo.Describe("[basic][default_node_sysctl] Node Tuning Operator defau
 		node := nodes[0]
 		ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 		pod, err := util.GetTunedForNode(cs, &node)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Expect the default worker node profile applied prior to getting any current values.
+		ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
+		err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("ensuring the default worker node profile was set")

--- a/test/e2e/basic/metrics_cert_rotation.go
+++ b/test/e2e/basic/metrics_cert_rotation.go
@@ -70,7 +70,6 @@ var _ = ginkgo.Describe("[basic][metrics] Node Tuning Operator certificate rotat
 				return false, nil
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
 		})
 	})
 })
@@ -101,7 +100,7 @@ func rotateTLSCertSecret() error {
 		}
 		latestCertContents := string(tlsSecret.Data["tls.crt"])
 		if len(latestCertContents) > 0 && latestCertContents != origCertContents {
-			//Secret has been updated.
+			// Secret has been updated.
 			return true, nil
 		}
 		return false, nil

--- a/test/e2e/basic/rollback.go
+++ b/test/e2e/basic/rollback.go
@@ -10,6 +10,7 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
@@ -52,6 +53,11 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 			node := nodes[0]
 			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err = util.GetTunedForNode(cs, &node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Expect the default worker node profile applied prior to getting any current values.
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the default %s value (%s) is set in Pod %s", sysctlVar, sysctlValDef, pod.Name))

--- a/test/e2e/basic/sysctl_d_override.go
+++ b/test/e2e/basic/sysctl_d_override.go
@@ -10,6 +10,7 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
@@ -58,6 +59,11 @@ var _ = ginkgo.Describe("[basic][sysctl_d_override] Node Tuning Operator /etc/sy
 			node := &nodes[0]
 			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Expect the default worker node profile applied prior to getting any current values.
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))

--- a/test/e2e/basic/tuned_builtin_expand.go
+++ b/test/e2e/basic/tuned_builtin_expand.go
@@ -9,6 +9,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	util "github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
@@ -50,6 +51,11 @@ var _ = ginkgo.Describe("[basic][tuned_builtin_expand] Node Tuning Operator cust
 			node = &nodes[0]
 			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
 			pod, err := util.GetTunedForNode(cs, node)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Expect the default worker node profile applied prior to getting any current values.
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))


### PR DESCRIPTION
The NTO e2e test suite runs as a series of short e2e tests starting
immediately once the previous test completes.  Some e2e tests rely on
tuning set by the default worker `TuneD` profile -- `openshift-node`.  Most
e2e test will complete without doing a full profile rollback (and/or)
application of the default worker `TuneD` profile.  If an e2e test relies
on this profile to be applied, block the execution of the test until it
applied.

Other changes:
  - Make sure `tuned_errors_and_recovery.go` e2e test can be run several
    times in a sequence on the same cluster.
  - Some formatting nits.
