### PR TITLE
PerformanceProfileCreator build and functional test execution adaptation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN INSTALL_PKGS=" \
 
 FROM centos:8
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/
 ENV APP_ROOT=/var/lib/tuned
 ENV PATH=${APP_ROOT}/bin:${PATH}

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -20,6 +20,7 @@ RUN INSTALL_PKGS=" \
 
 FROM registry.ci.openshift.org/ocp/4.11:base
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/
 ENV APP_ROOT=/var/lib/tuned
 ENV PATH=${APP_ROOT}/bin:${PATH}

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ clone-tuned:
 	  cd $(TUNED_DIR) && git checkout $(TUNED_COMMIT) && cd .. && \
 	  rm -rf $(TUNED_DIR)/.git)
 
-build: $(BINDATA) pkg/generated
+build: $(BINDATA) pkg/generated build-performance-profile-creator
 	$(GO_BUILD_RECIPE)
 	ln -sf $(PACKAGE_BIN) $(OUT_DIR)/openshift-tuned
 
@@ -190,3 +190,15 @@ pao-functests-only:
 cluster-clean-pao:
 	@echo "Cleaning up performance addons artifacts"
 	hack/clean-deploy.sh
+
+# Performance Profile Creator (PPC)
+.PHONY: build-performance-profile-creator
+build-performance-profile-creator: 
+	@echo "Building Performance Profile Creator (PPC)"
+	LDFLAGS="-s -w -X ${PACKAGE}/cmd/performance-profile-creator/version.Version=${REV} "; \
+	$(GO) build  -v $(LDFLAGS) -o $(OUT_DIR)/performance-profile-creator ./cmd/performance-profile-creator
+
+.PHONY: performance-profile-creator-tests
+performance-profile-creator-tests: build-performance-profile-creator
+	@echo "Running Performance Profile Creator Tests"
+	hack/run-perf-profile-creator-functests.sh

--- a/cmd/performance-profile-creator/README.md
+++ b/cmd/performance-profile-creator/README.md
@@ -1,50 +1,66 @@
 # Performance Profile Creator (PPC)
+
 A tool to automate the process of creating Performance Profile using the user supplied profile parameters.
 
 ## Software Components
-1. A CLI tool part of the Performance Addon Operator image
+
+1. A CLI tool part of the Node Tuning Operator image
 
 ## Flow
+
 1. PPC consumes a must-gather output.
 1. PPC output is a bunch of YAML data (PAO profile + NTO tuned part).
 
 ## Things to note before running Performance Profile Creator
-1. Performance Profile Creator is present as an entrypoint (in /usr/local/bin/performance-profile-creator) in the Performance Addon Operator image.
+
+1. Performance Profile Creator is present as an entrypoint (in /usr/bin/performance-profile-creator) in the Node Tuning Operator image.
 1. It is assumed that we have a must-gather directory available where we run the tool.
     1. Option 1: Run must-gather tool like below and use its output dir when you run PPC.
+
        ```bash
         oc adm must-gather --image=quay.io/openshift-kni/performance-addon-operator-must-gather:4.9-snapshot --dest-dir=<dir>
        ```
+
     1. Option 2: Use an existing must-gather tarball decompressed to a directory.
 
 ## Building Performance Profile Creator binary and image
+
 Developers can build the Performance Profile Creator images from the source tree using make targets.
- 1. Setup Environment variables
+
+1. Setup Environment variables
+
     ```bash
     export REGISTRY_NAMESPACE=<your quay.io namespace>
     export IMAGE_TAG=<the image tag to use> #defaults to "latest"
     export IMAGE_BUILD_CMD=podman
     ```
+
 1. To build from Performance Profile Creator source:
+
    ```bash
-   make create-performance-profile
+   make build-performance-profile-creator
    ```
+
 1. To build the Performance addon Operator image from source:
+
    ```bash
-   make operator-container
+   make local-image
    ```
-Alternatively, you can pull the latest master upstream image.  In the following examples, TAG has the format major.minor-snapshot. For example, the TAG for OpenShift 4.11 will be 4.11-snapshot:
+
+Alternatively, you can pull the latest master upstream image.  In the following examples, TAG has the format major.minor. For example, the TAG for OpenShift 4.11 will be 4.11:
 
 ```bash
-podman pull quay.io/openshift-kni/performance-addon-operator:4.11-snapshot
+podman pull quay.io/openshift/origin-cluster-node-tuning-operator:4.11
 ```
 
 ## Running Performance Profile Creator
+
 Depending on how the must-gather directory was set up the operator can now run the Performance Profile Creator tool with the required parameters.
 
 PPC Tool help output:
+
 ```bash
-$ podman run --entrypoint performance-profile-creator quay.io/openshift-kni/performance-addon-operator:4.11-snapshot -h
+$ podman run --entrypoint performance-profile-creator quay.io/openshift/origin-cluster-node-tuning-operator:4.11 -h
 A tool that automates creation of Performance Profiles
 
 Usage:
@@ -66,21 +82,25 @@ Flags:
 ```
 
 1. Option 1: Example of using must-gather output dir (obtained after running must gather manually) along with required arguments
+
    ```bash
    podman run --entrypoint performance-profile-creator -v /path/to/must-gather-output:/must-gather:z \
-   quay.io/openshift-kni/performance-addon-operator:4.11-snapshot --must-gather-dir-path /must-gather \
+   quay.io/openshift/origin-cluster-node-tuning-operator:4.11 --must-gather-dir-path /must-gather \
    --reserved-cpu-count 20 --mcp-name worker-cnf --rt-kernel false > performance-profile.yaml
    ```
