### PR TITLE
Bug 2066700: RBAC replace wildcards for tuned.openshift.io apiGroup

### DIFF
--- a/manifests/40-rbac.yaml
+++ b/manifests/40-rbac.yaml
@@ -24,8 +24,17 @@ metadata:
 rules:
 # We own (the right to perform anything with) tuned.openshift.io
 - apiGroups: ["tuned.openshift.io"]
-  resources: ["*"]
-  verbs: ["*"]
+  resources: ["tuneds"]
+  verbs: ["create","get","delete","list","update","watch","patch"]
+- apiGroups: ["tuned.openshift.io"]
+  resources: ["tuneds/finalizers"]
+  verbs: ["update"]
+- apiGroups: ["tuned.openshift.io"]
+  resources: ["profiles"]
+  verbs: ["create","get","delete","list","update","watch","patch"]
+- apiGroups: ["tuned.openshift.io"]
+  resources: ["profiles/finalizers"]
+  verbs: ["update"]
 # The operator oversees tuned daemonset.  It even needs to be able
 # to delete it when the operator is put into "Removed" state.
 - apiGroups: ["apps"]
@@ -128,8 +137,11 @@ metadata:
   name: cluster-node-tuning:tuned
 rules:
 - apiGroups: ["tuned.openshift.io"]
-  resources: ["*"]
-  verbs: ["*"]
+  resources: ["tuneds"]
+  verbs: ["get","list","watch"]
+- apiGroups: ["tuned.openshift.io"]
+  resources: ["profiles"]
+  verbs: ["get","list","update","watch","patch"]
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
   verbs: ["use"]


### PR DESCRIPTION
This PR is intended to fix [RHBZ#2066700](https://bugzilla.redhat.com/show_bug.cgi?id=2066700).

For an initial draft, I am replacing the wildcards with the full set of resources and verbs in the tuned.openshift.io apiGroup. I plan to experiment with removing some of the verbs, especially from the `cluster-node-tuning:tuned` clusterRole.