### PR TITLE
Bug 2087159: Modify PPC to generate new "offlined" parameter in Performance Profile

### DIFF
--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1a.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1a.json
@@ -1,0 +1,8 @@
+{
+  "must-gather-dir-path": "must-gather.bare-metal",
+  "mcp-name": "worker-cnf",
+  "reserved-cpu-count": 4,
+  "offlined-cpu-count": 4,
+  "rt-kernel": true,
+  "power-consumption-mode": "low-latency"
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1a.yaml
@@ -1,0 +1,20 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: 1,3-39,41,43,45,47,49-51,53-79
+    reserved: 0,2,40,42
+    offlined: 44,46,48,52
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1b.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1b.json
@@ -1,0 +1,8 @@
+{
+  "must-gather-dir-path": "must-gather.bare-metal",
+  "mcp-name": "worker-cnf",
+  "reserved-cpu-count": 4,
+  "offlined-cpu-count": 40,
+  "rt-kernel": true,
+  "power-consumption-mode": "low-latency"
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1b.yaml
@@ -1,0 +1,21 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    reserved: 0,2,40,42
+    isolated: 4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,44,46,48,50,52,54,56,58,60,62,64,66,68,70,72,74,76,78
+    offlined: 1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79
+
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1c.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1c.json
@@ -1,0 +1,8 @@
+{
+  "must-gather-dir-path": "must-gather.bare-metal",
+  "mcp-name": "worker-cnf",
+  "reserved-cpu-count": 4,
+  "offlined-cpu-count": 41,
+  "rt-kernel": true,
+  "power-consumption-mode": "low-latency"
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1c.yaml
@@ -1,0 +1,20 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    reserved: 0,2,40,42
+    isolated: 4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,46,48,50,52,54,56,58,60,62,64,66,68,70,72,74,76,78
+    offlined: 1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43-45,47,49,51,53,55,57,59,61,63,65,67,69,71,73,75,77,79
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2a.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2a.json
@@ -1,0 +1,9 @@
+{
+  "must-gather-dir-path": "must-gather.sno",
+  "mcp-name": "master",
+  "reserved-cpu-count": 1,
+  "offlined-cpu-count": 1,
+  "rt-kernel": false,
+  "user-level-networking": false,
+  "power-consumption-mode": "default"
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2a.yaml
@@ -1,0 +1,22 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: 2-11
+    reserved: 0
+    offlined: 1
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/master: ""
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: false
+  workloadHints:
+    highPowerConsumption: false
+    realtime: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2b.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2b.json
@@ -1,0 +1,9 @@
+{
+  "must-gather-dir-path": "must-gather.sno",
+  "mcp-name": "master",
+  "reserved-cpu-count": 1,
+  "offlined-cpu-count": 5,
+  "rt-kernel": false,
+  "user-level-networking": false,
+  "power-consumption-mode": "default"
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2b.yaml
@@ -1,0 +1,22 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: 6-11
+    reserved: 0
+    offlined: 1-5
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/master: ""
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: false
+  workloadHints:
+    highPowerConsumption: false
+    realtime: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3a.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3a.json
@@ -1,0 +1,11 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 5,
+    "offlined-cpu-count": 1,
+    "disable-ht": true,
+    "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
+    "split-reserved-cpus-across-numa": true,
+    "user-level-networking": false
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3a.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  additionalKernelArgs:
+  - nosmt
+  cpu:
+    reserved: 0-4
+    isolated: 5-7,9-39
+    offlined: 8
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3b.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3b.json
@@ -1,0 +1,11 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 5,
+    "offlined-cpu-count": 20,
+    "disable-ht": true,
+    "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
+    "split-reserved-cpus-across-numa": true,
+    "user-level-networking": false
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3b.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  additionalKernelArgs:
+  - nosmt
+  cpu:
+    reserved: 0-4
+    isolated: 11,13,15,17,19,21,23,25,27,29,31,33,35,37,39
+    offlined: 5-10,12,14,16,18,20,22,24,26,28,30,32,34,36,38
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3c.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3c.json
@@ -1,0 +1,11 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 5,
+    "offlined-cpu-count": 30,
+    "disable-ht": true,
+    "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
+    "split-reserved-cpus-across-numa": true,
+    "user-level-networking": false
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3c.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  additionalKernelArgs:
+  - nosmt
+  cpu:
+    reserved: 0-4
+    isolated: 31,33,35,37,39
+    offlined: 5-30,32,34,36,38
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4a.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4a.json
@@ -1,0 +1,10 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 12,
+    "offlined-cpu-count": 10,
+    "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
+    "disable-ht": true,
+    "user-level-networking": false
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4a.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  additionalKernelArgs:
+  - nosmt
+  cpu:
+    reserved: 0,2,4,6,8,10,12,14,16,18,20,22
+    isolated: 3,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39
+    offlined: 1,5,24,26,28,30,32,34,36,38
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4b.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4b.json
@@ -1,0 +1,10 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 12,
+    "offlined-cpu-count": 20,
+    "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
+    "disable-ht": true,
+    "user-level-networking": false
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4b.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  additionalKernelArgs:
+  - nosmt
+  cpu:
+    reserved: 0,2,4,6,8,10,12,14,16,18,20,22
+    isolated: 24,26,28,30,32,34,36,38
+    offlined: 1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39
+
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4c.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4c.json
@@ -1,0 +1,10 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 12,
+    "offlined-cpu-count": 24,
+    "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
+    "disable-ht": true,
+    "user-level-networking": false
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4c.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  additionalKernelArgs:
+  - nosmt
+  cpu:
+    reserved: 0,2,4,6,8,10,12,14,16,18,20,22
+    isolated: 30,34,36,38
+    offlined: 1,3,5,7,9,11,13,15,17,19,21,23-29,31-33,35,37,39
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5a.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5a.json
@@ -1,0 +1,11 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 4,
+    "offlined-cpu-count": 4,
+    "disable-ht": false,
+    "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
+    "split-reserved-cpus-across-numa": true,
+    "user-level-networking": false
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5a.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    offlined: 42,44,46,48
+    isolated: 2-39,43,45,47,49-79
+    reserved: 0-1,40-41
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5b.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5b.json
@@ -1,0 +1,11 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 4,
+    "offlined-cpu-count": 40,
+    "disable-ht": false,
+    "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
+    "split-reserved-cpus-across-numa": true,
+    "user-level-networking": false
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5b.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    reserved: 0-1,40-41
+    isolated: 2-3,5-7,9-39
+    offlined: 4,8,42-79
+
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    realtime: true


### PR DESCRIPTION
A new parameter is going to be added to Performance Profile  by #345. 
This PR aims to modify the Performance Profile Creator to be able to generate it.

To calculate offlined cpus we take into account the following input parameters:
- `offlined-cpu-count` : the number of cpus the user wants to set offline.
- `disable-ht`: Marks if the user want to disable logical processor siblings to disable hyperthreading
- `power-consumption-mode`: values: “default”, “low-latency”, “ultra-low-latency”

if `disable-ht` is true sibling logical processors will not be considered in the calculation of any of the CPUSets.
Unless `power-consumption-mode` is equal to `ultra-low-latency` ( which is considered a high-consumption scenario), we will first try to look for a complete socket to set offline, that is a socket where all the logical processors are still not in any set.
If we still have not set offline enough logical processors to fulfill the `offlined-cpu-count` we will try to set offline as many logical processor siblings as possible
If we still have not set offline enough logical processors to fulfill the `offlined-cpu-count` we will try to set offline any logical processor that is not already in a set.

Depends on #345 