### PR TITLE
render: initialize klog flag

### DIFF
--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -5,9 +5,8 @@ ARTIFACT_DIR=$(mktemp -d)
 
 cd "${WORKDIR}" || { echo "failed to change dir to ${WORKDIR}"; exit; }
 _output/cluster-node-tuning-operator render \
---performance-profile-input-files "${WORKDIR}"/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance/performance_profile.yaml \
---asset-input-dir "${WORKDIR}"/build/assets \
+--asset-input-dir "${WORKDIR}"/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance,"${WORKDIR}"/test/e2e/performanceprofile/cluster-setup/base/performance \
 --asset-output-dir "${ARTIFACT_DIR}"
 
-cp -r "${ARTIFACT_DIR}"/*  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output/
+cp "${ARTIFACT_DIR}"/*  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output
 rm -r "${ARTIFACT_DIR}"

--- a/pkg/performanceprofile/cmd/render/cmd.go
+++ b/pkg/performanceprofile/cmd/render/cmd.go
@@ -16,6 +16,7 @@ limitations under the License.
 package render
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -54,8 +55,8 @@ func NewRenderCommand() *cobra.Command {
 		},
 	}
 
+	addKlogFlags(cmd)
 	renderOpts.AddFlags(cmd.Flags())
-
 	return cmd
 }
 
@@ -86,4 +87,10 @@ func (r *renderOpts) Validate() error {
 
 func (r *renderOpts) Run() error {
 	return render(r.assetsInDir, r.assetsOutDir)
+}
+
+func addKlogFlags(cmd *cobra.Command) {
+	fs := flag.NewFlagSet("", flag.PanicOnError)
+	klog.InitFlags(fs)
+	cmd.Flags().AddGoFlagSet(fs)
 }

--- a/pkg/performanceprofile/cmd/render/render.go
+++ b/pkg/performanceprofile/cmd/render/render.go
@@ -66,6 +66,7 @@ func render(inputDir, outputDir string) error {
 
 	// Read asset directory fileInfo
 	filePaths, err := listFiles(inputDir)
+	klog.V(4).Infof("listed files: %v", filePaths)
 	if err != nil {
 		return err
 	}
@@ -115,6 +116,9 @@ func render(inputDir, outputDir string) error {
 		}
 	}
 
+	if len(perfProfiles) == 0 {
+		klog.Warning("zero performance profiles were found")
+	}
 	for _, pp := range perfProfiles {
 		mcp, err := selectMachineConfigPool(pools, pp.Spec.NodeSelector)
 		if err != nil {


### PR DESCRIPTION
klog flags are not initiated for the render command, so
passing klog arguments like `--v` would be ignored

In addition, added a few logs for debugging purposes.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>