### PR TITLE
OCPBUGS-5528: Run node selector tests only if we have 2 non Performance worker nodes

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -469,7 +469,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 
 			nonPerformancesWorkers, err := nodes.GetNonPerformancesWorkers(profile.Spec.NodeSelector)
 			Expect(err).ToNot(HaveOccurred())
-			if len(nonPerformancesWorkers) != 0 {
+			// we need atleast 2 non performance worker nodes to satisfy pod distribution budget
+			if len(nonPerformancesWorkers) > 1 {
 				newCnfNode = &nonPerformancesWorkers[0]
 			}
 			if newCnfNode == nil {


### PR DESCRIPTION
This is required because if we have only 1 non performance worker node and 1 performance worker node. As per the test when we re label one of the node to worker-test with mcp worker-test. The nodes will get stuck as there will no free worker nodes avaialable to satisfy pod distribution budget and mco will fail to evict the pods

Signed-off-by: Niranjan M.R <mrniranjan@redhat.com>