### PR TITLE
e2e: Fix metrics_cert_rotation.go

### DIFF
--- a/test/e2e/basic/metrics_cert_rotation.go
+++ b/test/e2e/basic/metrics_cert_rotation.go
@@ -59,7 +59,9 @@ var _ = ginkgo.Describe("[basic][metrics] Node Tuning Operator certificate rotat
 				secretCertContents := string(tlsSecret.Data["tls.crt"])
 
 				operatorPodIP := operatorPod.Status.PodIP
-				opensslCmd := "/host/usr/bin/openssl s_client -connect " + operatorPodIP + ":60000 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'"
+				// We need chroot because host may be using system libraries incompatible with the container
+				// image system libraries.  Alternatively, use container-shipped openssl.
+				opensslCmd := "/usr/sbin/chroot /host /usr/bin/openssl s_client -connect " + operatorPodIP + ":60000 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'"
 
 				serverCertContents, err := util.ExecCmdInPod(tunedPod, "/bin/bash", "-c", opensslCmd)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -358,7 +358,7 @@ func WaitForPoolMachineCount(cs *framework.ClientSet, pool string, count int32) 
 		}
 		return false, nil
 	}); err != nil {
-		return errors.Wrapf(err, "pool %s MachineCount != %d (waited %s): ", pool, count, time.Since(startTime), explain)
+		return errors.Wrapf(err, "pool %s MachineCount != %d (waited %s): %v", pool, count, time.Since(startTime), explain)
 	}
 	return nil
 }


### PR DESCRIPTION
Fix `metrics_cert_rotation.go` on systems where the host OS libraries do not match container libraries.  An alternative is to rely on container-shipped `openssl`, but we probably do not wish to add this dependency to the container image.

Other fixes:
  - insufficient number of arguments in `test/e2e/util/util.go`

/cc @dagrayvid 