### PR TITLE
Report host-level sysctls in conflict with TuneD ones

### DIFF
--- a/pkg/tuned/status.go
+++ b/pkg/tuned/status.go
@@ -114,14 +114,18 @@ func computeStatusConditions(status Bits, stderr string, conditions []tunedv1.Pr
 		tunedDegradedCondition.Status = corev1.ConditionTrue
 		tunedDegradedCondition.Reason = "TunedError"
 		tunedDegradedCondition.Message = "TuneD daemon issued one or more error message(s) during profile application. TuneD stderr: " + stderr
-	} else if (status & scWarn) != 0 {
-		tunedDegradedCondition.Status = corev1.ConditionFalse // consider warnings from TuneD as non-fatal
-		tunedDegradedCondition.Reason = "TunedWarning"
-		tunedDegradedCondition.Message = "No error messages observed by applying the TuneD daemon profile, only warning(s). TuneD stderr: " + stderr
+	} else if (status & scSysctlOverride) != 0 {
+		tunedDegradedCondition.Status = corev1.ConditionTrue // treat overrides as regular errors; users should use "reapply_sysctl: true" or remove conflicting sysctls
+		tunedDegradedCondition.Reason = "TunedSysctlOverride"
+		tunedDegradedCondition.Message = "TuneD daemon issued one or more sysctl override message(s) during profile application. Use reapply_sysctl=true or remove conflicting sysctl " + stderr
 	} else if (status & scTimeout) != 0 {
 		tunedDegradedCondition.Status = corev1.ConditionTrue
 		tunedDegradedCondition.Reason = "TimeoutWaitingForProfileApplied"
 		tunedDegradedCondition.Message = "Timeout waiting for profile to be applied"
+	} else if (status & scWarn) != 0 {
+		tunedDegradedCondition.Status = corev1.ConditionFalse // consider warnings from TuneD as non-fatal
+		tunedDegradedCondition.Reason = "TunedWarning"
+		tunedDegradedCondition.Message = "No error messages observed by applying the TuneD daemon profile, only warning(s). TuneD stderr: " + stderr
 	} else {
 		tunedDegradedCondition.Status = corev1.ConditionFalse
 		tunedDegradedCondition.Reason = "AsExpected"


### PR DESCRIPTION
Kernel parameters can be changed at runtime via various configuration files in `/run/sysctl.d/*.conf`, `/etc/sysctl.d/*.conf` and `/etc/sysctl.conf`

By default, NTO's node agents do not override these settings.  This matches the default TuneD behaviour `reapply_sysctl=1` in `tuned-main.conf`.

While NTO can be configured to set `reapply_sysctl=0` in `tuned-main.conf` to let TuneD manage all sysctls and override the host-level configuration files, many users do not know about this functionality.

This PR makes this potential issue more visible to users by reporting it issue via making the Profile Degraged with a status message set.

Also see:
* https://github.com/redhat-performance/tuned/pull/492
* https://github.com/redhat-performance/tuned/pull/501
