### PR TITLE
Skip PPC nodeSelector flaky test

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -439,6 +439,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 
 		//fetch existing MCP Selector if exists in profile
 		BeforeEach(func() {
+
+			Skip("TODO. Test if failing due timeout, it should be refactor")
+
 			//fetch existing MCP Selector if exists in profile
 			if profile.Spec.MachineConfigPoolSelector != nil {
 				oldMcpSelector = profile.Spec.DeepCopy().MachineConfigPoolSelector
@@ -558,6 +561,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 
 		AfterEach(func() {
+
+			Skip("TODO. Test if failing due timeout, it should be refactor")
+
 			if labelsDeletion == false {
 				err = removeLabels(profile.Spec.NodeSelector, newCnfNode)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Skip tests as in https://github.com/openshift/cluster-node-tuning-operator/pull/517 to compare execution ginkgo v1 vs ginkgo v2. Check fails and time that every lane takes and infra issues.

Add TODO to refactor them. These two tests takes a lot of time (around 40min) and fails because timeout of the suite many times.


Signed-off-by: Mario Fernandez <mariofer@redhat.com>