### PR TITLE
OCPBUGS-2167: Workload hints backwards compatibility intel_pstate=disable

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -165,8 +165,6 @@ cmdline_additionalArg=+{{.AdditionalArgs}}
 
 {{if .PerPodPowerManagement}}
 cmdline_pstate=+intel_pstate=passive
-{{end}}
-
-{{if .HighPowerConsumption}}
+{{else if .RealTimeHint}}
 cmdline_pstate=+intel_pstate=disable
 {{end}}

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -204,9 +204,10 @@ var _ = Describe("Tuned", func() {
 			})
 		})
 
-		When("perPodPowerManagement Hint is false", func() {
+		When("perPodPowerManagement Hint is false realTime Hint false", func() {
 			It("should not contain perPodPowerManagement related parameters", func() {
 				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.BoolPtr(false)
+				profile.Spec.WorkloadHints.RealTime = pointer.BoolPtr(false)
 				tunedData := getTunedStructuredData(profile)
 				cpuSection, err := tunedData.GetSection("cpu")
 				Expect(err).ToNot(HaveOccurred())
@@ -215,6 +216,21 @@ var _ = Describe("Tuned", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(bootLoaderSection.Key("cmdline_pstate").String()).ToNot(Equal(cmdlinePerPodPowerManagementHint))
 				Expect(bootLoaderSection.Key("cmdline_pstate").String()).ToNot(Equal(cmdlineHighPowerConsumptionPstate))
+			})
+		})
+
+		When("perPodPowerManagement Hint is false realTime Hint true", func() {
+			It("should not contain perPodPowerManagement related parameters but intel_pstate=disable", func() {
+				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.BoolPtr(false)
+				profile.Spec.WorkloadHints.RealTime = pointer.BoolPtr(true)
+				tunedData := getTunedStructuredData(profile)
+				cpuSection, err := tunedData.GetSection("cpu")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cpuSection.Key("enabled").String()).ToNot(Equal("false"))
+				bootLoaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootLoaderSection.Key("cmdline_pstate").String()).ToNot(Equal(cmdlinePerPodPowerManagementHint))
+				Expect(bootLoaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineHighPowerConsumptionPstate))
 			})
 		})
 

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -661,7 +661,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 					"kernel.sched_rt_runtime_us":    "950000",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{"processor.max_cstate=1", "intel_idle.max_cstate=0", "intel_pstate=disable"}
+				kernelParameters := []string{"processor.max_cstate=1", "intel_idle.max_cstate=0"}
 				checkTunedParameters(workerRTNodes, stalldEnabled, sysctlMap, kernelParameters, rtKernel)
 			})
 		})

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -55,7 +55,7 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\n\n\n"
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n"
     name: openshift-node-performance-manual
   recommend:
   - machineConfigLabels:


### PR DESCRIPTION
## Description

Maintain backwards compatibility after workloadHints change https://github.com/openshift/cluster-node-tuning-operator/pull/339

## Motivation and Context

The workloads hints feature introduced in 4.11 does not preserve the default tuning settings from 4.10: intel_pstate=disabled.

So if the customer wants to preserve the behavior they have in 4.10, they have to update their performance profile and incur another reboot.

The correct behavior the default setting should be preserved.

## Type of change

Add intel_pstate=disable to default configuration with no hints





Signed-off-by: Mario Fernandez <mariofer@redhat.com>