### PR TITLE
New annotation for enabling rps on all devices

### DIFF
--- a/assets/performanceprofile/configs/99-netdev-physical-rps.rules
+++ b/assets/performanceprofile/configs/99-netdev-physical-rps.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", ENV{DEVPATH}!="/devices/virtual/net/veth*", TAG+="systemd", ENV{SYSTEMD_WANTS}="update-rps@%k.service"

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -26,6 +26,10 @@ import (
 // objects.
 const PerformanceProfilePauseAnnotation = "performance.openshift.io/pause-reconcile"
 
+// PerformanceProfileEnableRpsAnnotation enables RPS mask setting with systemd for all
+// network devices by including physical interfaces from netdev-rps rule.
+const PerformanceProfileEnableRpsAnnotation = "performance.openshift.io/enable-physical-dev-rps"
+
 // PerformanceProfileSpec defines the desired state of PerformanceProfile.
 type PerformanceProfileSpec struct {
 	// CPU defines a set of CPU related parameters.

--- a/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
@@ -55,3 +55,16 @@ func IsPaused(profile *performancev2.PerformanceProfile) bool {
 
 	return false
 }
+
+// IsRpsEnabled or not RPS mask should be set for all physical net devices
+func IsRpsEnabled(profile *performancev2.PerformanceProfile) bool {
+	if profile.Annotations == nil {
+		return false
+	}
+	isRpsEnabled, ok := profile.Annotations[performancev2.PerformanceProfileEnableRpsAnnotation]
+	if ok && isRpsEnabled == "true" {
+		return true
+	}
+
+	return false
+}

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
 	componentprofile "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
+	profileutil "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cluster"
@@ -327,7 +328,12 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				Expect(rpsCPUs).To(Equal(expectedRPSCPUs), "the service rps mask is different from the reserved CPUs")
 
 				// Verify all host network devices have the correct RPS mask
-				cmd = []string{"find", "/rootfs/sys/devices", "-type", "f", "-name", "rps_cpus", "-exec", "cat", "{}", ";"}
+				if profileutil.IsRpsEnabled(profile) {
+					cmd = []string{"find", "/rootfs/sys/devices", "-type", "f", "-name", "rps_cpus", "-exec", "cat", "{}", ";"}
+				} else {
+					cmd = []string{"find", "/rootfs/sys/devices/virtual", "-type", "f", "-name", "rps_cpus", "-exec", "cat", "{}", ";"}
+				}
+
 				devsRPS, err := nodes.ExecCommandOnNode(cmd, &node)
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Setting the RPS mask for network devices by default is only for non physical interfaces. (as fixed in https://github.com/openshift/cluster-node-tuning-operator/pull/377)

A new annotation: "performance.openshift.io/enable-physical-dev-rps" , when added to a performance profile, will enable
RPS mask setting with systemd for all network devices by including physical interfaces from netdev-rps rule.