### PR TITLE
Fix e2e tests for aarch64 and SNO

### DIFF
--- a/examples/hugepages.yaml
+++ b/examples/hugepages.yaml
@@ -14,7 +14,7 @@ spec:
       # Comments that do not start at the beginning of a line as the TuneD
       # documentation states are currently (2021-09-15) a grey area and likely
       [sysctl]
-      vm.nr_hugepages=16	# a bad idea as rhbz#2004508 shows.
+      vm.nr_hugepages=1		# a bad idea as rhbz#2004508 shows.
     name: openshift-hugepages
   recommend:
   - match:

--- a/test/e2e/basic/custom_node_labels.go
+++ b/test/e2e/basic/custom_node_labels.go
@@ -52,8 +52,8 @@ var _ = ginkgo.Describe("[basic][custom_node_labels] Node Tuning Operator custom
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Expect the default worker node profile applied prior to getting any current values.
-			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
-			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.GetDefaultWorkerProfile(node), node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.GetDefaultWorkerProfile(node), tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))
@@ -69,7 +69,7 @@ var _ = ginkgo.Describe("[basic][custom_node_labels] Node Tuning Operator custom
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("ensuring the custom worker node profile was set")
-			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, "16")
+			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, "1")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom hugepages profile %s", profileHugepages))

--- a/test/e2e/basic/custom_pod_labels.go
+++ b/test/e2e/basic/custom_pod_labels.go
@@ -46,14 +46,14 @@ var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
-			node := nodes[0]
+			node := &nodes[0]
 			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
-			pod, err = util.GetTunedForNode(cs, &node)
+			pod, err = util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Expect the default worker node profile applied prior to getting any current values.
-			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
-			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.GetDefaultWorkerProfile(node), node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.GetDefaultWorkerProfile(node), tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))

--- a/test/e2e/basic/default_irq_smp_affinity.go
+++ b/test/e2e/basic/default_irq_smp_affinity.go
@@ -67,8 +67,8 @@ var _ = ginkgo.Describe("[basic][default_irq_smp_affinity] Node Tuning Operator 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Expect the default worker node profile applied prior to getting any current values.
-			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
-			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.GetDefaultWorkerProfile(node), node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.GetDefaultWorkerProfile(node), tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the original value of %s", procIrqDefaultSmpAffinity))

--- a/test/e2e/basic/default_node_sysctl.go
+++ b/test/e2e/basic/default_node_sysctl.go
@@ -28,14 +28,14 @@ var _ = ginkgo.Describe("[basic][default_node_sysctl] Node Tuning Operator defau
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
-		node := nodes[0]
+		node := &nodes[0]
 		ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
-		pod, err := util.GetTunedForNode(cs, &node)
+		pod, err := util.GetTunedForNode(cs, node)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Expect the default worker node profile applied prior to getting any current values.
-		ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
-		err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
+		ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.GetDefaultWorkerProfile(node), node.Name))
+		err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.GetDefaultWorkerProfile(node), tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("ensuring the default worker node profile was set")

