### PR TITLE
Enable basic sysctl tuning of HyperShift hosted cluster nodes

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -113,7 +113,6 @@ func operatorRun() {
 
 	restConfig := ctrl.GetConfigOrDie()
 	le := util.GetLeaderElectionConfig(restConfig, enableLeaderElection)
-
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		NewCache:                cache.MultiNamespacedCacheBuilder(namespaces),
 		Scheme:                  scheme,

--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -89,7 +89,9 @@ func prepareCommands() {
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
-	rootCmd.AddCommand(render.NewRenderCommand())
+	if !config.InHyperShift() {
+		rootCmd.AddCommand(render.NewRenderCommand())
+	}
 }
 
 func operatorRun() {
@@ -102,7 +104,7 @@ func operatorRun() {
 	// We have two namespaces that we need to watch:
 	// 1. NTO namespace - for NTO resources
 	// 2. None namespace - for cluster wide resources
-	ntoNamespace := config.OperatorNamespace()
+	ntoNamespace := config.WatchNamespace()
 	namespaces := []string{
 		ntoNamespace,
 		metav1.NamespaceNone,
@@ -110,6 +112,7 @@ func operatorRun() {
 
 	restConfig := ctrl.GetConfigOrDie()
 	le := util.GetLeaderElectionConfig(restConfig, enableLeaderElection)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		NewCache:                cache.MultiNamespacedCacheBuilder(namespaces),
 		Scheme:                  scheme,
@@ -126,8 +129,10 @@ func operatorRun() {
 		klog.Exit(err)
 	}
 
-	if err := removePerformanceOLMOperator(restConfig); err != nil {
-		klog.Fatalf("unable to remove Performance addons OLM operator: %v", err)
+	if !config.InHyperShift() {
+		if err := removePerformanceOLMOperator(restConfig); err != nil {
+			klog.Fatalf("unable to remove Performance addons OLM operator: %v", err)
+		}
 	}
 
 	controller, err := operator.NewController()
@@ -144,29 +149,30 @@ func operatorRun() {
 	}
 	metrics.RegisterVersion(version.Version)
 
-	if err = (&paocontroller.PerformanceProfileReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("performance-profile-controller"),
-	}).SetupWithManager(mgr); err != nil {
-		klog.Exitf("unable to create PerformanceProfile controller: %v", err)
+	if !config.InHyperShift() {
+		if err = (&paocontroller.PerformanceProfileReconciler{
+			Client:   mgr.GetClient(),
+			Scheme:   mgr.GetScheme(),
+			Recorder: mgr.GetEventRecorderFor("performance-profile-controller"),
+		}).SetupWithManager(mgr); err != nil {
+			klog.Exitf("unable to create PerformanceProfile controller: %v", err)
+		}
+
+		// Configure webhook server.
+		webHookServer := mgr.GetWebhookServer()
+		webHookServer.Port = webhookPort
+		webHookServer.CertDir = webhookCertDir
+		webHookServer.CertName = webhookCertName
+		webHookServer.KeyName = webhookKeyName
+
+		if err = (&performancev1.PerformanceProfile{}).SetupWebhookWithManager(mgr); err != nil {
+			klog.Exitf("unable to create PerformanceProfile v1 webhook: %v", err)
+		}
+
+		if err = (&performancev2.PerformanceProfile{}).SetupWebhookWithManager(mgr); err != nil {
+			klog.Exitf("unable to create PerformanceProfile v2 webhook: %v", err)
+		}
 	}
-
-	// Configure webhook server.
-	webHookServer := mgr.GetWebhookServer()
-	webHookServer.Port = webhookPort
-	webHookServer.CertDir = webhookCertDir
-	webHookServer.CertName = webhookCertName
-	webHookServer.KeyName = webhookKeyName
-
-	if err = (&performancev1.PerformanceProfile{}).SetupWebhookWithManager(mgr); err != nil {
-		klog.Exitf("unable to create PerformanceProfile v1 webhook: %v", err)
-	}
-
-	if err = (&performancev2.PerformanceProfile{}).SetupWebhookWithManager(mgr); err != nil {
-		klog.Exitf("unable to create PerformanceProfile v2 webhook: %v", err)
-	}
-
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		klog.Exitf("manager exited with non-zero code: %v", err)
 	}

--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -102,8 +102,9 @@ func operatorRun() {
 	}
 
 	// We have two namespaces that we need to watch:
-	// 1. NTO namespace - for NTO resources
-	// 2. None namespace - for cluster wide resources
+	// 1. NTO namespace: for NTO resources.  Note this is not necessarily where the operator itself
+	//    runs, for example operator managing HyperShift hosted clusters.
+	// 2. None namespace: for cluster-wide resources
 	ntoNamespace := config.WatchNamespace()
 	namespaces := []string{
 		ntoNamespace,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -44,9 +44,10 @@ func GetConfig() (*rest.Config, error) {
 }
 
 func GetInClusterConfig() (*rest.Config, error) {
-	if c, err := rest.InClusterConfig(); err == nil {
+	c, err := rest.InClusterConfig()
+	if err == nil {
 		return c, nil
 	}
 
-	return nil, fmt.Errorf("could not locate a kubeconfig")
+	return nil, fmt.Errorf("failed to get in-cluster config: %v", err)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -42,3 +42,11 @@ func GetConfig() (*rest.Config, error) {
 
 	return nil, fmt.Errorf("could not locate a kubeconfig")
 }
+
+func GetInClusterConfig() (*rest.Config, error) {
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+
+	return nil, fmt.Errorf("could not locate a kubeconfig")
+}

--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	dynamic "k8s.io/client-go/dynamic"
 	kubeset "k8s.io/client-go/kubernetes"
 	appsset "k8s.io/client-go/kubernetes/typed/apps/v1"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -12,12 +13,13 @@ import (
 )
 
 type Clients struct {
-	Kube            *kubeset.Clientset
-	ConfigClientSet *configclientset.Clientset
-	ConfigV1Client  *configv1client.ConfigV1Client
-	Tuned           *tunedset.Clientset
-	MC              *mcfgclientset.Clientset
-	Core            *coreset.CoreV1Client
-	Apps            *appsset.AppsV1Client
-	ManagementKube  *kubeset.Clientset
+	Kube              *kubeset.Clientset
+	ConfigClientSet   *configclientset.Clientset
+	ConfigV1Client    *configv1client.ConfigV1Client
+	Tuned             *tunedset.Clientset
+	MC                *mcfgclientset.Clientset
+	Core              *coreset.CoreV1Client
+	Apps              *appsset.AppsV1Client
+	ManagementKube    *kubeset.Clientset
+	ManagementDynamic dynamic.Interface
 }

--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -19,4 +19,5 @@ type Clients struct {
 	MC              *mcfgclientset.Clientset
 	Core            *coreset.CoreV1Client
 	Apps            *appsset.AppsV1Client
+	ManagementKube  *kubeset.Clientset
 }

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -21,4 +21,3 @@ type Listers struct {
 	MachineConfigs     mcfglisters.MachineConfigLister
 	MachineConfigPools mcfglisters.MachineConfigPoolLister
 }
-

--- a/pkg/client/listers.go
+++ b/pkg/client/listers.go
@@ -12,6 +12,7 @@ import (
 
 type Listers struct {
 	DaemonSets         kappslisters.DaemonSetNamespaceLister
+	ConfigMaps         kcorelisters.ConfigMapNamespaceLister
 	Pods               kcorelisters.PodLister
 	Nodes              kcorelisters.NodeLister
 	ClusterOperators   configlisters.ClusterOperatorLister
@@ -20,3 +21,4 @@ type Listers struct {
 	MachineConfigs     mcfglisters.MachineConfigLister
 	MachineConfigPools mcfglisters.MachineConfigPoolLister
 }
+

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,8 +27,8 @@ func NodeTunedImage() string {
 	return nodeTunedImageDefault
 }
 
-// OperatorName returns the operator namespace.
-func OperatorNamespace() string {
+// WatchNamespace returns the namespace that the Tuned and Profile CRs are in.
+func WatchNamespace() string {
 	operatorNamespace := os.Getenv("WATCH_NAMESPACE")
 
 	if len(operatorNamespace) > 0 {
@@ -36,6 +36,24 @@ func OperatorNamespace() string {
 	}
 
 	return operatorNamespaceDefault
+}
+
+// OperatorNamespace returns the namespace that the operator is running in
+func OperatorNamespace() string {
+	operatorNamespace := os.Getenv("MY_NAMESPACE")
+
+	if len(operatorNamespace) > 0 {
+		return operatorNamespace
+	}
+
+	return operatorNamespaceDefault
+}
+
+// InHyperShift returns a boolean which is True when NTO is used to manage tuning
+// of hosted cluster nodes.
+func InHyperShift() bool {
+	hypershiftEnv := os.Getenv("HYPERSHIFT")
+	return hypershiftEnv == "true"
 }
 
 // ResyncPeriod returns the configured or default Reconcile period.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ func WatchNamespace() string {
 	return operatorNamespaceDefault
 }
 
-// OperatorNamespace returns the namespace that the operator is running in
+// OperatorNamespace returns the namespace that the operator is running in.
 func OperatorNamespace() string {
 	operatorNamespace := os.Getenv("MY_NAMESPACE")
 

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -30,7 +30,7 @@ func TunedRenderedResource(tunedSlice []*tunedv1.Tuned) *tunedv1.Tuned {
 	cr := &tunedv1.Tuned{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tunedv1.TunedRenderedResourceName,
-			Namespace: ntoconfig.OperatorNamespace(),
+			Namespace: ntoconfig.WatchNamespace(),
 		},
 		Spec: tunedv1.TunedSpec{
 			Recommend: []tunedv1.TunedRecommend{},

--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -129,8 +129,12 @@ func tunedRenderedProfiles(tuned *tunedv1.Tuned, m map[string]tunedv1.TunedProfi
 	if tuned.Spec.Profile != nil {
 		for _, v := range tuned.Spec.Profile {
 			if v.Name != nil && v.Data != nil {
-				if _, found := m[*v.Name]; found {
-					klog.Warningf("WARNING: Duplicate profile %s", *v.Name)
+				if existingProfile, found := m[*v.Name]; found {
+					if *v.Data == *existingProfile.Data {
+						klog.Infof("duplicate profiles names %s but they have the same contents", *v.Name)
+					} else {
+						klog.Warningf("WARNING: duplicate profiles named %s with different contents", *v.Name)
+					}
 				}
 				m[*v.Name] = v
 			}

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -59,8 +59,8 @@ const (
 	wqKindConfigMap         = "configmap"
 	wqKindMachineConfigPool = "machineconfigpool"
 
-	tunedConfigMapLabel      = "hypershift.openshift.io/tuned-config"
-	tunedConfigMapConfigKey  = "tuned"
+	tunedConfigMapLabel     = "hypershift.openshift.io/tuned-config"
+	tunedConfigMapConfigKey = "tuned"
 )
 
 // Controller is the controller implementation for Tuned resources
@@ -299,8 +299,7 @@ func (c *Controller) sync(key wqKey) error {
 		return nil
 
 	case key.kind == wqKindConfigMap:
-		// This can only happen in HyperShift when NTO is used to manage tuning
-		// of hosted cluster nodes.
+		// This should only happen in HyperShift
 		klog.V(2).Infof("sync(): wqKindConfigMap %s", key.name)
 		err = c.syncHostedClusterTuneds()
 		return err

--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -111,7 +111,7 @@ func (c *Controller) getObjFromTunedConfigMap() ([]tunedv1.Tuned, error) {
 	for _, cm := range cmList.Items {
 		tunedConfig, ok := cm.Data[tunedConfigMapConfigKey]
 		if !ok {
-			klog.Warning("Tuned config in ConfigMap %s has no data for field %s", cm.ObjectMeta.Name, tunedConfigMapConfigKey)
+			klog.Warning("Tuned in ConfigMap %s has no data for field %s", cm.ObjectMeta.Name, tunedConfigMapConfigKey)
 			continue
 		}
 
@@ -133,12 +133,6 @@ func (c *Controller) getObjFromTunedConfigMap() ([]tunedv1.Tuned, error) {
 		}
 
 		cmTuneds = append(cmTuneds, tunedsFromConfigMapUnique...)
-
-		// TODO remove these log lines
-		for _, t := range cmTuneds {
-			klog.Infof("got Tuned %v from ConfigMap: %v", t.Name, cm.Name)
-		}
-		//klog.V(1).Infof("TunedConfig from ConfigMap: %v", string(tunedConfig[:]))
 	}
 
 	return cmTuneds, nil
@@ -154,12 +148,11 @@ func parseTunedManifests(data []byte) ([]tunedv1.Tuned, error) {
 		t := tunedv1.Tuned{}
 		if err := d.Decode(&t); err != nil {
 			if err == io.EOF {
-				klog.Infof("parseTunedManifests: EOF reached, num tuneds: %d", len(tuneds)) // TODO: do we want this log/verbosity here?
 				return tuneds, nil
 			}
 			return tuneds, fmt.Errorf("error parsing Tuned manifests: %v", err)
 		}
-		klog.Infof("parseTunedManifests: name: %s", t.GetName()) // TODO: do we want this log/verbosity here?
+		klog.V(2).Infof("parseTunedManifests: name: %s", t.GetName())
 
 		tuneds = append(tuneds, t)
 	}

--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"reflect"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +18,13 @@ import (
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
 )
 
-// TODO remove unnecessary debugging log lines.
+const (
+	hypershiftNodeOwnerNameLabel          = "cluster.x-k8s.io/owner-name"
+	hypershiftNodeOwnerKindLabel          = "cluster.x-k8s.io/owner-kind"
+	hypershiftNodePoolNamespacedNameLabel = "hypershift.openshift.io/nodePool"
+	hypershiftNodePoolNameLabel           = "hypershift.openshift.io/nodePoolName"
+)
+
 // syncHostedClusterTuneds synchronizes Tuned objects embedded in ConfigMaps
 // in management's cluster hosted namespace with Tuned objects in the hosted
 // cluster.  Returns non-nil error only when retry/resync is needed.
@@ -38,15 +46,16 @@ func (c *Controller) syncHostedClusterTuneds() error {
 		if hcTuned, ok := hcTunedMap[tunedName]; ok {
 			klog.V(1).Infof("hosted cluster already contains Tuned %v from ConfigMap", tunedName)
 			if reflect.DeepEqual(cmTuned.Spec.Profile, hcTuned.Spec.Profile) &&
-				reflect.DeepEqual(cmTuned.Spec.Recommend, hcTuned.Spec.Recommend) {
-				klog.V(2).Infof("Hosted cluster version of Tuned %v matches the ConfigMap %s config", tunedName, cmTuned.ObjectMeta.Name)
+				reflect.DeepEqual(cmTuned.Spec.Recommend, hcTuned.Spec.Recommend) &&
+				reflect.DeepEqual(cmTuned.ObjectMeta.Labels, hcTuned.ObjectMeta.Labels) {
+				klog.V(2).Infof("hosted cluster version of Tuned %v matches the ConfigMap %s config", tunedName, cmTuned.ObjectMeta.Name)
 			} else {
 				// This Tuned exists in the hosted cluster but is out-of-sync with the management configuration
 				newTuned := hcTuned.DeepCopy() // never update the objects from cache
 				newTuned.Spec.Profile = cmTuned.Spec.Profile
 				newTuned.Spec.Recommend = cmTuned.Spec.Recommend
 
-				klog.V(2).Infof("Updating Tuned %v from ConfigMap %s", tunedName, cmTuned.ObjectMeta.Name)
+				klog.V(2).Infof("updating Tuned %v from ConfigMap %s", tunedName, cmTuned.ObjectMeta.Name)
 				newTuned, err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Update(context.TODO(), newTuned, metav1.UpdateOptions{})
 				if err != nil {
 					if errors.IsInvalid(err) {
@@ -61,7 +70,7 @@ func (c *Controller) syncHostedClusterTuneds() error {
 			delete(hcTunedMap, tunedName)
 			delete(cmTunedMap, tunedName)
 		} else {
-			klog.V(1).Infof("Need to create Tuned %v based on ConfigMap %s", cmTuned.ObjectMeta.Name, tunedName)
+			klog.V(1).Infof("need to create Tuned %v based on ConfigMap %s", cmTuned.ObjectMeta.Name, tunedName)
 			// Create the Tuned in the hosted cluster from the config in ConfigMap
 			newTuned := cmTuned.DeepCopy()
 			newTuned, err := c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Create(context.TODO(), newTuned, metav1.CreateOptions{})
@@ -115,7 +124,14 @@ func (c *Controller) getObjFromTunedConfigMap() ([]tunedv1.Tuned, error) {
 			continue
 		}
 
-		tunedsFromConfigMap, err := parseTunedManifests([]byte(tunedConfig))
+		cmNodePoolNamespacedName, ok := cm.Annotations[hypershiftNodePoolNamespacedNameLabel]
+		if !ok {
+			klog.Warningf("failed to parseTunedManifests in ConfigMap %s, no label %s", cm.ObjectMeta.Name, hypershiftNodePoolNamespacedNameLabel)
+			continue
+		}
+		nodePoolName := parseNamespacedName(cmNodePoolNamespacedName)
+
+		tunedsFromConfigMap, err := parseTunedManifests([]byte(tunedConfig), nodePoolName)
 		if err != nil {
 			klog.Warningf("failed to parseTunedManifests in ConfigMap %s: %v", cm.ObjectMeta.Name, err)
 			continue
@@ -140,7 +156,7 @@ func (c *Controller) getObjFromTunedConfigMap() ([]tunedv1.Tuned, error) {
 
 // parseManifests parses a YAML or JSON document that may contain one or more
 // kubernetes resources.
-func parseTunedManifests(data []byte) ([]tunedv1.Tuned, error) {
+func parseTunedManifests(data []byte, nodePoolName string) ([]tunedv1.Tuned, error) {
 	r := bytes.NewReader(data)
 	d := yamlutil.NewYAMLOrJSONDecoder(r, 1024)
 	var tuneds []tunedv1.Tuned
@@ -152,8 +168,34 @@ func parseTunedManifests(data []byte) ([]tunedv1.Tuned, error) {
 			}
 			return tuneds, fmt.Errorf("error parsing Tuned manifests: %v", err)
 		}
+		// Make Tuned names unique if a Tuned is duplicated across NodePools
+		// for example, if one ConfigMap is referenced in multiple NodePools
+		t.SetName(t.ObjectMeta.Name + "-" + hashStruct(nodePoolName))
 		klog.V(2).Infof("parseTunedManifests: name: %s", t.GetName())
 
+		// Propagate NodePool name from ConfigMap down to Tuned object
+		if t.Labels == nil {
+			t.Labels = make(map[string]string)
+		}
+		t.Labels[hypershiftNodePoolNameLabel] = nodePoolName
 		tuneds = append(tuneds, t)
 	}
+}
+
+func hashStruct(o interface{}) string {
+	hash := fnv.New32a()
+	hash.Write([]byte(fmt.Sprintf("%v", o)))
+	intHash := hash.Sum32()
+	return fmt.Sprintf("%08x", intHash)
+}
+
+// parseNamespacedName expects a string with the format "namespace/name"
+// and returns the name only.
+// If given a string in the format "name" returns "name".
+func parseNamespacedName(nodePoolFullName string) string {
+	parts := strings.SplitN(nodePoolFullName, "/", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return parts[0]
 }

--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -7,19 +7,21 @@ import (
 	"io"
 	"reflect"
 
-	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
-	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog/v2"
+
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
 )
 
-// TODO remove unnecessary debugging log lines
+// TODO remove unnecessary debugging log lines and describe what this function does.
 func (c *Controller) syncHostedClusterTuneds() error {
 	cmTuneds, err := c.getObjFromTunedConfigMap()
 	hcTunedList, err := c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to list Tuneds %v", err)
+		return fmt.Errorf("failed to list Tuneds: %v", err)
 	}
 	hcTuneds := hcTunedList.Items
 	hcTunedMap := tunedMapFromList(hcTuneds)
@@ -30,48 +32,59 @@ func (c *Controller) syncHostedClusterTuneds() error {
 			klog.V(1).Infof("hosted cluster already contains Tuned %v from ConfigMap", tunedName)
 			if reflect.DeepEqual(cmTuned.Spec.Profile, hcTuned.Spec.Profile) &&
 				reflect.DeepEqual(cmTuned.Spec.Recommend, hcTuned.Spec.Recommend) {
-				klog.V(2).Infof("Hosted cluster version of Tuned %v matches the ConfigMap config", tunedName)
+				klog.V(2).Infof("Hosted cluster version of Tuned %v matches the ConfigMap %s config", tunedName, cmTuned.ObjectMeta.Name)
 			} else {
-				// This tuned exists in the hosted cluster but is out-of-sync with the management configuration
-				newTuned := hcTuned.DeepCopy() // TODO do we need to worry about cache here?
+				// This Tuned exists in the hosted cluster but is out-of-sync with the management configuration
+				newTuned := hcTuned.DeepCopy() // never update the objects from cache
 				newTuned.Spec.Profile = cmTuned.Spec.Profile
 				newTuned.Spec.Recommend = cmTuned.Spec.Recommend
 
-				klog.V(2).Infof("Updating Tuned %v from ConfigMap", tunedName)
+				klog.V(2).Infof("Updating Tuned %v from ConfigMap %s", tunedName, cmTuned.ObjectMeta.Name)
 				newTuned, err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Update(context.TODO(), newTuned, metav1.UpdateOptions{})
 				if err != nil {
-					klog.V(1).Infof("ERROR! failed to update Tuned %s: %v", tunedName, err)
+					if errors.IsInvalid(err) {
+						// The provided resource is not valid.  Log an error and do not try to resync.
+						klog.Errorf("failed to update Tuned due to invalid resource: %v", err)
+					} else {
+						// Failure to update Tuned, queue another sync().
+						return fmt.Errorf("failed to update Tuned %s: %v", tunedName, err)
+					}
 				}
 			}
 			delete(hcTunedMap, tunedName)
 			delete(cmTunedMap, tunedName)
 		} else {
-			klog.V(1).Infof("Need to create Tuned %v based on ConfigMap", tunedName)
+			klog.V(1).Infof("Need to create Tuned %v based on ConfigMap %s", cmTuned.ObjectMeta.Name, tunedName)
 			// Create the Tuned in the hosted cluster from the config in ConfigMap
 			newTuned := cmTuned.DeepCopy()
 			newTuned, err := c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Create(context.TODO(), newTuned, metav1.CreateOptions{})
 			if err != nil {
-				// TODO (jmencak): Do we need to retry?
-				klog.Errorf("failed to Create Tuned %s: %v", tunedName, err)
+				if errors.IsInvalid(err) {
+					// The provided resource is not valid.  Log an error and do not try to resync.
+					klog.Errorf("failed to create Tuned due to invalid resource: %v", err)
+				} else {
+					// Failure to create Tuned, queue another sync().
+					return fmt.Errorf("failed to create Tuned %s: %v", tunedName, err)
+				}
 			}
 			delete(cmTunedMap, tunedName)
 		}
 	}
 	// Anything left in hcMap should be deleted
-	for tunedName, _ := range hcTunedMap {
+	for tunedName := range hcTunedMap {
 		if tunedName != "default" && tunedName != "rendered" {
 			klog.V(1).Infof("found Tuned in HostedCluster named %s. Deleting.", tunedName)
 			err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Delete(context.TODO(), tunedName, metav1.DeleteOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to delete Tuned %s: %v", tunedName, err)
-			} else {
-				klog.Infof("deleted Tuned %s", tunedName)
 			}
+			klog.Infof("deleted Tuned %s", tunedName)
 		}
 	}
 	return nil
 }
 
+// TODO: describe what this function does.
 func (c *Controller) getObjFromTunedConfigMap() ([]tunedv1.Tuned, error) {
 	var cmTuneds []tunedv1.Tuned
 
@@ -84,19 +97,33 @@ func (c *Controller) getObjFromTunedConfigMap() ([]tunedv1.Tuned, error) {
 		return cmTuneds, fmt.Errorf("error listing ConfigMaps in namespace %s: %v", ntoconfig.OperatorNamespace(), err)
 	}
 
-	// TODO address cluster upgrades. Will there be multiple ConfigMaps? What if two tuned ConfigMaps contain objects of same name?
+	// TODO test cluster upgrades.
+	seenTunedObject := map[string]bool{}
 	for _, cm := range cmList.Items {
 		tunedConfig, ok := cm.Data[tunedConfigMapConfigKey]
 		if !ok {
-			klog.Warning("Tuned config has no data for field %s", tunedConfigMapConfigKey)
-			return cmTuneds, nil
+			klog.Warning("Tuned config in ConfigMap %s has no data for field %s", cm.ObjectMeta.Name, tunedConfigMapConfigKey)
+			continue
 		}
 
 		tunedsFromConfigMap, err := parseTunedManifests([]byte(tunedConfig))
 		if err != nil {
-			return cmTuneds, fmt.Errorf("failed to parseTunedManifests: %v", err)
+			klog.Warningf("failed to parseTunedManifests in ConfigMap %s: %v", cm.ObjectMeta.Name, err)
+			continue
 		}
-		cmTuneds = append(cmTuneds, tunedsFromConfigMap...)
+
+		tunedsFromConfigMapUnique := []tunedv1.Tuned{}
+		for j, t := range tunedsFromConfigMap {
+			tunedObjectName := tunedsFromConfigMap[j].ObjectMeta.Name
+			if seenTunedObject[tunedObjectName] {
+				klog.Warningf("ignoring duplicate Tuned Profile %s in ConfigMap %s", tunedObjectName, cm.ObjectMeta.Name)
+				continue
+			}
+			seenTunedObject[tunedObjectName] = true
+			tunedsFromConfigMapUnique = append(tunedsFromConfigMapUnique, t)
+		}
+
+		cmTuneds = append(cmTuneds, tunedsFromConfigMapUnique...)
 
 		// TODO remove these log lines
 		for _, t := range cmTuneds {
@@ -118,21 +145,13 @@ func parseTunedManifests(data []byte) ([]tunedv1.Tuned, error) {
 		t := tunedv1.Tuned{}
 		if err := d.Decode(&t); err != nil {
 			if err == io.EOF {
-				klog.Infof("parseTunedManifests: EOF reached, num tuneds: %d", len(tuneds))
+				klog.Infof("parseTunedManifests: EOF reached, num tuneds: %d", len(tuneds)) // TODO: do we want this log/verbosity here?
 				return tuneds, nil
 			}
-			return tuneds, fmt.Errorf("Error parsing Tuned manifests: %v", err)
+			return tuneds, fmt.Errorf("error parsing Tuned manifests: %v", err)
 		}
-		klog.Infof("parseTunedManifests: name: %s", t.GetName())
+		klog.Infof("parseTunedManifests: name: %s", t.GetName()) // TODO: do we want this log/verbosity here?
 
-		// TODO improve verification here? or trust nodepool controller?
-		// A dummy test for empty objects
-		if t.GetName() == "" {
-			klog.Infof("parseTunedManifests: Empty name in Tuned!")
-			continue
-		}
 		tuneds = append(tuneds, t)
 	}
-
 }
-

--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -1,0 +1,138 @@
+package operator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/klog/v2"
+)
+
+// TODO remove unnecessary debugging log lines
+func (c *Controller) syncHostedClusterTuneds() error {
+	cmTuneds, err := c.getObjFromTunedConfigMap()
+	hcTunedList, err := c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list Tuneds %v", err)
+	}
+	hcTuneds := hcTunedList.Items
+	hcTunedMap := tunedMapFromList(hcTuneds)
+	cmTunedMap := tunedMapFromList(cmTuneds)
+
+	for tunedName, cmTuned := range cmTunedMap {
+		if hcTuned, ok := hcTunedMap[tunedName]; ok {
+			klog.V(1).Infof("hosted cluster already contains Tuned %v from ConfigMap", tunedName)
+			if reflect.DeepEqual(cmTuned.Spec.Profile, hcTuned.Spec.Profile) &&
+				reflect.DeepEqual(cmTuned.Spec.Recommend, hcTuned.Spec.Recommend) {
+				klog.V(2).Infof("Hosted cluster version of Tuned %v matches the ConfigMap config", tunedName)
+			} else {
+				// This tuned exists in the hosted cluster but is out-of-sync with the management configuration
+				newTuned := hcTuned.DeepCopy() // TODO do we need to worry about cache here?
+				newTuned.Spec.Profile = cmTuned.Spec.Profile
+				newTuned.Spec.Recommend = cmTuned.Spec.Recommend
+
+				klog.V(2).Infof("Updating Tuned %v from ConfigMap", tunedName)
+				newTuned, err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Update(context.TODO(), newTuned, metav1.UpdateOptions{})
+				if err != nil {
+					klog.V(1).Infof("ERROR! failed to update Tuned %s: %v", tunedName, err)
+				}
+			}
+			delete(hcTunedMap, tunedName)
+			delete(cmTunedMap, tunedName)
+		} else {
+			klog.V(1).Infof("Need to create Tuned %v based on ConfigMap", tunedName)
+			// Create the Tuned in the hosted cluster from the config in ConfigMap
+			newTuned := cmTuned.DeepCopy()
+			newTuned, err := c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Create(context.TODO(), newTuned, metav1.CreateOptions{})
+			if err != nil {
+				// TODO (jmencak): Do we need to retry?
+				klog.Errorf("failed to Create Tuned %s: %v", tunedName, err)
+			}
+			delete(cmTunedMap, tunedName)
+		}
+	}
+	// Anything left in hcMap should be deleted
+	for tunedName, _ := range hcTunedMap {
+		if tunedName != "default" && tunedName != "rendered" {
+			klog.V(1).Infof("found Tuned in HostedCluster named %s. Deleting.", tunedName)
+			err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Delete(context.TODO(), tunedName, metav1.DeleteOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to delete Tuned %s: %v", tunedName, err)
+			} else {
+				klog.Infof("deleted Tuned %s", tunedName)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Controller) getObjFromTunedConfigMap() ([]tunedv1.Tuned, error) {
+	var cmTuneds []tunedv1.Tuned
+
+	cmListOptions := metav1.ListOptions{
+		LabelSelector: tunedConfigMapAnnotation + "=true",
+	}
+
+	cmList, err := c.clients.ManagementKube.CoreV1().ConfigMaps(ntoconfig.OperatorNamespace()).List(context.TODO(), cmListOptions)
+	if err != nil {
+		return cmTuneds, fmt.Errorf("error listing ConfigMaps in namespace %s: %v", ntoconfig.OperatorNamespace(), err)
+	}
+
+	// TODO address cluster upgrades. Will there be multiple ConfigMaps? What if two tuned ConfigMaps contain objects of same name?
+	for _, cm := range cmList.Items {
+		tunedConfig, ok := cm.Data[tunedConfigMapConfigKey]
+		if !ok {
+			klog.Warning("Tuned config has no data for field %s", tunedConfigMapConfigKey)
+			return cmTuneds, nil
+		}
+
+		tunedsFromConfigMap, err := parseTunedManifests([]byte(tunedConfig))
+		if err != nil {
+			return cmTuneds, fmt.Errorf("failed to parseTunedManifests: %v", err)
+		}
+		cmTuneds = append(cmTuneds, tunedsFromConfigMap...)
+
+		// TODO remove these log lines
+		for _, t := range cmTuneds {
+			klog.Infof("got Tuned %v from ConfigMap: %v", t.Name, cm.Name)
+		}
+		//klog.V(1).Infof("TunedConfig from ConfigMap: %v", string(tunedConfig[:]))
+	}
+
+	return cmTuneds, nil
+}
+
+// parseManifests parses a YAML or JSON document that may contain one or more
+// kubernetes resources.
+func parseTunedManifests(data []byte) ([]tunedv1.Tuned, error) {
+	r := bytes.NewReader(data)
+	d := yamlutil.NewYAMLOrJSONDecoder(r, 1024)
+	var tuneds []tunedv1.Tuned
+	for {
+		t := tunedv1.Tuned{}
+		if err := d.Decode(&t); err != nil {
+			if err == io.EOF {
+				klog.Infof("parseTunedManifests: EOF reached, num tuneds: %d", len(tuneds))
+				return tuneds, nil
+			}
+			return tuneds, fmt.Errorf("Error parsing Tuned manifests: %v", err)
+		}
+		klog.Infof("parseTunedManifests: name: %s", t.GetName())
+
+		// TODO improve verification here? or trust nodepool controller?
+		// A dummy test for empty objects
+		if t.GetName() == "" {
+			klog.Infof("parseTunedManifests: Empty name in Tuned!")
+			continue
+		}
+		tuneds = append(tuneds, t)
+	}
+
+}
+

--- a/pkg/operator/profilecalculator.go
+++ b/pkg/operator/profilecalculator.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
@@ -187,11 +189,7 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[stri
 				return "", nil, nil, operand, err
 			}
 
-			if config.InHyperShift() {
-				pools, err = nil, nil
-			} else {
-				pools, err = pc.getPoolsForNode(node)
-			}
+			pools, err = pc.getPoolsForNode(node)
 
 			if err != nil {
 				return "", nil, nil, operand, err
@@ -212,6 +210,61 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[stri
 	}
 
 	return defaultProfile, nil, nil, operand, fmt.Errorf("the default Tuned CR misses a catch-all profile selection")
+}
+
+// calculateProfileHyperShift calculates a tuned profile for Node nodeName.
+//
+// Returns
+// * the tuned daemon profile name
+// * the NodePool name for this Node
+// * whether to run the Tuned daemon in debug mode on node nodeName
+// * an error if any
+func (pc *ProfileCalculator) calculateProfileHyperShift(nodeName string) (string, string, tunedv1.OperandConfig, error) {
+	var operand tunedv1.OperandConfig
+
+	klog.V(3).Infof("calculateProfileHyperShift(%s)", nodeName)
+
+	node, err := pc.listers.Nodes.Get(nodeName)
+	if err != nil {
+		return "", "", operand, err
+	}
+
+	nodePoolName, err := pc.getNodePoolNameForNode(node)
+	if err != nil {
+		return "", "", operand, err
+	}
+
+	// In HyperShift, we only consider the default profile and
+	// the Tuned profiles from Tuneds referenced in this Nodes NodePool spec.
+	tunedList, err := pc.listers.TunedResources.List(labels.SelectorFromValidatedSet(
+		map[string]string{
+			hypershiftNodePoolNameLabel: nodePoolName,
+		}))
+	if err != nil {
+		return "", "", operand, fmt.Errorf("failed to list Tuneds in NodePool %s: %v", nodePoolName, err)
+	}
+	defaultTuned, err := pc.listers.TunedResources.Get(tunedv1.TunedDefaultResourceName)
+	if err != nil {
+		return defaultProfile, "", operand, fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedDefaultResourceName, err)
+	}
+	tunedList = append(tunedList, defaultTuned)
+
+	for _, recommend := range tunedRecommend(tunedList) {
+		// Start with node/pod label based matching
+		if recommend.Match != nil && pc.profileMatches(recommend.Match, nodeName) {
+			klog.V(2).Infof("calculateProfileHyperShift: node / pod label matching used. node: %s, tunedProfileName: %s, nodePoolName: %s, operand: %v", nodeName, *recommend.Profile, "", recommend.Operand)
+			return *recommend.Profile, "", recommend.Operand, nil
+		}
+
+		// If recommend.Match is empty, NodePool based matching is assumed
+		// or this is the default profile
+		if recommend.Match == nil {
+			klog.V(2).Infof("calculateProfileHyperShift: NodePool based matching used. node: %s, tunedProfileName:  %s, nodePoolName: %s", nodeName, *recommend.Profile, nodePoolName)
+			return *recommend.Profile, nodePoolName, recommend.Operand, nil
+		}
+	}
+
+	return defaultProfile, "", operand, fmt.Errorf("the default Tuned CR misses a catch-all profile selection")
 }
 
 // profileMatches returns true, if Node 'nodeName' fulfills all the necessary
@@ -466,6 +519,45 @@ func (pc *ProfileCalculator) tunedsUsePodLabels(tunedSlice []*tunedv1.Tuned) boo
 	return false
 }
 
+// This can be simplified and cleaned up a lot after
+// https://github.com/openshift/hypershift/pull/1702 merges.
+// Then the nodes will have a label with the NodePool name.
+func (pc *ProfileCalculator) getNodePoolNameForNode(node *corev1.Node) (string, error) {
+	var nodeMachineSetName string
+	var resourceGVK schema.GroupVersionResource
+
+	if node.Annotations[hypershiftNodeOwnerKindLabel] == "MachineSet" {
+		nodeMachineSetName = node.Annotations[hypershiftNodeOwnerNameLabel]
+		resourceGVK = schema.GroupVersionResource{
+			Group:    "cluster.x-k8s.io",
+			Version:  "v1beta1",
+			Resource: "machinesets"}
+	} else {
+		klog.Warning("unexpected node owner kind on Node %s: %s", node.Name, hypershiftNodeOwnerKindLabel)
+	}
+
+	unstructuredMachineSet, err := pc.clients.ManagementDynamic.Resource(resourceGVK).Namespace(config.OperatorNamespace()).Get(context.TODO(), nodeMachineSetName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error getting MachineSet for Node %s: %v", node.Name, err)
+	}
+
+	machineSetMetadata, ok := unstructuredMachineSet.Object["metadata"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("unable to get annotations of unstructured MachineSet for node: %s", node.Name)
+	}
+	machineSetAnnotations, ok := machineSetMetadata["annotations"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("unable to get metadata of unstructured MachineSet for node: %s", node.Name)
+	}
+	nodePoolNamespacedName, ok := machineSetAnnotations[hypershiftNodePoolNamespacedNameLabel].(string)
+	if !ok {
+		return "", fmt.Errorf("unable to get nodePool annotation value of unstructured MachineSet for node: %s", node.Name)
+	}
+	nodePoolName := parseNamespacedName((nodePoolNamespacedName))
+	klog.Infof("calculated nodePoolName: %s for node %s with nodeMachineSet value: %s", nodePoolName, node.Name, nodeMachineSetName)
+	return nodePoolName, nil
+}
+
 // tunedRecommend returns a priority-sorted TunedRecommend slice out of
 // a slice of Tuned objects for profile-calculation purposes.
 func tunedRecommend(tunedSlice []*tunedv1.Tuned) []tunedv1.TunedRecommend {
@@ -496,7 +588,11 @@ func tunedRecommend(tunedSlice []*tunedv1.Tuned) []tunedv1.TunedRecommend {
 		if recommendAll[i].Priority == nil || recommendAll[i+1].Priority == nil {
 			continue
 		}
-		if *recommendAll[i].Priority == *recommendAll[i+1].Priority {
+		// Warn if two profiles have the same priority, and different names.
+		// If they have the same name and different contents a separate warning
+		// will be issued by manifests.tunedRenderedProfiles()
+		if *recommendAll[i].Priority == *recommendAll[i+1].Priority &&
+			*recommendAll[i].Profile != *recommendAll[i+1].Profile {
 			klog.Warningf("profiles %s/%s have the same priority %d, please use a different priority for your custom profiles!",
 				*recommendAll[i].Profile, *recommendAll[i+1].Profile, *recommendAll[i].Priority)
 		}

--- a/pkg/operator/profilecalculator.go
+++ b/pkg/operator/profilecalculator.go
@@ -188,9 +188,9 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[stri
 			}
 
 			if config.InHyperShift() {
-				pools, err = pc.getPoolsForNode(node)
-			} else {
 				pools, err = nil, nil
+			} else {
+				pools, err = pc.getPoolsForNode(node)
 			}
 
 			if err != nil {

--- a/pkg/operator/profilecalculator.go
+++ b/pkg/operator/profilecalculator.go
@@ -13,6 +13,7 @@ import (
 
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	ntoclient "github.com/openshift/cluster-node-tuning-operator/pkg/client"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/util"
 
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -186,7 +187,12 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[stri
 				return "", nil, nil, operand, err
 			}
 
-			pools, err = pc.getPoolsForNode(node)
+			if config.InHyperShift() {
+				pools, err = pc.getPoolsForNode(node)
+			} else {
+				pools, err = nil, nil
+			}
+
 			if err != nil {
 				return "", nil, nil, operand, err
 			}

--- a/test/e2e/basic/available.go
+++ b/test/e2e/basic/available.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe("[basic][available] Node Tuning Operator availability", 
 	ginkgo.It(fmt.Sprintf("Tuned/%s exists", tunedv1.TunedDefaultResourceName), func() {
 		ginkgo.By(fmt.Sprintf("waiting for Tuned/%s existence", tunedv1.TunedDefaultResourceName))
 		err := wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
-			_, err := cs.Tuneds(ntoconfig.OperatorNamespace()).Get(context.TODO(), tunedv1.TunedDefaultResourceName, metav1.GetOptions{})
+			_, err := cs.Tuneds(ntoconfig.WatchNamespace()).Get(context.TODO(), tunedv1.TunedDefaultResourceName, metav1.GetOptions{})
 			if err != nil {
 				explain = err.Error()
 				return false, nil

--- a/test/e2e/basic/custom_node_labels.go
+++ b/test/e2e/basic/custom_node_labels.go
@@ -33,7 +33,7 @@ var _ = ginkgo.Describe("[basic][custom_node_labels] Node Tuning Operator custom
 			if node != nil {
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelHugepages+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileHugepages)
 		})
 
 		ginkgo.It(fmt.Sprintf("%s set", sysctlVar), func() {
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe("[basic][custom_node_labels] Node Tuning Operator custom
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating the custom hugepages profile %s", profileHugepages))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileHugepages)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("ensuring the custom worker node profile was set")
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("[basic][custom_node_labels] Node Tuning Operator custom
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom hugepages profile %s", profileHugepages))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileHugepages)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the original %s value (%s) is set in Pod %s", sysctlVar, valOrig, pod.Name))

--- a/test/e2e/basic/custom_pod_labels.go
+++ b/test/e2e/basic/custom_pod_labels.go
@@ -31,9 +31,9 @@ var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom 
 		ginkgo.AfterEach(func() {
 			ginkgo.By("cluster changes rollback")
 			if pod != nil {
-				util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.OperatorNamespace(), pod.Name, podLabelIngress+"-")
+				util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.WatchNamespace(), pod.Name, podLabelIngress+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileIngress)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileIngress)
 		})
 
 		ginkgo.It(fmt.Sprintf("%s set", sysctlVar), func() {
@@ -61,11 +61,11 @@ var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("labelling Pod %s with label %s", pod.Name, podLabelIngress))
-			_, _, err = util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.OperatorNamespace(), pod.Name, podLabelIngress+"=")
+			_, _, err = util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.WatchNamespace(), pod.Name, podLabelIngress+"=")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating the custom ingress profile %s", profileIngress))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileIngress)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileIngress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("ensuring the custom worker node profile was set")
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("removing label %s from Pod %s", podLabelIngress, pod.Name))
-			_, _, err = util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.OperatorNamespace(), pod.Name, podLabelIngress+"-")
+			_, _, err = util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.WatchNamespace(), pod.Name, podLabelIngress+"-")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the original %s value (%s) is set in Pod %s", sysctlVar, valOrig, pod.Name))
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("[basic][custom_pod_labels] Node Tuning Operator custom 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom ingress profile %s", profileIngress))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileIngress)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileIngress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 	})

--- a/test/e2e/basic/default_irq_smp_affinity.go
+++ b/test/e2e/basic/default_irq_smp_affinity.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe("[basic][default_irq_smp_affinity] Node Tuning Operator 
 			if node != nil {
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelAffinity+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileAffinity0)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileAffinity0)
 		})
 
 		ginkgo.It(fmt.Sprintf("default_irq_smp_affinity: %s set", procIrqDefaultSmpAffinity), func() {
@@ -82,7 +82,7 @@ var _ = ginkgo.Describe("[basic][default_irq_smp_affinity] Node Tuning Operator 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating the custom affinity profile %s", profileAffinity0))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileAffinity0)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileAffinity0)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Check only the last nibble of the /proc/irq/default_smp_affinity mask.  Some virtualized (Xen) systems have
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("[basic][default_irq_smp_affinity] Node Tuning Operator 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("applying the custom affinity profile %s", profileAffinity1))
-			_, _, err = util.ExecAndLogCommand("oc", "apply", "-n", ntoconfig.OperatorNamespace(), "-f", profileAffinity1)
+			_, _, err = util.ExecAndLogCommand("oc", "apply", "-n", ntoconfig.WatchNamespace(), "-f", profileAffinity1)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the correct value of %s was set in the last nibble of %s", maskExp1, procIrqDefaultSmpAffinity))
@@ -105,7 +105,7 @@ var _ = ginkgo.Describe("[basic][default_irq_smp_affinity] Node Tuning Operator 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom affinity profile %s", profileAffinity0))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileAffinity0)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileAffinity0)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the original value of %s was set in the last nibble of %s", valOrig, procIrqDefaultSmpAffinity))

--- a/test/e2e/basic/metrics_cert_rotation.go
+++ b/test/e2e/basic/metrics_cert_rotation.go
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("[basic][metrics] Node Tuning Operator certificate rotat
 
 			ginkgo.By("checking if server TLS certificate matches TLS certificate in Secret")
 			err = wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
-				tlsSecret, err := cs.Secrets(ntoconfig.OperatorNamespace()).Get(context.TODO(), "node-tuning-operator-tls", metav1.GetOptions{})
+				tlsSecret, err := cs.Secrets(ntoconfig.WatchNamespace()).Get(context.TODO(), "node-tuning-operator-tls", metav1.GetOptions{})
 				if err != nil {
 					util.Logf("error getting secret/node-tuning-operator-tls. May not exist yet. Err: %v", err)
 					return false, nil
@@ -78,14 +78,14 @@ var _ = ginkgo.Describe("[basic][metrics] Node Tuning Operator certificate rotat
 // waits up to 2 minutes for it to be recreated with the new certificate.
 func rotateTLSCertSecret() error {
 	// Get original Secret.
-	tlsSecret, err := cs.Secrets(ntoconfig.OperatorNamespace()).Get(context.TODO(), "node-tuning-operator-tls", metav1.GetOptions{})
+	tlsSecret, err := cs.Secrets(ntoconfig.WatchNamespace()).Get(context.TODO(), "node-tuning-operator-tls", metav1.GetOptions{})
 	if err != nil {
 		util.Logf("Error getting secret/node-tuning-operator-tls. May not exist yet. Err: %v", err)
 		return err
 	}
 	origCertContents := string(tlsSecret.Data["tls.crt"])
 
-	_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "secret/node-tuning-operator-tls")
+	_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "secret/node-tuning-operator-tls")
 	if err != nil {
 		util.Logf("Error deleting secret/node-tuning-operator/tls")
 		return err
@@ -93,7 +93,7 @@ func rotateTLSCertSecret() error {
 
 	// Wait for new certificate to be injected into the Secret.
 	err = wait.PollImmediate(2*time.Second, 2*time.Minute, func() (bool, error) {
-		tlsSecret, err = cs.Secrets(ntoconfig.OperatorNamespace()).Get(context.TODO(), "node-tuning-operator-tls", metav1.GetOptions{})
+		tlsSecret, err = cs.Secrets(ntoconfig.WatchNamespace()).Get(context.TODO(), "node-tuning-operator-tls", metav1.GetOptions{})
 		if err != nil {
 			util.Logf("Error getting secret/node-tuning-operator-tls. May not exist yet. Err: %v", err)
 			return false, nil

--- a/test/e2e/basic/modules.go
+++ b/test/e2e/basic/modules.go
@@ -33,7 +33,7 @@ var _ = ginkgo.Describe("[basic][modules] Node Tuning Operator load kernel modul
 			if node != nil {
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelModules+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileModules)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileModules)
 		})
 
 		ginkgo.It(fmt.Sprintf("modules: %s loaded", moduleName), func() {
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe("[basic][modules] Node Tuning Operator load kernel modul
 			gomega.Expect(err).To(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating profile %s", profileModules))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileModules)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileModules)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the %s module is loaded", moduleName))
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("[basic][modules] Node Tuning Operator load kernel modul
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting profile %s", profileModules))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileModules)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileModules)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("removing label %s from node %s", nodeLabelModules, node.Name))

--- a/test/e2e/basic/netdev_set_channels.go
+++ b/test/e2e/basic/netdev_set_channels.go
@@ -34,7 +34,7 @@ var _ = ginkgo.Describe("[basic][netdev_set_channels] Node Tuning Operator adjus
 			if node != nil {
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelNetdev+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileNetdev)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileNetdev)
 		})
 
 		ginkgo.It("adjust netdev queue count for physical network devices via ethtool", func() {
@@ -142,7 +142,7 @@ var _ = ginkgo.Describe("[basic][netdev_set_channels] Node Tuning Operator adjus
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating profile %s", profileNetdev))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileNetdev)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileNetdev)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the number of multi-purpose channels is set to %d for %s on node %s", chLen, phyDev, node.Name))
@@ -162,7 +162,7 @@ var _ = ginkgo.Describe("[basic][netdev_set_channels] Node Tuning Operator adjus
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), explain)
 
 			ginkgo.By(fmt.Sprintf("deleting profile %s", profileNetdev))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileNetdev)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileNetdev)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("removing label %s from node %s", nodeLabelNetdev, node.Name))

--- a/test/e2e/basic/profile_status.go
+++ b/test/e2e/basic/profile_status.go
@@ -28,7 +28,7 @@ var _ = ginkgo.Describe("[basic][profile_status] Profile status conditions appli
 
 	ginkgo.It("Profile status conditions applied and not degraded", func() {
 		err := wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
-			profileList, err := cs.Profiles(ntoconfig.OperatorNamespace()).List(context.TODO(), metav1.ListOptions{})
+			profileList, err := cs.Profiles(ntoconfig.WatchNamespace()).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				explain = err.Error()
 				return false, nil

--- a/test/e2e/basic/rollback.go
+++ b/test/e2e/basic/rollback.go
@@ -33,9 +33,9 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 		ginkgo.AfterEach(func() {
 			ginkgo.By("cluster changes rollback")
 			if pod != nil {
-				util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.OperatorNamespace(), pod.Name, podLabelIngress+"-")
+				util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.WatchNamespace(), pod.Name, podLabelIngress+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileIngress)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileIngress)
 		})
 
 		ginkgo.It(fmt.Sprintf("%s set", sysctlVar), func() {
@@ -65,11 +65,11 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("labelling Pod %s with label %s", pod.Name, podLabelIngress))
-			_, _, err = util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.OperatorNamespace(), pod.Name, podLabelIngress+"=")
+			_, _, err = util.ExecAndLogCommand("oc", "label", "pod", "--overwrite", "-n", ntoconfig.WatchNamespace(), pod.Name, podLabelIngress+"=")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating custom profile %s", profileIngress))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileIngress)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileIngress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("ensuring the custom worker node profile was set")
@@ -77,7 +77,7 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting Pod %s", pod.Name))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "pod", pod.Name, "--wait")
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "pod", pod.Name, "--wait")
 			pod = nil
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting custom profile %s", profileIngress))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileIngress)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileIngress)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 	})

--- a/test/e2e/basic/sysctl_d_override.go
+++ b/test/e2e/basic/sysctl_d_override.go
@@ -39,9 +39,9 @@ var _ = ginkgo.Describe("[basic][sysctl_d_override] Node Tuning Operator /etc/sy
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelSysctlOverride+"-")
 			}
 			if pod != nil {
-				util.ExecAndLogCommand("oc", "exec", "-n", ntoconfig.OperatorNamespace(), pod.Name, "--", "rm", sysctlFile)
+				util.ExecAndLogCommand("oc", "exec", "-n", ntoconfig.WatchNamespace(), pod.Name, "--", "rm", sysctlFile)
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileSysctlOverride)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileSysctlOverride)
 		})
 
 		ginkgo.It(fmt.Sprintf("%s set", sysctlVar), func() {
@@ -71,14 +71,14 @@ var _ = ginkgo.Describe("[basic][sysctl_d_override] Node Tuning Operator /etc/sy
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("writing %s override file on the host with %s=%s", sysctlFile, sysctlVar, sysctlValSet))
-			_, _, err = util.ExecAndLogCommand("oc", "exec", "-n", ntoconfig.OperatorNamespace(), pod.Name, "--", "sh", "-c",
+			_, _, err = util.ExecAndLogCommand("oc", "exec", "-n", ntoconfig.WatchNamespace(), pod.Name, "--", "sh", "-c",
 				fmt.Sprintf("echo %s=%s > %s; sync %s", sysctlVar, sysctlValSet, sysctlFile, sysctlFile))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			util.ExecAndLogCommand("oc", "rsh", "-n", ntoconfig.OperatorNamespace(), pod.Name, "cat", sysctlFile)
+			util.ExecAndLogCommand("oc", "rsh", "-n", ntoconfig.WatchNamespace(), pod.Name, "cat", sysctlFile)
 
 			ginkgo.By(fmt.Sprintf("deleting Pod %s", pod.Name))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "pod", pod.Name, "--wait")
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "pod", pod.Name, "--wait")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("waiting for a new TuneD Pod to be ready on node %s", node.Name))
@@ -101,7 +101,7 @@ var _ = ginkgo.Describe("[basic][sysctl_d_override] Node Tuning Operator /etc/sy
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating the custom profile %s", profileSysctlOverride))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileSysctlOverride)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileSysctlOverride)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("ensuring the custom worker node profile was set")
@@ -113,15 +113,15 @@ var _ = ginkgo.Describe("[basic][sysctl_d_override] Node Tuning Operator /etc/sy
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom profile %s", profileSysctlOverride))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileSysctlOverride)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileSysctlOverride)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("removing %s override file on the host", sysctlFile))
-			_, _, err = util.ExecAndLogCommand("oc", "exec", "-n", ntoconfig.OperatorNamespace(), pod.Name, "--", "rm", sysctlFile)
+			_, _, err = util.ExecAndLogCommand("oc", "exec", "-n", ntoconfig.WatchNamespace(), pod.Name, "--", "rm", sysctlFile)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting Pod %s", pod.Name))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "pod", pod.Name, "--wait")
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "pod", pod.Name, "--wait")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("waiting for a new TuneD Pod to be ready on node %s", node.Name))

--- a/test/e2e/basic/tuned_builtin_expand.go
+++ b/test/e2e/basic/tuned_builtin_expand.go
@@ -34,8 +34,8 @@ var _ = ginkgo.Describe("[basic][tuned_builtin_expand] Node Tuning Operator cust
 			if node != nil {
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelBuiltinExpand+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileBuiltinExpand)
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileBuiltinExpand)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileHugepages)
 		})
 
 		ginkgo.It(fmt.Sprintf("%s set", sysctlVar), func() {
@@ -67,11 +67,11 @@ var _ = ginkgo.Describe("[basic][tuned_builtin_expand] Node Tuning Operator cust
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating the custom profile %s", profileHugepages))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileHugepages)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating the custom profile %s", profileBuiltinExpand))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileBuiltinExpand)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileBuiltinExpand)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("ensuring the custom worker node profile was set")
@@ -79,11 +79,11 @@ var _ = ginkgo.Describe("[basic][tuned_builtin_expand] Node Tuning Operator cust
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom profile %s", profileBuiltinExpand))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileBuiltinExpand)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileBuiltinExpand)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom profile %s", profileHugepages))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileHugepages)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileHugepages)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("ensuring the original %s value (%s) is set in Pod %s", sysctlVar, valOrig, pod.Name))

--- a/test/e2e/basic/tuned_errors_and_recovery.go
+++ b/test/e2e/basic/tuned_errors_and_recovery.go
@@ -36,11 +36,11 @@ var _ = ginkgo.Describe("[basic][tuned_errors_and_recovery] Cause TuneD daemon e
 			if node != nil {
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelCauseTunedFailure+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileCauseTunedFailure)
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileDummy)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileCauseTunedFailure)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileDummy)
 			if pod != nil {
 				// Without removing the profile directory this e2e test fails when invoking for the second time on the same system.
-				util.ExecAndLogCommand("oc", "exec", "-n", ntoconfig.OperatorNamespace(), pod.Name, "--", "rm", "-rf", "/etc/tuned/openshift-dummy")
+				util.ExecAndLogCommand("oc", "exec", "-n", ntoconfig.WatchNamespace(), pod.Name, "--", "rm", "-rf", "/etc/tuned/openshift-dummy")
 			}
 		})
 
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("[basic][tuned_errors_and_recovery] Cause TuneD daemon e
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating the custom profile %s", profileCauseTunedFailure))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileCauseTunedFailure)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileCauseTunedFailure)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("waiting for ClusterOperator/%s condition %s reason %s", tunedv1.TunedClusterOperatorResourceName, configv1.OperatorAvailable, reasonProfileDegraded))
@@ -78,7 +78,7 @@ var _ = ginkgo.Describe("[basic][tuned_errors_and_recovery] Cause TuneD daemon e
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating the custom profile %s", profileDummy))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileDummy)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileDummy)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Check for rhbz#1998247, reload TuneD when deps of recommended profile change.
@@ -87,11 +87,11 @@ var _ = ginkgo.Describe("[basic][tuned_errors_and_recovery] Cause TuneD daemon e
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom profile %s", profileCauseTunedFailure))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileCauseTunedFailure)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileCauseTunedFailure)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom profile %s", profileDummy))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileDummy)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileDummy)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("waiting for ClusterOperator/%s condition %s reason %s", tunedv1.TunedClusterOperatorResourceName, configv1.OperatorAvailable, reasonAsExpected))

--- a/test/e2e/reboots/kernel_parameter_add_rm.go
+++ b/test/e2e/reboots/kernel_parameter_add_rm.go
@@ -37,8 +37,8 @@ var _ = ginkgo.Describe("[reboots][kernel_parameter_add_rm] Node Tuning Operator
 			if node != nil {
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelRealtime+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileParent)
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileChild)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileParent)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileChild)
 			util.ExecAndLogCommand("oc", "delete", "-f", mcpRealtime)
 		})
 
@@ -76,7 +76,7 @@ var _ = ginkgo.Describe("[reboots][kernel_parameter_add_rm] Node Tuning Operator
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating custom parent profile %s", profileParent))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileParent)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileParent)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating custom MachineConfigPool %s", mcpRealtime))
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("[reboots][kernel_parameter_add_rm] Node Tuning Operator
 			}
 
 			ginkgo.By(fmt.Sprintf("creating custom child profile %s", profileChild))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileChild)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileChild)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			waitForMCPFlip()
@@ -120,11 +120,11 @@ var _ = ginkgo.Describe("[reboots][kernel_parameter_add_rm] Node Tuning Operator
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom parent profile %s", profileParent))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileParent)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileParent)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom child profile %s", profileChild))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileChild)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileChild)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Wait for the worker machineCount to go to the original value when the node was not part of worker-rt pool.

