### PR TITLE
Implement new workloadHint perPodPowerManagement

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -19,6 +19,10 @@ isolated_cores={{.IsolatedCpus}}
 
 not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
 
+{{if .PerPodPowerManagement}}
+[cpu]
+enabled=false
+{{else}}
 [cpu]
 #> latency-performance
 #> (override)
@@ -26,6 +30,7 @@ force_latency=cstate.id:1|3
 governor=performance
 energy_perf_bias=performance
 min_perf_pct=100
+{{end}}
 
 {{if .RealTimeHint}}
 [service]
@@ -144,7 +149,7 @@ cmdline_realtime=+nohz_full=${isolated_cores} tsc=nowatchdog nosoftlockup nmi_wa
 {{end}}
 
 {{if .HighPowerConsumption}}
-cmdline_power_performance=+processor.max_cstate=1 intel_idle.max_cstate=0 intel_pstate=disable
+cmdline_power_performance=+processor.max_cstate=1 intel_idle.max_cstate=0
 {{end}}
 
 {{if and .HighPowerConsumption .RealTimeHint}}
@@ -154,3 +159,11 @@ cmdline_idle_poll=+idle=poll
 cmdline_hugepages=+{{if .DefaultHugepagesSize}} default_hugepagesz={{.DefaultHugepagesSize}} {{end}} {{if .Hugepages}} {{.Hugepages}} {{end}}
 
 cmdline_additionalArg=+{{if .AdditionalArgs}} {{.AdditionalArgs}} {{end}}
+
+{{if .PerPodPowerManagement}}
+cmdline_pstate=+intel_pstate=passive
+{{end}}
+
+{{if .HighPowerConsumption}}
+cmdline_pstate=+intel_pstate=disable
+{{end}}

--- a/docs/performanceprofile/performance_profile.md
+++ b/docs/performanceprofile/performance_profile.md
@@ -180,5 +180,6 @@ WorkloadHints defines the set of upper level flags for different type of workloa
 | ----- | ----------- | ------ | -------- |
 | highPowerConsumption | HighPowerConsumption defines if the node should be configured in high power consumption mode. The flag will affect the power consumption but will improve the CPUs latency. | *bool | false |
 | realTime | RealTime defines if the node should be configured for the real time workload. | *bool | false |
+| perPodPowerManagement | PerPodPowerManagement defines if the node should be configured in per pod power management. PerPodPowerManagement and HighPowerConsumption hints can not be enabled together. | *bool | false |
 
 [Back to TOC](#table-of-contents)

--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -161,6 +161,9 @@ spec:
                     highPowerConsumption:
                       description: HighPowerConsumption defines if the node should be configured in high power consumption mode. The flag will affect the power consumption but will improve the CPUs latency.
                       type: boolean
+                    perPodPowerManagement:
+                      description: PerPodPowerManagement defines if the node should be configured in per pod power management. PerPodPowerManagement and HighPowerConsumption hints can not be enabled together.
+                      type: boolean
                     realTime:
                       description: RealTime defines if the node should be configured for the real time workload.
                       type: boolean
@@ -465,6 +468,9 @@ spec:
                   properties:
                     highPowerConsumption:
                       description: HighPowerConsumption defines if the node should be configured in high power consumption mode. The flag will affect the power consumption but will improve the CPUs latency.
+                      type: boolean
+                    perPodPowerManagement:
+                      description: PerPodPowerManagement defines if the node should be configured in per pod power management. PerPodPowerManagement and HighPowerConsumption hints can not be enabled together.
                       type: boolean
                     realTime:
                       description: RealTime defines if the node should be configured for the real time workload.

--- a/pkg/apis/performanceprofile/v1/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v1/performanceprofile_types.go
@@ -175,6 +175,10 @@ type WorkloadHints struct {
 	// +default=true
 	// +optional
 	RealTime *bool `json:"realTime,omitempty"`
+	// +optional
+	// PerPodPowerManagement defines if the node should be configured in per pod power management.
+	// PerPodPowerManagement and HighPowerConsumption hints can not be enabled together.
+	PerPodPowerManagement *bool `json:"perPodPowerManagement,omitempty"`
 }
 
 // PerformanceProfileStatus defines the observed state of PerformanceProfile.

--- a/pkg/apis/performanceprofile/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/performanceprofile/v1/zz_generated.deepcopy.go
@@ -380,6 +380,11 @@ func (in *WorkloadHints) DeepCopyInto(out *WorkloadHints) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PerPodPowerManagement != nil {
+		in, out := &in.PerPodPowerManagement, &out.PerPodPowerManagement
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -183,6 +183,10 @@ type WorkloadHints struct {
 	// +default=true
 	// +optional
 	RealTime *bool `json:"realTime,omitempty"`
+	// +optional
+	// PerPodPowerManagement defines if the node should be configured in per pod power management.
+	// PerPodPowerManagement and HighPowerConsumption hints can not be enabled together.
+	PerPodPowerManagement *bool `json:"perPodPowerManagement,omitempty"`
 }
 
 // PerformanceProfileStatus defines the observed state of PerformanceProfile.

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -323,5 +323,11 @@ func (r *PerformanceProfile) validateWorkloadHints() field.ErrorList {
 		}
 	}
 
+	if r.Spec.WorkloadHints.HighPowerConsumption != nil && *r.Spec.WorkloadHints.HighPowerConsumption {
+		if r.Spec.WorkloadHints.PerPodPowerManagement != nil && *r.Spec.WorkloadHints.PerPodPowerManagement {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec.workloadHints.HighPowerConsumption"), r.Spec.WorkloadHints.HighPowerConsumption, "Invalid WorkloadHints configuration: HighPowerConsumption and PerPodPowerManagement can not be both enabled"))
+		}
+	}
+
 	return allErrs
 }

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -367,6 +367,17 @@ var _ = Describe("PerformanceProfile", func() {
 					Expect(errors[0].Error()).To(ContainSubstring("realtime kernel is enabled, but realtime workload hint is explicitly disable"))
 				})
 			})
