### PR TITLE
Dockerfile: provide full URL to CentOS stream image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 RUN make build
 
-FROM centos:stream8 as tuned
+FROM quay.io/centos/centos:stream8 as tuned
 WORKDIR /root
 COPY assets /root/assets
 RUN INSTALL_PKGS=" \
@@ -18,7 +18,7 @@ RUN INSTALL_PKGS=" \
     cd ../stalld && \
     make
 
-FROM centos:stream8
+FROM quay.io/centos/centos:stream8
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/


### PR DESCRIPTION
I believe explicit is better than implicit in this case.
