### PR TITLE
OCPBUGS-5529: Skip offline multiple ranges test if number of cores less than 20

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -1018,7 +1018,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 			}
 			isolatedCpus := strings.Join(isolated, ",")
-
 			// Create new performance with offlined
 			reservedSet := performancev2.CPUSet(reservedCpus)
 			isolatedSet := performancev2.CPUSet(isolatedCpus)
@@ -1052,7 +1051,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				Expect(offlinedCPUSet.Equals(offlinedCPUSetProfile))
 			}
 		})
-
 		It("[test_id:50966]verify offlined parameter accepts multiple ranges of cpuid's", func() {
 			var reserved, isolated, offlined []string
 			//This map is of the form numaNode[core][cpu-siblings]
@@ -1093,9 +1091,11 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 					cores = append(cores, k)
 				}
 				sort.Ints(cores)
-				middleCoreIds := cores[len(cores)/2]
-				for i := middleCoreIds; i < middleCoreIds+10; i++ {
-					siblings := nodes.GetCpuSiblings(numaCoreSiblings, i)
+				if len(cores) < 20 {
+					Skip(fmt.Sprintf("This test needs systems with at least 20 cores per socket"))
+				}
+				for i := 0; i < len(cores)/2; i++ {
+					siblings := nodes.GetCpuSiblings(numaCoreSiblings, cores[i])
 					offlined = append(offlined, siblings...)
 				}
 			}

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -439,7 +439,7 @@ func GetCpuSiblings(numaCoreSiblings map[int]map[int][]int, coreKey int) []strin
 	for key := range numaCoreSiblings {
 		for _, c := range numaCoreSiblings[key][coreKey] {
 			cpuSiblings = append(cpuSiblings, strconv.Itoa(c))
-			delete(numaCoreSiblings[key], c)
+			delete(numaCoreSiblings[key], coreKey)
 		}
 	}
 	return cpuSiblings


### PR DESCRIPTION
Minor fix to GetCpuSiblings function to use core as key instead of cpu siblings

Signed-off-by: Niranjan M.R <mrniranjan@redhat.com>