### PR TITLE
tests: image: bump to the latest version

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/images/images.go
+++ b/test/e2e/performanceprofile/functests/utils/images/images.go
@@ -13,7 +13,7 @@ func init() {
 	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
 
 	if cnfTestsImage == "" {
-		cnfTestsImage = "cnf-tests:4.9"
+		cnfTestsImage = "cnf-tests:4.14"
 	}
 
 	if registry == "" {


### PR DESCRIPTION
We should try to avoid floating tag (`latest`). Release-referring floating tags are the lesser evil, so it's OK(-ish).

Ideally, the tests should detect the cluster version and pick the tests version automatically by default.