--- a/test/e2e/reboots/machine_config_labels.go
+++ b/test/e2e/reboots/machine_config_labels.go
@@ -36,7 +36,7 @@ var _ = ginkgo.Describe("[reboots][machine_config_labels] Node Tuning Operator m
 			if node != nil {
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelRealtime+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileRealtime)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileRealtime)
 			util.ExecAndLogCommand("oc", "delete", "-f", mcpRealtime)
 		})
 
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("[reboots][machine_config_labels] Node Tuning Operator m
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating custom realtime profile %s", profileRealtime))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileRealtime)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileRealtime)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating custom MachineConfigPool %s", mcpRealtime))
@@ -98,7 +98,7 @@ var _ = ginkgo.Describe("[reboots][machine_config_labels] Node Tuning Operator m
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom realtime profile %s", profileRealtime))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileRealtime)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileRealtime)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Wait for the worker machineCount to go to the original value when the node was not part of worker-rt pool.

--- a/test/e2e/reboots/stalld.go
+++ b/test/e2e/reboots/stalld.go
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 			if node != nil {
 				util.ExecAndLogCommand("oc", "label", "node", "--overwrite", node.Name, nodeLabelRealtime+"-")
 			}
-			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileStalldOn)
+			util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileStalldOn)
 			util.ExecAndLogCommand("oc", "delete", "-f", mcpRealtime)
 		})
 
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 
 			// BZ1926903: check for the systemd/TuneD [service] plug-in race
 			ginkgo.By(fmt.Sprintf("creating custom realtime profile %s with stalld service stopped,disabled", profileStalldOff))
