### PR TITLE
HyperShift: rename Tuned ConfigMap key from tuned to tuning

### DIFF
--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -28,8 +28,8 @@ const (
 	hypershiftNodePoolLabel      = "hypershift.openshift.io/nodePool"
 	hypershiftNodePoolNameLabel  = "hypershift.openshift.io/nodePoolName"
 
-	tunedConfigMapLabel     = "hypershift.openshift.io/tuned-config"
-	tunedConfigMapConfigKey = "tuned"
+	tunedConfigMapLabel      = "hypershift.openshift.io/tuned-config"
+	tuningConfigMapConfigKey = "tuning"
 
 	operatorGeneratedMachineConfig = "hypershift.openshift.io/nto-generated-machine-config"
 	mcConfigMapDataKey             = "config"
@@ -129,9 +129,9 @@ func (c *Controller) getObjFromTunedConfigMap() ([]tunedv1.Tuned, error) {
 
 	seenTunedObject := map[string]bool{}
 	for _, cm := range cmList.Items {
-		tunedConfig, ok := cm.Data[tunedConfigMapConfigKey]
+		tunedConfig, ok := cm.Data[tuningConfigMapConfigKey]
 		if !ok {
-			klog.Warning("Tuned in ConfigMap %s has no data for field %s", cm.ObjectMeta.Name, tunedConfigMapConfigKey)
+			klog.Warningf("ConfigMap %s has no data in field %s. Expected Tuned manifests.", cm.ObjectMeta.Name, tuningConfigMapConfigKey)
 			continue
 		}
 


### PR DESCRIPTION
This PR enables NTO to support the Tuned ConfigMap key `tuned` and `tuning` in HyperShift.

This is required so that we can rename this key from `tuned` and `tuning` on the HyperShift side without disrupting HyperShift CI. We are renaming this and the spec.TunedConfig section in order to keep the names more general so that we can reference PerformanceProfiles in these ConfigMaps later on when we enable the PerformanceProfile controller.

I split this PR into two commits, so that once the rename happens on the HyperShift side, we can simply revert the second commit

See: https://github.com/openshift/hypershift/pull/1802
/cc @jmencak @jlojosnegros 