### PR TITLE
Add performanceProfile API offline cores

### DIFF
--- a/assets/performanceprofile/scripts/set-cpus-offline.sh
+++ b/assets/performanceprofile/scripts/set-cpus-offline.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+for cpu in ${OFFLINE_CPUS//,/ };
+  do
+    online_cpu_file="/sys/devices/system/cpu/cpu$cpu/online"
+    if [ ! -f "${online_cpu_file}" ]; then
+      echo "ERROR: ${online_cpu_file} does not exist, abort script execution"
+      exit 1
+    fi
+  done
+
+echo "All cpus offlined exists, set them offline"
+
+for cpu in ${OFFLINE_CPUS//,/ };
+  do
+    online_cpu_file="/sys/devices/system/cpu/cpu$cpu/online"
+    echo 0 > "${online_cpu_file}"
+    echo "offline cpu num $cpu"
+  done
+

--- a/docs/performanceprofile/performance_profile.md
+++ b/docs/performanceprofile/performance_profile.md
@@ -31,6 +31,7 @@ CPU defines a set of CPU related features.
 | reserved | Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet. | *[CPUSet](#cpuset) | true |
 | isolated | Isolated defines a set of CPUs that will be used to give to application threads the most execution time possible, which means removing as many extraneous tasks off a CPU as possible. It is important to notice the CPU manager can choose any CPU to run the workload except the reserved CPUs. In order to guarantee that your workload will run on the isolated CPU:\n  1. The union of reserved CPUs and isolated CPUs should include all online CPUs\n  2. The isolated CPUs field should be the complementary to reserved CPUs field | *[CPUSet](#cpuset) | true |
 | balanceIsolated | BalanceIsolated toggles whether or not the Isolated CPU set is eligible for load balancing work loads. When this option is set to \"false\", the Isolated CPU set will be static, meaning workloads have to explicitly assign each thread to a specific cpu in order to work across multiple CPUs. Setting this to \"true\" allows workloads to be balanced across CPUs. Setting this to \"false\" offers the most predictable performance for guaranteed workloads, but it offloads the complexity of cpu load balancing to the application. Defaults to \"true\" | *bool | false |
+| offlined | Offline defines a set of CPUs that will be unused and set offline | *[CPUSet](#cpuset) | true |
 
 [Back to TOC](#table-of-contents)
 

--- a/examples/performanceprofile/samples/performance_v2_performanceprofile.yaml
+++ b/examples/performanceprofile/samples/performance_v2_performanceprofile.yaml
@@ -11,8 +11,9 @@ spec:
     - "idle=poll"
     - "intel_idle.max_cstate=0"
   cpu:
-    isolated: "2-3"
-    reserved: "0-1"
+      isolated: "2"
+      reserved: "0-1"
+      offlined: "3"
   hugepages:
     defaultHugepagesSize: "1G"
     pages:

--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -370,6 +370,9 @@ spec:
                     isolated:
                       description: 'Isolated defines a set of CPUs that will be used to give to application threads the most execution time possible, which means removing as many extraneous tasks off a CPU as possible. It is important to notice the CPU manager can choose any CPU to run the workload except the reserved CPUs. In order to guarantee that your workload will run on the isolated CPU:   1. The union of reserved CPUs and isolated CPUs should include all online CPUs   2. The isolated CPUs field should be the complementary to reserved CPUs field'
                       type: string
+                    offlined:
+                      description: Offline defines a set of CPUs that will be unused and set offline
+                      type: string
                     reserved:
                       description: Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet.
                       type: string

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -98,6 +98,9 @@ type CPU struct {
 	// Defaults to "true"
 	// +optional
 	BalanceIsolated *bool `json:"balanceIsolated,omitempty"`
+	// Offline defines a set of CPUs that will be unused and set offline
+	// +optional
+	Offlined *CPUSet `json:"offlined,omitempty"`
 }
 
 // HugePageSize defines size of huge pages, can be 2M or 1G.

--- a/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
@@ -28,6 +28,11 @@ func (in *CPU) DeepCopyInto(out *CPU) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Offlined != nil {
+		in, out := &in.Offlined, &out.Offlined
+		*out = new(CPUSet)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -33,6 +33,27 @@ const hugepagesAllocationService = `
         name: hugepages-allocation-1048576kB-NUMA0.service
 `
 
+const offlineCPUS = `
+      - contents: |
+          [Unit]
+          Description=Set cpus offline: 6,7
+          Before=kubelet.service
+
+          [Service]
+          Environment=OFFLINE_CPUS=6,7
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/set-cpus-offline.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: set-cpus-offline.service
+`
+
+var CPUs = []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+var CPUstring = "1,2,3,4,5,6,7,8,9"
+
 var _ = Describe("Machine Config", func() {
 
 	Context("machine config creation ", func() {
@@ -45,7 +66,7 @@ var _ = Describe("Machine Config", func() {
 		})
 	})
 
-	Context("with hugepages with specified NUMA node", func() {
+	Context("with hugepages with specified NUMA node and offlinedCPUs", func() {
 		var manifest string
 
 		BeforeEach(func() {
@@ -73,5 +94,15 @@ var _ = Describe("Machine Config", func() {
 			Expect(manifest).To(ContainSubstring(hugepagesAllocationService))
 		})
 
+		It("should add systemd unit to offlineCPUs", func() {
+			Expect(manifest).To(ContainSubstring(offlineCPUS))
+		})
+	})
+
+	Context("check listToString ", func() {
+		It("should create string from CPUSet", func() {
+			res := components.ListToString(CPUs)
+			Expect(res).To(Equal(CPUstring))
+		})
 	})
 })

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Tuned", func() {
 			manifest := getTunedManifest(profile)
 
 			Expect(manifest).To(ContainSubstring(expectedMatchSelector))
-			Expect(manifest).To(ContainSubstring("isolated_cores=4-7"))
+			Expect(manifest).To(ContainSubstring("isolated_cores=4-5"))
 			Expect(manifest).To(ContainSubstring("governor=performance"))
 			Expect(manifest).To(ContainSubstring("service.stalld=start,enable"))
 			Expect(manifest).To(ContainSubstring("sched_rt_runtime_us=-1"))

--- a/pkg/performanceprofile/controller/performanceprofile/components/utils_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/utils_test.go
@@ -21,11 +21,12 @@ var cpuListToMask = []listToMask{
 }
 
 func intersectHelper(cpuListA, cpuListB string) ([]int, error) {
-	cpuLists, err := NewCPULists(cpuListA, cpuListB)
+	offlined := ""
+	cpuLists, err := NewCPULists(cpuListA, cpuListB, offlined)
 	if err != nil {
 		return nil, err
 	}
-	return cpuLists.Intersect(), nil
+	return Intersect(cpuLists.isolated, cpuLists.reserved), nil
 }
 
 var _ = Describe("Components utils", func() {

--- a/pkg/performanceprofile/utils/testing/testing.go
+++ b/pkg/performanceprofile/utils/testing/testing.go
@@ -15,10 +15,11 @@ const (
 	// HugePagesCount defines the huge page count used for tests
 	HugePagesCount = 4
 	// IsolatedCPUs defines the isolated CPU set used for tests
-	IsolatedCPUs = performancev2.CPUSet("4-7")
+	IsolatedCPUs = performancev2.CPUSet("4-5")
 	// ReservedCPUs defines the reserved CPU set used for tests
 	ReservedCPUs = performancev2.CPUSet("0-3")
-	// SingleNUMAPolicy defines the topologyManager policy used for tests
+	// OfflinedCPUs defines the Offline CPU set used for tests
+	OfflinedCPUs     = performancev2.CPUSet("6-7") // SingleNUMAPolicy defines the topologyManager policy used for tests
 	SingleNUMAPolicy = "single-numa-node"
 
 	//MachineConfigLabelKey defines the MachineConfig label key of the test profile
@@ -36,6 +37,7 @@ func NewPerformanceProfile(name string) *performancev2.PerformanceProfile {
 	size := HugePageSize
 	isolatedCPUs := IsolatedCPUs
 	reservedCPUs := ReservedCPUs
+	offlineCPUs := OfflinedCPUs
 	numaPolicy := SingleNUMAPolicy
 
 	return &performancev2.PerformanceProfile{
@@ -48,6 +50,7 @@ func NewPerformanceProfile(name string) *performancev2.PerformanceProfile {
 			CPU: &performancev2.CPU{
 				Isolated: &isolatedCPUs,
 				Reserved: &reservedCPUs,
+				Offlined: &offlineCPUs,
 			},
 			HugePages: &performancev2.HugePages{
 				DefaultHugePagesSize: &size,

--- a/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance/performance_profile.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance/performance_profile.yaml
@@ -4,8 +4,9 @@ metadata:
   name: manual
 spec:
   cpu:
-    isolated: "1-3"
+    isolated: "1"
     reserved: "0"
+    offlined: "2,3"
   hugepages:
     defaultHugepagesSize: "1G"
     pages:

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
@@ -46,6 +46,13 @@ spec:
           path: /usr/local/bin/set-rps-mask.sh
           user: {}
         - contents:
+            source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9iYXNoCgpzZXQgLWV1byBwaXBlZmFpbAoKZm9yIGNwdSBpbiAke09GRkxJTkVfQ1BVUy8vLC8gfTsKICBkbwogICAgb25saW5lX2NwdV9maWxlPSIvc3lzL2RldmljZXMvc3lzdGVtL2NwdS9jcHUkY3B1L29ubGluZSIKICAgIGlmIFsgISAtZiAiJHtvbmxpbmVfY3B1X2ZpbGV9IiBdOyB0aGVuCiAgICAgIGVjaG8gIkVSUk9SOiAke29ubGluZV9jcHVfZmlsZX0gZG9lcyBub3QgZXhpc3QsIGFib3J0IHNjcmlwdCBleGVjdXRpb24iCiAgICAgIGV4aXQgMQogICAgZmkKICBkb25lCgplY2hvICJBbGwgY3B1cyBvZmZsaW5lZCBleGlzdHMsIHNldCB0aGVtIG9mZmxpbmUiCgpmb3IgY3B1IGluICR7T0ZGTElORV9DUFVTLy8sLyB9OwogIGRvCiAgICBvbmxpbmVfY3B1X2ZpbGU9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vY3B1L2NwdSRjcHUvb25saW5lIgogICAgZWNobyAwID4gIiR7b25saW5lX2NwdV9maWxlfSIKICAgIGVjaG8gIm9mZmxpbmUgY3B1IG51bSAkY3B1IgogIGRvbmUKCg==
+            verification: {}
+          group: {}
+          mode: 448
+          path: /usr/local/bin/set-cpus-offline.sh
+          user: {}
+        - contents:
             source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMCIKCgojIFdlIHNob3VsZCBjb3B5IHBhc3RlIHRoZSBkZWZhdWx0IHJ1bnRpbWUgYmVjYXVzZSB0aGlzIHNuaXBwZXQgd2lsbCBvdmVycmlkZSB0aGUgd2hvbGUgcnVudGltZXMgc2VjdGlvbgpbY3Jpby5ydW50aW1lLnJ1bnRpbWVzLnJ1bmNdCnJ1bnRpbWVfcGF0aCA9ICIiCnJ1bnRpbWVfdHlwZSA9ICJvY2kiCnJ1bnRpbWVfcm9vdCA9ICIvcnVuL3J1bmMiCgojIFRoZSBDUkktTyB3aWxsIGNoZWNrIHRoZSBhbGxvd2VkX2Fubm90YXRpb25zIHVuZGVyIHRoZSBydW50aW1lIGhhbmRsZXIgYW5kIGFwcGx5IGhpZ2gtcGVyZm9ybWFuY2UgaG9va3Mgd2hlbiBvbmUgb2YKIyBoaWdoLXBlcmZvcm1hbmNlIGFubm90YXRpb25zIHByZXNlbnRzIHVuZGVyIGl0LgojIFdlIHNob3VsZCBwcm92aWRlIHRoZSBydW50aW1lX3BhdGggYmVjYXVzZSB3ZSBuZWVkIHRvIGluZm9ybSB0aGF0IHdlIHdhbnQgdG8gcmUtdXNlIHJ1bmMgYmluYXJ5IGFuZCB3ZQojIGRvIG5vdCBoYXZlIGhpZ2gtcGVyZm9ybWFuY2UgYmluYXJ5IHVuZGVyIHRoZSAkUEFUSCB0aGF0IHdpbGwgcG9pbnQgdG8gaXQuCltjcmlvLnJ1bnRpbWUucnVudGltZXMuaGlnaC1wZXJmb3JtYW5jZV0KcnVudGltZV9wYXRoID0gIi9iaW4vcnVuYyIKcnVudGltZV90eXBlID0gIm9jaSIKcnVudGltZV9yb290ID0gIi9ydW4vcnVuYyIKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iXQo=
             verification: {}
           group: {}
@@ -93,6 +100,21 @@ spec:
             Type=oneshot
             ExecStart=/usr/local/bin/set-rps-mask.sh %i 00000001
           name: update-rps@.service
+        - contents: |
+            [Unit]
+            Description=Set cpus offline: 2,3
+            Before=kubelet.service
+
+            [Service]
+            Environment=OFFLINE_CPUS=2,3
+            Type=oneshot
+            RemainAfterExit=true
+            ExecStart=/usr/local/bin/set-cpus-offline.sh
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: set-cpus-offline.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -20,7 +20,7 @@ spec:
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1-3\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n#> Override
       the value set by cpu-partitioning with an empty one\nbanned_cpus=\"\"\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\nsched_min_granularity_ns=10000000\nsched_migration_cost_ns=5000000\nnuma_balancing=0\n\nsched_rt_runtime_us=-1\n\n\ndefault_irq_smp_affinity


### PR DESCRIPTION
## Description

Provide the ability through the performance addon operator to offline a set of unused cpus to reduce the overall power consumption of the cluster.

## Type of change

- [x] Add PerformanceProfile API 
- [ ] Add e2e test
- [ ] Add must gather data collect

## Testing steps
Launch test with PerformanceProfile:

  cpu:
    isolated: "1-2"
    reserved: "0"
    offlined: "4"

check if offlined cpu are offline:
sh-4.4# cat /sys/devices/system/cpu/offline 
4


Signed-off-by: Mario Fernandez <mariofer@redhat.com>