### PR TITLE
workloadHints not included in validateFields()

### DIFF
--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -108,6 +108,7 @@ func (r *PerformanceProfile) validateFields() field.ErrorList {
 	allErrs = append(allErrs, r.validateHugePages()...)
 	allErrs = append(allErrs, r.validateNUMA()...)
 	allErrs = append(allErrs, r.validateNet()...)
+	allErrs = append(allErrs, r.validateWorkloadHints()...)
 
 	return allErrs
 }


### PR DESCRIPTION
workloadHints are not included in validateFields()
Thus, are not applying correctly. 
Also validateFields is not being testing.

- [X]  Add validateWorkloadHints to function.
- [X]  Add tests.

Related: https://github.com/openshift/cluster-node-tuning-operator/issues/339

Signed-off-by: Mario Fernandez <mariofer@redhat.com>