+			When("HighPowerConsumption hint is enabled and PerPodPowerManagement hint is enabled", func() {
+				It("should raise validation error", func() {
+					profile.Spec.WorkloadHints = &WorkloadHints{
+						HighPowerConsumption:  pointer.BoolPtr(true),
+						PerPodPowerManagement: pointer.BoolPtr(true),
+					}
+					errors := profile.validateWorkloadHints()
+					Expect(errors).NotTo(BeEmpty())
+					Expect(errors[0].Error()).To(ContainSubstring("Invalid WorkloadHints configuration: HighPowerConsumption and PerPodPowerManagement can not be both enabled"))
+				})
+			})
 		})
 	})
 })

--- a/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
@@ -380,6 +380,11 @@ func (in *WorkloadHints) DeepCopyInto(out *WorkloadHints) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PerPodPowerManagement != nil {
+		in, out := &in.PerPodPowerManagement, &out.PerPodPowerManagement
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/performanceprofile/utils/testing/testing.go
+++ b/pkg/performanceprofile/utils/testing/testing.go
@@ -81,8 +81,9 @@ func NewPerformanceProfile(name string) *performancev2.PerformanceProfile {
 				"nodekey": "nodeValue",
 			},
 			WorkloadHints: &performancev2.WorkloadHints{
-				HighPowerConsumption: pointer.BoolPtr(false),
-				RealTime:             pointer.BoolPtr(true),
+				HighPowerConsumption:  pointer.BoolPtr(false),
+				RealTime:              pointer.BoolPtr(true),
+				PerPodPowerManagement: pointer.BoolPtr(false),
 			},
 			AdditionalKernelArgs: additionalKernelArgs,
 		},

--- a/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance/performance_profile.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance/performance_profile.yaml
@@ -24,4 +24,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
-
+    perPodPowerManagement: false

--- a/test/e2e/performanceprofile/functests/0_config/config.go
+++ b/test/e2e/performanceprofile/functests/0_config/config.go
@@ -195,8 +195,9 @@ func testProfile() *performancev2.PerformanceProfile {
 				UserLevelNetworking: pointer.BoolPtr(true),
 			},
 			WorkloadHints: &performancev2.WorkloadHints{
-				HighPowerConsumption: pointer.BoolPtr(false),
-				RealTime:             pointer.BoolPtr(true),
+				RealTime:              pointer.BoolPtr(true),
+				HighPowerConsumption:  pointer.BoolPtr(false),
+				PerPodPowerManagement: pointer.BoolPtr(false),
 			},
 		},
 	}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -20,8 +20,8 @@ spec:
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n[cpu]\n#>
-      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
+      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\nsched_min_granularity_ns=10000000\nsched_migration_cost_ns=5000000\nnuma_balancing=0\n\nsched_rt_runtime_us=-1\n\n\ndefault_irq_smp_affinity
@@ -55,7 +55,7 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\ncmdline_additionalArg=+\n"
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\ncmdline_additionalArg=+\n\n\n\n\n"
     name: openshift-node-performance-manual
   recommend:
   - machineConfigLabels:


### PR DESCRIPTION
## Description

Add new workloadHint PerPodPowerManagement

## Motivation and context
PerPodPowerManagement workloadHint allows power management to be configured on a per pod (v.s. per node) basis. Using this workloadHint will configure the node to run with c-states and p-states enabled, instead of being disabled (which is the default).

WorkloadHints HighPowerConsumption and PerPodPowerManagement cannot be enabled at the same time.

## Type of change

- [X] Add PerPodPowerManagement API type
- [X] Add logic
- [X] Modify tuned template to include new WorkloadHint
- [X] Add basic unit test and 
- [X] Add basic functional test

Signed-off-by: Mario Fernandez <mariofer@redhat.com>