### PR TITLE
irqbalance: add unit to clear the cpu ban list

### DIFF
--- a/assets/performanceprofile/scripts/clear-irqbalance-banned-cpus.sh
+++ b/assets/performanceprofile/scripts/clear-irqbalance-banned-cpus.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+# const
+SED="/usr/bin/sed"
+# tunable - overridable for testing purposes
+IRQBALANCE_CONF="${1:-/etc/sysconfig/irqbalance}"
+CRIO_ORIG_BANNED_CPUS="${2:-/etc/sysconfig/orig_irq_banned_cpus}"
+
+[ ! -f ${IRQBALANCE_CONF} ] && exit 0
+
+${SED} -i '/^\s*IRQBALANCE_BANNED_CPUS\b/d' ${IRQBALANCE_CONF} || exit 0
+echo "IRQBALANCE_BANNED_CPUS=" >> ${IRQBALANCE_CONF}
+
+# we now own this configuration. But CRI-O has code to restore the configuration,
+# and until it gains the option to disable this restore flow, we need to make
+# the configuration consistent such as the CRI-O restore will do nothing.
+if [ -n ${CRIO_ORIG_BANNED_CPUS} ] && [ -f ${CRIO_ORIG_BANNED_CPUS} ]; then
+	true > ${CRIO_ORIG_BANNED_CPUS}
+fi

