### PR TITLE
e2e: performance profile: Latency tests stabilization

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -548,13 +548,13 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 			err := testclient.Client.Create(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = pods.WaitForPredicate(testpod, 10*time.Minute, func(pod *corev1.Pod) (bool, error) {
+			currentPod, err := pods.WaitForPredicate(testpod, 10*time.Minute, func(pod *corev1.Pod) (bool, error) {
 				if pod.Status.Phase != corev1.PodPending {
 					return true, nil
 				}
 				return false, nil
 			})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "expected the pod to keep pending, but its current phase is %s", currentPod.Status.Phase)
 
 			updatedPod := &corev1.Pod{}
 			err = testclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(testpod), updatedPod)

--- a/test/e2e/performanceprofile/functests/4_latency/latency.go
+++ b/test/e2e/performanceprofile/functests/4_latency/latency.go
@@ -313,7 +313,7 @@ func getLatencyTestCpus() (int, error) {
 		if err != nil {
 			return val, fmt.Errorf("the environment variable LATENCY_TEST_CPUS has incorrect value %q, it must be a positive integer with maximum value of %d: %w", latencyTestCpusEnv, math.MaxInt32, err)
 		}
-		if val < 0 || val > math.MaxInt32 {
+		if val <= 0 || val > math.MaxInt32 {
 			return val, fmt.Errorf("the environment variable LATENCY_TEST_CPUS has an invalid number %q, it must be a positive integer with maximum value of %d", latencyTestCpusEnv, math.MaxInt32)
 		}
 		return val, nil

--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -199,32 +199,35 @@ func clearEnv() {
 func getValidValuesTests(toolToTest string) []latencyTest {
 	var testSet []latencyTest
 
-	//testRuntime: let runtime be 10 seconds for most of the tests and not less, that is to let the tools
-	//have their time to measure latency properly hence stabilizing the tests
+	//testRuntime: for tests with success message (hence anticipated to run the tools),let runtime be 30 seconds for most of the tests for two reasons:
+	//1. to let the tools have their time to measure latency properly 2. have time to check that the pod phase turned running and not completed immediately
 	//testCpus: for tests that expect a success output message, note that an even CPU number is needed, otherwise the test would fail with SMTAlignmentError
-	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: "10", testMaxLatency: guaranteedLatency, testCpus: "2", outputMsgs: []string{success}, toolToTest: toolToTest})
-	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: "10", testMaxLatency: guaranteedLatency, testCpus: "6", outputMsgs: []string{success}, toolToTest: toolToTest})
-	testSet = append(testSet, latencyTest{testDelay: "1", testRun: "true", testRuntime: "10", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
-	testSet = append(testSet, latencyTest{testDelay: "60", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+
+	successRuntime := "30"
+	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: successRuntime, testMaxLatency: guaranteedLatency, testCpus: "4", outputMsgs: []string{success}, toolToTest: toolToTest})
+	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: successRuntime, testMaxLatency: guaranteedLatency, testCpus: "6", outputMsgs: []string{success}, toolToTest: toolToTest})
+	testSet = append(testSet, latencyTest{testDelay: "1", testRun: "true", testRuntime: successRuntime, testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+	testSet = append(testSet, latencyTest{testDelay: "60", testRun: "true", testRuntime: successRuntime, testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
 	testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "2", testCpus: "5", testMaxLatency: guaranteedLatency, outputMsgs: []string{skip, skipOddCpuNumber}, toolToTest: toolToTest})
 
 	if toolToTest != hwlatdetect {
 		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "1", outputMsgs: []string{skip, skipMaxLatency}, toolToTest: toolToTest})
 	}
 	if toolToTest == oslat {
-		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "10", testMaxLatency: "1", oslatMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
-		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "10", oslatMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: successRuntime, testMaxLatency: "1", oslatMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+		//TODO add tests when requested cpus for oslat is 2 once BZ 2055267 is resolved
+		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: successRuntime, oslatMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
 		//TODO: update isolated CPUs in PP to 1 and restore the original set post test
 	}
 	if toolToTest == cyclictest {
-		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "10", testMaxLatency: "1", cyclictestMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
-		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "10", cyclictestMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
-
+		//TODO add tests when requested cpus for cyclictest is 2 or less once BZ 2094046 is resolved
+		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: successRuntime, testMaxLatency: "1", cyclictestMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: successRuntime, cyclictestMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
 	}
 	if toolToTest == hwlatdetect {
-		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "10", testMaxLatency: "1", hwlatdetectMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
-		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "10", hwlatdetectMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
-		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "10", outputMsgs: []string{success}, toolToTest: toolToTest})
+		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: successRuntime, testMaxLatency: "1", hwlatdetectMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: successRuntime, hwlatdetectMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: successRuntime, outputMsgs: []string{success}, toolToTest: toolToTest})
 	}
 	return testSet
 }