-			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileStalldOff)
+			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.WatchNamespace(), "-f", profileStalldOff)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("creating custom MachineConfigPool %s", mcpRealtime))
@@ -90,7 +90,7 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 			gomega.Expect(err).To(gomega.HaveOccurred()) // pidof exits 1 when there is no running process found
 
 			ginkgo.By(fmt.Sprintf("applying custom realtime profile %s with stalld service", profileStalldOn))
-			_, _, err = util.ExecAndLogCommand("oc", "apply", "-n", ntoconfig.OperatorNamespace(), "-f", profileStalldOn)
+			_, _, err = util.ExecAndLogCommand("oc", "apply", "-n", ntoconfig.WatchNamespace(), "-f", profileStalldOn)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("checking the stalld daemon is running on node %s", node.Name))
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By(fmt.Sprintf("deleting the custom realtime profile %s with stalld service", profileStalldOn))
-			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.OperatorNamespace(), "-f", profileStalldOn)
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", profileStalldOn)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Wait for the worker machineCount to go to the original value when the node was not part of worker-rt pool.

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -57,7 +57,7 @@ func GetTunedForNode(cs *framework.ClientSet, node *corev1.Node) (*corev1.Pod, e
 		LabelSelector: labels.SelectorFromSet(labels.Set{"openshift-app": "tuned"}).String(),
 	}
 
