### PR TITLE
latency-tests: improve logs clarity

### DIFF
--- a/test/e2e/performanceprofile/functests/4_latency/latency.go
+++ b/test/e2e/performanceprofile/functests/4_latency/latency.go
@@ -441,6 +441,7 @@ func logEventsForPod(testPod *corev1.Pod) {
 	if err != nil {
 		testlog.Error(err)
 	}
+	testlog.Infof("log pod %s/%s events due to failure", testPod.Namespace, testPod.Name)
 	for _, event := range events.Items {
 		testlog.Warningf("-> %s %s %s", event.Action, event.Reason, event.Message)
 	}
@@ -462,7 +463,6 @@ func createLatencyTestPod(testPod *corev1.Pod, node *corev1.Node, logName string
 		return false, nil
 	})
 	if err != nil {
-		testlog.Error(err)
 		logEventsForPod(testPod)
 	}
 	Expect(err).ToNot(HaveOccurred(), "pod %q did not reach %q phase; current phase %q", podKey, corev1.PodRunning, currentPod.Status.Phase)
@@ -480,7 +480,6 @@ func createLatencyTestPod(testPod *corev1.Pod, node *corev1.Node, logName string
 	podTimeout := time.Duration(timeout + 120)
 	err = pods.WaitForPhase(testPod, corev1.PodSucceeded, podTimeout*time.Second)
 	if err != nil {
-		testlog.Error(err)
 		logEventsForPod(testPod)
 		testlog.Info(getLogFile(node, logName))
 	}

--- a/test/e2e/performanceprofile/functests/4_latency/latency.go
+++ b/test/e2e/performanceprofile/functests/4_latency/latency.go
@@ -454,6 +454,7 @@ func createLatencyTestPod(testPod *corev1.Pod, node *corev1.Node, logName string
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Waiting two minutes to download the latencyTest image")
+	podKey := fmt.Sprintf("%s/%s", testPod.Namespace, testPod.Name)
 	currentPod, err := pods.WaitForPredicate(testPod, 2*time.Minute, func(pod *corev1.Pod) (bool, error) {
 		if pod.Status.Phase == corev1.PodRunning {
 			return true, nil
@@ -464,7 +465,7 @@ func createLatencyTestPod(testPod *corev1.Pod, node *corev1.Node, logName string
 		testlog.Error(err)
 		logEventsForPod(testPod)
 	}
-	Expect(err).ToNot(HaveOccurred(), "expected the pod to reach running phase, its current phase is %s", currentPod.Status.Phase)
+	Expect(err).ToNot(HaveOccurred(), "pod %q did not reach %q phase; current phase %q", podKey, corev1.PodRunning, currentPod.Status.Phase)
 
 	if runtime, _ := strconv.Atoi(latencyTestRuntime); runtime > 1 {
 		By("Checking actual CPUs number for the running pod")
@@ -483,7 +484,7 @@ func createLatencyTestPod(testPod *corev1.Pod, node *corev1.Node, logName string
 		logEventsForPod(testPod)
 		testlog.Info(getLogFile(node, logName))
 	}
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), "pod %q did not reach %q phase; error: %v", podKey, corev1.PodSucceeded, err)
 }
 
 func extractLatencyValues(logName string, exp string, node *corev1.Node) string {

--- a/test/e2e/performanceprofile/functests/utils/pods/pods.go
+++ b/test/e2e/performanceprofile/functests/utils/pods/pods.go
@@ -176,11 +176,11 @@ func ExecCommandOnPod(c *kubernetes.Clientset, pod *corev1.Pod, command []string
 		Tty:    true,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to run command %v: output %s; error %s", command, outputBuf.String(), errorBuf.String())
+		return nil, fmt.Errorf("failed to run command %v: output %q; error %q; %w", command, outputBuf.String(), errorBuf.String(), err)
 	}
 
 	if errorBuf.Len() != 0 {
-		return nil, fmt.Errorf("failed to run command %v: output %s; error %s", command, outputBuf.String(), errorBuf.String())
+		return nil, fmt.Errorf("failed to run command %v: output %q; error %q", command, outputBuf.String(), errorBuf.String())
 	}
 
 	return outputBuf.Bytes(), nil


### PR DESCRIPTION
A couple of log improvements for latency-tests to make it easier to debug in case of test failures.