### PR TITLE
OCPBUGS-851: [release-4.11] Dockerfile: provide full URL to CentOS stream image #406 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 RUN make build
 
-FROM centos:8 as tuned
+FROM quay.io/centos/centos:stream8 as tuned
 WORKDIR /root
 COPY assets /root/assets
 RUN INSTALL_PKGS=" \
@@ -18,7 +18,7 @@ RUN INSTALL_PKGS=" \
     cd ../stalld && \
     make
 
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/


### PR DESCRIPTION
Manual cherry-pick from https://github.com/openshift/cluster-node-tuning-operator/pull/406
Signed-off-by: Mario Fernandez <mariofer@redhat.com>