### PR TITLE
Clean output of kernel args if no hugepages or additional args are present

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -156,9 +156,12 @@ cmdline_power_performance=+processor.max_cstate=1 intel_idle.max_cstate=0
 cmdline_idle_poll=+idle=poll
 {{end}}
 
-cmdline_hugepages=+{{if .DefaultHugepagesSize}} default_hugepagesz={{.DefaultHugepagesSize}} {{end}} {{if .Hugepages}} {{.Hugepages}} {{end}}
+{{if .DefaultHugepagesSize}}
+cmdline_hugepages=+ default_hugepagesz={{.DefaultHugepagesSize}} {{end}} {{if .Hugepages}} {{.Hugepages}} {{end}}
 
-cmdline_additionalArg=+{{if .AdditionalArgs}} {{.AdditionalArgs}} {{end}}
+{{if .AdditionalArgs}}
+cmdline_additionalArg=+{{.AdditionalArgs}} 
+{{end}}
 
 {{if .PerPodPowerManagement}}
 cmdline_pstate=+intel_pstate=passive

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -30,7 +30,7 @@ var (
 	cmdlineHighPowerConsumption       = "+processor.max_cstate=1 intel_idle.max_cstate=0"
 	cmdlineIdlePoll                   = "+idle=poll"
 	cmdlineHugepages                  = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4"
-	cmdlineAdditionalArgs             = "+ audit=0 processor.max_cstate=1 idle=poll intel_idle.max_cstate=0"
+	cmdlineAdditionalArgs             = "+audit=0 processor.max_cstate=1 idle=poll intel_idle.max_cstate=0"
 	cmdlineDummy2MHugePages           = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=0"
 	cmdlineMultipleHugePages          = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=128"
 	cmdlinePerPodPowerManagementHint  = "+intel_pstate=passive"

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -54,8 +54,8 @@ spec:
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\ncmdline_additionalArg=+\n\n\n\n\n"
+      tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\n\n\n"
     name: openshift-node-performance-manual
   recommend:
   - machineConfigLabels:


### PR DESCRIPTION
If hugepages or additional arguments cmdline is no present in the perfromanceProfile, the ouptut of /proc/cmdline is dirty with "+" as:

Before fix:
[...]
rcutree.kthread_prio= 11 + + intel_pstate=passive

After fix:
[...]
rcutree.kthread_prio= 11 intel_pstate=passive



Signed-off-by: Mario Fernandez <mariofer@redhat.com>