### PR TITLE
Fix local e2e test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ test-e2e:
 	done
 
 .PHONY: test-e2e-local
-test-e2e-local: build performance-profile-creator-tests
+test-e2e-local: $(BINDATA) performance-profile-creator-tests
+	$(GO_BUILD_RECIPE)
 	for d in performanceprofile/functests-render-command/1_render_command; do \
 	  $(GO) test -v -timeout 40m ./test/e2e/$$d -ginkgo.v -ginkgo.noColor -ginkgo.failFast || exit; \
 	done


### PR DESCRIPTION
Change test-e2e-local to use only local directives
instead of the whole build target.