### PR TITLE
Add PPC argument for perPodPowerManagement WorkloadHint

### DIFF
--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1.yaml
@@ -17,3 +17,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1a.yaml
@@ -18,3 +18,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1b.yaml
@@ -19,3 +19,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile1c.yaml
@@ -18,3 +18,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2.yaml
@@ -19,3 +19,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: false
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2a.yaml
@@ -20,3 +20,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: false
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2b.yaml
@@ -20,3 +20,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: false
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3a.yaml
@@ -23,3 +23,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3b.yaml
@@ -23,3 +23,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile3c.yaml
@@ -23,3 +23,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4.yaml
@@ -22,3 +22,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4a.yaml
@@ -23,3 +23,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4b.yaml
@@ -24,3 +24,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile4c.yaml
@@ -23,3 +23,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5.yaml
@@ -20,3 +20,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5a.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5a.yaml
@@ -21,3 +21,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5b.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile5b.yaml
@@ -22,3 +22,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
+    perPodpowerManagement: false

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile6.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile6.json
@@ -1,0 +1,12 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 4,
+    "offlined-cpu-count": 40,
+    "disable-ht": false,
+    "rt-kernel": true,
+    "power-consumption-mode": "low-latency",
+    "split-reserved-cpus-across-numa": true,
+    "user-level-networking": false,
+    "per-pod-power-management": true
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile6.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile6.yaml
@@ -4,11 +4,11 @@ kind: PerformanceProfile
 metadata:
   name: performance
 spec:
-  additionalKernelArgs:
-  - nosmt
   cpu:
-    isolated: 5-39
-    reserved: 0-4
+    reserved: 0-1,40-41
+    isolated: 2-3,5-7,9-39
+    offlined: 4,8,42-79
+
   machineConfigPoolSelector:
     machineconfiguration.openshift.io/role: worker-cnf
   net:
@@ -22,4 +22,4 @@ spec:
   workloadHints:
     highPowerConsumption: false
     realTime: true
-    perPodpowerManagement: false
+    perPodpowerManagement: true


### PR DESCRIPTION
## Description

Add PPC argument for perPodPowerManagement WorkloadHint 

## Motivation and context
After add the new workloadHint https://github.com/openshift/cluster-node-tuning-operator/pull/415 it is necessary to add a new argument in Performance Profile Creator to configure it.

## Type of change

- [X] Add per-pod-power-management arg
- [X] Add exclusion between HighPowerConsumption and PerPodPowerManagement
- [X] Add test 
- 