### PR TITLE
OCPBUGS-13262: Add PerformanceProfiles to 'oc adm must-gather'

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -340,6 +340,7 @@ func getRelatedObjects() []configv1.ObjectReference {
 		{Group: "tuned.openshift.io", Resource: "profiles", Name: "", Namespace: tunedMf.Namespace},
 		{Group: "tuned.openshift.io", Resource: "tuneds", Name: "", Namespace: tunedMf.Namespace},
 		{Group: "apps", Resource: "daemonsets", Name: dsMf.Name, Namespace: dsMf.Namespace},
+		{Group: "performance.openshift.io", Resource: "performanceprofiles", Name: ""},
 	}
 }
 


### PR DESCRIPTION
Add PerformanceProfiles as a RelatedObject for the must-gather tool.