### PR TITLE
OCPBUGS-9959: check scheduler settings under /sys/kernel/debug/sched/ 

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -85,13 +85,6 @@ net.core.busy_read=50
 net.core.busy_poll=50
 net.ipv4.tcp_fastopen=3
 
-# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-#> latency-performance
-kernel.sched_min_granularity_ns=10000000
-
 # If a workload mostly uses anonymous memory and it hits this limit, the entire
 # working set is buffered for I/O, and any more write buffering would require
 # swapping, so it's time to throttle writes until I/O can catch up.  Workloads
@@ -116,11 +109,6 @@ vm.dirty_background_ratio=3
 #> latency-performance
 vm.swappiness=10
 
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-#> latency-performance
-kernel.sched_migration_cost_ns=5000000
 
 [selinux]
 #> Custom (atomic host)

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -31,9 +31,6 @@ spec:
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
       (= 1)\nkernel.timer_migration=1\n#> network-latency\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
-      ktune sysctl settings for rhel6 servers, maximizing i/o throughput\n#\n# Minimal
-      preemption granularity for CPU-bound tasks:\n# (default: 1 msec#  (1 + ilog(ncpus)),
-      units: nanoseconds)\n#> latency-performance\nkernel.sched_min_granularity_ns=10000000\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -45,10 +42,7 @@ spec:
       out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
       swapping processes out of physical memory\n# for as long as possible\n# 100
       tells the kernel to aggressively swap processes out of physical memory\n# and
-      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# The total
-      time the scheduler will consider a migrated process\n# \"cache hot\" and thus
-      less likely to be re-migrated\n# (system default is 500000, i.e. 0.5 ms)\n#>
-      latency-performance\nkernel.sched_migration_cost_ns=5000000\n\n[selinux]\n#>
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}


### PR DESCRIPTION
…sctl

On RHEL9.2 scheduler settings have been moved under  /sys/kernel/debug/sched/ instead of setting them using sysctl