### PR TITLE
Bug 2093267: Exclude physical interfaces from netdev-rps rule

### DIFF
--- a/assets/performanceprofile/configs/99-netdev-rps.rules
+++ b/assets/performanceprofile/configs/99-netdev-rps.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="net", ACTION=="add", ENV{DEVPATH}!="/devices/virtual/net/veth*", TAG+="systemd", ENV{SYSTEMD_WANTS}="update-rps@%k.service"
+SUBSYSTEM=="net", ACTION=="add", ENV{DEVPATH}!="/devices/virtual/net/veth*", ENV{ID_BUS}!="pci", TAG+="systemd", ENV{SYSTEMD_WANTS}="update-rps@%k.service"

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
@@ -67,7 +67,7 @@ spec:
           path: /etc/containers/oci/hooks.d/99-low-latency-hooks.json
           user: {}
         - contents:
-            source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0iYWRkIiwgRU5We0RFVlBBVEh9IT0iL2RldmljZXMvdmlydHVhbC9uZXQvdmV0aCoiLCBUQUcrPSJzeXN0ZW1kIiwgRU5We1NZU1RFTURfV0FOVFN9PSJ1cGRhdGUtcnBzQCVrLnNlcnZpY2UiCg==
+            source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0iYWRkIiwgRU5We0RFVlBBVEh9IT0iL2RldmljZXMvdmlydHVhbC9uZXQvdmV0aCoiLCBFTlZ7SURfQlVTfSE9InBjaSIsIFRBRys9InN5c3RlbWQiLCBFTlZ7U1lTVEVNRF9XQU5UU309InVwZGF0ZS1ycHNAJWsuc2VydmljZSIK
             verification: {}
           group: {}
           mode: 420


### PR DESCRIPTION
Updated udev rule in 99-netdev-rps.rules to also exclude physical
interfaces.

Co-Authored-By: Brent Rowsell <browsell@redhat.com>
Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @yanirq @MarSik 