### PR TITLE
Switch to golang 1.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.13

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-node-tuning-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/RHsyseng/operator-utils v0.0.0-20200213165520-1a022eb07a43

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,7 +12,7 @@ import (
 
 // GetConfig creates a *rest.Config for talking to a Kubernetes apiserver.
 //
-// Config precedence
+// # Config precedence
 //
 // * KUBECONFIG environment variable pointing at a file
 // * In-cluster config if running in cluster

--- a/pkg/generated/clientset/versioned/fake/register.go
+++ b/pkg/generated/clientset/versioned/fake/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/generated/clientset/versioned/scheme/register.go
+++ b/pkg/generated/clientset/versioned/scheme/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/operator/profilecalculator.go
+++ b/pkg/operator/profilecalculator.go
@@ -60,10 +60,10 @@ func NewProfileCalculator(listers *ntoclient.Listers, clients *ntoclient.Clients
 // podChangeHandler processes an event for Pod 'podNamespace/podName'.
 //
 // Returns
-// * the name of the Node the Pod is associated with in the
-//   ProfileCalculator internal data structures
-// * an indication whether the event caused a node-wide Pod label change
-// * an error if any
+//   - the name of the Node the Pod is associated with in the
+//     ProfileCalculator internal data structures
+//   - an indication whether the event caused a node-wide Pod label change
+//   - an error if any
 func (pc *ProfileCalculator) podChangeHandler(podNamespace string, podName string) (string, bool, error) {
 	var sb strings.Builder
 
@@ -430,10 +430,10 @@ func (pc *ProfileCalculator) nodeRemove(nodeName string) {
 // in terms of Pod label uniqueness.
 //
 // Returns
-// * the name of the Node the Pod was removed from (empty string if the removal
-//   didn't take place)
-// * an indication whether the Pod removal causes a Node-wide change in terms
-//   of Pod label uniqueness
+//   - the name of the Node the Pod was removed from (empty string if the removal
+//     didn't take place)
+//   - an indication whether the Pod removal causes a Node-wide change in terms
+//     of Pod label uniqueness
 func (pc *ProfileCalculator) podRemove(podNamespaceNameRemove string) (string, bool) {
 	for nodeName, podsPerNode := range pc.state.podLabels {
 		for podNamespaceName, podLabels := range podsPerNode {

--- a/pkg/performanceprofile/cmd/render/render.go
+++ b/pkg/performanceprofile/cmd/render/render.go
@@ -61,7 +61,7 @@ func (ppf *performanceProfileFiles) Set(value string) error {
 	return nil
 }
 
-//NewRenderCommand creates a render command.
+// NewRenderCommand creates a render command.
 func NewRenderCommand() *cobra.Command {
 	renderOpts := renderOpts{}
 

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -366,11 +366,11 @@ func profilesEqual(profileFile string, profileData string) bool {
 
 // profilesExtract extracts TuneD daemon profiles to the daemon configuration directory.
 // Returns:
-// - True if the data in the to-be-extracted recommended profile or the profiles being
-//   included from the current recommended profile have changed.
-// - A map with successfully extracted TuneD profile names.
-// - A map with names of TuneD profiles the current TuneD recommended profile depends on.
-// - Error if any or nil.
+//   - True if the data in the to-be-extracted recommended profile or the profiles being
+//     included from the current recommended profile have changed.
+//   - A map with successfully extracted TuneD profile names.
+//   - A map with names of TuneD profiles the current TuneD recommended profile depends on.
+//   - Error if any or nil.
 func profilesExtract(profiles []tunedv1.TunedProfile, recommendedProfile string) (bool, map[string]bool, map[string]bool, error) {
 	var (
 		change bool
@@ -428,9 +428,9 @@ func profilesExtract(profiles []tunedv1.TunedProfile, recommendedProfile string)
 // and removes any TuneD profiles from /etc/tuned/<profile>/ once the same TuneD
 // <profile> is no longer defined in the 'profiles' slice.
 // Returns:
-// - True if the data in the to-be-extracted recommended profile or the profiles being
-//   included from the current recommended profile have changed.
-// - Error if any or nil.
+//   - True if the data in the to-be-extracted recommended profile or the profiles being
+//     included from the current recommended profile have changed.
+//   - Error if any or nil.
 func profilesSync(profiles []tunedv1.TunedProfile, recommendedProfile string) (bool, error) {
 	change, extractedNew, recommendedProfileDeps, err := profilesExtract(profiles, recommendedProfile)
 	if err != nil {

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -1384,7 +1384,7 @@ func getUpdatedNodes() []corev1.Node {
 	return workerRTNodes
 }
 
-//Check All tunables and kernel paramters for workloadHint
+// Check All tunables and kernel paramters for workloadHint
 func checkTunedParameters(workerRTNodes []corev1.Node, stalld bool, sysctlMap map[string]string, kernelParameters []string, rtkernel bool) {
 	for _, node := range workerRTNodes {
 		stalld_pid, err := nodes.ExecCommandOnNode([]string{"pidof", "stalld"}, &node)

--- a/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -31,7 +31,7 @@ import (
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
-//TODO get commonly used variables from one shared file that defines constants
+// TODO get commonly used variables from one shared file that defines constants
 const testExecutablePath = "../../../../../build/_output/bin/latency-e2e.test"
 
 var prePullNamespace = &corev1.Namespace{

--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -15,7 +15,7 @@ import (
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 )
 
-//TODO get commonly used variables from one shared file that defines constants
+// TODO get commonly used variables from one shared file that defines constants
 const (
 	testExecutablePath = "../../../../../build/_output/bin/latency-e2e.test"
 	//tool to test
@@ -77,7 +77,7 @@ const (
 	positiveTesting   = true
 )
 
-//Struct to hold each test parameters
+// Struct to hold each test parameters
 type latencyTest struct {
 	testDelay             string
 	testRun               string

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -289,9 +289,10 @@ func GetDefaultSmpAffinityRaw(node *corev1.Node) (string, error) {
 
 // GetDefaultSmpAffinitySet returns the default smp affinity mask for the node
 // Warning: Please note that default smp affinity mask is not aware
-//          of offline cpus and will return the affinity bits for those
-//          as well. You must intersect the mask with the mask returned
-//          by GetOnlineCPUsSet if this is not desired.
+//
+//	of offline cpus and will return the affinity bits for those
+//	as well. You must intersect the mask with the mask returned
+//	by GetOnlineCPUsSet if this is not desired.
 func GetDefaultSmpAffinitySet(node *corev1.Node) (cpuset.CPUSet, error) {
 	defaultSmpAffinity, err := GetDefaultSmpAffinityRaw(node)
 	if err != nil {
@@ -378,7 +379,7 @@ func GetCoreSiblings(node *corev1.Node) (map[int]map[int][]int, error) {
 	return coreSiblings, err
 }
 
-//TunedForNode find tuned pod for appropriate node
+// TunedForNode find tuned pod for appropriate node
 func TunedForNode(node *corev1.Node, sno bool) *corev1.Pod {
 
 	listOptions := &client.ListOptions{
@@ -444,8 +445,8 @@ func GetCpuSiblings(numaCoreSiblings map[int]map[int][]int, coreKey int) []strin
 	return cpuSiblings
 }
 
-//GetNumaRanges function Splits the numa Siblings in to multiple Ranges
-//Example for Cpu Siblings:  10,50,11,51,12,52,13,53,14,54 , will return 10-14,50-54
+// GetNumaRanges function Splits the numa Siblings in to multiple Ranges
+// Example for Cpu Siblings:  10,50,11,51,12,52,13,53,14,54 , will return 10-14,50-54
 func GetNumaRanges(cpuString string) string {
 	cpuList := strings.Split(cpuString, ",")
 	var cpuIds = []int{}

--- a/test/e2e/performanceprofile/functests/utils/profilesupdate/profile_update.go
+++ b/test/e2e/performanceprofile/functests/utils/profilesupdate/profile_update.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 )
 
-//UpdateIsolatedReservedCpus Updates the current performance profile with new sets of isolated and reserved cpus, and returns true if the update was successfull and false otherwise
+// UpdateIsolatedReservedCpus Updates the current performance profile with new sets of isolated and reserved cpus, and returns true if the update was successfull and false otherwise
 func UpdateIsolatedReservedCpus(isolatedSet performancev2.CPUSet, reservedSet performancev2.CPUSet) error {
 	profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 	if err != nil {
@@ -39,7 +39,7 @@ func UpdateIsolatedReservedCpus(isolatedSet performancev2.CPUSet, reservedSet pe
 	return err
 }
 
-//ApplyProfile applies the new profile and returns true if the changes were applied indeed and false otherwise
+// ApplyProfile applies the new profile and returns true if the changes were applied indeed and false otherwise
 func ApplyProfile(profile *performancev2.PerformanceProfile) error {
 	testlog.Info("Getting MCP for profile")
 	mcpLabel := profilecontroller.GetMachineConfigLabel(profile)


### PR DESCRIPTION
This change switches to golang 1.19 and addresses formatting issues in the code fixed by the switch to golang 1.19.