### PR TITLE
OCPBUGS-7745: Remove trailing spaces from test names

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/utils_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/utils_test.go
@@ -32,7 +32,7 @@ func intersectHelper(cpuListA, cpuListB string) ([]int, error) {
 
 var _ = Describe("Components utils", func() {
 	Context("Convert CPU list to CPU mask", func() {
-		It("should generate a valid CPU mask from CPU list ", func() {
+		It("should generate a valid CPU mask from CPU list", func() {
 			for _, cpuEntry := range cpuListToMask {
 				cpuMask, err := CPUListToMaskList(cpuEntry.cpuList)
 				Expect(err).ToNot(HaveOccurred())
@@ -42,7 +42,7 @@ var _ = Describe("Components utils", func() {
 	})
 
 	Context("Convert CPU mask to CPU list", func() {
-		It("should generate a valid CPU list from CPU mask ", func() {
+		It("should generate a valid CPU list from CPU mask", func() {
 			for _, cpuEntry := range cpuListToMask {
 				cpuSetFromList, err := cpuset.Parse(cpuEntry.cpuList)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/performanceprofile/profilecreator/profilecreator_test.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator_test.go
@@ -1299,7 +1299,7 @@ var _ = Describe("PerformanceProfileCreator: Test Helper Functions getCPUsSplitA
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isolatedCPUSet.String()).To(Equal("10-39,50-79"))
 		})
-		It("Ensure reserved and isolated CPUs populated are correctly by getCPUsSplitAcrossNUMAwhen when splitReservedCPUsAcrossNUMA is enabled and htEnabled is disabled ", func() {
+		It("Ensure reserved and isolated CPUs populated are correctly by getCPUsSplitAcrossNUMAwhen when splitReservedCPUsAcrossNUMA is enabled and htEnabled is disabled", func() {
 			reservedCPUCount = 20 // random number, no special meaning
 			offlinedCPUs := cpuset.CPUSet{}
 			htEnabled = false

--- a/test/e2e/performanceprofile/functests/1_performance/netqueues.go
+++ b/test/e2e/performanceprofile/functests/1_performance/netqueues.go
@@ -91,7 +91,7 @@ var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", Ordered, func() 
 	})
 
 	Context("Updating performance profile for netqueues", func() {
-		It("[test_id:40308][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Network device queues Should be set to the profile's reserved CPUs count ", func() {
+		It("[test_id:40308][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Network device queues Should be set to the profile's reserved CPUs count", func() {
 			nodesDevices := make(map[string]map[string]int)
 			if profile.Spec.Net != nil {
 				if profile.Spec.Net.UserLevelNetworking != nil && *profile.Spec.Net.UserLevelNetworking && len(profile.Spec.Net.Devices) == 0 {


### PR DESCRIPTION
Remove trailing spaces from all tests which have them.