### PR TITLE
Bug 2102109: Remove stale Profiles.

### DIFF
--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -559,7 +559,10 @@ func (c *Controller) tunedRun() {
 			strIndex := strings.Index(l, " WARNING ")
 			if strIndex >= 0 {
 				c.daemon.status |= scWarn
-				c.daemon.stderr = l[strIndex:] // trim timestamp from log
+				prevError := ((c.daemon.status & scError) != 0)
+				if !prevError { // don't overwrite an error message
+					c.daemon.stderr = l[strIndex:] // trim timestamp from log
+				}
 			}
 
 			strIndex = strings.Index(l, " ERROR ")


### PR DESCRIPTION
For every Node object, there is a corresponding Profile object.  While
we have code that removes Profile objects on Node removal, these events
can be missed and/or deletion attempts stopped after several
unsuccessful deletion trials at a given time.

While the existence of these stale Profile objects is not a major
problem, they cause misleading messages in the co/node-tuning object.

Changes:
  - Enable periodic resync of all Profile objects and their deletion
    unless a corresponding Node object exists.
  - Do not overwrite Profile status ERROR messages with lower priority
    WARNING message -- credits David Gray.

Resolves rhbz#2102109