### PR TITLE
hack: performance: skip tests under 5_latency_testing

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -29,4 +29,4 @@ echo "Running Functional Tests: ${GINKGO_SUITS}"
 # --failFast: ginkgo will stop the suite right after the first spec failure
 # --flakeAttempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
-GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast --flakeAttempts=2 -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts
+GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast -skipPackage="5_latency_testing" --flakeAttempts=2 -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts

--- a/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -3,6 +3,7 @@ package __latency_testing_test
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -29,6 +30,9 @@ import (
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
+//TODO get commonly used variables from one shared file that defines constants
+const testExecutablePath = "../../../../../build/_output/bin/latency-e2e.test"
+
 var prePullNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "testing-prepull",
@@ -37,6 +41,7 @@ var prePullNamespace = &corev1.Namespace{
 var profile *performancev2.PerformanceProfile
 
 var _ = BeforeSuite(func() {
+	Expect(isTestExecutableFound()).To(BeTrue())
 	Expect(testclient.ClientsEnabled).To(BeTrue())
 
 	// update PP isolated CPUs. the new cpu set for isolated should have an even number of CPUs to avoid failing the pod on SMTAlignment error,
@@ -116,4 +121,11 @@ func createNamespace() error {
 	}
 	testlog.Infof("created namespace %q err=%v", prePullNamespace.Name, err)
 	return err
+}
+
+func isTestExecutableFound() bool {
+	if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
+		return false
+	}
+	return true
 }

--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -96,9 +96,6 @@ var _ = table.DescribeTable("Test latency measurement tools tests", func(testGro
 		clearEnv()
 		testDescription := setEnvAndGetDescription(test)
 		By(testDescription)
-		if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
-			Skip("The executable test file does not exist , skipping the test.")
-		}
 		output, err := exec.Command(testExecutablePath, "-ginkgo.focus", test.toolToTest).Output()
 		if err != nil {
 			//we don't log Error level here because the test might be a negative check


### PR DESCRIPTION
The tests in 5_latency_testing should run only on-demand and by using different make target with relevant dependencies. Skip this package using ginkgo skipPackage flag.
And fail the suite if the binary is not found.

Signed-off-by: shereenH <shajmakh@redhat.com>