### PR TITLE
makefile: enable running pao latency testing suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,10 @@ dist-docs-generator:
 		echo "Using pre-built docs-generator tool";\
 	fi
 
+.PHONY: dist-latency-tests
+dist-latency-tests:
+	./hack/build-latency-test-bin.sh
+
 .PHONY: cluster-label-worker-cnf
 cluster-label-worker-cnf:
 	@echo "Adding worker-cnf label to worker nodes"
@@ -192,6 +196,12 @@ pao-functests-only:
 	@echo "Cluster Version"
 	hack/show-cluster-version.sh
 	hack/run-functests.sh
+
+.PHONY: pao-functests-latency-testing
+pao-functests-latency-testing: dist-latency-tests
+	@echo "Cluster Version"
+	hack/show-cluster-version.sh
+	hack/run-latency-testing.sh
 
 .PHONY: cluster-clean-pao
 cluster-clean-pao:

--- a/hack/build-latency-test-bin.sh
+++ b/hack/build-latency-test-bin.sh
@@ -7,4 +7,4 @@ if ! which go &>/dev/null; then
   exit 1
 fi
 
-go test -v -c -o build/_output/bin/latency-e2e.test ./functests/4_latency
+go test -v -c -o build/_output/bin/latency-e2e.test ./test/e2e/performanceprofile/functests/4_latency

--- a/hack/run-latency-testing.sh
+++ b/hack/run-latency-testing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GINKGO_SUITS=${GINKGO_SUITS:-functests/5_latency_testing}
+GINKGO_SUITS=${GINKGO_SUITS:-"./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/5_latency_testing"}
 
 which ginkgo
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
 Add target in the MakeFile to enable running the 5_latency_testing suite: dist-latency-tests to create the load binary and pao-functests-latency-testing to consume it in the tests. Also adjust the path of the suites to match to their new place in NTO directories.

Signed-off-by: shereenH <shajmakh@redhat.com>