### PR TITLE
  Add build and ppc test invocation under one target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test-e2e:
 	done
 
 .PHONY: test-e2e-local
-test-e2e-local:
+test-e2e-local: build performance-profile-creator-tests
 	for d in performanceprofile/functests-render-command/1_render_command; do \
 	  $(GO) test -v -timeout 40m ./test/e2e/$$d -ginkgo.v -ginkgo.noColor -ginkgo.failFast || exit; \
 	done


### PR DESCRIPTION
Add build and ppc test targets under `test-e2e-local`
that already contains the render test so there will be one main
target for local e2e tests.