### PR TITLE
WIP: tuned: disable irqbalance, handle ban cpus earlier - using crio

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -38,8 +38,10 @@ transparent_hugepages=never
 
 {{if not .GloballyDisableIrqLoadBalancing}}
 [irqbalance]
-#> Override the value set by cpu-partitioning with an empty one
-banned_cpus=""
+# Disable the plugin entirely, which was enabled by the parent profile `cpu-partitioning`.
+# It can be racy if TuneD restarts for whatever reason.
+#> cpu-partitioning
+enabled=false
 {{end}}
 
 [scheduler]

--- a/pkg/performanceprofile/controller/performanceprofile/components/utils.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/utils.go
@@ -140,7 +140,7 @@ func CPUMaskToCPUSet(cpuMask string) (cpuset.CPUSet, error) {
 		}
 		mask, err := strconv.ParseUint(chunk, 16, bitsInWord)
 		if err != nil {
-			return cpuset.NewCPUSet(), fmt.Errorf("failed to parse the CPU mask %q: %v", cpuMask, err)
+			return cpuset.NewCPUSet(), fmt.Errorf("failed to parse the CPU mask %q (chunk %q): %v", cpuMask, chunk, err)
 		}
 		for j := 0; j < bitsInWord; j++ {
 			if mask&1 == 1 {

--- a/pkg/performanceprofile/controller/performanceprofile/components/utils_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/utils_test.go
@@ -16,6 +16,7 @@ var cpuListToMask = []listToMask{
 	{"0", "00000001"},
 	{"2-3", "0000000c"},
 	{"3,4,53-55,61-63", "e0e00000,00000018"},
+	{"1,3-7", "000000fa"},
 	{"0-127", "ffffffff,ffffffff,ffffffff,ffffffff"},
 	{"0-255", "ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff"},
 }

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -1,0 +1,139 @@
+package __performance
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
+	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/pods"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
+	"github.com/openshift/cluster-node-tuning-operator/test/framework"
+)
+
+var (
+	cs = framework.NewClientSet()
+)
+
+var _ = Describe("[performance] Checking IRQBalance settings", func() {
+	var workerRTNodes []corev1.Node
+	var profile *performancev2.PerformanceProfile
+	var performanceMCP string
+	var err error
+
+	BeforeEach(func() {
+		if discovery.Enabled() && testutils.ProfileNotFound {
+			Skip("Discovery mode enabled, performance profile not found")
+		}
+
+		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
+		Expect(err).ToNot(HaveOccurred())
+		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+		Expect(err).ToNot(HaveOccurred())
+		performanceMCP, err = mcps.GetByProfile(profile)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify that worker and performance MCP have updated state equals to true
+		for _, mcpName := range []string{testutils.RoleWorker, performanceMCP} {
+			mcps.WaitForCondition(mcpName, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
+		}
+	})
+
+	Context("Verify IRQ Balancing", func() {
+
+		var testpod *corev1.Pod
+
+		AfterEach(func() {
+			deleteTestPod(testpod)
+		})
+
+		It("Should not overwrite the banned CPU set on tuned restart", func() {
+			if profile.Status.RuntimeClass == nil {
+				Skip("runtime class not generated")
+			}
+			runtimeClass := profile.Status.RuntimeClass
+
+			irqLoadBalancingDisabled := profile.Spec.GloballyDisableIrqLoadBalancing != nil && *profile.Spec.GloballyDisableIrqLoadBalancing
+			if irqLoadBalancingDisabled {
+				Skip("this test needs dynamic IRQ balancing")
+			}
+
+			node := workerRTNodes[0] // any random node is fine
+			By(fmt.Sprintf("verifying worker node %q", node.Name))
+
+			var err error
+
+			bannedCPUs, err := nodes.BannedCPUs(node)
+			Expect(err).ToNot(HaveOccurred(), "failed to extract the banned CPUs from node %q", node.Name)
+			Expect(bannedCPUs.IsEmpty()).To(BeTrue(), "banned CPUs %v not empty on node %q", bannedCPUs, node.Name)
+
+			smpAffinitySet, err := nodes.GetDefaultSmpAffinitySet(&node)
+			Expect(err).ToNot(HaveOccurred(), "failed to get default smp affinity")
+
+			onlineCPUsSet, err := nodes.GetOnlineCPUsSet(&node)
+			Expect(err).ToNot(HaveOccurred(), "failed to get Online CPUs list")
+
+			// expect no irqbalance run in the system already, AKA start from pristine conditions.
+			// This is not an hard requirement, just the easier state to manage and check
+			Expect(smpAffinitySet.Equals(onlineCPUsSet)).To(BeTrue(), "found default_smp_affinity %v, expected %v - IRQBalance already run?", smpAffinitySet, onlineCPUsSet)
+
+			cpuRequest := 2 // minimum amount to be reasonably sure we're SMT-aligned
+			testpod = getStressPod(node.Name, cpuRequest)
+			testpod.Namespace = testutils.NamespaceTesting
+			testpod.Annotations = map[string]string{
+				"irq-load-balancing.crio.io": "disable",
+				"cpu-quota.crio.io":          "disable",
+			}
+			testpod.Spec.NodeName = node.Name
+			testpod.Spec.RuntimeClassName = runtimeClass
+			promotePodToGuaranteed(testpod)
+
+			err = testclient.Client.Create(context.TODO(), testpod)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = pods.WaitForCondition(testpod, corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
+			logEventsForPod(testpod)
+			Expect(err).ToNot(HaveOccurred())
+
+			// now we have something in the IRQBalance cpu list. Let's make sure the restart doesn't overwrite this data.
+			postCreateBannedCPUs, err := nodes.BannedCPUs(node)
+			Expect(err).ToNot(HaveOccurred(), "failed to extract the banned CPUs from node %q", node.Name)
+			Expect(postCreateBannedCPUs.IsEmpty()).To(BeFalse(), "banned CPUs %v not empty on node %q", postCreateBannedCPUs, node.Name)
+
+			By(fmt.Sprintf("getting a TuneD Pod running on node %s", node.Name))
+			pod, err := util.GetTunedForNode(cs, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("causing a restart of the tuned pod (deleting the pod) on %s", node.Name))
+			_, _, err = util.ExecAndLogCommand("oc", "delete", "pod", "--wait=true", "-n", pod.Namespace, pod.Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("getting again a TuneD Pod running on node %s", node.Name))
+			pod, err = util.GetTunedForNode(cs, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("waiting for the TuneD daemon running on node %s", node.Name))
+			_, err = util.WaitForCmdInPod(5*time.Second, 5*time.Minute, pod, "test", "-e", "/run/tuned/tuned.pid")
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("re-verifying worker node %q after TuneD restart", node.Name))
+
+			postRestartBannedCPUs, err := nodes.BannedCPUs(node)
+			Expect(err).ToNot(HaveOccurred(), "failed to extract the banned CPUs from node %q", node.Name)
+			Expect(postRestartBannedCPUs).To(Equal(postCreateBannedCPUs), "banned CPUs changed post tuned restart on node %q", postRestartBannedCPUs, node.Name)
+		})
+	})
+})

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -232,12 +232,21 @@ func BannedCPUs(node corev1.Node) (banned cpuset.CPUSet, err error) {
 		return cpuset.NewCPUSet(), nil // TODO: should this be a error?
 	}
 
-	banned, err = components.CPUMaskToCPUSet(bannedCPUs)
+	unquotedBannedCPUs := unquote(bannedCPUs)
+
+	banned, err = components.CPUMaskToCPUSet(unquotedBannedCPUs)
 	if err != nil {
 		return cpuset.NewCPUSet(), fmt.Errorf("failed to parse the banned CPUs: %v", err)
 	}
 
 	return banned, nil
+}
+
+func unquote(s string) string {
+	q := "\""
+	s = strings.TrimPrefix(s, q)
+	s = strings.TrimSuffix(s, q)
+	return s
 }
 
 // GetDefaultSmpAffinitySet returns the default smp affinity mask for the node

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -22,8 +22,9 @@ spec:
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
       isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
-      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n#> Override
-      the value set by cpu-partitioning with an empty one\nbanned_cpus=\"\"\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\nsched_min_granularity_ns=10000000\nsched_migration_cost_ns=5000000\nnuma_balancing=0\n\nsched_rt_runtime_us=-1\n\n\ndefault_irq_smp_affinity
+      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
+      plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\nsched_min_granularity_ns=10000000\nsched_migration_cost_ns=5000000\nnuma_balancing=0\n\nsched_rt_runtime_us=-1\n\n\ndefault_irq_smp_affinity
       = ignore\n\n\n[sysctl]\n\n#> cpu-partitioning #realtime\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #realtime\nkernel.nmi_watchdog=0\n#> realtime\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #realtime\nvm.stat_interval=10\n\n# cpu-partitioning and realtime


### PR DESCRIPTION
counterpart of https://github.com/openshift/cluster-node-tuning-operator/pull/396 leveraging existing crio functionality

The tuned irqbalance plugin clears the irqbalance banned CPUs list
when tuned starts. The list is then managed dynamically by the runtime
handlers.

On node restart, the tuned pod can be started AFTER the workload pods
(kubelet nor kubernetes offers ordering guarantees when recovering the
node state); clearing the banned CPUs list while pods are running and
compromising the IRQ isolation guarantees. Same holds true if the
NTO pod restarts for whatever reason.

The fix is twofold:
1. disable the irqbalance plugin, so tuned doesn't clear the irqbalance
   banned list anymore.
2. explicitly and predictably set the banned CPU list early in the boot
   leveraging crio functionality.

Signed-off-by: Francesco Romani <fromani@redhat.com>