### PR TITLE
Remove pao namespace from watched namespaces

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -90,7 +90,6 @@ func main() {
 		ntoNamespace := config.OperatorNamespace()
 		namespaces := []string{
 			ntoNamespace,
-			"openshift-performance-addon-operator",
 			metav1.NamespaceNone,
 		}
 


### PR DESCRIPTION
Performance addons operator namespace removed from the controller runtime manager's namespace watch list to decrease the number of watches.

The only code aligned to this fix is the PAO OLM removal which is a one time operation that will not use the namespace above explicitly. 