### PR TITLE
podsecurity: disable OCP label sync

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
+++ b/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
@@ -31,9 +31,10 @@ var TestingNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: testutils.NamespaceTesting,
 		Labels: map[string]string{
-			"pod-security.kubernetes.io/audit":   "privileged",
-			"pod-security.kubernetes.io/enforce": "privileged",
-			"pod-security.kubernetes.io/warn":    "privileged",
+			"security.openshift.io/scc.podSecurityLabelSync": "false",
+			"pod-security.kubernetes.io/audit":               "privileged",
+			"pod-security.kubernetes.io/enforce":             "privileged",
+			"pod-security.kubernetes.io/warn":                "privileged",
 		},
 	},
 }


### PR DESCRIPTION
Per last OCP recommendation (internal doc) is not sufficient to
declare the pod security labels, we also need to disable the
label sync, which we do in this PR.

Signed-off-by: Francesco Romani <fromani@redhat.com>