### PR TITLE
Adjust nto_custom_profiles:count metric to count by _id

### DIFF
--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -129,5 +129,5 @@ spec:
       for: 2h
       labels:
         severity: warning
-    - expr: count(nto_profile_calculated_total{profile!~"openshift-node",profile!~"openshift-control-plane",profile!~"openshift"})
+    - expr: count by (_id) (nto_profile_calculated_total{profile!~"openshift-node",profile!~"openshift-control-plane",profile!~"openshift"})
       record: nto_custom_profiles:count


### PR DESCRIPTION
This is needed in HyperShift management clusters when HyperShift is configured to have hosted control plane metrics scraped by the platform monitoring prometheus. In this case, metrics from all NTOs in all hosted control plane namespaces will be summed into one count. We want one count per cluster. This has no impact on standalone OCP.