### PR TITLE
Add clientset.go missing pkg/generated file

### DIFF
--- a/pkg/generated/clientset/versioned/clientset.go
+++ b/pkg/generated/clientset/versioned/clientset.go
@@ -45,6 +45,10 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
 
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
 	// share the transport between all clients
 	httpClient, err := rest.HTTPClientFor(&configShallowCopy)
 	if err != nil {


### PR DESCRIPTION
After: Bump vendor dependencies to k8s 1.24.2 #386 
make pkt/generated a new file

Signed-off-by: Mario Fernandez <mariofer@redhat.com>