### PR TITLE
e2e: add podsecurity labels 

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
+++ b/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
@@ -30,6 +30,11 @@ func init() {
 var TestingNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: testutils.NamespaceTesting,
+		Labels: map[string]string{
+			"pod-security.kubernetes.io/audit":   "privileged",
+			"pod-security.kubernetes.io/enforce": "privileged",
+			"pod-security.kubernetes.io/warn":    "privileged",
+		},
 	},
 }
 


### PR DESCRIPTION
OCP >= 4.12 wants to have stricter podsecurity rules.
In our e2e tests we do a bunch of stuff, including running privileged pods. We just annotate the test namespace(s) to signal we need top  privileges. Since e2e tests run in very controlled envs (CI mostly), and since test namespace should be gone anyway once the e2e tests are finished, this is still fair game.

Signed-off-by: Francesco Romani <fromani@redhat.com>