### PR TITLE
Bug 2073938: Replace RuntimeClass version from v1beta1 to v1 

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/tuned"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
-	nodev1beta1 "k8s.io/api/node/v1beta1"
+	nodev1 "k8s.io/api/node/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -19,7 +19,7 @@ type ManifestResultSet struct {
 	MachineConfig *mcov1.MachineConfig
 	KubeletConfig *mcov1.KubeletConfig
 	Tuned         *tunedv1.Tuned
-	RuntimeClass  *nodev1beta1.RuntimeClass
+	RuntimeClass  *nodev1.RuntimeClass
 }
 
 // ManifestTable is map with Kind name as key and component's instance as value

--- a/pkg/performanceprofile/controller/performanceprofile/components/runtimeclass/runtimeclass.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/runtimeclass/runtimeclass.go
@@ -4,14 +4,14 @@ import (
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 
-	nodev1beta1 "k8s.io/api/node/v1beta1"
+	nodev1 "k8s.io/api/node/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // New returns a new RuntimeClass object
-func New(profile *performancev2.PerformanceProfile, handler string) *nodev1beta1.RuntimeClass {
+func New(profile *performancev2.PerformanceProfile, handler string) *nodev1.RuntimeClass {
 	name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
-	return &nodev1beta1.RuntimeClass{
+	return &nodev1.RuntimeClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RuntimeClass",
 			APIVersion: "node.k8s.io/v1beta1",
@@ -20,7 +20,7 @@ func New(profile *performancev2.PerformanceProfile, handler string) *nodev1beta1
 			Name: name,
 		},
 		Handler: handler,
-		Scheduling: &nodev1beta1.Scheduling{
+		Scheduling: &nodev1.Scheduling{
 			NodeSelector: profile.Spec.NodeSelector,
 		},
 	}

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -33,7 +33,7 @@ import (
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
-	nodev1beta1 "k8s.io/api/node/v1beta1"
+	nodev1 "k8s.io/api/node/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serros "k8s.io/apimachinery/pkg/api/errors"
@@ -126,7 +126,7 @@ func (r *PerformanceProfileReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Owns(&mcov1.MachineConfig{}, builder.WithPredicates(p)).
 		Owns(&mcov1.KubeletConfig{}, builder.WithPredicates(kubeletPredicates)).
 		Owns(&tunedv1.Tuned{}, builder.WithPredicates(p)).
-		Owns(&nodev1beta1.RuntimeClass{}, builder.WithPredicates(p)).
+		Owns(&nodev1.RuntimeClass{}, builder.WithPredicates(p)).
 		Watches(
 			&source.Kind{Type: &mcov1.MachineConfigPool{}},
 			handler.EnqueueRequestsFromMapFunc(r.mcpToPerformanceProfile),

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -25,7 +25,7 @@ import (
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	nodev1beta1 "k8s.io/api/node/v1beta1"
+	nodev1 "k8s.io/api/node/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -142,7 +142,7 @@ var _ = Describe("Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// verify RuntimeClass creation
-			runtimeClass := &nodev1beta1.RuntimeClass{}
+			runtimeClass := &nodev1.RuntimeClass{}
 			err = r.Get(context.TODO(), key, runtimeClass)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -362,7 +362,7 @@ var _ = Describe("Controller", func() {
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 
 			// verify that no RuntimeClass was created
-			runtimeClass := &nodev1beta1.RuntimeClass{}
+			runtimeClass := &nodev1.RuntimeClass{}
 			err = r.Get(context.TODO(), key, runtimeClass)
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
@@ -371,7 +371,7 @@ var _ = Describe("Controller", func() {
 			var mc *mcov1.MachineConfig
 			var kc *mcov1.KubeletConfig
 			var tunedPerformance *tunedv1.Tuned
-			var runtimeClass *nodev1beta1.RuntimeClass
+			var runtimeClass *nodev1.RuntimeClass
 
 			BeforeEach(func() {
 				var err error
@@ -615,7 +615,7 @@ var _ = Describe("Controller", func() {
 					Name:      components.GetComponentName(profile.Name, components.ComponentNamePrefix),
 					Namespace: metav1.NamespaceAll,
 				}
-				runtimeClass := &nodev1beta1.RuntimeClass{}
+				runtimeClass := &nodev1.RuntimeClass{}
 				err := r.Get(context.TODO(), key, runtimeClass)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/performanceprofile/controller/resources.go
+++ b/pkg/performanceprofile/controller/resources.go
@@ -8,7 +8,7 @@ import (
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
-	nodev1beta1 "k8s.io/api/node/v1beta1"
+	nodev1 "k8s.io/api/node/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -263,8 +263,8 @@ func (r *PerformanceProfileReconciler) deleteTuned(name string, namespace string
 	return r.Delete(context.TODO(), tuned)
 }
 
-func (r *PerformanceProfileReconciler) getRuntimeClass(name string) (*nodev1beta1.RuntimeClass, error) {
-	runtimeClass := &nodev1beta1.RuntimeClass{}
+func (r *PerformanceProfileReconciler) getRuntimeClass(name string) (*nodev1.RuntimeClass, error) {
+	runtimeClass := &nodev1.RuntimeClass{}
 	key := types.NamespacedName{
 		Name: name,
 	}
@@ -274,7 +274,7 @@ func (r *PerformanceProfileReconciler) getRuntimeClass(name string) (*nodev1beta
 	return runtimeClass, nil
 }
 
-func (r *PerformanceProfileReconciler) getMutatedRuntimeClass(runtimeClass *nodev1beta1.RuntimeClass) (*nodev1beta1.RuntimeClass, error) {
+func (r *PerformanceProfileReconciler) getMutatedRuntimeClass(runtimeClass *nodev1.RuntimeClass) (*nodev1.RuntimeClass, error) {
 	existing, err := r.getRuntimeClass(runtimeClass.Name)
 	if errors.IsNotFound(err) {
 		return runtimeClass, nil
@@ -301,7 +301,7 @@ func (r *PerformanceProfileReconciler) getMutatedRuntimeClass(runtimeClass *node
 	return mutated, nil
 }
 
-func (r *PerformanceProfileReconciler) createOrUpdateRuntimeClass(runtimeClass *nodev1beta1.RuntimeClass) error {
+func (r *PerformanceProfileReconciler) createOrUpdateRuntimeClass(runtimeClass *nodev1.RuntimeClass) error {
 	_, err := r.getRuntimeClass(runtimeClass.Name)
 	if errors.IsNotFound(err) {
 		klog.Infof("Create runtime class %q", runtimeClass.Name)

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/node/v1beta1"
+	nodev1 "k8s.io/api/node/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
@@ -568,7 +568,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			Expect(kubeletConfig.Spec.MachineConfigPoolSelector.MatchLabels[machineconfigv1.MachineConfigRoleLabelKey]).Should(Equal(newRole))
 			Expect(kubeletConfig.Spec.KubeletConfig.Raw).Should(ContainSubstring("restricted"), "Can't find value in KubeletConfig")
 
-			runtimeClass := &v1beta1.RuntimeClass{}
+			runtimeClass := &nodev1.RuntimeClass{}
 			err = testclient.GetWithRetry(context.TODO(), configKey, runtimeClass)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find RuntimeClass profile object %s", runtimeClass.Name))
 			Expect(runtimeClass.Handler).Should(Equal(machineconfig.HighPerformanceRuntime))

--- a/test/e2e/performanceprofile/functests/3_performance_status/status.go
+++ b/test/e2e/performanceprofile/functests/3_performance_status/status.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 
 	corev1 "k8s.io/api/core/v1"
-	nodev1beta1 "k8s.io/api/node/v1beta1"
+	nodev1 "k8s.io/api/node/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
@@ -83,7 +83,7 @@ var _ = Describe("Status testing of performance profile", func() {
 				Name:      components.GetComponentName(profile.Name, components.ComponentNamePrefix),
 				Namespace: metav1.NamespaceAll,
 			}
-			runtimeClass := &nodev1beta1.RuntimeClass{}
+			runtimeClass := &nodev1.RuntimeClass{}
 			err = testclient.GetWithRetry(context.TODO(), key, runtimeClass)
 			Expect(err).ToNot(HaveOccurred(), "cannot find the RuntimeClass object "+key.String())
 


### PR DESCRIPTION
RuntimeClass in the node.k8s.io/v1beta1 API version
will [no longer be served in v1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#runtimeclass-v125), therefore all occurrences in code containing v1beta1 are replaced with v1.
Kubernetes already supports the seamless transition for existing runtimeclasses.node.k8s.io v1beta1 to v1.