### PR TITLE
Skip tests depending on Jira or Bz issue status

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -300,6 +300,8 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		})
 
 		It("[test_id:32646] should disable CPU load balancing for CPU's used by the pod", func() {
+			testutils.KnownIssueJira("OCPNODE-1538")
+
 			var err error
 			By("Starting the pod")
 			err = testclient.Client.Create(context.TODO(), testpod)

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -165,6 +165,9 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 				Skip("this test needs dynamic IRQ balancing")
 			}
 
+			testutils.KnownIssueBugzilla(2181546)
+			testutils.KnownIssueJira("OCPNODE-1538")
+
 			targetNodeIdx := pickNodeIdx(workerRTNodes)
 			targetNode = &workerRTNodes[targetNodeIdx]
 			Expect(targetNode).ToNot(BeNil(), "missing target node")
@@ -265,6 +268,9 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 			// This _likely_ means the first time the provisioned node boots, and in this case is _likely_ the node
 			// has not any IRQ pinning, thus the saved CPU ban list is the empty list. But we don't control nor declare this state.
 			// It's all best effort.
+
+			testutils.KnownIssueBugzilla(2181546)
+			testutils.KnownIssueJira("OCPNODE-1538")
 
 			nodeIdx := pickNodeIdx(workerRTNodes)
 			node := &workerRTNodes[nodeIdx]

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -395,6 +395,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 
 	Context("Network latency parameters adjusted by the Node Tuning Operator", func() {
 		It("[test_id:28467][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Should contain configuration injected through the openshift-node-performance profile", func() {
+			testutils.KnownIssueJira("OCPBUGS-9959")
 			sysctlMap := map[string]string{
 				"net.ipv4.tcp_fastopen":           "3",
 				"kernel.sched_min_granularity_ns": "10000000",

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -628,6 +628,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 		When("HighPower Consumption workload enabled", func() {
 			It("[test_id:50992][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", func() {
+				testutils.KnownIssueJira("OCPBUGS-10635")
 				By("Modifying profile")
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
 					HighPowerConsumption: pointer.Bool(true),

--- a/test/e2e/performanceprofile/functests/utils/bugzilla/client.go
+++ b/test/e2e/performanceprofile/functests/utils/bugzilla/client.go
@@ -1,0 +1,79 @@
+package bugzilla
+
+import (
+	"encoding/json"
+	"github.com/pkg/errors"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+const BUGZILLA_BASE_URL = "https://bugzilla.redhat.com"
+
+type Bug struct {
+	Id int `json:"id"`
+
+	Status  string `json:"status"`
+	Summary string `json:"summary"`
+}
+
+type bugzillaResponse struct {
+	Error   bool   `json:"error"`
+	Message string `json:"message"`
+	Total   int    `json:"total_matches"`
+}
+
+type searchResultFull struct {
+	bugzillaResponse
+	Bugs []Bug `json:"bugs"`
+}
+
+func getBugzilla(params *url.Values) ([]Bug, error) {
+	searchResult := searchResultFull{}
+
+	fullUrl := BUGZILLA_BASE_URL + "/rest/bug?" + params.Encode()
+
+	req, err := http.NewRequest("GET", fullUrl, nil)
+	if err != nil {
+		return searchResult.Bugs, errors.Wrap(err, "Could not create bugzilla request")
+	}
+	ret, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		return searchResult.Bugs, errors.Wrap(err, "Could not query bugzilla")
+	}
+	defer ret.Body.Close()
+
+	if ret.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("%d %s", ret.StatusCode, ret.Status)
+	}
+
+	decoder := json.NewDecoder(ret.Body)
+	err = decoder.Decode(&searchResult)
+	if err != nil {
+		return searchResult.Bugs, errors.Wrap(err, "Could not query bugzilla")
+	}
+
+	if searchResult.Error {
+		return searchResult.Bugs, errors.Errorf("search error: %s", searchResult.Message)
+	}
+
+	return searchResult.Bugs, nil
+}
+
+func RetrieveBug(bugId int) (*Bug, error) {
+	params := url.Values{}
+	params.Set("include_fields", "id,summary,status")
+	params.Set("id", strconv.Itoa(bugId))
+
+	bugs, err := getBugzilla(&params)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(bugs) == 0 {
+		return nil, errors.Errorf("no bugs with expected id rhbz#%d retrieved", bugId)
+	}
+
+	return &bugs[0], nil
+}

--- a/test/e2e/performanceprofile/functests/utils/jira/status.go
+++ b/test/e2e/performanceprofile/functests/utils/jira/status.go
@@ -1,0 +1,53 @@
+package jira
+
+import (
+	"encoding/json"
+	"github.com/pkg/errors"
+	"net/http"
+	"net/url"
+)
+
+const JIRA_BASE_URL = "https://issues.redhat.com"
+
+type JiraIssueStatusResponseFieldsStatus = struct {
+	Name string `json:"name"`
+}
+
+type JiraIssueStatusResponseFields = struct {
+	Status  JiraIssueStatusResponseFieldsStatus `json:"status"`
+	Summary string                              `json:"summary"`
+}
+
+type JiraIssueStatusResponse = struct {
+	Key    string                        `json:"key"`
+	Fields JiraIssueStatusResponseFields `json:"fields"`
+}
+
+func RetrieveJiraStatus(key string) (*JiraIssueStatusResponse, error) {
+	local_params := url.Values{}
+	local_params.Set("fields", "summary,status")
+
+	fullUrl := JIRA_BASE_URL + "/rest/api/2/issue/" + key + "?" + local_params.Encode()
+	req, err := http.NewRequest("GET", fullUrl, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create request for Jira status of %s", key)
+	}
+	ret, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create client to get jira status of %s", key)
+	}
+	defer ret.Body.Close()
+
+	if ret.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("failed to get jira status of %s: %d %s", key, ret.StatusCode, ret.Status)
+	}
+
+	response := JiraIssueStatusResponse{}
+	decoder := json.NewDecoder(ret.Body)
+	err = decoder.Decode(&response)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode jira status of %s", key)
+	}
+
+	return &response, nil
+}


### PR DESCRIPTION
This adds an automatic skip of known issues based on the issue status. The moment an issue is fixed, the skip will no longer be effective.

See the two added methods:

testutils.KnownIssueBugzilla(2181546)
testutils.KnownIssueJira("OCPNODE-1538")