### PR TITLE
Bug 2089414: PAO Add validation check between isolated and offlined CPUs

### DIFF
--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -155,6 +155,9 @@ func (r *PerformanceProfile) validateCPUs() field.ErrorList {
 				if overlap := components.Intersect(cpuLists.GetReserved(), cpuLists.GetOfflined()); len(overlap) != 0 {
 					allErrs = append(allErrs, field.Invalid(field.NewPath("spec.cpu"), r.Spec.CPU, fmt.Sprintf("reserved and offlined cpus overlap: %v", overlap)))
 				}
+				if overlap := components.Intersect(cpuLists.GetIsolated(), cpuLists.GetOfflined()); len(overlap) != 0 {
+					allErrs = append(allErrs, field.Invalid(field.NewPath("spec.cpu"), r.Spec.CPU, fmt.Sprintf("isolated and offlined cpus overlap: %v", overlap)))
+				}
 			}
 		}
 	}

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -191,8 +191,20 @@ var _ = Describe("PerformanceProfile", func() {
 			profile.Spec.CPU.Isolated = &isolatedCPUs
 			profile.Spec.CPU.Offlined = &offlinedCPUs
 			errors := profile.validateCPUs()
-			Expect(errors).NotTo(BeEmpty(), "should have validation error when reserved and isolation CPUs have overlap")
+			Expect(errors).NotTo(BeEmpty(), "should have validation error when reserved and offlined CPUs have overlap")
 			Expect(errors[0].Error()).To(ContainSubstring("reserved and offlined cpus overlap"))
+		})
+
+		It("should reject cpus allocation with overlapping sets between isolated and offlined", func() {
+			reservedCPUs := CPUSet("0-7")
+			isolatedCPUs := CPUSet("8-11")
+			offlinedCPUs := CPUSet("10-15")
+			profile.Spec.CPU.Reserved = &reservedCPUs
+			profile.Spec.CPU.Isolated = &isolatedCPUs
+			profile.Spec.CPU.Offlined = &offlinedCPUs
+			errors := profile.validateCPUs()
+			Expect(errors).NotTo(BeEmpty(), "should have validation error when isolated and offlined CPUs have overlap")
+			Expect(errors[0].Error()).To(ContainSubstring("isolated and offlined cpus overlap"))
 		})
 	})
 


### PR DESCRIPTION
Isolated and offlined can not share any CPUs.
If there is an overlap, it fails.

Signed-off-by: Mario Fernandez <mariofer@redhat.com>