### PR TITLE
Add test ethtool must-gather

### DIFF
--- a/test/e2e/performanceprofile/functests/6_mustgather_testing/mustgather.go
+++ b/test/e2e/performanceprofile/functests/6_mustgather_testing/mustgather.go
@@ -131,6 +131,8 @@ var _ = Describe("[rfe_id: 50649] Performance Addon Operator Must Gather", func(
 				"podresources.json",
 				"proc_cmdline",
 				"sysinfo.log",
+				"ethtool_features",
+				"ethtool_channels",
 			}
 
 			err = checkfilesExist(nodeSpecificFiles, snapShotPath)


### PR DESCRIPTION
Add test ethtool from must-gather

Depends on https://github.com/openshift-kni/performance-addon-operators/pull/935

Signed-off-by: Mario Fernandez <mariofer@redhat.com>