### PR TITLE
Fix typo realTime Hint in PerformanceProfile.yaml

### DIFF
--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1.yaml
@@ -16,4 +16,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1a.yaml
@@ -17,4 +17,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1b.yaml
@@ -18,4 +18,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1c.yaml
@@ -17,4 +17,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2.yaml
@@ -18,4 +18,4 @@ spec:
     enabled: false
   workloadHints:
     highPowerConsumption: false
-    realtime: false
+    realTime: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2a.yaml
@@ -19,4 +19,4 @@ spec:
     enabled: false
   workloadHints:
     highPowerConsumption: false
-    realtime: false
+    realTime: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2b.yaml
@@ -19,4 +19,4 @@ spec:
     enabled: false
   workloadHints:
     highPowerConsumption: false
-    realtime: false
+    realTime: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3.yaml
@@ -21,4 +21,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3a.yaml
@@ -22,4 +22,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3b.yaml
@@ -22,4 +22,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3c.yaml
@@ -22,4 +22,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4.yaml
@@ -21,4 +21,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4a.yaml
@@ -22,4 +22,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4b.yaml
@@ -23,4 +23,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4c.yaml
@@ -22,4 +22,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5.yaml
@@ -19,4 +19,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5a.yaml
@@ -20,4 +20,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5b.yaml
@@ -21,4 +21,4 @@ spec:
     enabled: true
   workloadHints:
     highPowerConsumption: false
-    realtime: true
+    realTime: true


### PR DESCRIPTION
Typo in realtime workloadHints in PerformanceProfile.yaml
```

  workloadHints:
    highPowerConsumption: false
    realtime: true

```
to:  

```
workloadHints:
    highPowerConsumption: false
    realTime: true
```

Signed-off-by: Mario Fernandez <mariofer@redhat.com>