### PR TITLE
Bug 2108222 - Add offlined cpus to v1 api

### DIFF
--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -68,6 +68,9 @@ spec:
                     isolated:
                       description: 'Isolated defines a set of CPUs that will be used to give to application threads the most execution time possible, which means removing as many extraneous tasks off a CPU as possible. It is important to notice the CPU manager can choose any CPU to run the workload except the reserved CPUs. In order to guarantee that your workload will run on the isolated CPU:   1. The union of reserved CPUs and isolated CPUs should include all online CPUs   2. The isolated CPUs field should be the complementary to reserved CPUs field'
                       type: string
+                    offlined:
+                      description: Offline defines a set of CPUs that will be unused and set offline
+                      type: string
                     reserved:
                       description: Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet.
                       type: string

--- a/pkg/apis/performanceprofile/v1/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v1/performanceprofile_types.go
@@ -98,6 +98,9 @@ type CPU struct {
 	// Defaults to "true"
 	// +optional
 	BalanceIsolated *bool `json:"balanceIsolated,omitempty"`
+	// Offline defines a set of CPUs that will be unused and set offline
+	// +optional
+	Offlined *CPUSet `json:"offlined,omitempty"`
 }
 
 // HugePageSize defines size of huge pages, can be 2M or 1G.

--- a/pkg/apis/performanceprofile/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/performanceprofile/v1/zz_generated.deepcopy.go
@@ -28,6 +28,11 @@ func (in *CPU) DeepCopyInto(out *CPU) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Offlined != nil {
+		in, out := &in.Offlined, &out.Offlined
+		*out = new(CPUSet)
+		**out = **in
+	}
 	return
 }
 

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -1182,6 +1182,16 @@ func verifyV2Conversion(v2Profile *performancev2.PerformanceProfile, v1Profile *
 			}
 		}
 
+		if (specCPU.Offlined == nil) != (v1Profile.Spec.CPU.Offlined == nil) {
+			return fmt.Errorf("spec CPUs Isolated field is different")
+		}
+		if specCPU.Offlined != nil {
+			if string(*specCPU.Offlined) != string(*v1Profile.Spec.CPU.Offlined) {
+				return fmt.Errorf("Offlined CPUs are different [v2: %s, v1: %s]",
+					*specCPU.Offlined, *v1Profile.Spec.CPU.Offlined)
+			}
+		}
+
 		if (specCPU.BalanceIsolated == nil) != (v1Profile.Spec.CPU.BalanceIsolated == nil) {
 			return fmt.Errorf("spec CPUs BalanceIsolated field is different")
 		}


### PR DESCRIPTION
## Description

Field spec.cpu.offlined must be also in v1 API as v1 and v2 API must be compatible

## Type of change

- [X] Add offlined cpu to v1 API
- [X] Generate new API and docs
- [] Add test


## Testing steps

Signed-off-by: Mario Fernandez <mariofer@redhat.com>