### PR TITLE
OCPBUGS-10247: Update NTO-generated MC on MachineCount <= 1

### DIFF
--- a/pkg/operator/mc.go
+++ b/pkg/operator/mc.go
@@ -150,6 +150,15 @@ func getMachineConfigNameForPools(pools []*mcfgv1.MachineConfigPool) string {
 	return sb.String()
 }
 
+func (pc *ProfileCalculator) getMachineCountForMachineConfigPool(mcpName string) (int32, error) {
+	mcp, err := pc.listers.MachineConfigPools.Get(mcpName)
+	if err != nil {
+		return 0, err
+	}
+
+	return mcp.Status.MachineCount, nil
+}
+
 // getPoolsForMachineConfigLabels chooses the MachineConfigPools that use MachineConfigs with labels 'mcLabels'.
 // Errors are only returned in cases that warrant event reques (e.g. a failure to list k8s objects).
 func (pc *ProfileCalculator) getPoolsForMachineConfigLabels(mcLabels map[string]string) ([]*mcfgv1.MachineConfigPool, error) {


### PR DESCRIPTION
PR558 added support for informing users about nodes with incompatible topologies within the same MCP.  However, a recovery from this state is not handled in a user-friendly way.  Currently, the entire MCP or NTO-generated MC needs to be deleted or manually adjusted to recover.

This PR fixes the situation so that when the MachineCount of the MCP which had nodes with conflicting topologies is equal or less than 1, updates to the NTO-generated MC are allowed even though the input configuration did not change and the new kernel parameters do not match the MC's kernel parameters.

Fixes OCPBUGS-10247