### PR TITLE
convert core and cpu strings to integer

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -315,6 +315,12 @@ func GetCoreSiblings(node *corev1.Node) (map[int]map[int][]int, error) {
 		if numaNode, err = strconv.Atoi(value.Node); err != nil {
 			break
 		}
+		if core, err = strconv.Atoi(value.Core); err != nil {
+			break
+		}
+		if cpu, err = strconv.Atoi(value.CPU); err != nil {
+			break
+		}
 		if coreSiblings[numaNode] == nil {
 			coreSiblings[numaNode] = make(map[int][]int)
 		}


### PR DESCRIPTION
This is minor fix to the PR#403 where
only node was converted to string, Cpu and core
information from lscpu also needs to be
converted to integer.

Signed-off-by: Niranjan M.R <mrniranjan@redhat.com>