### PR TITLE
e2e: perfprof: unbreak the e2e-gcp PAO lane

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
+++ b/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
@@ -31,9 +31,10 @@ var TestingNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: testutils.NamespaceTesting,
 		Labels: map[string]string{
-			"pod-security.kubernetes.io/audit":   "privileged",
-			"pod-security.kubernetes.io/enforce": "privileged",
-			"pod-security.kubernetes.io/warn":    "privileged",
+			"security.openshift.io/scc.podSecurityLabelSync": "false",
+			"pod-security.kubernetes.io/audit":               "privileged",
+			"pod-security.kubernetes.io/enforce":             "privileged",
+			"pod-security.kubernetes.io/warn":                "privileged",
 		},
 	},
 }

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -268,8 +268,8 @@ func fixMaskPadding(rawMask string, maskLen int) string {
 	testlog.Infof("fixed mask (dealing with incorrect crio padding) on node is {%s} len=%d", fixedMask, maskLen)
 
 	retMask := fixedMask[0:8]
-	for i := 8; i+8 <= len(maskString); i += 8 {
-		retMask = retMask + "," + maskString[i:i+8]
+	for i := 8; i+8 <= len(fixedMask); i += 8 {
+		retMask = retMask + "," + fixedMask[i:i+8]
 	}
 	return retMask
 }


### PR DESCRIPTION
this PR combine both #436 and #437. We need _both_ to unbreak the lane, but either alone is not sufficient, and they are unrelated to each other