### PR TITLE
Make the enable-leader-election option work

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -121,7 +121,7 @@ func operatorRun() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		NewCache:                cache.MultiNamespacedCacheBuilder(namespaces),
 		Scheme:                  scheme,
-		LeaderElection:          true,
+		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        config.OperatorLockName,
 		LeaderElectionNamespace: ntoNamespace,
 		LeaseDuration:           &le.LeaseDuration.Duration,


### PR DESCRIPTION
The `--enable-leader-election=false` currently does not work.  Leader election is always on.  This change fixes the issue.