### PR TITLE
Improve tuned test suite

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -11,6 +11,7 @@ import (
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	testutils "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/utils/testing"
+	"gopkg.in/ini.v1"
 
 	cpuset "k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 	"k8s.io/utils/pointer"
@@ -22,19 +23,17 @@ const expectedMatchSelector = `
 `
 
 var (
-	cmdlineCPUsPartitioning                 = regexp.MustCompile(`\s*cmdline_cpu_part=\+\s*nohz=on\s+rcu_nocbs=\${isolated_cores}\s+tuned.non_isolcpus=\${not_isolated_cpumask}\s+systemd.cpu_affinity=\${not_isolated_cores_expanded}\s+intel_iommu=on\s+iommu=pt\s*`)
-	cmdlineWithStaticIsolation              = regexp.MustCompile(`\s*cmdline_isolation=\+\s*isolcpus=managed_irq,\${isolated_cores}\s*`)
-	cmdlineWithoutStaticIsolation           = regexp.MustCompile(`\s*cmdline_isolation=\+\s*isolcpus=domain,managed_irq,\${isolated_cores}\s*`)
-	cmdlineWithRealtime                     = regexp.MustCompile(`\s*cmdline_realtime=\+\s*nohz_full=\${isolated_cores}\s+tsc=nowatchdog\s+nosoftlockup\s+nmi_watchdog=0\s+mce=off\s+skew_tick=1\s*`)
-	cmdlineHighPowerConsumption             = regexp.MustCompile(`\s*cmdline_power_performance=\+\s*processor.max_cstate=1\s+intel_idle.max_cstate=0\s+intel_pstate=disable\s*`)
-	cmdlineHighPowerConsumptionWithRealtime = regexp.MustCompile(`\s*cmdline_idle_poll=\+\s*idle=poll\s*`)
-	cmdlineHugepages                        = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s*`)
-	cmdlineAdditionalArg                    = regexp.MustCompile(`\s*cmdline_additionalArg=\+\s*test1=val1\s+test2=val2\s*`)
-	cmdlineDummy2MHugePages                 = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s+hugepagesz=2M\s+hugepages=0\s*`)
-	cmdlineMultipleHugePages                = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s+hugepagesz=2M\s+hugepages=128\s*`)
+	cmdlineCPUsPartitioning       = "+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded} intel_iommu=on iommu=pt"
+	cmdlineWithStaticIsolation    = "+isolcpus=domain,managed_irq,${isolated_cores}"
+	cmdlineWithoutStaticIsolation = "+isolcpus=managed_irq,${isolated_cores}"
+	cmdlineRealtime               = "+nohz_full=${isolated_cores} tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11"
+	cmdlineHighPowerConsumption   = "+processor.max_cstate=1 intel_idle.max_cstate=0 intel_pstate=disable"
+	cmdlineIdlePoll               = "+idle=poll"
+	cmdlineHugepages              = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4"
+	cmdlineAdditionalArgs         = "+ audit=0 processor.max_cstate=1 idle=poll intel_idle.max_cstate=0"
+	cmdlineDummy2MHugePages       = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=0"
+	cmdlineMultipleHugePages      = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=128"
 )
-
-var additionalArgs = []string{"test1=val1", "test2=val2"}
 
 var _ = Describe("Tuned", func() {
 	var profile *performancev2.PerformanceProfile
@@ -51,98 +50,188 @@ var _ = Describe("Tuned", func() {
 		return string(y)
 	}
 
+	getTunedStructuredData := func(profile *performancev2.PerformanceProfile) *ini.File {
+		tuned, err := NewNodePerformance(profile)
+		Expect(err).ToNot(HaveOccurred())
+		tunedData := []byte(*tuned.Spec.Profile[0].Data)
+		cfg, err := ini.Load(tunedData)
+		Expect(err).ToNot(HaveOccurred())
+		return cfg
+	}
+
 	Context("with worker performance profile", func() {
 		It("should generate yaml with expected parameters", func() {
 			manifest := getTunedManifest(profile)
+			tunedData := getTunedStructuredData(profile)
+			isolated, err := tunedData.GetSection("variables")
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(manifest).To(ContainSubstring(expectedMatchSelector))
-			Expect(manifest).To(ContainSubstring("isolated_cores=4-5"))
-			Expect(manifest).To(ContainSubstring("governor=performance"))
-			Expect(manifest).To(ContainSubstring("service.stalld=start,enable"))
-			Expect(manifest).To(ContainSubstring("sched_rt_runtime_us=-1"))
-			Expect(manifest).To(ContainSubstring("kernel.hung_task_timeout_secs=600"))
-			Expect(manifest).To(ContainSubstring("kernel.sched_rt_runtime_us=-1"))
-			By("Populating CPU partitioning cmdline")
-			Expect(cmdlineCPUsPartitioning.MatchString(manifest)).To(BeTrue())
-			By("Populating static isolation cmdline")
-			Expect(cmdlineWithStaticIsolation.MatchString(manifest)).To(BeTrue())
-			By("Populating hugepages cmdline")
-			Expect(cmdlineHugepages.MatchString(manifest)).To(BeTrue())
-			By("Populating empty additional kernel arguments cmdline")
-			Expect(manifest).To(ContainSubstring("cmdline_additionalArg="))
-			By("Populating realtime cmdline")
-			Expect(cmdlineWithRealtime.MatchString(manifest)).To(BeTrue())
+			Expect(isolated.Key("isolated_cores").String()).To(Equal("4-5"))
+
+			cpuSection, err := tunedData.GetSection("cpu")
+			Expect(err).ToNot(HaveOccurred())
+			Expect((cpuSection.Key("force_latency").String())).To(Equal("cstate.id:1|3"))
+			Expect((cpuSection.Key("governor").String())).To(Equal("performance"))
+			Expect((cpuSection.Key("energy_perf_bias").String())).To(Equal("performance"))
+			Expect((cpuSection.Key("min_perf_pct").String())).To(Equal("100"))
+
+			serviceSection, err := tunedData.GetSection("service")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serviceSection.Key("service.stalld").String()).To(Equal("start,enable"))
+
+			schedulerSection, err := tunedData.GetSection("scheduler")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(schedulerSection.Key("sched_rt_runtime_us").String()).To(Equal("-1"))
+
+			sysctlSection, err := tunedData.GetSection("sysctl")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sysctlSection.Key("kernel.hung_task_timeout_secs").String()).To(Equal("600"))
+			Expect(sysctlSection.Key("kernel.sched_rt_runtime_us").String()).To(Equal("-1"))
+
+			bootLoaderSection, err := tunedData.GetSection("bootloader")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bootLoaderSection.Key("cmdline_cpu_part").String()).To(Equal(cmdlineCPUsPartitioning))
+			Expect(bootLoaderSection.Key("cmdline_isolation").String()).To(Equal(cmdlineWithoutStaticIsolation))
+			Expect(bootLoaderSection.Key("cmdline_hugepages").String()).To(Equal(cmdlineHugepages))
+			Expect(bootLoaderSection.Key("cmdline_additionalArg").String()).To(Equal(cmdlineAdditionalArgs))
+			Expect(bootLoaderSection.Key("cmdline_realtime").String()).To(Equal(cmdlineRealtime))
+		})
+
+		Context("default profile default tuned", func() {
+			It("should [cpu] section in tuned", func() {
+				tunedData := getTunedStructuredData(profile)
+				cpuSection, err := tunedData.GetSection("cpu")
+				Expect(err).ToNot(HaveOccurred())
+				Expect((cpuSection.Key("force_latency").String())).To(Equal("cstate.id:1|3"))
+				Expect((cpuSection.Key("governor").String())).To(Equal("performance"))
+				Expect((cpuSection.Key("energy_perf_bias").String())).To(Equal("performance"))
+				Expect((cpuSection.Key("min_perf_pct").String())).To(Equal("100"))
+			})
 		})
 
 		When("realtime hint disabled", func() {
-			BeforeEach(func() {
-				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{RealTime: pointer.BoolPtr(false)}
-			})
-
 			It("should not contain realtime related parameters", func() {
-				manifest := getTunedManifest(profile)
-				Expect(manifest).ToNot(ContainSubstring("service.stalld=start,enable"))
-				Expect(manifest).ToNot(ContainSubstring("sched_rt_runtime_us=-1"))
-				Expect(manifest).ToNot(ContainSubstring("kernel.hung_task_timeout_secs=600"))
-				Expect(manifest).ToNot(ContainSubstring("kernel.sched_rt_runtime_us=-1"))
-				By("Populating realtime cmdline")
-				Expect(cmdlineWithRealtime.MatchString(manifest)).ToNot(BeTrue())
+				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{RealTime: pointer.BoolPtr(false)}
+				tunedData := getTunedStructuredData(profile)
+				_, err := tunedData.GetSection("service")
+				Expect(err).To(HaveOccurred(), "expected the validation error")
+
+				schedulerSection, err := tunedData.GetSection("scheduler")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(schedulerSection.Key("sched_rt_runtime_us").String()).ToNot(Equal("-1"))
+
+				sysctlSection, err := tunedData.GetSection("sysctl")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sysctlSection.Key("kernel.hung_task_timeout_secs").String()).ToNot(Equal("600"))
+				Expect(sysctlSection.Key("kernel.sched_rt_runtime_us").String()).ToNot(Equal("-1"))
+
+				bootLoaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootLoaderSection.Key("cmdline_realtime").String()).ToNot(Equal(cmdlineRealtime))
 			})
 		})
 
-		When("high power consumption hint enabled", func() {
-			BeforeEach(func() {
-				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{HighPowerConsumption: pointer.BoolPtr(true)}
+		When("realtime hint enabled", func() {
+			It("should contain realtime related parameters", func() {
+				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{RealTime: pointer.BoolPtr(true)}
+				tunedData := getTunedStructuredData(profile)
+				service, err := tunedData.GetSection("service")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(service.Key("service.stalld").String()).To(Equal("start,enable"))
+				scheduler, err := tunedData.GetSection("scheduler")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(scheduler.Key("sched_rt_runtime_us").String()).To(Equal("-1"))
+				sysctl, err := tunedData.GetSection("sysctl")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sysctl.Key("kernel.hung_task_timeout_secs").String()).To(Equal("600"))
+				Expect(sysctl.Key("kernel.sched_rt_runtime_us").String()).To(Equal("-1"))
+				bootLoader, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootLoader.Key("cmdline_realtime").String()).To(Equal(cmdlineRealtime))
+			})
+		})
+
+		Context("high power consumption hint enabled", func() {
+			When("default realtime workload settings", func() {
+				It("should contain high power consumption related parameters", func() {
+					profile.Spec.WorkloadHints = &performancev2.WorkloadHints{HighPowerConsumption: pointer.BoolPtr(true)}
+					tunedData := getTunedStructuredData(profile)
+					bootLoader, err := tunedData.GetSection("bootloader")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bootLoader.Key("cmdline_power_performance").String()).To(Equal(cmdlineHighPowerConsumption))
+				})
 			})
 
-			When("realtime workload hint disabled", func() {
-				BeforeEach(func() {
+			When("realtime workload enabled", func() {
+				It("should not contain idle=poll cmdline", func() {
+					profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
+						RealTime:             pointer.BoolPtr(false),
+						HighPowerConsumption: pointer.BoolPtr(false),
+					}
+					tunedData := getTunedStructuredData(profile)
+					bootLoader, err := tunedData.GetSection("bootloader")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bootLoader.Key("cmdline_idle_poll").String()).ToNot(Equal(cmdlineIdlePoll))
+				})
+			})
+
+			When("realtime workload disabled", func() {
+				It("should contain idle=poll cmdline", func() {
 					profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
 						HighPowerConsumption: pointer.BoolPtr(true),
-						RealTime:             pointer.BoolPtr(false),
+						RealTime:             pointer.BoolPtr(true),
 					}
+					tunedData := getTunedStructuredData(profile)
+					bootLoader, err := tunedData.GetSection("bootloader")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bootLoader.Key("cmdline_idle_poll").String()).To(Equal(cmdlineIdlePoll))
 				})
-
-				It("should not contain idle=poll cmdline", func() {
-					manifest := getTunedManifest(profile)
-					By("Populating idle poll cmdline")
-					Expect(cmdlineHighPowerConsumptionWithRealtime.MatchString(manifest)).To(BeFalse())
-				})
-
-			})
-
-			It("should contain high power consumption related parameters", func() {
-				manifest := getTunedManifest(profile)
-				By("Populating high power consumption cmdline")
-				Expect(cmdlineHighPowerConsumption.MatchString(manifest)).To(BeTrue())
-				By("Populating idle poll cmdline")
-				Expect(cmdlineHighPowerConsumptionWithRealtime.MatchString(manifest)).To(BeTrue())
 			})
 		})
 
 		It("should generate yaml with expected parameters for Isolated balancing disabled", func() {
 			profile.Spec.CPU.BalanceIsolated = pointer.BoolPtr(false)
-			manifest := getTunedManifest(profile)
-
-			Expect(cmdlineWithoutStaticIsolation.MatchString(manifest)).To(BeTrue())
+			tunedData := getTunedStructuredData(profile)
+			bootLoader, err := tunedData.GetSection("bootloader")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bootLoader.Key("cmdline_isolation").String()).To(Equal(cmdlineWithStaticIsolation))
 		})
 
-		It("should generate yaml with expected parameters for additional kernel arguments", func() {
-			profile.Spec.AdditionalKernelArgs = additionalArgs
-			manifest := getTunedManifest(profile)
+		It("should generate yaml with expected parameters for Isolated balancing enabled", func() {
+			profile.Spec.CPU.BalanceIsolated = pointer.BoolPtr(true)
+			tunedData := getTunedStructuredData(profile)
+			bootLoader, err := tunedData.GetSection("bootloader")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bootLoader.Key("cmdline_isolation").String()).To(Equal(cmdlineWithoutStaticIsolation))
+		})
 
-			Expect(cmdlineAdditionalArg.MatchString(manifest)).To(BeTrue())
+		// This tests checking Additional arguments is an example of how additional kernel args could look like
+		// they have been selected randomly with no concrete purpose
+		It("should contain additional additional parameters", func() {
+			tunedData := getTunedStructuredData(profile)
+			bootLoader, err := tunedData.GetSection("bootloader")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bootLoader.Key("cmdline_additionalArg").String()).To(Equal(cmdlineAdditionalArgs))
+		})
+
+		It("should not contain additional additional parameters", func() {
+			profile.Spec.AdditionalKernelArgs = nil
+			tunedData := getTunedStructuredData(profile)
+			bootLoader, err := tunedData.GetSection("bootloader")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bootLoader.Key("cmdline_additionalArg").String()).ToNot(Equal(cmdlineAdditionalArgs))
 		})
 
 		It("should not allocate hugepages on the specific NUMA node via kernel arguments", func() {
 			manifest := getTunedManifest(profile)
-			Expect(strings.Count(manifest, "hugepagesz=")).Should(BeNumerically("==", 2))
-			Expect(strings.Count(manifest, "hugepages=")).Should(BeNumerically("==", 3))
+			Expect(strings.Count(manifest, "hugepagesz=")).To(BeNumerically("==", 2))
+			Expect(strings.Count(manifest, "hugepages=")).To(BeNumerically("==", 3))
 
 			profile.Spec.HugePages.Pages[0].Node = pointer.Int32Ptr(1)
 			manifest = getTunedManifest(profile)
-			Expect(strings.Count(manifest, "hugepagesz=")).Should(BeNumerically("==", 1))
-			Expect(strings.Count(manifest, "hugepages=")).Should(BeNumerically("==", 2))
+			Expect(strings.Count(manifest, "hugepagesz=")).To(BeNumerically("==", 1))
+			Expect(strings.Count(manifest, "hugepages=")).To(BeNumerically("==", 2))
 		})
 
 		Context("with 1G default huge pages", func() {
@@ -154,8 +243,10 @@ var _ = Describe("Tuned", func() {
 						Node:  pointer.Int32Ptr(0),
 					})
 
-					manifest := getTunedManifest(profile)
-					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeTrue())
+					tunedData := getTunedStructuredData(profile)
+					bootLoader, err := tunedData.GetSection("bootloader")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bootLoader.Key("cmdline_hugepages").String()).To(Equal(cmdlineDummy2MHugePages))
 				})
 			})
 
@@ -166,16 +257,20 @@ var _ = Describe("Tuned", func() {
 						Count: 128,
 					})
 
-					manifest := getTunedManifest(profile)
-					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeFalse())
-					Expect(cmdlineMultipleHugePages.MatchString(manifest)).To(BeTrue())
+					tunedData := getTunedStructuredData(profile)
+					bootLoader, err := tunedData.GetSection("bootloader")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bootLoader.Key("cmdline_hugepages").String()).ToNot(Equal(cmdlineDummy2MHugePages))
+					Expect(bootLoader.Key("cmdline_hugepages").String()).To(Equal(cmdlineMultipleHugePages))
 				})
 			})
 
 			Context("without requested 2M hugepages", func() {
 				It("should not append dummy 2M huge pages kernel arguments", func() {
-					manifest := getTunedManifest(profile)
-					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeFalse())
+					tunedData := getTunedStructuredData(profile)
+					bootLoader, err := tunedData.GetSection("bootloader")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bootLoader.Key("cmdline_hugepages").String()).ToNot(Equal(cmdlineDummy2MHugePages))
 				})
 			})
 
@@ -191,9 +286,11 @@ var _ = Describe("Tuned", func() {
 						Count: 128,
 					})
 
-					manifest := getTunedManifest(profile)
-					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeFalse())
-					Expect(cmdlineMultipleHugePages.MatchString(manifest)).To(BeTrue())
+					tunedData := getTunedStructuredData(profile)
+					bootLoader, err := tunedData.GetSection("bootloader")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bootLoader.Key("cmdline_hugepages").String()).ToNot(Equal(cmdlineDummy2MHugePages))
+					Expect(bootLoader.Key("cmdline_hugepages").String()).To(Equal(cmdlineMultipleHugePages))
 				})
 			})
 		})
@@ -209,9 +306,11 @@ var _ = Describe("Tuned", func() {
 						Node:  pointer.Int32Ptr(0),
 					})
 
-					manifest := getTunedManifest(profile)
-					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeFalse())
-					Expect(cmdlineMultipleHugePages.MatchString(manifest)).To(BeFalse())
+					tunedData := getTunedStructuredData(profile)
+					bootLoader, err := tunedData.GetSection("bootloader")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bootLoader.Key("cmdline_hugepages").String()).ToNot(Equal(cmdlineDummy2MHugePages))
+					Expect(bootLoader.Key("cmdline_hugepages").String()).ToNot(Equal(cmdlineMultipleHugePages))
 				})
 			})
 		})

--- a/pkg/performanceprofile/utils/testing/testing.go
+++ b/pkg/performanceprofile/utils/testing/testing.go
@@ -32,6 +32,9 @@ const (
 	MachineConfigPoolLabelValue = "mcpValue"
 )
 
+// Additional Kernel Args
+var AdditionalKernelArgs = []string{"audit=0", "processor.max_cstate=1", "idle=poll", "intel_idle.max_cstate=0"}
+
 // NewPerformanceProfile returns new performance profile object that used for tests
 func NewPerformanceProfile(name string) *performancev2.PerformanceProfile {
 	size := HugePageSize
@@ -39,6 +42,7 @@ func NewPerformanceProfile(name string) *performancev2.PerformanceProfile {
 	reservedCPUs := ReservedCPUs
 	offlineCPUs := OfflinedCPUs
 	numaPolicy := SingleNUMAPolicy
+	additionalKernelArgs := AdditionalKernelArgs
 
 	return &performancev2.PerformanceProfile{
 		TypeMeta: metav1.TypeMeta{Kind: "PerformanceProfile"},
@@ -76,6 +80,11 @@ func NewPerformanceProfile(name string) *performancev2.PerformanceProfile {
 			NodeSelector: map[string]string{
 				"nodekey": "nodeValue",
 			},
+			WorkloadHints: &performancev2.WorkloadHints{
+				HighPowerConsumption: pointer.BoolPtr(false),
+				RealTime:             pointer.BoolPtr(true),
+			},
+			AdditionalKernelArgs: additionalKernelArgs,
 		},
 	}
 }


### PR DESCRIPTION
## Description
Improve legibility and facility to add test in tuned test suite. 
Remove Regex and parse data from template

## Motivation and Context
Difficulty to add new test and understand the current ones

## How has this been tested?
Test are launched in ci under ci/prow/e2e-no-cluster  lane

## Types of changes

- [x] Parse INI structure of tuned template to improve test legibility
- [x] Delete regex in order to reduce complexity 
- [x] Re order test. Improve different combinations at the expense of little more verbosity. Add all possible combinations 

Signed-off-by: Mario Fernandez <mariofer@redhat.com>