### PR TITLE
[WIP] PAO Skip rt parameters if rt kernel is not present

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -29,6 +29,7 @@ min_perf_pct=100
 
 {{if .RealTime}}
 [service]
+#uname_regex=rt
 service.stalld=start,enable
 {{end}}
 
@@ -59,6 +60,7 @@ default_irq_smp_affinity = ignore
 {{end}}
 
 [sysctl]
+#uname_regex=rt
 {{if .RealTime}}
 #> cpu-partitioning #realtime
 kernel.hung_task_timeout_secs=600


### PR DESCRIPTION
Applied RealTime parameters when rt kernel is disabled show different errors. 

Signed-off-by: Mario Fernandez <mariofer@redhat.com>