### PR TITLE
kubectl explain to explicitly state workloadHint default values

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -39,7 +39,7 @@ that require a cluster to properly test your code.
 In those situations, you will need to:
 
 1) build the NTO image you're interested in testing
-2) TODO
+2) Push the image to an OpenShift cluster
 
 ## Build NTO image
 
@@ -67,4 +67,40 @@ ORG=username
 TAG=tag
 
 make local-image-push IMAGE=${REGISTRY}/${ORG}/cluster-node-tuning-operator:${TAG}
+```
+
+## Push the image to an OpenShift cluster
+
+```
+override_tuning_operator ()
+{
+  oc patch clusterversion version --type json -p '[{"op":"add","path":"/spec/overrides","value":[{"kind":"Deployment","group":"apps","name":"cluster-node-tuning-operator","namespace":"openshift-cluster-node-tuning-operator","unmanaged":true}]}]'
+}
+
+custom_tuning_operator ()
+{
+  TUNING_IMAGE=${REGISTRY}/${ORG}/cluster-node-tuning-operator:${TAG}
+  override_tuning_operator
+  oc scale deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator --replicas=0
+  oc patch deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator -p \
+    '{"spec":{"template":{"spec":{"containers":[{"name":"cluster-node-tuning-operator","image":"'${TUNING_IMAGE}'"}]}}}}'
+  oc patch deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator -p \
+    '{"spec":{"template":{"spec":{"containers":[{"name":"cluster-node-tuning-operator","env":[{"name":"CLUSTER_NODE_TUNED_IMAGE","value":"'${TUNING_IMAGE}'"}]}]}}}}'
+  oc describe  deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator | grep --color=auto Image
+  oc describe  deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator | grep --color=auto CLUSTER_NODE_TUNED_IMAGE
+  oc delete ds -n openshift-cluster-node-tuning-operator tuned
+  oc scale deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator --replicas=1
+  sleep 10
+  oc wait deployment -n openshift-cluster-node-tuning-operator cluster-node-tuning-operator --for condition=Available=True --timeout=90s
+  for i in {1..36}; do
+    echo "Waiting for DS to be deployed, try $i"
+    sleep 10
+    if oc get ds -n openshift-cluster-node-tuning-operator tuned 2>/dev/null; then
+      break
+    fi
+  done
+  oc rollout status daemonset -n openshift-cluster-node-tuning-operator tuned --timeout=90s
+  oc get deployment -n openshift-cluster-node-tuning-operator
+  oc get ds -n openshift-cluster-node-tuning-operator
+}
 ```

--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -468,13 +468,13 @@ spec:
                   type: object
                   properties:
                     highPowerConsumption:
-                      description: HighPowerConsumption defines if the node should be configured in high power consumption mode. The flag will affect the power consumption but will improve the CPUs latency.
+                      description: HighPowerConsumption defines if the node should be configured in high power consumption mode. The flag will affect the power consumption but will improve the CPUs latency. Defaults to false.
                       type: boolean
                     perPodPowerManagement:
-                      description: PerPodPowerManagement defines if the node should be configured in per pod power management. PerPodPowerManagement and HighPowerConsumption hints can not be enabled together.
+                      description: PerPodPowerManagement defines if the node should be configured in per pod power management. PerPodPowerManagement and HighPowerConsumption hints can not be enabled together. Defaults to false.
                       type: boolean
                     realTime:
-                      description: RealTime defines if the node should be configured for the real time workload.
+                      description: RealTime defines if the node should be configured for the real time workload. Defaults to true.
                       type: boolean
             status:
               description: PerformanceProfileStatus defines the observed state of PerformanceProfile.

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -176,16 +176,16 @@ type RealTimeKernel struct {
 // WorkloadHints defines the set of upper level flags for different type of workloads.
 type WorkloadHints struct {
 	// HighPowerConsumption defines if the node should be configured in high power consumption mode.
-	// The flag will affect the power consumption but will improve the CPUs latency.
+	// The flag will affect the power consumption but will improve the CPUs latency. Defaults to false.
 	// +optional
 	HighPowerConsumption *bool `json:"highPowerConsumption,omitempty"`
-	// RealTime defines if the node should be configured for the real time workload.
+	// RealTime defines if the node should be configured for the real time workload. Defaults to true.
 	// +default=true
 	// +optional
 	RealTime *bool `json:"realTime,omitempty"`
 	// +optional
 	// PerPodPowerManagement defines if the node should be configured in per pod power management.
-	// PerPodPowerManagement and HighPowerConsumption hints can not be enabled together.
+	// PerPodPowerManagement and HighPowerConsumption hints can not be enabled together. Defaults to false.
 	PerPodPowerManagement *bool `json:"perPodPowerManagement,omitempty"`
 }
 


### PR DESCRIPTION
kubectl explain to explicitly state worloadHint default values

Even though default values are set for the API, when kubebuilder builds
the CRDs it does not give end users a hint about the default values of
the fields. Improve the field comments to mention the default field
values. This way, admins who run oc explain can clearly see that the
realTime field has a different default value than the other 2 fields.

-----------------------

 Hacking instructions: Deploy custom tuning operator image on OpenShift

Add instructions to deploy the custom tuning operator image on
OpenShift.

-----------------------

With the change:
~~~
[akaris@linux perf-profile-creator]$ oc explain performanceprofile.spec.workloadHints 
KIND:     PerformanceProfile
VERSION:  performance.openshift.io/v2

RESOURCE: workloadHints <Object>

DESCRIPTION:
     WorkloadHints defines hints for different types of workloads. It will allow
     defining exact set of tuned and kernel arguments that should be applied on
     top of the node.

FIELDS:
   highPowerConsumption	<boolean>
     HighPowerConsumption defines if the node should be configured in high power
     consumption mode. The flag will affect the power consumption but will
     improve the CPUs latency. Defaults to false.

   perPodPowerManagement	<boolean>
     PerPodPowerManagement defines if the node should be configured in per pod
     power management. PerPodPowerManagement and HighPowerConsumption hints can
     not be enabled together. Defaults to false.

   realTime	<boolean>
     RealTime defines if the node should be configured for the real time
     workload. Defaults to true.
~~~