### PR TITLE
OCPBUGS-10635: workload-hints: disable stalld when rt disabled

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -35,6 +35,9 @@ min_perf_pct=100
 {{if .RealTimeHint}}
 [service]
 service.stalld=start,enable
+{{else}}
+[service]
+service.stalld=stop,disable
 {{end}}
 
 [vm]

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -119,8 +119,9 @@ var _ = Describe("Tuned", func() {
 			It("should not contain realtime related parameters", func() {
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{RealTime: pointer.BoolPtr(false)}
 				tunedData := getTunedStructuredData(profile)
-				_, err := tunedData.GetSection("service")
-				Expect(err).To(HaveOccurred(), "expected the validation error")
+				service, err := tunedData.GetSection("service")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(service.Key("service.stalld").String()).To(Equal("stop,disable"))
 
 				schedulerSection, err := tunedData.GetSection("scheduler")
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
When RealTime workload hint configured as false, we should
explicitly disable stalld service

Signed-off-by: Talor Itzhak <titzhak@redhat.com>