### PR TITLE
OCPBUGS-10217: Remove the preStop hook for openshift-tuned

### DIFF
--- a/assets/bin/run
+++ b/assets/bin/run
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-openshift_tuned_socket=/var/lib/tuned/openshift-tuned.sock
 export SYSTEMD_IGNORE_CHROOT=1
 
 start() {
@@ -11,19 +10,12 @@ start() {
   # - http://bugs.python.org/issue1663329
   ulimit -Sn 1024	# workaround for the issue above
 
-  openshift-tuned \
+  exec /usr/bin/openshift-tuned \
     -v=0
 }
 
 stop() {
-  local timeout=10	# wait $timeout [s] for a reply via the socket
-  local response=$(echo stop | nc -i$timeout -U $openshift_tuned_socket 2>/dev/null)
-
-  if [ "$response" != "ok" ]; then
-    # provide a failure message in the event log
-    echo "openshift-tuned stop response: $response" 1>&2
-    return 1
-  fi
+  :
 }
 
 $@

--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -29,10 +29,6 @@ spec:
             memory: 50Mi
         image: ${CLUSTER_NODE_TUNED_IMAGE}
         imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/var/lib/tuned/bin/run","stop"]
         name: tuned
         securityContext:
           privileged: true


### PR DESCRIPTION
The preStop hook for `openshift-tuned` and the socket interface to talk to it is not really needed.  The reason for having it in the first place was to ensure a rollback of `TuneD` settings.  However, realistically, the rollback of setting should never take more than a couple of seconds, often *much* less than that (typically ~0.1s).  This is well within the `terminationGracePeriodSeconds` of 30s.

This also fixes the issue of the TERM signal not reaching `openshift-tuned` during pod terminations by omitting the "exec" in the Pod startup script.  Now, we simply rely on the TERM signal to be sent to openshift-tuned, which catches the signal, handles `TuneD` termination (either gracefully or forcefully if it does not exit within 10s) and then `openshift-tuned` exits itself.

Also see OCPBUGS-10217