--- a/test/e2e/basic/modules.go
+++ b/test/e2e/basic/modules.go
@@ -19,7 +19,7 @@ var _ = ginkgo.Describe("[basic][modules] Node Tuning Operator load kernel modul
 		profileModules   = "../testing_manifests/tuned_modules_load.yaml"
 		nodeLabelModules = "tuned.openshift.io/module-load"
 		procModules      = "/proc/modules"
-		moduleName       = "joydev"
+		moduleName       = "md4"
 	)
 
 	ginkgo.Context("module loading", func() {

--- a/test/e2e/basic/rollback.go
+++ b/test/e2e/basic/rollback.go
@@ -50,14 +50,14 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
-			node := nodes[0]
+			node := &nodes[0]
 			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
-			pod, err = util.GetTunedForNode(cs, &node)
+			pod, err = util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Expect the default worker node profile applied prior to getting any current values.
-			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
-			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.GetDefaultWorkerProfile(node), node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.GetDefaultWorkerProfile(node), tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the default %s value (%s) is set in Pod %s", sysctlVar, sysctlValDef, pod.Name))
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 
 			ginkgo.By(fmt.Sprintf("waiting for a new TuneD Pod to be ready on node %s", node.Name))
 			err = wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
-				pod, err = util.GetTunedForNode(cs, &node)
+				pod, err = util.GetTunedForNode(cs, node)
 				if err != nil {
 					explain = err.Error()
 					return false, nil

--- a/test/e2e/basic/sysctl_d_override.go
+++ b/test/e2e/basic/sysctl_d_override.go
@@ -56,14 +56,14 @@ var _ = ginkgo.Describe("[basic][sysctl_d_override] Node Tuning Operator /etc/sy
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
 
-			node := &nodes[0]
+			node = &nodes[0]
 			ginkgo.By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
-			pod, err := util.GetTunedForNode(cs, node)
+			pod, err = util.GetTunedForNode(cs, node)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Expect the default worker node profile applied prior to getting any current values.
-			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
-			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.GetDefaultWorkerProfile(node), node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.GetDefaultWorkerProfile(node), tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))

--- a/test/e2e/basic/tuned_builtin_expand.go
+++ b/test/e2e/basic/tuned_builtin_expand.go
@@ -54,8 +54,8 @@ var _ = ginkgo.Describe("[basic][tuned_builtin_expand] Node Tuning Operator cust
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Expect the default worker node profile applied prior to getting any current values.
-			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.DefaultWorkerProfile, node.Name))
-			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.DefaultWorkerProfile, tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
+			ginkgo.By(fmt.Sprintf("waiting for TuneD profile %s on node %s", util.GetDefaultWorkerProfile(node), node.Name))
+			err = util.WaitForProfileConditionStatus(cs, pollInterval, waitDuration, node.Name, util.GetDefaultWorkerProfile(node), tunedv1.TunedProfileApplied, coreapi.ConditionTrue)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("getting the current value of %s in Pod %s", sysctlVar, pod.Name))
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("[basic][tuned_builtin_expand] Node Tuning Operator cust
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("ensuring the custom worker node profile was set")
-			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, "16")
+			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, "1")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom profile %s", profileBuiltinExpand))

--- a/test/e2e/testing_manifests/tuned_modules_load.yaml
+++ b/test/e2e/testing_manifests/tuned_modules_load.yaml
@@ -7,10 +7,10 @@ spec:
   profile:
   - data: |
       [main]
-      summary=An OpenShift profile to load 'joydev' module
+      summary=An OpenShift profile to load 'md4' module
       include=openshift-node
       [modules]
-      joydev=+r
+      md4=+r
     name: openshift-module-load
   recommend:
   - match:

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -25,6 +25,8 @@ import (
 )
 
 const (
+	// The default master profile.  See: assets/tuned/manifests/default-cr-tuned.yaml
+	DefaultMasterProfile = "openshift-control-plane"
 	// The default worker profile.  See: assets/tuned/manifests/default-cr-tuned.yaml
 	DefaultWorkerProfile = "openshift-node"
 )
@@ -364,4 +366,17 @@ func WaitForPoolUpdatedMachineCount(cs *framework.ClientSet, pool string, count 
 		return errors.Wrapf(err, "pool %s UpdatedMachineCount != %d (waited %s)", pool, count, time.Since(startTime))
 	}
 	return nil
+}
+
+// GetDefaultWorkerProfile returns name of the default out-of-the-box TuneD profile for a node.
+// See: assets/tuned/manifests/default-cr-tuned.yaml
+func GetDefaultWorkerProfile(node *corev1.Node) string {
+	_, master := node.Labels["node-role.kubernetes.io/master"]
+	_, infra := node.Labels["node-role.kubernetes.io/infra"]
+
+	if master || infra {
+		return DefaultMasterProfile
+	}
+
+	return DefaultWorkerProfile
 }


### PR DESCRIPTION
This PR fixes operator e2e tests for for aarch64 and clusters with
worker nodes that also have a master role, such as SNO.

Other changes:
  - Fix for `sysctl_d_override.go` rollback (node/pod was always nil
    and rollback in case of a test failure was not performed).
  - Consistency changes across the tests.