### PR TITLE
e2e:latency: count LATENCY_TEST_DELAY in timeout

### DIFF
--- a/test/e2e/performanceprofile/functests/4_latency/latency.go
+++ b/test/e2e/performanceprofile/functests/4_latency/latency.go
@@ -471,7 +471,7 @@ func createLatencyTestPod(testPod *corev1.Pod) {
 	}
 
 	By("Waiting another two minutes to give enough time for the cluster to move the pod to Succeeded phase")
-	podTimeout := time.Duration(timeout + 120)
+	podTimeout := time.Duration(timeout + latencyTestDelay + 120)
 	err = pods.WaitForPhase(testPod, corev1.PodSucceeded, podTimeout*time.Second)
 	if err != nil {
 		logEventsForPod(testPod)


### PR DESCRIPTION
While waiting for latency test pod to transition to `Succeeded` phase, we are not taking into account
the `LATENCY_TEST_DELAY` value when calculating
the timeout.

if `LATENCY_TEST_DELAY` > 120 then we might failed the test although it's still running.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>