### PR TITLE
Fix CPU's overlapping error output

### DIFF
--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -147,16 +147,16 @@ func (r *PerformanceProfile) validateCPUs() field.ErrorList {
 				}
 
 				if overlap := components.Intersect(cpuLists.GetIsolated(), cpuLists.GetReserved()); len(overlap) != 0 {
-					allErrs = append(allErrs, field.Invalid(field.NewPath("spec.cpu"), r.Spec.CPU, fmt.Sprintf("reserved and isolated cpus overlap: %v", overlap)))
+					allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.cpu"), fmt.Sprintf("reserved and isolated cpus overlap: %v", overlap)))
 				}
 			}
 
 			if r.Spec.CPU.Offlined != nil {
 				if overlap := components.Intersect(cpuLists.GetReserved(), cpuLists.GetOfflined()); len(overlap) != 0 {
-					allErrs = append(allErrs, field.Invalid(field.NewPath("spec.cpu"), r.Spec.CPU, fmt.Sprintf("reserved and offlined cpus overlap: %v", overlap)))
+					allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.cpu"), fmt.Sprintf("reserved and offlined cpus overlap: %v", overlap)))
 				}
 				if overlap := components.Intersect(cpuLists.GetIsolated(), cpuLists.GetOfflined()); len(overlap) != 0 {
-					allErrs = append(allErrs, field.Invalid(field.NewPath("spec.cpu"), r.Spec.CPU, fmt.Sprintf("isolated and offlined cpus overlap: %v", overlap)))
+					allErrs = append(allErrs, field.Forbidden(field.NewPath("spec.cpu"), fmt.Sprintf("isolated and offlined cpus overlap: %v", overlap)))
 				}
 			}
 		}


### PR DESCRIPTION
## Description:

Output when forbidden CPU's overlapping is not formatted and it shows the object value

## Type of change

- [x] Change error output

## Testing steps
Launch PerformanceProfile as this one:
spec:
  cpu:
    isolated: "0-2"
    reserved: "0-2"

apply -f *.yaml
```
The PerformanceProfile "performance" is invalid: spec.cpu: Invalid value: v2.CPU{Reserved:(*v2.CPUSet)(0xc001017d30), Isolated:(*
v2.CPUSet)(0xc001017d20), BalanceIsolated:(*bool)(nil), Offlined:(*v2.CPUSet)(nil)}: **reserved and isolated cpus overlap**: [0 1 2] 
```

Also the code shows error as invalid, and it should be forbidden.

Fixed output:

```
The PerformanceProfile "performance" is invalid: spec.cpu: Forbidden: reserved and isolated cpus overlap: [0 1 2]
```

Also fixed for "reserved and offlined" and "isolated and offlined".


Signed-off-by: Mario Fernandez <mariofer@redhat.com>