### PR TITLE
OCPBUGS-1131: [release-4.11] e2e: perfprof: unbreak the e2e-gcp PAO lane

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
+++ b/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
@@ -30,6 +30,12 @@ func init() {
 var TestingNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: testutils.NamespaceTesting,
+		Labels: map[string]string{
+			"security.openshift.io/scc.podSecurityLabelSync": "false",
+			"pod-security.kubernetes.io/audit":               "privileged",
+			"pod-security.kubernetes.io/enforce":             "privileged",
+			"pod-security.kubernetes.io/warn":                "privileged",
+		},
 	},
 }
 

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -267,8 +267,8 @@ func fixMaskPadding(rawMask string, maskLen int) string {
 	testlog.Infof("fixed mask (dealing with incorrect crio padding) on node is {%s} len=%d", fixedMask, maskLen)
 
 	retMask := fixedMask[0:8]
-	for i := 8; i+8 <= len(maskString); i += 8 {
-		retMask = retMask + "," + maskString[i:i+8]
+	for i := 8; i+8 <= len(fixedMask); i += 8 {
+		retMask = retMask + "," + fixedMask[i:i+8]
 	}
 	return retMask
 }


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/cluster-node-tuning-operator/pull/438

e2e: add podsecurity labels, disable OCP label sync

Backport and squash two commits related to handling
of security labels:

b0024584fb244691097916665d5cec1e7c1dc5f4 (partial):    
    OCP >= 4.12 wants to have stricter podsecurity rules.
    In our e2e tests we do a bunch of stuff, including running privileged
    pods. We just annotate the test namespace(s) to signal we need top
    privileges. Since e2e tests run in very controlled envs (CI mostly),
    and since test namespace should be gone anyway once the e2e tests
    are finished, this is still fair game.
    
    Signed-off-by: Francesco Romani <fromani@redhat.com>

b0024584fb244691097916665d5cec1e7c1dc5f4
    podsecurity: disable OCP label sync

    Per last OCP recommendation (internal doc) is not sufficient to
    declare the pod security labels, we also need to disable the
    label sync, which we do here.

    Signed-off-by: Francesco Romani <fromani@redhat.com>
    
Co-Authored-by: Mario Fernandez <mariofer@redhat.com>
Signed-off-by: Francesco Romani <fromani@redhat.com>
