### PR TITLE
Remove dynamic client and simplify getNodePoolNameFromNode

### DIFF
--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	dynamic "k8s.io/client-go/dynamic"
 	kubeset "k8s.io/client-go/kubernetes"
 	appsset "k8s.io/client-go/kubernetes/typed/apps/v1"
 	coreset "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -13,13 +12,12 @@ import (
 )
 
 type Clients struct {
-	Kube              *kubeset.Clientset
-	ConfigClientSet   *configclientset.Clientset
-	ConfigV1Client    *configv1client.ConfigV1Client
-	Tuned             *tunedset.Clientset
-	MC                *mcfgclientset.Clientset
-	Core              *coreset.CoreV1Client
-	Apps              *appsset.AppsV1Client
-	ManagementKube    *kubeset.Clientset
-	ManagementDynamic dynamic.Interface
+	Kube            *kubeset.Clientset
+	ConfigClientSet *configclientset.Clientset
+	ConfigV1Client  *configv1client.ConfigV1Client
+	Tuned           *tunedset.Clientset
+	MC              *mcfgclientset.Clientset
+	Core            *coreset.CoreV1Client
+	Apps            *appsset.AppsV1Client
+	ManagementKube  *kubeset.Clientset
 }

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
 	kubeinformers "k8s.io/client-go/informers"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	kubeset "k8s.io/client-go/kubernetes"
@@ -158,10 +157,6 @@ func NewController() (*Controller, error) {
 			return nil, err
 		}
 		controller.clients.ManagementKube, err = kubeset.NewForConfig(managementKubeconfig)
-		if err != nil {
-			return nil, err
-		}
-		controller.clients.ManagementDynamic, err = dynamic.NewForConfig(managementKubeconfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	hypershiftNodeOwnerNameLabel          = "cluster.x-k8s.io/owner-name"
-	hypershiftNodeOwnerKindLabel          = "cluster.x-k8s.io/owner-kind"
-	hypershiftNodePoolNamespacedNameLabel = "hypershift.openshift.io/nodePool"
-	hypershiftNodePoolNameLabel           = "hypershift.openshift.io/nodePoolName"
+	hypershiftNodeOwnerNameLabel = "cluster.x-k8s.io/owner-name"
+	hypershiftNodeOwnerKindLabel = "cluster.x-k8s.io/owner-kind"
+	hypershiftNodePoolLabel      = "hypershift.openshift.io/nodePool"
+	hypershiftNodePoolNameLabel  = "hypershift.openshift.io/nodePoolName"
 )
 
 // syncHostedClusterTuneds synchronizes Tuned objects embedded in ConfigMaps
@@ -124,9 +124,9 @@ func (c *Controller) getObjFromTunedConfigMap() ([]tunedv1.Tuned, error) {
 			continue
 		}
 
-		cmNodePoolNamespacedName, ok := cm.Annotations[hypershiftNodePoolNamespacedNameLabel]
+		cmNodePoolNamespacedName, ok := cm.Annotations[hypershiftNodePoolLabel]
 		if !ok {
-			klog.Warningf("failed to parseTunedManifests in ConfigMap %s, no label %s", cm.ObjectMeta.Name, hypershiftNodePoolNamespacedNameLabel)
+			klog.Warningf("failed to parseTunedManifests in ConfigMap %s, no label %s", cm.ObjectMeta.Name, hypershiftNodePoolLabel)
 			continue
 		}
 		nodePoolName := parseNamespacedName(cmNodePoolNamespacedName)
@@ -192,8 +192,8 @@ func hashStruct(o interface{}) string {
 // parseNamespacedName expects a string with the format "namespace/name"
 // and returns the name only.
 // If given a string in the format "name" returns "name".
-func parseNamespacedName(nodePoolFullName string) string {
-	parts := strings.SplitN(nodePoolFullName, "/", 2)
+func parseNamespacedName(namespacedName string) string {
+	parts := strings.SplitN(namespacedName, "/", 2)
 	if len(parts) > 1 {
 		return parts[1]
 	}


### PR DESCRIPTION
In #390 we added the dynamic go-client to look at MachineSets to map Nodes to HyperShift NodePools in the function `getNodePoolNameForNode(node *corev1.Node)`, without needing a dependency on the cluster-api. Since then,  https://github.com/openshift/hypershift/pull/1702 has merged which adds the NodePool labels directly to the Nodes in HyperShift, removing the need for the dynamic client.

This PR greatly simplifies the function `getNodePoolNameForNode(node *corev1.Node)` in `pkg/operator/hypershift.go` and removes the dynamic client.

This has been manually tested with the latest version of the HyperShift work in https://github.com/openshift/hypershift/pull/1651.