### PR TITLE
Configuration hotfixes documentation fixes

### DIFF
--- a/docs/performanceprofile/configuration_hotfixes.md
+++ b/docs/performanceprofile/configuration_hotfixes.md
@@ -204,7 +204,7 @@ spec:
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: "worker-cnf"
-    priority: 20
+    priority: 15
     profile: openshift-configuration-hotfixes
 _EOF_
 
@@ -255,7 +255,7 @@ spec:
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: "worker-cnf"
-    priority: 20
+    priority: 15
     profile: openshift-configuration-hotfixes
 _EOF_
 


### PR DESCRIPTION
PerformanceProfile controller generates Tuned CRs with priority 20.  We need to make the priority of the "hotfix" CRs higher, for example 15.

/cc @yanirq 
/cc @MarSik 
