### PR TITLE
Handle different # of CPUs are in the same MCP

### DIFF
--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -22,6 +22,15 @@ const (
 	// Annotation on Profiles to denote the operand version responsible for calculating and reporting
 	// the Profile status.
 	GeneratedByOperandVersionAnnotationKey string = "tuned.openshift.io/generated-by-operand-version"
+
+	// Tuned 'TunedRenderedResourceName' CR's .metadata.generation.  This annotation is used on resources
+	// to note the Tuned 'TunedRenderedResourceName' generation based on which the resources with this
+	// annotation were created/updated.
+	RendredTunedGenerationAnnotationKey string = "tuned.openshift.io/rendered-tuned-generation"
+
+	// The value of this annotation is the TuneD profile based on which the resource with this annotation was
+	// created/updated.
+	TunedProfileAnnotationKey string = "tuned.openshift.io/tuned-profile"
 )
 
 /////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Generally, nodes with different topologies are discouraged to be used in
the same MachineConfigPool (MCP).  Consider two nodes with different CPU
count.  If they belong to the same MCP, they will share the same
NTO-generated MachineConfig (MC).  It is then entirely possible for the
operator's node agent together with TuneD to return different CPU
parameters (e.g. systemd.cpu_affinity) in the kernel command line for
each of these nodes.  This will result in a race to update NTO-generated
MC and ensuing boot loops.

This change adds annotations to NTO-generated MCs to keep track of the
configuration based on which they were generated.  Updates to these MCs 
are only accepted if they come from a different input (Tuned CR)
configuration.

See: https://issues.redhat.com/browse/PSAP-993

Suggested basic pre-merge testing.  Test on a cluster with 2 worker nodes, one with 4 CPUs, the other one with 2 CPUs.

Create the following Tuned CR:

```
apiVersion: tuned.openshift.io/v1
kind: Tuned
metadata:
  name: openshift-bootcmdline-cpu
  namespace: openshift-cluster-node-tuning-operator
spec:
  profile:
  - data: |
      [main]
      summary=Custom OpenShift profile
      [bootloader]
      cmdline=+cpus=${f:exec:/usr/bin/bash:-c:nproc|tr -d '\n'}
    name: openshift-bootcmdline-cpu

  recommend:
  - machineConfigLabels:
      machineconfiguration.openshift.io/role: "worker"
    priority: 20
    profile: openshift-bootcmdline-cpu
```

In the operator logs, you should see something like:

```
W0223 10:53:21.903929       1 controller.go:832] refusing to update MachineConfig for XYZ-HOST due to kernel arguments change with unchanged input configuration (1/openshift-bootcmdline-cpu). Node(s) with different (CPU) topology in the same MCP?
```

And the `oc get co/node-tuning` should output:

```
NAME          VERSION               AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
node-tuning   0.0.1-snapshot-4.13   True        False         True       5m2s    1/3 Profiles with bootcmdline conflict
```

More testing might include overriding the profiles and/or removing the nodes from the worker MCP and seeing the kernel command-line parameters are set correctly and `co/node-tuning` adjusted approriately.