### PR TITLE
OCPBUGS-5529: Fix updating numa core siblings map in GetCpuSiblings function

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -1442,7 +1442,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				// Select the last core id
 				higherCoreIds := cores[len(cores)-1]
 				// Get cpu siblings from the selected cores and delete the selected cores  from the map
-				cpusiblings := nodes.GetCpuSiblings(numaCoreSiblings, higherCoreIds)
+				cpusiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, higherCoreIds)
 				offline = append(offline, cpusiblings...)
 			}
 			offlineCpus := strings.Join(offline, ",")
@@ -1450,7 +1450,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				cpusiblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				cpusiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, cpusiblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
@@ -1458,7 +1458,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			// numaCoreSiblings map is used in isolatedCpus
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					cpusiblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					cpusiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, cpusiblings...)
 				}
 			}
@@ -1512,14 +1512,14 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 				sort.Ints(cores)
 				middleCoreIds := cores[len(cores)/2]
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, middleCoreIds)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, middleCoreIds)
 				offline = append(offline, siblings...)
 			}
 			offlineCpus := strings.Join(offline, ",")
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, siblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
@@ -1527,7 +1527,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			// numaCoreSiblings map is used in isolatedCpus
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					siblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, siblings...)
 				}
 			}
@@ -1587,7 +1587,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, siblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
@@ -1600,7 +1600,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 				sort.Ints(cores)
 				for i := 0; i < len(cores)/2; i++ {
-					siblings := nodes.GetCpuSiblings(numaCoreSiblings, cores[i])
+					siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, cores[i])
 					offlined = append(offlined, siblings...)
 				}
 			}
@@ -1609,7 +1609,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			// map is used in isolatedCpus
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					siblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, siblings...)
 				}
 			}
@@ -1666,7 +1666,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, siblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
@@ -1674,7 +1674,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			// numaCoreSiblings map is used in isolatedCpus
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					siblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, siblings...)
 				}
 			}
@@ -1729,20 +1729,20 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, siblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
 
 			discreteCores := []int{3, 13, 15, 24, 29}
 			for _, v := range discreteCores {
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, v)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, v)
 				offlined = append(offlined, siblings...)
 			}
 			offlineCpus := strings.Join(offlined, ",")
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					cpusiblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					cpusiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, cpusiblings...)
 				}
 			}
@@ -1890,13 +1890,13 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				sort.Ints(coreids)
 				Expect(len(coreids)).ToNot(Equal(0))
 				middleCoreIds := coreids[len(coreids)/2]
-				coresiblings := nodes.GetCpuSiblings(numaCoreSiblings, middleCoreIds)
+				coresiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, middleCoreIds)
 				reserved = append(reserved, coresiblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
 			for numaNode := range numaCoreSiblings {
 				for coreids := range numaCoreSiblings[numaNode] {
-					coresiblings := nodes.GetCpuSiblings(numaCoreSiblings, coreids)
+					coresiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, coreids)
 					isolated = append(isolated, coresiblings...)
 				}
 			}

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -1580,6 +1580,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for _, node := range workerRTNodes {
 				numaCoreSiblings, err = nodes.GetCoreSiblings(&node)
 			}
+			if len(numaCoreSiblings[0]) < 20 {
+				Skip(fmt.Sprintf("This test needs systems with at least 20 cores per socket"))
+			}
 			// Get reserved core siblings from 0, 1
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
@@ -1596,9 +1599,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 					cores = append(cores, k)
 				}
 				sort.Ints(cores)
-				if len(cores) < 20 {
-					Skip(fmt.Sprintf("This test needs systems with at least 20 cores per socket"))
-				}
 				for i := 0; i < len(cores)/2; i++ {
 					siblings := nodes.GetCpuSiblings(numaCoreSiblings, cores[i])
 					offlined = append(offlined, siblings...)

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -441,21 +441,21 @@ func GetByCpuCapacity(nodesList []corev1.Node, cpuQty int) []corev1.Node {
 	return nodesWithSufficientCpu
 }
 
-// GetCpuSiblings function returns the cpus siblings associated with core
+// GetAndRemoveCpuSiblingsFromMap function returns the cpus siblings associated with core
 // Also updates the map by deleting the cpu siblings returned
-func GetCpuSiblings(numaCoreSiblings map[int]map[int][]int, coreKey int) []string {
+func GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings map[int]map[int][]int, coreId int) []string {
 	var cpuSiblings []string
-	// key here is Numa node id
-	for key := range numaCoreSiblings {
-		_, ok := numaCoreSiblings[key][coreKey]
-		// if coreId exists
+	// Iterate over the  Numa node in the map
+	for node := range numaCoreSiblings {
+		// Check if the coreId exists in the Numa node
+		_, ok := numaCoreSiblings[node][coreId]
 		if ok {
-			for _, sibling := range numaCoreSiblings[key][coreKey] {
+			// Iterate over the siblings of the coreId
+			for _, sibling := range numaCoreSiblings[node][coreId] {
 				cpuSiblings = append(cpuSiblings, strconv.Itoa(sibling))
 			}
 			// Delete the cpusiblings of that particular coreid
-			// map is now updated with used cores
-			delete(numaCoreSiblings[key], coreKey)
+			delete(numaCoreSiblings[node], coreId)
 		}
 	}
 	return cpuSiblings

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -445,14 +445,19 @@ func GetByCpuCapacity(nodesList []corev1.Node, cpuQty int) []corev1.Node {
 // Also updates the map by deleting the cpu siblings returned
 func GetCpuSiblings(numaCoreSiblings map[int]map[int][]int, coreKey int) []string {
 	var cpuSiblings []string
-	var numanode int
+	// key here is Numa node id
 	for key := range numaCoreSiblings {
-		for _, sibling := range numaCoreSiblings[key][coreKey] {
-			cpuSiblings = append(cpuSiblings, strconv.Itoa(sibling))
-			numanode = key
+		_, ok := numaCoreSiblings[key][coreKey]
+		// if coreId exists
+		if ok {
+			for _, sibling := range numaCoreSiblings[key][coreKey] {
+				cpuSiblings = append(cpuSiblings, strconv.Itoa(sibling))
+			}
+			// Delete the cpusiblings of that particular coreid
+			// map is now updated with used cores
+			delete(numaCoreSiblings[key], coreKey)
 		}
 	}
-	delete(numaCoreSiblings[numanode], coreKey)
 	return cpuSiblings
 }
 

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -445,12 +445,14 @@ func GetByCpuCapacity(nodesList []corev1.Node, cpuQty int) []corev1.Node {
 // Also updates the map by deleting the cpu siblings returned
 func GetCpuSiblings(numaCoreSiblings map[int]map[int][]int, coreKey int) []string {
 	var cpuSiblings []string
+	var numanode int
 	for key := range numaCoreSiblings {
-		for _, c := range numaCoreSiblings[key][coreKey] {
-			cpuSiblings = append(cpuSiblings, strconv.Itoa(c))
-			delete(numaCoreSiblings[key], coreKey)
+		for _, sibling := range numaCoreSiblings[key][coreKey] {
+			cpuSiblings = append(cpuSiblings, strconv.Itoa(sibling))
+			numanode = key
 		}
 	}
+	delete(numaCoreSiblings[numanode], coreKey)
 	return cpuSiblings
 }
 


### PR DESCRIPTION
move the delete operation outside of for loop.
Also minor fixes to offline tests to check if the worker node has 20 cores earlier in the test function

Signed-off-by: Niranjan M.R <mrniranjan@redhat.com>