### PR TITLE
Adapt PPC to use workload hints instead of setting additional kernel arguments

### DIFF
--- a/pkg/performanceprofile/profilecreator/profilecreator_test.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator_test.go
@@ -738,63 +738,23 @@ var _ = Describe("PerformanceProfileCreator: Test Helper Function ensureSameTopo
 })
 
 var _ = Describe("PerformanceProfileCreator: Test Helper Function GetAdditionalKernelArgs", func() {
-	var powerMode string
 	var disableHT bool
-	Context("Ensure kernel args are populated correctly", func() {
-		It("Ensure kernel args are populated correctly in case of low-latency ", func() {
-			powerMode = "default"
-			disableHT = false
-			kernelArgs := GetAdditionalKernelArgs(powerMode, disableHT)
-			Expect(kernelArgs).To(BeEquivalentTo([]string{}))
-		})
 
-	})
-	Context("Ensure kernel args are populated correctly", func() {
-		It("Ensure kernel args are populated correctly in case of low-latency ", func() {
-			powerMode = "low-latency"
+	Context("with hyper-threading enabled", func() {
+		It("should not append additional kernel arguments", func() {
 			disableHT = false
-			args := []string{"audit=0",
-				"mce=off",
-				"nmi_watchdog=0",
-			}
-			kernelArgs := GetAdditionalKernelArgs(powerMode, disableHT)
-			sort.Strings(kernelArgs) // sort to avoid inequality due to difference in order
-			Expect(kernelArgs).To(BeEquivalentTo(args))
+			kernelArgs := GetAdditionalKernelArgs(disableHT)
+			Expect(kernelArgs).To(BeEmpty())
 		})
-
 	})
-	Context("Ensure kernel args are populated correctly", func() {
-		It("Ensure kernel args are populated correctly in case of ultra-low-latency ", func() {
-			powerMode = "ultra-low-latency"
-			disableHT = false
-			args := []string{"audit=0",
-				"idle=poll",
-				"intel_idle.max_cstate=0",
-				"mce=off",
-				"nmi_watchdog=0",
-				"processor.max_cstate=1",
-			}
-			kernelArgs := GetAdditionalKernelArgs(powerMode, disableHT)
-			sort.Strings(kernelArgs) // sort to avoid inequality due to difference in order
-			Expect(kernelArgs).To(BeEquivalentTo(args))
-		})
 
-	})
-	Context("Ensure kernel args are populated correctly", func() {
-		It("Ensure kernel args are populated correctly in case of disableHT=true ", func() {
-			powerMode = "ultra-low-latency"
+	Context("with hyper-threading disable", func() {
+		It("should append nosmt argument", func() {
 			disableHT = true
-			args := []string{"audit=0",
-				"idle=poll",
-				"intel_idle.max_cstate=0",
-				"mce=off",
-				"nmi_watchdog=0",
-				"nosmt",
-				"processor.max_cstate=1",
-			}
-			kernelArgs := GetAdditionalKernelArgs(powerMode, disableHT)
-			sort.Strings(kernelArgs) // sort to avoid inequality due to difference in order
-			Expect(kernelArgs).To(BeEquivalentTo(args))
+			expectedArgs := []string{"nosmt"}
+			sort.Strings(expectedArgs) // sort to avoid inequality due to difference in order
+			kernelArgs := GetAdditionalKernelArgs(disableHT)
+			Expect(kernelArgs).To(BeEquivalentTo(expectedArgs))
 		})
 
 	})

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1.json
@@ -2,5 +2,6 @@
   "must-gather-dir-path": "must-gather.bare-metal",
   "mcp-name": "worker-cnf",
   "reserved-cpu-count": 4,
-  "rt-kernel": true
+  "rt-kernel": true,
+  "power-consumption-mode": "low-latency"
 }

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1.yaml
@@ -14,3 +14,6 @@ spec:
     topologyPolicy: restricted
   realTimeKernel:
     enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2.json
@@ -3,5 +3,6 @@
   "mcp-name": "master",
   "reserved-cpu-count": 1,
   "rt-kernel": false,
-  "user-level-networking": false
+  "user-level-networking": false,
+  "power-consumption-mode": "default"
 }

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2.yaml
@@ -16,3 +16,6 @@ spec:
     topologyPolicy: restricted
   realTimeKernel:
     enabled: false
+  workloadHints:
+    highPowerConsumption: false
+    realtime: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3.json
@@ -4,8 +4,7 @@
     "reserved-cpu-count": 5,
     "disable-ht": true,
     "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
     "split-reserved-cpus-across-numa": true,
     "user-level-networking": false
 }
-    
-    

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3.yaml
@@ -19,3 +19,6 @@ spec:
     topologyPolicy: restricted
   realTimeKernel:
     enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4.json
@@ -3,6 +3,7 @@
     "mcp-name": "worker-cnf",
     "reserved-cpu-count": 12,
     "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
     "disable-ht": true, 
     "user-level-networking": false
 }

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4.yaml
@@ -19,3 +19,6 @@ spec:
     topologyPolicy: restricted
   realTimeKernel:
     enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5.json
@@ -4,6 +4,7 @@
     "reserved-cpu-count": 4,
     "disable-ht": false,
     "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
     "split-reserved-cpus-across-numa": true,
     "user-level-networking": false
 }

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5.yaml
@@ -17,3 +17,6 @@ spec:
     topologyPolicy: restricted
   realTimeKernel:
     enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true


### PR DESCRIPTION
Now power consumption modes will work together with workload hints:

1. low-latency -> enable real-time workload hint
2. ultra-low-latency -> enable realtime and highPowerConsumtion hints

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>