--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -273,6 +273,7 @@ func getNegativeTests(toolToTest string) []latencyTest {
 	testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "2", testMaxLatency: "1", testCpus: "p", outputMsgs: []string{incorrectCpuNumber, fail}, toolToTest: toolToTest})
 	testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "2", testMaxLatency: "1", testCpus: fmt.Sprint(math.MaxInt32 + 1), outputMsgs: []string{invalidCpuNumber, fail}, toolToTest: toolToTest})
 	testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "2", testCpus: "-1", outputMsgs: []string{invalidCpuNumber, fail}, toolToTest: toolToTest})
+	testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "2", testCpus: "0", outputMsgs: []string{invalidCpuNumber, fail}, toolToTest: toolToTest})
 	if toolToTest == oslat {
 		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "2", oslatMaxLatency: "&", outputMsgs: []string{incorrectOslatMaxLatency, fail}, toolToTest: toolToTest})
 		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "2", oslatMaxLatency: fmt.Sprint(math.MaxInt32 + 1), outputMsgs: []string{invalidNumberOslatMaxLatency, fail}, toolToTest: toolToTest})

--- a/test/e2e/performanceprofile/functests/utils/images/prepull.go
+++ b/test/e2e/performanceprofile/functests/utils/images/prepull.go
@@ -56,11 +56,10 @@ func PrePull(cli client.Client, pullSpec, namespace, tag string) (*appsv1.Daemon
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:            "prepullcontainer",
-							Image:           pullSpec,
-							Command:         []string{"/bin/sleep"},
-							Args:            []string{"inf"},
-							ImagePullPolicy: corev1.PullAlways,
+							Name:    "prepullcontainer",
+							Image:   pullSpec,
+							Command: []string{"/bin/sleep"},
+							Args:    []string{"inf"},
 						},
 					},
 				},

--- a/test/e2e/performanceprofile/functests/utils/pods/pods.go
+++ b/test/e2e/performanceprofile/functests/utils/pods/pods.go
@@ -86,8 +86,9 @@ func WaitForCondition(pod *corev1.Pod, conditionType corev1.PodConditionType, co
 }
 
 // WaitForPredicate waits until the given predicate against the pod returns true or error.
-func WaitForPredicate(pod *corev1.Pod, timeout time.Duration, pred func(pod *corev1.Pod) (bool, error)) error {
-	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+func WaitForPredicate(pod *corev1.Pod, timeout time.Duration, pred func(pod *corev1.Pod) (bool, error)) (*corev1.Pod, error) {
+	updatedPod := &corev1.Pod{}
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		updatedPod := &corev1.Pod{}
 		if err := testclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(pod), updatedPod); err != nil {
 			return false, nil
@@ -99,6 +100,7 @@ func WaitForPredicate(pod *corev1.Pod, timeout time.Duration, pred func(pod *cor
 		}
 		return ret, nil
 	})
+	return updatedPod, err
 }
 
 // WaitForPhase waits until the pod will have specified phase


### PR DESCRIPTION
- e2e: latency: fail the test if CPUs number is less than 1
- images: change ImagePullPolicy to default
- e2e: pp-latency: verify tool args
- e2e: pp-latency: add the runtime to stabilize the pod-phase condition

Please find each commit for more details