### PR TITLE
Remove omitempty on reserved CPU API v1

### DIFF
--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -61,6 +61,7 @@ spec:
                   type: object
                   required:
                     - isolated
+                    - reserved
                   properties:
                     balanceIsolated:
                       description: BalanceIsolated toggles whether or not the Isolated CPU set is eligible for load balancing work loads. When this option is set to "false", the Isolated CPU set will be static, meaning workloads have to explicitly assign each thread to a specific cpu in order to work across multiple CPUs. Setting this to "true" allows workloads to be balanced across CPUs. Setting this to "false" offers the most predictable performance for guaranteed workloads, but it offloads the complexity of cpu load balancing to the application. Defaults to "true"

--- a/pkg/apis/performanceprofile/v1/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v1/performanceprofile_types.go
@@ -82,7 +82,7 @@ type CPUSet string
 // CPU defines a set of CPU related features.
 type CPU struct {
 	// Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet.
-	Reserved *CPUSet `json:"reserved,omitempty"`
+	Reserved *CPUSet `json:"reserved"`
 	// Isolated defines a set of CPUs that will be used to give to application threads the most execution time possible,
 	// which means removing as many extraneous tasks off a CPU as possible.
 	// It is important to notice the CPU manager can choose any CPU to run the workload


### PR DESCRIPTION
Remove omitempty on reserved CPU also on API v1

Related: https://github.com/openshift-kni/performance-addon-operators/pull/792

Signed-off-by: Mario Fernandez <mariofer@redhat.com>