### PR TITLE
Bug 2109965: low-latency-hook script optimization

### DIFF
--- a/assets/performanceprofile/scripts/low-latency-hooks.sh
+++ b/assets/performanceprofile/scripts/low-latency-hooks.sh
@@ -2,6 +2,7 @@
 
 JQ="/usr/bin/jq"
 IP="/usr/sbin/ip"
+WORKDIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 
 mask="${1}"
 [ -n "${mask}" ] || { logger "${0}: The rps-mask parameter is missing" ; exit 0; }
@@ -20,19 +21,6 @@ for link_index in ${netns_link_indexes}; do
 done
 
 # Updates the RPS mask for the interface inside of the container network namespace
-mode=$(${IP} netns exec "${ns}" [ -w /sys ] && echo "rw" || echo "ro" 2>&1)
-[ $? -eq 0 ] || { logger "${0} Failed to determine if the /sys is writable: ${mode}"; exit 0; }
-
-if [ "${mode}" = "ro" ]; then
-    res=$(${IP} netns exec "${ns}" mount -o remount,rw /sys 2>&1)
-    [ $? -eq 0 ] || { logger "${0}: Failed to remount /sys as rw: ${res}"; exit 0; }
-fi
-
-# /sys/class/net can't be used recursively to find the rps_cpus file, use /sys/devices/virtual instead
-res=$(${IP} netns exec "${ns}" find /sys/devices/virtual -type f -name rps_cpus -exec sh -c "echo ${mask} | cat > {}" \; 2>&1)
-[[ $? -eq 0 && -z "${res}" ]] || logger "${0}: Failed to apply the RPS mask: ${res}"
-
-if [ "${mode}" = "ro" ]; then
-    ${IP} netns exec "${ns}" mount -o remount,ro /sys
-    [ $? -eq 0 ] || exit 1 # Error out so the pod will not start with a writable /sys
+if ! ${IP} netns exec "${ns}" ${WORKDIR}/set-ns-rps-mask.sh ${mask}; then
+  exit 1
 fi

--- a/assets/performanceprofile/scripts/low-latency-hooks.sh
+++ b/assets/performanceprofile/scripts/low-latency-hooks.sh
@@ -14,7 +14,9 @@ ns=$(${IP} netns identify "${pid}" 2>&1)
 [[ $? -eq 0 && -n "${ns}" ]] || { logger "${0} Failed to identify the namespace: ${ns}"; exit 0; }
 
 # Updates the container veth RPS mask on the node
-netns_link_indexes=$(${IP} netns exec "${ns}" ${IP} -j link | ${JQ} ".[] | select(.link_index != null) | .link_index")
+jlink=$(${IP} netns exec "${ns}" ${IP} -j link)
+netns_link_indexes=$(${JQ} ".[] | select(.link_index != null) | .link_index" <<< ${jlink} | sort --unique)
+
 for link_index in ${netns_link_indexes}; do
   container_veth=$(${IP} -j link | ${JQ} ".[] | select(.ifindex == ${link_index}) | .ifname" | tr -d '"')
   echo ${mask} > /sys/devices/virtual/net/${container_veth}/queues/rx-0/rps_cpus

--- a/assets/performanceprofile/scripts/low-latency-hooks.sh
+++ b/assets/performanceprofile/scripts/low-latency-hooks.sh
@@ -14,7 +14,7 @@ ns=$(${IP} netns identify "${pid}" 2>&1)
 [[ $? -eq 0 && -n "${ns}" ]] || { logger "${0} Failed to identify the namespace: ${ns}"; exit 0; }
 
 # Updates the container veth RPS mask on the node
-jlink=$(${IP} netns exec "${ns}" ${IP} -j link)
+jlink=$(${IP} -n "${ns}" -j link)
 netns_link_indexes=$(${JQ} ".[] | select(.link_index != null) | .link_index" <<< ${jlink} | sort --unique)
 
 for link_index in ${netns_link_indexes}; do

--- a/assets/performanceprofile/scripts/set-ns-rps-mask.sh
+++ b/assets/performanceprofile/scripts/set-ns-rps-mask.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+MASK=${1}
+
+if ! [[ -w /sys ]]; then
+  if ! res=$(mount -o remount,rw /sys 2>&1); then
+    logger "${0}: Failed to remount /sys as rw: ${res}"; exit 0;
+  fi
+fi
+
+# /sys/class/net can't be used recursively to find the rps_cpus file, use /sys/devices/virtual instead
+for dev in /sys/devices/virtual/net/*; do
+          echo ${MASK} > ${dev}/queues/rx-0/rps_cpus || logger "${0}: Failed to apply the RPS mask on ${dev}:"
+done

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -54,6 +54,7 @@ const (
 	setCPUsOffline            = "set-cpus-offline"
 	ociHooks                  = "low-latency-hooks"
 	setRPSMask                = "set-rps-mask"
+	setNSRPSMask              = "set-ns-rps-mask"
 	clearIRQBalanceBannedCPUs = "clear-irqbalance-banned-cpus"
 )
 
@@ -148,7 +149,7 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile) (*igntypes.Con
 	// add script files under the node /usr/local/bin directory
 	if profileutil.IsRpsEnabled(profile) || profile.Spec.WorkloadHints == nil ||
 		profile.Spec.WorkloadHints.RealTime == nil || *profile.Spec.WorkloadHints.RealTime {
-		scripts = []string{hugepagesAllocation, ociHooks, setRPSMask, setCPUsOffline, clearIRQBalanceBannedCPUs}
+		scripts = []string{hugepagesAllocation, ociHooks, setRPSMask, setNSRPSMask, setCPUsOffline, clearIRQBalanceBannedCPUs}
 	} else {
 		// realtime is explicitly disabled by workload hint
 		scripts = []string{hugepagesAllocation, setCPUsOffline, clearIRQBalanceBannedCPUs}


### PR DESCRIPTION
Measurements show that the script spends most of its time in entering/leaving the containers` network namespace.

This PR contains a couple of modifications that are trying to minimize entering the network namespace as much as possible.

A detailed explanation about each modification is listed in the commits themselves.