### PR TITLE
CNF-6946: feat: expand support to render based on files in dir

### DIFF
--- a/docs/performanceprofile/performance_controller.md
+++ b/docs/performanceprofile/performance_controller.md
@@ -62,7 +62,7 @@ The operator can render manifests for all the components it supposes to create, 
 You need to provide the following environment variables
 
 ```shell
-export PERFORMANCE_PROFILE_INPUT_FILES=<comma separated list of your Performance Profiles>
+export ASSET_INPUT_DIR=<input path containing performance profile manifests>
 export ASSET_OUTPUT_DIR=<output path for the rendered manifests>
 ```
 
@@ -75,7 +75,7 @@ _output/cluster-node-tuning-operator render
 Or provide the variables via command line arguments
 
 ```shell
-_output/cluster-node-tuning-operator render --performance-profile-input-files <path> --asset-output-dir<path>
+_output/cluster-node-tuning-operator render --asset-input-dir <path> --asset-output-dir <path>
 ```
 
 ## Troubleshooting

--- a/pkg/performanceprofile/cmd/render/cmd.go
+++ b/pkg/performanceprofile/cmd/render/cmd.go
@@ -1,0 +1,89 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/klog"
+)
+
+type renderOpts struct {
+	assetsInDir  string
+	assetsOutDir string
+}
+
+// NewRenderCommand creates a render command.
+// The render command will read in the asset directory and walk the paths to ingest relevant data.
+// It will generate the machine configs based off of the supplied PerformanceProfiles and any manifest
+// needed to generate the machine configs.
+func NewRenderCommand() *cobra.Command {
+	renderOpts := renderOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "render",
+		Short: "Render performance-addon-operator manifests",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			if err := renderOpts.Validate(); err != nil {
+				klog.Fatal(err)
+			}
+
+			if err := renderOpts.Run(); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+
+	renderOpts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (r *renderOpts) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&r.assetsInDir, "asset-input-dir", components.AssetsDir, "Input path for the assets directory. (Can be a comma separated list of directories.)")
+	fs.StringVar(&r.assetsOutDir, "asset-output-dir", r.assetsOutDir, "Output path for the rendered manifests.")
+	// environment variables has precedence over standard input
+	r.readFlagsFromEnv()
+}
+
+func (r *renderOpts) readFlagsFromEnv() {
+	if assetInDir := os.Getenv("ASSET_INPUT_DIR"); len(assetInDir) > 0 {
+		r.assetsInDir = assetInDir
+	}
+
+	if assetsOutDir := os.Getenv("ASSET_OUTPUT_DIR"); len(assetsOutDir) > 0 {
+		r.assetsOutDir = assetsOutDir
+	}
+}
+
+func (r *renderOpts) Validate() error {
+	if len(r.assetsOutDir) == 0 {
+		return fmt.Errorf("asset-output-dir must be specified")
+	}
+
+	return nil
+}
+
+func (r *renderOpts) Run() error {
+	return render(r.assetsInDir, r.assetsOutDir)
+}

--- a/pkg/performanceprofile/cmd/render/manifests.go
+++ b/pkg/performanceprofile/cmd/render/manifests.go
@@ -1,0 +1,95 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type manifest struct {
+	Raw []byte
+}
+
+// UnmarshalJSON unmarshals bytes of single kubernetes object to manifest.
+func (m *manifest) UnmarshalJSON(in []byte) error {
+	if m == nil {
+		return errors.New("manifest: UnmarshalJSON on nil pointer")
+	}
+
+	// This happens when marshalling
+	// <yaml>
+	// ---	(this between two `---`)
+	// ---
+	// <yaml>
+	if bytes.Equal(in, []byte("null")) {
+		m.Raw = nil
+		return nil
+	}
+
+	m.Raw = append(m.Raw[0:0], in...)
+	return nil
+}
+
+// parseManifests parses a YAML or JSON document that may contain one or more
+// kubernetes resources.
+func parseManifests(filename string, r io.Reader) ([]manifest, error) {
+	d := yamlutil.NewYAMLOrJSONDecoder(r, 1024)
+	var manifests []manifest
+	for {
+		m := manifest{}
+		if err := d.Decode(&m); err != nil {
+			if err == io.EOF {
+				return manifests, nil
+			}
+			return manifests, fmt.Errorf("error parsing %q: %w", filename, err)
+		}
+		m.Raw = bytes.TrimSpace(m.Raw)
+		if len(m.Raw) == 0 || bytes.Equal(m.Raw, []byte("null")) {
+			continue
+		}
+		manifests = append(manifests, m)
+	}
+}
+
+func listFiles(dirPaths string) ([]string, error) {
+	dirs := strings.Split(dirPaths, ",")
+	results := []string{}
+	for _, dir := range dirs {
+		err := filepath.WalkDir(dir,
+			func(path string, info os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil
+				}
+				results = append(results, path)
+				return nil
+			})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}

--- a/pkg/performanceprofile/controller/performanceprofile/components/runtimeclass/runtimeclass.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/runtimeclass/runtimeclass.go
@@ -14,7 +14,7 @@ func New(profile *performancev2.PerformanceProfile, handler string) *nodev1.Runt
 	return &nodev1.RuntimeClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RuntimeClass",
-			APIVersion: "node.k8s.io/v1beta1",
+			APIVersion: "node.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,

