### PR TITLE
e2e: perfprof: get cpus from node capacity

### DIFF
--- a/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -59,7 +59,7 @@ var _ = BeforeSuite(func() {
 	latencyReservedSet := performancev2.CPUSet("0")
 
 	totalCpus := cpuset.MustParse(string(latencyIsolatedSet)).Size() + cpuset.MustParse(string(latencyReservedSet)).Size()
-	nodesWithSufficientCpu := nodes.GetByCpuAllocatable(workerNodes, totalCpus)
+	nodesWithSufficientCpu := nodes.GetByCpuCapacity(workerNodes, totalCpus)
 	//before applying the changes verify that there are compute nodes with sufficient cpus
 	if len(nodesWithSufficientCpu) != 0 {
 		if *initialIsolated != latencyIsolatedSet || *initialReserved != latencyReservedSet {

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -414,3 +414,14 @@ func GetByCpuAllocatable(nodesList []corev1.Node, cpuQty int) []corev1.Node {
 	}
 	return nodesWithSufficientCpu
 }
+
+func GetByCpuCapacity(nodesList []corev1.Node, cpuQty int) []corev1.Node {
+	nodesWithSufficientCpu := []corev1.Node{}
+	for _, node := range nodesList {
+		capacityCPU, _ := node.Status.Capacity.Cpu().AsInt64()
+		if capacityCPU >= int64(cpuQty) {
+			nodesWithSufficientCpu = append(nodesWithSufficientCpu, node)
+		}
+	}
+	return nodesWithSufficientCpu
+}


### PR DESCRIPTION
Lately, the latency testing suite starting to fail and that was because the tests didn't reconfigure the performance profile to be compatible with the tests prerequisites, hence they were using the existing profile mainly missing the correct isolated CPUs value.

The reason for not changing the profile is that there were no nodes with sufficient CPUs on the compute nodes. This check was actually fetching the allocatable CPUs (total of isolated) and that is excluding the resreved CPUs, and this is expected because this is the configuration of the PP that was applied earlier on the cluster.

To fix that, fetch that CPUs value from node capacity instead in order to include all CPUs on the node.
Signed-off-by: shereenH <shajmakh@redhat.com>