### PR TITLE
performance-profile: render: make target for render sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,3 +219,7 @@ build-performance-profile-creator:
 performance-profile-creator-tests: build-performance-profile-creator
 	@echo "Running Performance Profile Creator Tests"
 	hack/run-perf-profile-creator-functests.sh
+
+.PHONY: render-sync
+render-sync: build
+	hack/render-sync.sh

--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+WORKDIR=$(dirname "$(realpath "$0")")/..
+ARTIFACT_DIR=$(mktemp -d)
+
+cd "${WORKDIR}" || { echo "failed to change dir to ${WORKDIR}"; exit; }
+_output/cluster-node-tuning-operator render \
+--performance-profile-input-files "${WORKDIR}"/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance/performance_profile.yaml \
+--asset-input-dir "${WORKDIR}"/build/assets \
+--asset-output-dir "${ARTIFACT_DIR}"
+
+cp -r "${ARTIFACT_DIR}"/*  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output/
+rm -r "${ARTIFACT_DIR}"


### PR DESCRIPTION
For every change in PAO's assets, we should render the manifests and copy the data into `/test/e2e/performanceprofile/testdata/render-expected-output/`

This patch adds a make target to automate the process. For now, the make target itself should be called manually. If it proves itself useful, we can add it as a dependency of other targets.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>