--- a/pkg/performanceprofile/controller/performanceprofile/components/assets_scripts_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/assets_scripts_test.go
@@ -1,0 +1,227 @@
+package components
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	ClearIRQBalanceBannedCPUs = "clear-irqbalance-banned-cpus.sh"
+)
+
+var _ = Describe("Assets scripts", func() {
+	var scriptsPath string
+
+	BeforeEach(func() {
+		var err error
+		scriptsPath, err = getScriptsPath()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("Clear IRQBalance Banned CPU List", func() {
+		It("should handle missing irqbalance file", func() {
+			cmdline := []string{
+				filepath.Join(scriptsPath, ClearIRQBalanceBannedCPUs),
+				"/tmp/this/path/will/never/exist/conf.txt",
+				"",
+			}
+			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = GinkgoWriter
+
+			_, err := cmd.Output()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should handle missing ban list", func() {
+			confName, err := writeTempFile(confTemplate)
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(confName)
+
+			cmdline := []string{
+				filepath.Join(scriptsPath, ClearIRQBalanceBannedCPUs),
+				confName,
+				"",
+			}
+			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = GinkgoWriter
+
+			_, err = cmd.Output()
+			Expect(err).ToNot(HaveOccurred())
+
+			data, err := os.ReadFile(confName)
+			Expect(err).ToNot(HaveOccurred())
+
+			bannedCPUs, ok := extractBannedCPUs(string(data))
+			Expect(ok).To(BeTrue())
+			Expect(bannedCPUs).To(BeEmpty())
+		})
+
+		It("should handle empty ban list", func() {
+			confData := confTemplate + "\nIRQBALANCE_BANNED_CPUS=\n"
+			confName, err := writeTempFile(confData)
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(confName)
+
+			cmdline := []string{
+				filepath.Join(scriptsPath, ClearIRQBalanceBannedCPUs),
+				confName,
+				"",
+			}
+			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = GinkgoWriter
+
+			_, err = cmd.Output()
+			Expect(err).ToNot(HaveOccurred())
+
+			data, err := os.ReadFile(confName)
+			Expect(err).ToNot(HaveOccurred())
+
+			bannedCPUs, ok := extractBannedCPUs(string(data))
+			Expect(ok).To(BeTrue())
+			Expect(bannedCPUs).To(BeEmpty())
+		})
+
+		It("should clear existing ban list", func() {
+			// the actual ban list doesn't matter, we just need a value
+			bannedCPUs := "0,1-3"
+			confData := confTemplate + "\nIRQBALANCE_BANNED_CPUS=" + bannedCPUs + "\n"
+			confName, err := writeTempFile(confData)
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(confName)
+
+			restoreConf, err := os.CreateTemp("", "test-irqbalance-orig")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(restoreConf.Name())
+
+			cmdline := []string{
+				filepath.Join(scriptsPath, ClearIRQBalanceBannedCPUs),
+				confName,
+				restoreConf.Name(),
+			}
+			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = GinkgoWriter
+
+			_, err = cmd.Output()
+			Expect(err).ToNot(HaveOccurred())
+
+			data, err := os.ReadFile(confName)
+			Expect(err).ToNot(HaveOccurred())
+
+			updatedBannedCPUs, ok := extractBannedCPUs(string(data))
+			Expect(ok).To(BeTrue())
+			Expect(updatedBannedCPUs).To(BeEmpty())
+		})
+	})
+})
+
+func writeTempFile(content string) (string, error) {
+	f, err := os.CreateTemp("", "test-irqbalance-conf")
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := f.Write([]byte(confTemplate)); err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+func getScriptsPath() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("cannot retrieve tests directory")
+	}
+	basedir := filepath.Dir(file)
+	return filepath.Abs(
+		filepath.Join(
+			basedir,
+			"..", "..", "..", "..", "..",
+			"assets", "performanceprofile", "scripts",
+		),
+	)
+}
+
+func extractBannedCPUs(text string) (string, bool) {
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if idx := strings.Index(line, "#"); idx != -1 {
+			line = line[:idx]
+		}
+
+		if !strings.Contains(line, "IRQBALANCE_BANNED_CPUS") {
+			continue
+		}
+
+		return getBannedCPUs(line)
+	}
+
+	return "", false
+}
+
+func getBannedCPUs(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	items := strings.FieldsFunc(line, func(r rune) bool {
+		return r == '='
+	})
+	// missing value is interpreted (by shell and by us) as empty string
+	if len(items) == 1 {
+		return "", true
+	}
+	// too many values, bail out
+	if len(items) != 2 {
+		return "", false
+	}
+	// expected values (key, value)
+	return strings.TrimSpace(items[1]), true
+}
+
+const confTemplate = `# irqbalance is a daemon process that distributes interrupts across
+# CPUS on SMP systems. The default is to rebalance once every 10
+# seconds. This is the environment file that is specified to systemd via the
+# EnvironmentFile key in the service unit file (or via whatever method the init
+# system you're using has.
+#
+# ONESHOT=yes
+# after starting, wait for a minute, then look at the interrupt
+# load and balance it once; after balancing exit and do not change
+# it again.
+#IRQBALANCE_ONESHOT=
+
+#
+# IRQBALANCE_BANNED_CPUS
+# 64 bit bitmask which allows you to indicate which cpu's should
+# be skipped when reblancing irqs. Cpu numbers which have their
+# corresponding bits set to one in this mask will not have any
+# irq's assigned to them on rebalance
+#
+#IRQBALANCE_BANNED_CPUS=
+
+#
+# IRQBALANCE_ARGS
+# append any args here to the irqbalance daemon as documented in the man page
+#
+#IRQBALANCE_ARGS=
+`

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -76,7 +77,10 @@ var _ = Describe("[performance] Checking IRQBalance settings", func() {
 				Skip("this test needs dynamic IRQ balancing")
 			}
 
+			targetNodeIdx := pickNodeIdx(workerRTNodes)
+			targetNode = workerRTNodes[nodeIdx]
 			Expect(targetNode).ToNot(BeNil(), "missing target node")
+			By(fmt.Sprintf("verifying worker node %q", targetNode.Name))
 
 			irqAffBegin, err := getIrqDefaultSMPAffinity(targetNode)
 			Expect(err).ToNot(HaveOccurred(), "failed to extract the default IRQ affinity from node %q", targetNode.Name)
@@ -163,6 +167,89 @@ var _ = Describe("[performance] Checking IRQBalance settings", func() {
 
 			Expect(postRestartBannedCPUs.ToSlice()).To(Equal(postCreateBannedCPUs.ToSlice()), "banned CPUs changed post tuned restart on node %q", postRestartBannedCPUs.ToSlice(), targetNode.Name)
 		})
+
+		It("Should store empty cpu mask in the backup file", func() {
+			// crio stores the irqbalance CPU ban list in the backup file once, at startup, if the file doesn't exist.
+			// This _likely_ means the first time the provisioned node boots, and in this case is _likely_ the node
+			// has not any IRQ pinning, thus the saved CPU ban list is the empty list. But we don't control nor declare this state.
+			// It's all best effort.
+
+			nodeIdx := pickNodeIdx(workerRTNodes)
+			node := &workerRTNodes[nodeIdx]
+			By(fmt.Sprintf("verifying worker node %q", node.Name))
+
+			By(fmt.Sprintf("Checking the default IRQ affinity on node %q", node.Name))
+			smpAffinitySet, err := nodes.GetDefaultSmpAffinitySet(node)
+			Expect(err).ToNot(HaveOccurred(), "failed to get default smp affinity")
+
+			By(fmt.Sprintf("Checking the online CPU Set on node %q", node.Name))
+			onlineCPUsSet, err := nodes.GetOnlineCPUsSet(node)
+			Expect(err).ToNot(HaveOccurred(), "failed to get Online CPUs list")
+
+			// expect no irqbalance run in the system already, AKA start from pristine conditions.
+			// This is not an hard requirement, just the easier state to manage and check
+			Expect(smpAffinitySet.Equals(onlineCPUsSet)).To(BeTrue(), "found default_smp_affinity %v, expected %v - IRQBalance already run?", smpAffinitySet, onlineCPUsSet)
+
+			origBannedCPUsFile := "/etc/sysconfig/orig_irq_banned_cpus"
+			By(fmt.Sprintf("Checking content of %q on node %q", origBannedCPUsFile, node.Name))
+			expectFileEmpty(node, origBannedCPUsFile)
+		})
+
+		It("Should DO overwrite the banned CPU set on CRI-O restart", func() {
+
+			nodeIdx := pickNodeIdx(workerRTNodes)
+			node := &workerRTNodes[nodeIdx]
+			By(fmt.Sprintf("verifying worker node %q", node.Name))
+
+			var err error
+
+			By(fmt.Sprintf("Checking the default IRQ affinity on node %q", node.Name))
+			smpAffinitySet, err := nodes.GetDefaultSmpAffinitySet(node)
+			Expect(err).ToNot(HaveOccurred(), "failed to get default smp affinity")
+
+			By(fmt.Sprintf("Checking the online CPU Set on node %q", node.Name))
+			onlineCPUsSet, err := nodes.GetOnlineCPUsSet(node)
+			Expect(err).ToNot(HaveOccurred(), "failed to get Online CPUs list")
+
+			// expect no irqbalance run in the system already, AKA start from pristine conditions.
+			// This is not an hard requirement, just the easier state to manage and check
+			Expect(smpAffinitySet.Equals(onlineCPUsSet)).To(BeTrue(), "found default_smp_affinity %v, expected %v - IRQBalance already run?", smpAffinitySet, onlineCPUsSet)
+
+			// setup the CRI-O managed irq banned cpu list
+			By("Preparing fake data for the irqbalance config file")
+			irqBalanceConfFile := "/etc/sysconfig/irqbalance"
+			restoreIRQBalance := makeBackupForFile(node, irqBalanceConfFile)
+			defer restoreIRQBalance()
+
+			// completely fake data. We are backupping the original file anyway, and we succeed if we have empty ban list anyway. So it's good.
+			_, err = nodes.ExecCommandOnNode([]string{"echo", "IRQBALANCE_BANNED_CPUS=2,3", ">", "/rootfs/" + irqBalanceConfFile}, node)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Preparing fake data for the irqbalance cpu ban list file")
+			origBannedCPUsFile := "/etc/sysconfig/orig_irq_banned_cpus"
+			restoreBanned := makeBackupForFile(node, origBannedCPUsFile)
+			defer restoreBanned()
+
+			// because a limitation of ExecCommandOnNode, which interprets lack of output og any kind as failure (!), we
+			// need a command which emits output.
+			_, err = nodes.ExecCommandOnNode([]string{"/usr/bin/dd", "if=/dev/null", "of=/rootfs/" + origBannedCPUsFile}, node)
+			Expect(err).ToNot(HaveOccurred())
+
+			By(fmt.Sprintf("Restarting CRI-O on %q", node.Name))
+			_, err = nodes.ExecCommandOnNode([]string{"/usr/bin/systemctl", "restart", "crio"}, node)
+			Expect(err).ToNot(HaveOccurred())
+
+			var bannedCPUs cpuset.CPUSet
+			By(fmt.Sprintf("Getting again banned CPUs on %q", node.Name))
+			Eventually(func() bool {
+				bannedCPUs, err = getIrqBalanceBannedCPUs(node)
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "getting banned CPUS from %q: %v", node.Name, err)
+					return false
+				}
+				return bannedCPUs.IsEmpty()
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).ShouldNot(BeTrue(), "banned CPUs %v not empty on node %q", bannedCPUs, node.Name)
+		})
 	})
 })
 
