### PR TITLE
[release-4.11] [manual] OCPBUGS-5020: pao: latency-tests: read test log directly from pod

### DIFF
--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -96,7 +96,7 @@ var _ = table.DescribeTable("Test latency measurement tools tests", func(testGro
 		clearEnv()
 		testDescription := setEnvAndGetDescription(test)
 		By(testDescription)
-		output, err := exec.Command(testExecutablePath, "-ginkgo.focus", test.toolToTest).Output()
+		output, err := exec.Command(testExecutablePath, "-ginkgo.v", "-ginkgo.focus", test.toolToTest).Output()
 		if err != nil {
 			//we don't log Error level here because the test might be a negative check
 			testlog.Info(err.Error())


### PR DESCRIPTION
Instead of having the neccessaty to copy all the tests\` output into a log file and then read everything from the log, we can skip this extra step and read the log directly from the pod. The latency test tools, i.e. oslat/cyclictest/hwlatdetect, redirect their output to stdout/stderr anyway, so by reading pod\'s log we get tools\` output.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>