### PR TITLE
e2e: perfprof: crio mask fix workaround part 2

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -268,8 +268,8 @@ func fixMaskPadding(rawMask string, maskLen int) string {
 	testlog.Infof("fixed mask (dealing with incorrect crio padding) on node is {%s} len=%d", fixedMask, maskLen)
 
 	retMask := fixedMask[0:8]
-	for i := 8; i+8 <= len(maskString); i += 8 {
-		retMask = retMask + "," + maskString[i:i+8]
+	for i := 8; i+8 <= len(fixedMask); i += 8 {
+		retMask = retMask + "," + fixedMask[i:i+8]
 	}
 	return retMask
 }


### PR DESCRIPTION
In commit c5cf0bd33c5afae7695fd86d08c62aef269105d8 we added
a workaround for the incorrect crio mask padding (see:
https://github.com/cri-o/cri-o/issues/6145 )
But the fix implemented here is partial. Address the gap.

Signed-off-by: Francesco Romani <fromani@redhat.com>