### PR TITLE
Fix RPS e2e test condition

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -293,7 +293,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 
 	Context("RPS configuration", func() {
 		It("Should have the correct RPS configuration", func() {
-			if profile.Spec.CPU == nil || profile.Spec.CPU.Reserved != nil {
+			if profile.Spec.CPU == nil || profile.Spec.CPU.Reserved == nil {
 				return
 			}
 			if profile.Spec.WorkloadHints != nil && profile.Spec.WorkloadHints.RealTime != nil && !*profile.Spec.WorkloadHints.RealTime {


### PR DESCRIPTION
RPS e2e test never actually ran since the enter condition was wrong