### PR TITLE
Fix banned cpu parsing

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -233,7 +233,7 @@ var _ = Describe("[performance] Checking IRQBalance settings", func() {
 					return false
 				}
 				return bannedCPUs.IsEmpty()
-			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).ShouldNot(BeTrue(), "banned CPUs %v not empty on node %q", bannedCPUs, targetNode.Name)
+			}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(BeTrue(), "banned CPUs %v not empty on node %q", bannedCPUs, targetNode.Name)
 		})
 	})
 })


### PR DESCRIPTION
The test goal is to check that the banned cpus list is overwritten after a CRI-O restart. After applying a fake data in the banned cpus list, the test restarts the CRI-O but expects to find a non-empty list. Fix the expectation to empty list.