### PR TITLE
e2e: perfprof: add pod-security labels to latency namespace

### DIFF
--- a/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -36,6 +36,12 @@ const testExecutablePath = "../../../../../build/_output/bin/latency-e2e.test"
 var prePullNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "testing-prepull",
+		Labels: map[string]string{
+			"pod-security.kubernetes.io/audit":               "privileged",
+			"pod-security.kubernetes.io/enforce":             "privileged",
+			"pod-security.kubernetes.io/warn":                "privileged",
+			"security.openshift.io/scc.podSecurityLabelSync": "false",
+		},
 	},
 }
 var profile *performancev2.PerformanceProfile


### PR DESCRIPTION
The prepull pods (pulling test image on all nodes before test starts) are failing to run because the namespace doesn't have the pod-security labels which are required starting OCP 4.12. Add the missing labels to enable running the those pods.

Signed-off-by: shereenH <shajmakh@redhat.com>