### PR TITLE
OCPBUGS-7384: Remove optimization to allow full resync

### DIFF
--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -966,16 +966,6 @@ func (c *Controller) informerEventHandler(workqueueKey wqKey) cache.ResourceEven
 				klog.Errorf("unable to get accessor for new object: %s", err)
 				return
 			}
-			oldAccessor, err := kmeta.Accessor(o)
-			if err != nil {
-				klog.Errorf("unable to get accessor for old object: %s", err)
-				return
-			}
-			if newAccessor.GetResourceVersion() == oldAccessor.GetResourceVersion() {
-				// Periodic resync will send update events for all known resources.
-				// Two different versions of the same resource will always have different RVs.
-				return
-			}
 			klog.V(2).Infof("add event to workqueue due to %s (update)", util.ObjectInfo(n))
 			c.wqKube.Add(wqKey{kind: workqueueKey.kind, name: newAccessor.GetName()})
 		},


### PR DESCRIPTION
There are edge cases (e.g. OCPBUGS-7384), where full resync seems to be necessary.  Remove an optimization to skip Tuned and Profile resync for NTO operands when the old and new Accessor are the same.  This will add on average 4% more CPU cycles, but should ensure more reliable operation.
