### PR TITLE
OCPBUGS-764: [release-4.11] Add intel_pstate=disable to default configuration with no hints (#480)

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -144,7 +144,7 @@ cmdline_realtime=+nohz_full=${isolated_cores} tsc=nowatchdog nosoftlockup nmi_wa
 {{end}}
 
 {{if .HighPowerConsumption}}
-cmdline_power_performance=+processor.max_cstate=1 intel_idle.max_cstate=0 intel_pstate=disable
+cmdline_power_performance=+processor.max_cstate=1 intel_idle.max_cstate=0 
 {{end}}
 
 {{if and .HighPowerConsumption .RealTime}}
@@ -154,3 +154,7 @@ cmdline_idle_poll=+idle=poll
 cmdline_hugepages=+{{if .DefaultHugepagesSize}} default_hugepagesz={{.DefaultHugepagesSize}} {{end}} {{if .Hugepages}} {{.Hugepages}} {{end}}
 
 cmdline_additionalArg=+{{if .AdditionalArgs}} {{.AdditionalArgs}} {{end}}
+
+{{if .RealTime}}
+cmdline_pstate=+intel_pstate=disable
+{{end}}

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -26,12 +26,13 @@ var (
 	cmdlineWithStaticIsolation              = regexp.MustCompile(`\s*cmdline_isolation=\+\s*isolcpus=managed_irq,\${isolated_cores}\s*`)
 	cmdlineWithoutStaticIsolation           = regexp.MustCompile(`\s*cmdline_isolation=\+\s*isolcpus=domain,managed_irq,\${isolated_cores}\s*`)
 	cmdlineWithRealtime                     = regexp.MustCompile(`\s*cmdline_realtime=\+\s*nohz_full=\${isolated_cores}\s+tsc=nowatchdog\s+nosoftlockup\s+nmi_watchdog=0\s+mce=off\s+skew_tick=1\s*`)
-	cmdlineHighPowerConsumption             = regexp.MustCompile(`\s*cmdline_power_performance=\+\s*processor.max_cstate=1\s+intel_idle.max_cstate=0\s+intel_pstate=disable\s*`)
+	cmdlineHighPowerConsumption             = regexp.MustCompile(`\s*cmdline_power_performance=\+\s*processor.max_cstate=1\s+intel_idle.max_cstate=0\s*`)
 	cmdlineHighPowerConsumptionWithRealtime = regexp.MustCompile(`\s*cmdline_idle_poll=\+\s*idle=poll\s*`)
 	cmdlineHugepages                        = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s*`)
 	cmdlineAdditionalArg                    = regexp.MustCompile(`\s*cmdline_additionalArg=\+\s*test1=val1\s+test2=val2\s*`)
 	cmdlineDummy2MHugePages                 = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s+hugepagesz=2M\s+hugepages=0\s*`)
 	cmdlineMultipleHugePages                = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s+hugepagesz=2M\s+hugepages=128\s*`)
+	cmdlinePstateDisable                    = regexp.MustCompile(`\s*cmdline_pstate=\+\s*intel_pstate=disable\s*`)
 )
 
 var additionalArgs = []string{"test1=val1", "test2=val2"}
@@ -72,6 +73,8 @@ var _ = Describe("Tuned", func() {
 			Expect(manifest).To(ContainSubstring("cmdline_additionalArg="))
 			By("Populating realtime cmdline")
 			Expect(cmdlineWithRealtime.MatchString(manifest)).To(BeTrue())
+			By("Populating pstate disable default cmdline")
+			Expect(cmdlinePstateDisable.MatchString(manifest)).To(BeTrue())
 		})
 
 		When("realtime hint disabled", func() {
@@ -87,6 +90,8 @@ var _ = Describe("Tuned", func() {
 				Expect(manifest).ToNot(ContainSubstring("kernel.sched_rt_runtime_us=-1"))
 				By("Populating realtime cmdline")
 				Expect(cmdlineWithRealtime.MatchString(manifest)).ToNot(BeTrue())
+				By("Populating pstate disable cmdline")
+				Expect(cmdlinePstateDisable.MatchString(manifest)).ToNot(BeTrue())
 			})
 		})
 

--- a/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance/performance_profile.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance/performance_profile.yaml
@@ -21,3 +21,6 @@ spec:
     topologyPolicy: "single-numa-node"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
+  workloadHints:
+    highPowerConsumption: false
+    realTime: true

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -627,7 +627,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 					"kernel.sched_rt_runtime_us":    "950000",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{"processor.max_cstate=1", "intel_idle.max_cstate=0", "intel_pstate=disable"}
+				kernelParameters := []string{"processor.max_cstate=1", "intel_idle.max_cstate=0"}
 				checkTunedParameters(workerRTNodes, stalldEnabled, sysctlMap, kernelParameters, rtKernel)
 			})
 		})

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -55,7 +55,7 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\ncmdline_additionalArg=+\n"
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\ncmdline_additionalArg=+\n\n\ncmdline_pstate=+intel_pstate=disable\n\n"
     name: openshift-node-performance-manual
   recommend:
   - machineConfigLabels:


### PR DESCRIPTION
Maintain backwards compatibility after workloadHints feature

The workloads hints feature introduced in 4.11 does not preserve the default tuning settings from 4.10: intel_pstate=disabled.

So if the customer wants to preserve the behavior they have in 4.10, they have to update their performance profile and incur another reboot.

The correct behavior the default setting should be preserved.

manual cherry-pick https://github.com/openshift/cluster-node-tuning-operator/pull/480:

Signed-off-by: Mario Fernandez <mariofer@redhat.com>