-	podList, err := cs.Pods(ntoconfig.OperatorNamespace()).List(context.TODO(), listOptions)
+	podList, err := cs.Pods(ntoconfig.WatchNamespace()).List(context.TODO(), listOptions)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get a list of TuneD Pods: %v", err)
 	}
@@ -78,7 +78,7 @@ func GetNodeTuningOperatorPod(cs *framework.ClientSet) (*corev1.Pod, error) {
 		LabelSelector: labels.SelectorFromSet(labels.Set{"name": "cluster-node-tuning-operator"}).String(),
 	}
 
-	podList, err := cs.Pods(ntoconfig.OperatorNamespace()).List(context.TODO(), listOptions)
+	podList, err := cs.Pods(ntoconfig.WatchNamespace()).List(context.TODO(), listOptions)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't list potential NTO operator Pods: %v", err)
 	}
@@ -121,7 +121,7 @@ func ExecAndLogCommand(name string, args ...string) (bytes.Buffer, bytes.Buffer,
 
 // ExecCmdInPod executes command with arguments 'cmd' in Pod 'pod'.
 func ExecCmdInPod(pod *corev1.Pod, cmd ...string) (string, error) {
-	ocArgs := []string{"rsh", "-n", ntoconfig.OperatorNamespace(), pod.Name}
+	ocArgs := []string{"rsh", "-n", ntoconfig.WatchNamespace(), pod.Name}
 	ocArgs = append(ocArgs, cmd...)
 
 	stdout, stderr, err := execCommand(false, "oc", ocArgs...)
@@ -298,7 +298,7 @@ func WaitForProfileConditionStatus(cs *framework.ClientSet, interval, duration t
 
 	startTime := time.Now()
 	if err := wait.PollImmediate(interval, duration, func() (bool, error) {
-		p, err := cs.Profiles(ntoconfig.OperatorNamespace()).Get(context.TODO(), profile, metav1.GetOptions{})
+		p, err := cs.Profiles(ntoconfig.WatchNamespace()).Get(context.TODO(), profile, metav1.GetOptions{})
 		if err != nil {
 			explain = err
 			return false, nil


### PR DESCRIPTION
/cc @jmencak 

This PR enables the Node Tuning operator to run in HyperShift environments, to manage the tuning of hosted cluster nodes.

**A brief explanation of the design:**
The operator will run in the management cluster, in the hosted cluster control plane namespace, alongside some other cluster operators like OLM, network operator, etc. It will manage Tuned / Profile objects and a Tuned daemonset that exist in the hosted cluster API, but are subordinate to Tuned YAMLs in ConfigMaps in the management cluster hosted control plane namespace. To create Tuned in this environment, a user will create a ConfigMap which contains a Tuned manifest in the data.tuned field, and then reference this ConfigMap in the NodePool API spec.tunedConfig field. The NTO operator watches for the ConfigMap in the hosted cluster control plane namespace, and reconciles Tuned objects in the hosted cluster accordingly. See the corresponding HyperShift PR: https://github.com/openshift/hypershift/pull/1651

This PR is "phase-1" of NTO enablement on HyperShift and only supports basic sysctl settings. It does not support kernel args (depends on MachineConfig API), and it does not support MachineConfigPool matching. We plan to enable kernel parameter functionality in "phase-2" which will require a follow-up PR to NTO and the HyperShift repo.

**How to try it out:**
First, build the HyperShift binary and install HyperShift similarly to how it is explained in the [HyperShift docs](https://hypershift-docs.netlify.app/getting-started/), but with a custom image.

```
git clone https://github.com/dagrayvid/hypershift.git
cd hypershift
git checkout nto-poc
make build
sudo install -m 0755 bin/hypershift /usr/local/bin/hypershift

hypershift install --hypershift-image=quay.io/dagray/hypershift-operator:nto-poc --oidc-storage-provider-s3-bucket-name $BUCKET_NAME --oidc-storage-provider-s3-credentials $AWS_CREDS --oidc-storage-provider-s3-region $REGION
```

Then create a HyperShift cluster, using the same custom image as the control-plane-operator image:
```
hypershift create cluster aws --name $CLUSTER_NAME --node-pool-replicas=2 --base-domain $BASE_DOMAIN --pull-secret $PULL_SECRET --aws-creds $AWS_CREDS --region $REGION --generate-ssh --control-plane-operator-image quay.io/dagray/hypershift-operator:nto-poc
```

This should automatically deploy NTO in the control-plane namespace along with the other resources. 

An example of how to build a custom HyperShift image from my fork:
```
git clone https://github.com/dagrayvid/hypershift.git
cd hypershift
git checkout nto-poc
RUNTIME=podman AUTHFILE="--authfile=<PATH_TO_AUTHFILE>" IMG=quay.io/dagray/hypershift-operator:nto-poc make docker-build
podman push --authfile=<PATH_TO_AUTHFILE> quay.io/dagray/hypershift-operator:nto-poc
```

As an example of how to apply some custom tuning to the hosted cluster nodes, you can create the following ConfigMap which contains a Tuned object inside of it:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: hypershift-tuned-test
  namespace: clusters
data:
  tuned: |
    apiVersion: tuned.openshift.io/v1
    kind: Tuned
    metadata:
      name: openshift-dummy
      namespace: openshift-cluster-node-tuning-operator
    spec:
      profile:
      - data: |
          [main]
          summary=Custom OpenShift profile
          include=openshift-node

          [sysctl]   # Section with minimum changes
          net.ipv4.ip_local_port_range="1024 65532"
        name: openshift-dummy
      recommend:
      - match:
        - label: dummy-profile
        priority: 20
        profile: openshift-dummy
```
Note the metadata.namespace field. This should be the same namespace as the NodePool object that it will correspond to.

Reference this ConfigMap in the spec.tunedConfig field of the NodePool:
`oc patch -n clusters nodepool dagray-hypershift-1-us-east-1a --type merge -p '{"spec":{"tunedConfig":[{"name": "hypershift-tuned-test"}]}}'`

From there, the nodepool controller should reconcile this, embedding the tuned configuration into the tuned ConfigMap  in the control plane namespace. For example:

```
$ oc get configmaps -n clusters-dagray-hypershift-1 | grep tuned
tuned-dagray-hypershift-2-us-east-1a   1      22m
```
The data.tuned field of this ConfigMap will contain the Tuned manifests referenced in the NodePool.

Then, in our hosted cluster if we label a node with dummy-profile="", we should see this tuning applied to the node.