### PR TITLE
e2e: fix a race in [reboots] tests.

### DIFF
--- a/test/e2e/reboots/kernel_parameter_add_rm.go
+++ b/test/e2e/reboots/kernel_parameter_add_rm.go
@@ -83,9 +83,7 @@ var _ = ginkgo.Describe("[reboots][kernel_parameter_add_rm] Node Tuning Operator
 			_, _, err = util.ExecAndLogCommand("oc", "create", "-f", mcpRealtime)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By("waiting for worker-rt MachineConfigPool UpdatedMachineCount == 1")
-			err = util.WaitForPoolUpdatedMachineCount(cs, "worker-rt", 1)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			waitForMCPFlip()
 
 			ginkgo.By(fmt.Sprintf("getting the current %s value in Pod %s", procCmdline, pod.Name))
 			cmdlineNew, err := util.WaitForCmdInPod(pollInterval, waitDuration, pod, cmdCatCmdline...)
@@ -102,14 +100,7 @@ var _ = ginkgo.Describe("[reboots][kernel_parameter_add_rm] Node Tuning Operator
 			_, _, err = util.ExecAndLogCommand("oc", "create", "-n", ntoconfig.OperatorNamespace(), "-f", profileChild)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// By creating the custom child profile, we will first see worker-rt MachineConfigPool UpdatedMachineCount drop to 0 first...
-			ginkgo.By("waiting for worker-rt MachineConfigPool UpdatedMachineCount == 0")
-			err = util.WaitForPoolUpdatedMachineCount(cs, "worker-rt", 0)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			// ...and go up to 1 again next.
-			ginkgo.By("waiting for worker-rt MachineConfigPool UpdatedMachineCount == 1")
-			err = util.WaitForPoolUpdatedMachineCount(cs, "worker-rt", 1)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			waitForMCPFlip()
 
 			ginkgo.By(fmt.Sprintf("getting the current %s value in Pod %s", procCmdline, pod.Name))
 			cmdlineNew, err = util.WaitForCmdInPod(pollInterval, waitDuration, pod, cmdCatCmdline...)

--- a/test/e2e/reboots/machine_config_labels.go
+++ b/test/e2e/reboots/machine_config_labels.go
@@ -77,9 +77,7 @@ var _ = ginkgo.Describe("[reboots][machine_config_labels] Node Tuning Operator m
 			_, _, err = util.ExecAndLogCommand("oc", "create", "-f", mcpRealtime)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By("waiting for worker-rt MachineConfigPool UpdatedMachineCount == 1")
-			err = util.WaitForPoolUpdatedMachineCount(cs, "worker-rt", 1)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			waitForMCPFlip()
 
 			ginkgo.By(fmt.Sprintf("getting the current %s value in Pod %s", procCmdline, pod.Name))
 			cmdlineNew, err := util.WaitForCmdInPod(pollInterval, waitDuration, pod, cmdCatCmdline...)

--- a/test/e2e/reboots/operator_test.go
+++ b/test/e2e/reboots/operator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 	"github.com/openshift/cluster-node-tuning-operator/test/framework"
 )
 
@@ -17,4 +18,15 @@ var (
 func TestNodeTuningOperator(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "Node Tuning Operator e2e tests: reboots")
+}
+
+func waitForMCPFlip() {
+	// By creating the custom child profile, we will first see worker-rt MachineConfigPool UpdatedMachineCount drop to 0 first...
+	ginkgo.By("waiting for worker-rt MachineConfigPool UpdatedMachineCount == 0")
+	err := util.WaitForPoolUpdatedMachineCount(cs, "worker-rt", 0)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	// ...and go up to 1 again next.
+	ginkgo.By("waiting for worker-rt MachineConfigPool UpdatedMachineCount == 1")
+	err = util.WaitForPoolUpdatedMachineCount(cs, "worker-rt", 1)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }

--- a/test/e2e/reboots/stalld.go
+++ b/test/e2e/reboots/stalld.go
@@ -71,9 +71,7 @@ var _ = ginkgo.Describe("[reboots][stalld] Node Tuning Operator installing syste
 			_, _, err = util.ExecAndLogCommand("oc", "create", "-f", mcpRealtime)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			ginkgo.By("waiting for worker-rt MachineConfigPool UpdatedMachineCount == 1")
-			err = util.WaitForPoolUpdatedMachineCount(cs, "worker-rt", 1)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			waitForMCPFlip()
 
 			waitForTuneD := func() {
 				ginkgo.By(fmt.Sprintf("waiting for the TuneD daemon running on node %s", node.Name))


### PR DESCRIPTION
Wait for a flip to MachineConfigPool UpdatedMachineCount == 0 prior to
waiting for it to be updated (== 1) again.