### PR TITLE
pao: latency-tests: read test log directly from pod

### DIFF
--- a/test/e2e/performanceprofile/functests/4_latency/latency.go
+++ b/test/e2e/performanceprofile/functests/4_latency/latency.go
@@ -64,11 +64,8 @@ var _ = Describe("[performance] Latency Test", func() {
 	var profile *performancev2.PerformanceProfile
 	var latencyTestPod *corev1.Pod
 	var err error
-	var logName string
 
 	BeforeEach(func() {
-		logName = time.Now().Format("20060102150405")
-
 		latencyTestRun, err = getLatencyTestRun()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -115,7 +112,6 @@ var _ = Describe("[performance] Latency Test", func() {
 	})
 
 	AfterEach(func() {
-		removeLogfile(workerRTNode, logName)
 		err = testclient.Client.Delete(context.TODO(), latencyTestPod)
 		if err != nil {
 			testlog.Error(err)
@@ -155,21 +151,24 @@ var _ = Describe("[performance] Latency Test", func() {
 		})
 
 		It("should succeed", func() {
+			defer func() {
+				logs, err := pods.GetLogs(testclient.K8sClient, latencyTestPod)
+				Expect(err).ToNot(HaveOccurred())
+				testlog.Infof(logs)
+			}()
 			oslatArgs := []string{
 				fmt.Sprintf("-runtime=%s", latencyTestRuntime),
 			}
-			latencyTestPod = getLatencyTestPod(profile, workerRTNode, testName, oslatArgs, logName)
-			createLatencyTestPod(latencyTestPod, workerRTNode, logName)
-			logFileContent := getLogFile(workerRTNode, logName)
+			latencyTestPod = getLatencyTestPod(profile, workerRTNode, testName, oslatArgs)
+			createLatencyTestPod(latencyTestPod)
 
 			// verify the maximum latency only when it requested, because this value can be very different
 			// on different systems
 			if maximumLatency == -1 {
-				testlog.Info(logFileContent)
 				Skip("no maximum latency value provided, skip buckets latency check")
 			}
 
-			latencies := extractLatencyValues(logName, `Maximum:\t*([\s\d]*)\(us\)`, workerRTNode)
+			latencies := extractLatencyValues(`Maximum:\t*([\s\d]*)\(us\)`, latencyTestPod)
 			latenciesList := strings.Split(latencies, " ")
 			for _, lat := range latenciesList {
 				if lat == "" {
@@ -177,12 +176,8 @@ var _ = Describe("[performance] Latency Test", func() {
 				}
 				curr, err := strconv.Atoi(lat)
 				Expect(err).ToNot(HaveOccurred())
-
-				Expect(curr < maximumLatency).To(BeTrue(), "The current latency %d is bigger than the expected one %d : \n %s", curr, maximumLatency, logFileContent)
-
+				Expect(curr < maximumLatency).To(BeTrue(), "The current latency %d is bigger than the expected one %d", curr, maximumLatency)
 			}
-			//Use Println here so that this output will be displayed upon executing the test binary
-			fmt.Println(logFileContent)
 		})
 	})
 
@@ -199,20 +194,23 @@ var _ = Describe("[performance] Latency Test", func() {
 		})
 
 		It("should succeed", func() {
+			defer func() {
+				logs, err := pods.GetLogs(testclient.K8sClient, latencyTestPod)
+				Expect(err).ToNot(HaveOccurred())
+				testlog.Infof(logs)
+			}()
 			cyclictestArgs := []string{
 				fmt.Sprintf("-duration=%s", latencyTestRuntime),
 			}
-			latencyTestPod = getLatencyTestPod(profile, workerRTNode, testName, cyclictestArgs, logName)
-			createLatencyTestPod(latencyTestPod, workerRTNode, logName)
-			logFileContent := getLogFile(workerRTNode, logName)
+			latencyTestPod = getLatencyTestPod(profile, workerRTNode, testName, cyclictestArgs)
+			createLatencyTestPod(latencyTestPod)
 
 			// verify the maximum latency only when it requested, because this value can be very different
 			// on different systems
 			if maximumLatency == -1 {
-				testlog.Info(logFileContent)
 				Skip("no maximum latency value provided, skip buckets latency check")
 			}
-			latencies := extractLatencyValues(logName, `# Max Latencies:\t*\s*(.*)\s*\t*`, workerRTNode)
+			latencies := extractLatencyValues(`# Max Latencies:\t*\s*(.*)\s*\t*`, latencyTestPod)
 			for _, lat := range strings.Split(latencies, " ") {
 				if lat == "" {
 					continue
@@ -220,12 +218,8 @@ var _ = Describe("[performance] Latency Test", func() {
 
 				curr, err := strconv.Atoi(lat)
 				Expect(err).ToNot(HaveOccurred())
-
-				Expect(curr < maximumLatency).To(BeTrue(), "The current latency %d is bigger than the expected one %d : \n %s", curr, maximumLatency, logFileContent)
-
+				Expect(curr < maximumLatency).To(BeTrue(), "The current latency %d is bigger than the expected one %d", curr, maximumLatency)
 			}
-			//Use Println here so that this output will be displayed upon executing the test binary
-			fmt.Println(logFileContent)
 		})
 	})
 
@@ -238,6 +232,11 @@ var _ = Describe("[performance] Latency Test", func() {
 		})
 
 		It("should succeed", func() {
+			defer func() {
+				logs, err := pods.GetLogs(testclient.K8sClient, latencyTestPod)
+				Expect(err).ToNot(HaveOccurred())
+				testlog.Infof(logs)
+			}()
 			hardLimit := maximumLatency
 			if hardLimit == -1 {
 				// This value should be > than max latency,
@@ -256,14 +255,10 @@ var _ = Describe("[performance] Latency Test", func() {
 				hwlatdetectArgs = append(hwlatdetectArgs, fmt.Sprintf("-threshold=%d", maximumLatency))
 			}
 
-			latencyTestPod = getLatencyTestPod(profile, workerRTNode, testName, hwlatdetectArgs, logName)
-			createLatencyTestPod(latencyTestPod, workerRTNode, logName)
-			logFileContent := getLogFile(workerRTNode, logName)
-
+			latencyTestPod = getLatencyTestPod(profile, workerRTNode, testName, hwlatdetectArgs)
+			createLatencyTestPod(latencyTestPod)
 			// here we don't need to parse the latency values.
 			// hwlatdetect will do that for us and exit with error if needed.
-			//Use Println here so that this output will be displayed upon executing the test binary
-			fmt.Println(logFileContent)
 		})
 	})
 })
@@ -353,7 +348,7 @@ func getMaximumLatency(testName string) (int, error) {
 	return val, err
 }
 
-func getLatencyTestPod(profile *performancev2.PerformanceProfile, node *corev1.Node, testName string, testSpecificArgs []string, logName string) *corev1.Pod {
+func getLatencyTestPod(profile *performancev2.PerformanceProfile, node *corev1.Node, testName string, testSpecificArgs []string) *corev1.Pod {
 	runtimeClass := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
 	testNamePrefix := fmt.Sprintf("%s-", testName)
 	runnerName := fmt.Sprintf("%srunner", testNamePrefix)
@@ -370,7 +365,6 @@ func getLatencyTestPod(profile *performancev2.PerformanceProfile, node *corev1.N
 	latencyTestRunnerArgs := []string{
 		"-logtostderr=false",
 		"-alsologtostderr=true",
-		fmt.Sprintf("-log_file=/host/%s.log", logName),
 	}
 
 	latencyTestRunnerArgs = append(latencyTestRunnerArgs, testSpecificArgs...)
@@ -447,7 +441,7 @@ func logEventsForPod(testPod *corev1.Pod) {
 	}
 }
 
-func createLatencyTestPod(testPod *corev1.Pod, node *corev1.Node, logName string) {
+func createLatencyTestPod(testPod *corev1.Pod) {
 	err := testclient.Client.Create(context.TODO(), testPod)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -481,13 +475,13 @@ func createLatencyTestPod(testPod *corev1.Pod, node *corev1.Node, logName string
 	err = pods.WaitForPhase(testPod, corev1.PodSucceeded, podTimeout*time.Second)
 	if err != nil {
 		logEventsForPod(testPod)
-		testlog.Info(getLogFile(node, logName))
 	}
 	Expect(err).ToNot(HaveOccurred(), "pod %q did not reach %q phase; error: %v", podKey, corev1.PodSucceeded, err)
 }
 
-func extractLatencyValues(logName string, exp string, node *corev1.Node) string {
-	out := getLogFile(node, logName)
+func extractLatencyValues(exp string, pod *corev1.Pod) string {
+	out, err := pods.GetLogs(testclient.K8sClient, pod)
+	Expect(err).ToNot(HaveOccurred())
 
 	maximumRegex, err := regexp.Compile(exp)
 	Expect(err).ToNot(HaveOccurred())
@@ -496,24 +490,6 @@ func extractLatencyValues(logName string, exp string, node *corev1.Node) string 
 	Expect(len(latencies)).To(Equal(2))
 
 	return latencies[1]
-}
-
-func getLogFile(node *corev1.Node, logName string) string {
-	cmd := []string{"cat", fmt.Sprintf("/rootfs/var/log/%s.log", logName)}
-	out, err := nodes.ExecCommandOnNode(cmd, node)
-	if err != nil {
-		testlog.Error(err)
-	}
-	return out
-}
-
-func removeLogfile(node *corev1.Node, logName string) {
-	cmd := []string{"rm", "-f", fmt.Sprintf("/rootfs/var/log/%s.log", logName)}
-	_, err := nodes.ExecCommandOnNode(cmd, node)
-	if err != nil {
-		testlog.Error(err)
-	}
-
 }
 
 func isEqual(qty *resource.Quantity, amount int) bool {

--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -96,7 +96,7 @@ var _ = table.DescribeTable("Test latency measurement tools tests", func(testGro
 		clearEnv()
 		testDescription := setEnvAndGetDescription(test)
 		By(testDescription)
-		output, err := exec.Command(testExecutablePath, "-ginkgo.focus", test.toolToTest).Output()
+		output, err := exec.Command(testExecutablePath, "-ginkgo.v", "-ginkgo.focus", test.toolToTest).Output()
 		if err != nil {
 			//we don't log Error level here because the test might be a negative check
 			testlog.Info(err.Error())


### PR DESCRIPTION
Instead of having the neccessaty to copy all the tests\` output into a log file and then read everything from the log, we can skip this extra step and read the log directly from the pod. The latency test tools, i.e. oslat/cyclictest/hwlatdetect, redirect their output to stdout/stderr anyway, so by reading pod\'s log we get tools\` output.

In addition, this patch is a prerequisite for
https://github.com/openshift-kni/cnf-features-deploy/pull/1301

Signed-off-by: Talor Itzhak <titzhak@redhat.com>