### PR TITLE
Switch to OS-shipped stalld

### DIFF
--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -79,7 +79,7 @@ const (
 	// If useSystemStalld is set to true, use the OS-shipped stalld; otherwise, use the
 	// NTO-shipped version.  The aim here is to switch back to the legacy code easily just
 	// by setting this constant to false.
-	useSystemStalld = false
+	useSystemStalld = true
 )
 
 // Types


### PR DESCRIPTION
OS-shipped `stalld` matured to version 1.15 in OCP 4.10 and fixes a number of issues, namely running the stalld process as `unconfined_service_t` type.