### PR TITLE
Bug 2102450: set rcutree.kthread_prio to ksoftirqd prio

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -138,7 +138,7 @@ cmdline_isolation=+isolcpus=managed_irq,${isolated_cores}
 {{end}}
 
 {{if .RealTime}}
-cmdline_realtime=+nohz_full=${isolated_cores} tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1
+cmdline_realtime=+nohz_full=${isolated_cores} tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11
 {{end}}
 
 {{if .HighPowerConsumption}}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -53,7 +53,7 @@ spec:
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1\n\n\n\n\n\n\ncmdline_hugepages=+
+      tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\ncmdline_hugepages=+
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\ncmdline_additionalArg=+\n"
     name: openshift-node-performance-manual
   recommend:


### PR DESCRIPTION
When a performance profile is applied, the priority of the
ksoftirqd and rcuc realtime attributes are set to to FIFO:11.
The rcutree.kthread_prio must be set accordingly to avoid
RCU stall situations with rt kernel

Signed-off-by: Vitaly Grinberg <vgrinber@redhat.com>