+
 1. Option 2: Example of using an existing must-gather tarball which is decompressed to a directory along with required arguments
+
    ```bash
    podman run --entrypoint performance-profile-creator -v /path/to/decompressed-tarball:/must-gather:z \
-   quay.io/openshift-kni/performance-addon-operator:4.11-snapshot --must-gather-dir-path /must-gather \
+   quay.io/openshift/origin-cluster-node-tuning-operator:4.11 --must-gather-dir-path /must-gather \
    --reserved-cpu-count 20 --mcp-name worker-cnf --rt-kernel false > performance-profile.yaml
     ```
 
 ## Running Performance Profile Creator using Wrapper script
 
 1. Example of how the following wrapper script can be used to create a performance profle:
+
    ```bash
    ./hack/run-perf-profile-creator.sh -t must-gather.tar.gz -- --mcp-name=worker-cnf --reserved-cpu-count=20 \
    --rt-kernel=false --split-reserved-cpus-across-numa=true --topology-manager-policy=restricted \
@@ -90,6 +110,7 @@ Flags:
 ## Discovery mode
 
 To learn about the key details of the cluster you want to create a profile for, you may use the `discovery` (aka `info`) mode:
+
 ```bash
    ./hack/run-perf-profile-creator.sh -t must-gather.tar.gz -- --info=log
 

--- a/hack/run-perf-profile-creator.sh
+++ b/hack/run-perf-profile-creator.sh
@@ -7,7 +7,7 @@ readonly IMG_EXISTS_CMD="${CONTAINER_RUNTIME} image exists"
 readonly IMG_PULL_CMD="${CONTAINER_RUNTIME} image pull"
 readonly MUST_GATHER_VOL="/must-gather"
 
-PAO_IMG="quay.io/openshift-kni/performance-addon-operator:4.11-snapshot"
+NTO_IMG="quay.io/openshift/origin-cluster-node-tuning-operator:4.11"
 MG_TARBALL=""
 DATA_DIR=""
 
@@ -17,10 +17,10 @@ usage() {
   print ""
   print "Options:"
   print "   -h                 help for ${CURRENT_SCRIPT}"
-  print "   -p                 Performance Addon Operator image"
+  print "   -p                 Node Tuning Operator image"
   print "   -t                 path to a must-gather tarball"
 
-  ${IMG_EXISTS_CMD} "${PAO_IMG}" && ${CMD} "${PAO_IMG}" -h
+  ${IMG_EXISTS_CMD} "${NTO_IMG}" && ${CMD} "${NTO_IMG}" -h
 }
 
 function cleanup {
@@ -39,8 +39,8 @@ print() {
 }
 
 check_requirements() {
-  ${IMG_EXISTS_CMD} "${PAO_IMG}" || ${IMG_PULL_CMD} "${PAO_IMG}" || \
-      exit_error "Performance Addon Operator image not found"
+  ${IMG_EXISTS_CMD} "${NTO_IMG}" || ${IMG_PULL_CMD} "${NTO_IMG}" || \
+      exit_error "Node Tuning Operator image not found"
 
   [ -n "${MG_TARBALL}" ] || exit_error "Must-gather tarball file path is mandatory"
   [ -f "${MG_TARBALL}" ] || exit_error "Must-gather tarball file not found"
@@ -60,7 +60,7 @@ main() {
         exit 0
         ;;
       p)
-        PAO_IMG="${OPTARG}"
+        NTO_IMG="${OPTARG}"
         ;;
       t)
         MG_TARBALL="${OPTARG}"
@@ -74,7 +74,7 @@ main() {
 
   check_requirements || exit 1
 
-  ${CMD} -v "${DATA_DIR}:${MUST_GATHER_VOL}:z" "${PAO_IMG}" "$@" --must-gather-dir-path "${MUST_GATHER_VOL}"
+  ${CMD} -v "${DATA_DIR}:${MUST_GATHER_VOL}:z" "${NTO_IMG}" "$@" --must-gather-dir-path "${MUST_GATHER_VOL}"
   echo "" 1>&2
 }
 

--- a/test/e2e/performanceprofile/functests-performance-profile-creator/1_performance-profile_creator/ppc.go
+++ b/test/e2e/performanceprofile/functests-performance-profile-creator/1_performance-profile_creator/ppc.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	mustGatherPath       = "../../test/e2e/performanceprofile/testdata/must-gather"
-	expectedProfilesPath = "../../test/e2e/performanceprofile/testdata/ppc-expected-profiles"
-	expectedInfoPath     = "../../test/e2e/performanceprofile/testdata/ppc-expected-info"
-	ppcPath              = "../../build/_output/bin/performance-profile-creator"
+	mustGatherPath       = "../../../../../test/e2e/performanceprofile/testdata/must-gather"
+	expectedProfilesPath = "../../../../../test/e2e/performanceprofile/testdata/ppc-expected-profiles"
+	expectedInfoPath     = "../../../../../test/e2e/performanceprofile/testdata/ppc-expected-info"
+	ppcPath              = "../../../../../_output/performance-profile-creator"
 )
 
 var mustGatherFullPath = path.Join(mustGatherPath, "must-gather.bare-metal")


### PR DESCRIPTION
Align PPC with new folder structure in NTO
    
- Create new targets in Makefile to build PPC and execute functional tests
- Modify paths in functional tests to adapt them to the new folder
structure.

This PR depends on #322 and its related with #324