### PR TITLE
Add +optional and +default=true to workloadHints API

### DIFF
--- a/pkg/apis/performanceprofile/v1/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v1/performanceprofile_types.go
@@ -72,6 +72,7 @@ type PerformanceProfileSpec struct {
 	GloballyDisableIrqLoadBalancing *bool `json:"globallyDisableIrqLoadBalancing,omitempty"`
 	// WorkloadHints defines hints for different types of workloads. It will allow defining exact set of tuned and
 	// kernel arguments that should be applied on top of the node.
+	// +optional
 	WorkloadHints *WorkloadHints `json:"workloadHints,omitempty"`
 }
 
@@ -165,8 +166,11 @@ type RealTimeKernel struct {
 type WorkloadHints struct {
 	// HighPowerConsumption defines if the node should be configured in high power consumption mode.
 	// The flag will affect the power consumption but will improve the CPUs latency.
+	// +optional
 	HighPowerConsumption *bool `json:"highPowerConsumption,omitempty"`
 	// RealTime defines if the node should be configured for the real time workload.
+	// +default=true
+	// +optional
 	RealTime *bool `json:"realTime,omitempty"`
 }
 

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -76,6 +76,7 @@ type PerformanceProfileSpec struct {
 	GloballyDisableIrqLoadBalancing *bool `json:"globallyDisableIrqLoadBalancing,omitempty"`
 	// WorkloadHints defines hints for different types of workloads. It will allow defining exact set of tuned and
 	// kernel arguments that should be applied on top of the node.
+	// +optional
 	WorkloadHints *WorkloadHints `json:"workloadHints,omitempty"`
 }
 
@@ -172,8 +173,11 @@ type RealTimeKernel struct {
 type WorkloadHints struct {
 	// HighPowerConsumption defines if the node should be configured in high power consumption mode.
 	// The flag will affect the power consumption but will improve the CPUs latency.
+	// +optional
 	HighPowerConsumption *bool `json:"highPowerConsumption,omitempty"`
 	// RealTime defines if the node should be configured for the real time workload.
+	// +default=true
+	// +optional
 	RealTime *bool `json:"realTime,omitempty"`
 }
 


### PR DESCRIPTION
Fix optional parameter in workloadHints. 
To improve readability and avoid mistakes add +default=true to realTime Hint API. If no realTime parameter is added in performanceProfile, realTime is set to true and the user can get Spec.WorkloadHints.RealTime

Add +optional to workloadHints API
Add +default=true to realTimeHint to maintain compatibility with previous versions

Signed-off-by: Mario Fernandez <mariofer@redhat.com>