### PR TITLE
Fix two irqbalance tests - smp affinity vs online

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -96,6 +96,10 @@ var _ = Describe("[performance] Checking IRQBalance settings", func() {
 			onlineCPUsSet, err := nodes.GetOnlineCPUsSet(targetNode)
 			Expect(err).ToNot(HaveOccurred(), "failed to get Online CPUs list")
 
+			// Mask the smpAffinitySet according to the current onlineCpuSet
+			// as smp_default_affinity is not online cpu aware
+			smpAffinitySet = smpAffinitySet.Intersection(onlineCPUsSet)
+
 			// expect no irqbalance run in the system already, AKA start from pristine conditions.
 			// This is not an hard requirement, just the easier state to manage and check
 			Expect(smpAffinitySet.Equals(onlineCPUsSet)).To(BeTrue(), "found default_smp_affinity %v, expected %v - IRQBalance already run?", smpAffinitySet, onlineCPUsSet)
@@ -185,6 +189,10 @@ var _ = Describe("[performance] Checking IRQBalance settings", func() {
 			By(fmt.Sprintf("Checking the online CPU Set on node %q", node.Name))
 			onlineCPUsSet, err := nodes.GetOnlineCPUsSet(node)
 			Expect(err).ToNot(HaveOccurred(), "failed to get Online CPUs list")
+
+			// Mask the smpAffinitySet according to the current onlineCpuSet
+			// as smp_default_affinity is not online cpu aware
+			smpAffinitySet = smpAffinitySet.Intersection(onlineCPUsSet)
 
 			// expect no irqbalance run in the system already, AKA start from pristine conditions.
 			// This is not an hard requirement, just the easier state to manage and check

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -288,6 +288,10 @@ func GetDefaultSmpAffinityRaw(node *corev1.Node) (string, error) {
 }
 
 // GetDefaultSmpAffinitySet returns the default smp affinity mask for the node
+// Warning: Please note that default smp affinity mask is not aware
+//          of offline cpus and will return the affinity bits for those
+//          as well. You must intersect the mask with the mask returned
+//          by GetOnlineCPUsSet if this is not desired.
 func GetDefaultSmpAffinitySet(node *corev1.Node) (cpuset.CPUSet, error) {
 	defaultSmpAffinity, err := GetDefaultSmpAffinityRaw(node)
 	if err != nil {


### PR DESCRIPTION
On a system with offline cpus (like when nosmt is being used), the default_smp_affinity still shows all bits as one even though the respective cpus are offline.

[core@cnfdd7 ~]$ cat /proc/irq/default_smp_affinity ff,ffffffff,ffffffff,ffffffff
[core@cnfdd7 ~]$ cat /sys/devices/system/cpu/online 0-51

Our tests did not expect that.

The test is trying to check if all online cpus can handle interrupts before the tuning is applied and so this fix simply removes the offline cpus from the default affinity mask.