@@ -224,6 +311,21 @@ func findIrqBalanceBannedCPUsVarFromConf(conf string) string {
 	return ""
 }
 
+func makeBackupForFile(node *corev1.Node, path string) func() {
+	fullPath := filepath.Join("/", "rootfs", path)
+	savePath := fullPath + ".save"
+
+	out, err := nodes.ExecCommandOnNode([]string{"/usr/bin/cp", "-v", fullPath, savePath}, node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	fmt.Fprintf(GinkgoWriter, "%s", out)
+
+	return func() {
+		out, err := nodes.ExecCommandOnNode([]string{"/usr/bin/mv", "-v", savePath, fullPath}, node)
+		Expect(err).ToNot(HaveOccurred())
+		fmt.Fprintf(GinkgoWriter, "%s", out)
+	}
+}
+
 func pickNodeIdx(nodes []corev1.Node) int {
 	name, ok := os.LookupEnv("E2E_PAO_TARGET_NODE")
 	if !ok {
@@ -244,4 +346,12 @@ func unquote(s string) string {
 	s = strings.TrimPrefix(s, q)
 	s = strings.TrimSuffix(s, q)
 	return s
+}
+
+func expectFileEmpty(node *corev1.Node, path string) {
+	fullPath := filepath.Join("/", "rootfs", path)
+	out, err := nodes.ExecCommandOnNode([]string{"wc", "-c", fullPath}, node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	expected := "0 " + fullPath
+	ExpectWithOffset(1, out).To(Equal(expected), "file %s (%s) not empty", path, fullPath)
 }

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
@@ -53,6 +53,13 @@ spec:
           path: /usr/local/bin/set-cpus-offline.sh
           user: {}
         - contents:
+            source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLWV1byBwaXBlZmFpbApzZXQgLXgKCiMgY29uc3QKU0VEPSIvdXNyL2Jpbi9zZWQiCiMgdHVuYWJsZSAtIG92ZXJyaWRhYmxlIGZvciB0ZXN0aW5nIHB1cnBvc2VzCklSUUJBTEFOQ0VfQ09ORj0iJHsxOi0vZXRjL3N5c2NvbmZpZy9pcnFiYWxhbmNlfSIKQ1JJT19PUklHX0JBTk5FRF9DUFVTPSIkezI6LS9ldGMvc3lzY29uZmlnL29yaWdfaXJxX2Jhbm5lZF9jcHVzfSIKClsgISAtZiAke0lSUUJBTEFOQ0VfQ09ORn0gXSAmJiBleGl0IDAKCiR7U0VEfSAtaSAnL15ccypJUlFCQUxBTkNFX0JBTk5FRF9DUFVTXGIvZCcgJHtJUlFCQUxBTkNFX0NPTkZ9IHx8IGV4aXQgMAplY2hvICJJUlFCQUxBTkNFX0JBTk5FRF9DUFVTPSIgPj4gJHtJUlFCQUxBTkNFX0NPTkZ9CgojIHdlIG5vdyBvd24gdGhpcyBjb25maWd1cmF0aW9uLiBCdXQgQ1JJLU8gaGFzIGNvZGUgdG8gcmVzdG9yZSB0aGUgY29uZmlndXJhdGlvbiwKIyBhbmQgdW50aWwgaXQgZ2FpbnMgdGhlIG9wdGlvbiB0byBkaXNhYmxlIHRoaXMgcmVzdG9yZSBmbG93LCB3ZSBuZWVkIHRvIG1ha2UKIyB0aGUgY29uZmlndXJhdGlvbiBjb25zaXN0ZW50IHN1Y2ggYXMgdGhlIENSSS1PIHJlc3RvcmUgd2lsbCBkbyBub3RoaW5nLgppZiBbIC1uICR7Q1JJT19PUklHX0JBTk5FRF9DUFVTfSBdICYmIFsgLWYgJHtDUklPX09SSUdfQkFOTkVEX0NQVVN9IF07IHRoZW4KCXRydWUgPiAke0NSSU9fT1JJR19CQU5ORURfQ1BVU30KZmkK
+            verification: {}
+          group: {}
+          mode: 448
+          path: /usr/local/bin/clear-irqbalance-banned-cpus.sh
+          user: {}
+        - contents:
             source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMCIKCgojIFdlIHNob3VsZCBjb3B5IHBhc3RlIHRoZSBkZWZhdWx0IHJ1bnRpbWUgYmVjYXVzZSB0aGlzIHNuaXBwZXQgd2lsbCBvdmVycmlkZSB0aGUgd2hvbGUgcnVudGltZXMgc2VjdGlvbgpbY3Jpby5ydW50aW1lLnJ1bnRpbWVzLnJ1bmNdCnJ1bnRpbWVfcGF0aCA9ICIiCnJ1bnRpbWVfdHlwZSA9ICJvY2kiCnJ1bnRpbWVfcm9vdCA9ICIvcnVuL3J1bmMiCgojIFRoZSBDUkktTyB3aWxsIGNoZWNrIHRoZSBhbGxvd2VkX2Fubm90YXRpb25zIHVuZGVyIHRoZSBydW50aW1lIGhhbmRsZXIgYW5kIGFwcGx5IGhpZ2gtcGVyZm9ybWFuY2UgaG9va3Mgd2hlbiBvbmUgb2YKIyBoaWdoLXBlcmZvcm1hbmNlIGFubm90YXRpb25zIHByZXNlbnRzIHVuZGVyIGl0LgojIFdlIHNob3VsZCBwcm92aWRlIHRoZSBydW50aW1lX3BhdGggYmVjYXVzZSB3ZSBuZWVkIHRvIGluZm9ybSB0aGF0IHdlIHdhbnQgdG8gcmUtdXNlIHJ1bmMgYmluYXJ5IGFuZCB3ZQojIGRvIG5vdCBoYXZlIGhpZ2gtcGVyZm9ybWFuY2UgYmluYXJ5IHVuZGVyIHRoZSAkUEFUSCB0aGF0IHdpbGwgcG9pbnQgdG8gaXQuCltjcmlvLnJ1bnRpbWUucnVudGltZXMuaGlnaC1wZXJmb3JtYW5jZV0KcnVudGltZV9wYXRoID0gIi9iaW4vcnVuYyIKcnVudGltZV90eXBlID0gIm9jaSIKcnVudGltZV9yb290ID0gIi9ydW4vcnVuYyIKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iXQo=
             verification: {}
           group: {}
@@ -115,6 +122,21 @@ spec:
             WantedBy=multi-user.target
           enabled: true
           name: set-cpus-offline.service
+        - contents: |
+            [Unit]
+            Description=Clear the IRQBalance Banned CPU mask early in the boot
+            Before=kubelet.service
+            Before=irqbalance.service
+
+            [Service]
+            Type=oneshot
+            RemainAfterExit=true
+            ExecStart=/usr/local/bin/clear-irqbalance-banned-cpus.sh
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: clear-irqbalance-banned-cpus.service
   extensions: null
   fips: false
   kernelArguments: null


### PR DESCRIPTION
irqbalance: add unit to clear the cpu ban list

Add a oneshot unit to clear the CPU ban list once  and explicitely per node reboot.
CRI-O has a facility to restore the irqbalance ban list, which only partially fit this scenario.

For this reason, to really ensure the desired behavior we tamper the CRI-O private irqbalance ban list, until CRI-O gains better
support for this flow.

Depends on #396 
