### PR TITLE
Update NTO-generated annotations in MCs

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -722,6 +722,7 @@ func (c *Controller) syncMachineConfig(name string, labels map[string]string, bo
 		return nil
 	}
 	mc = mc.DeepCopy() // never update the objects from cache
+	mc.ObjectMeta.Annotations = mcNew.ObjectMeta.Annotations
 	mc.Spec.KernelArguments = kernelArguments
 	mc.Spec.Config = mcNew.Spec.Config
 


### PR DESCRIPTION
When updating NTO-generated MachineConfigs, update `tuned.openshift.io/generated-by-controller-version` annotation with the NTO version performing the update.