--- a/test/e2e/performanceprofile/functests-render-command/1_render_command/render_suite_test.go
+++ b/test/e2e/performanceprofile/functests-render-command/1_render_command/render_suite_test.go
@@ -18,6 +18,10 @@ var (
 	testDir      string
 	workspaceDir string
 	binPath      string
+
+	ignorePathTestCase = []string{
+		`root["metadata"].(map[string]interface {})["ownerReferences"].([]interface {})[0].(map[string]interface {})["uid"]`,
+	}
 )
 
 func TestRenderCmd(t *testing.T) {
@@ -54,6 +58,12 @@ func getFilesDiff(wantFile, gotFile []byte) (string, error) {
 	if err := yaml.Unmarshal(gotFile, &gotObj); err != nil {
 		return "", fmt.Errorf("failed to unmarshal data for 'got':%s", err)
 	}
-
-	return cmp.Diff(wantObj, gotObj), nil
+	return cmp.Diff(wantObj, gotObj, cmp.FilterPath(func(p cmp.Path) bool {
+		for _, value := range ignorePathTestCase {
+			if p.GoString() == value {
+				return true
+			}
+		}
+		return false
+	}, cmp.Ignore())), nil
 }

--- a/test/e2e/performanceprofile/functests-render-command/1_render_command/render_test.go
+++ b/test/e2e/performanceprofile/functests-render-command/1_render_command/render_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,8 +14,8 @@ import (
 
 var (
 	assetsOutDir string
-	assetsInDir  string
-	ppInFiles    string
+	assetsInDirs []string
+	ppDir        string
 	testDataPath string
 )
 
@@ -22,9 +23,10 @@ var _ = Describe("render command e2e test", func() {
 
 	BeforeEach(func() {
 		assetsOutDir = createTempAssetsDir()
-		assetsInDir = filepath.Join(workspaceDir, "build", "assets")
-		ppInFiles = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "manual-cluster", "performance", "performance_profile.yaml")
+		assetsInDir := filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "base", "performance")
+		ppDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "manual-cluster", "performance")
 		testDataPath = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "testdata")
+		assetsInDirs = []string{assetsInDir, ppDir}
 	})
 
 	Context("With a single performance-profile", func() {
@@ -33,8 +35,7 @@ var _ = Describe("render command e2e test", func() {
 			cmdline := []string{
 				filepath.Join(binPath, "cluster-node-tuning-operator"),
 				"render",
-				"--performance-profile-input-files", ppInFiles,
-				"--asset-input-dir", assetsInDir,
+				"--asset-input-dir", strings.Join(assetsInDirs, ","),
 				"--asset-output-dir", assetsOutDir,
 			}
 			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
@@ -53,8 +54,7 @@ var _ = Describe("render command e2e test", func() {
 
 			cmd := exec.Command(cmdline[0], cmdline[1:]...)
 			cmd.Env = append(cmd.Env,
-				fmt.Sprintf("PERFORMANCE_PROFILE_INPUT_FILES=%s", ppInFiles),
-				fmt.Sprintf("ASSET_INPUT_DIR=%s", assetsInDir),
+				fmt.Sprintf("ASSET_INPUT_DIR=%s", strings.Join(assetsInDirs, ",")),
 				fmt.Sprintf("ASSET_OUTPUT_DIR=%s", assetsOutDir),
 			)
 			runAndCompare(cmd)

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   name: performance-manual
   ownerReferences:
-  - apiVersion: ""
+  - apiVersion: "performance.openshift.io/v2"
     kind: PerformanceProfile
     name: manual
     uid: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
@@ -6,7 +6,7 @@ metadata:
     machineconfiguration.openshift.io/role: worker-cnf
   name: 50-performance-manual
   ownerReferences:
-  - apiVersion: ""
+  - apiVersion: "performance.openshift.io/v2"
     kind: PerformanceProfile
     name: manual
     uid: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_runtimeclass.yaml
@@ -1,11 +1,11 @@
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 handler: high-performance
 kind: RuntimeClass
 metadata:
   creationTimestamp: null
   name: performance-manual
   ownerReferences:
-  - apiVersion: ""
+  - apiVersion: "performance.openshift.io/v2"
     kind: PerformanceProfile
     name: manual
     uid: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-node-performance-manual
   namespace: openshift-cluster-node-tuning-operator
   ownerReferences:
-  - apiVersion: ""
+  - apiVersion: "performance.openshift.io/v2"
     kind: PerformanceProfile
     name: manual
     uid: ""


### PR DESCRIPTION
This PR updates our render command to be more inline with a more flexible approach during the bootstrapping process.

Typically operators that need to generate files during bootstrapping might need some initial cluster state information in order to correctly render the resource files, some have static information that is retrieved and others more dynamic. In this approach we take the pattern used by MCO where the manifest directory is inspected and the relevant files are read in and parsed to render out the resulting configurations. ([see](https://github.com/openshift/machine-config-operator/blob/bff62e7ea81a3180860b28068fd33a7209475f14/pkg/controller/bootstrap/bootstrap.go#L52-L232))

This affords us some niceties like not being over prescriptive with file names for performance profile manifests that are supplied during bootstrap, as well as the ability to get the bootstrap cluster state and inform our rendering of the configuration files. 

Signed-off-by: ehila <ehila@redhat.com>