### PR TITLE
render: remove uid from render-sync target

### DIFF
--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -9,4 +9,8 @@ _output/cluster-node-tuning-operator render \
 --asset-output-dir "${ARTIFACT_DIR}"
 
 cp "${ARTIFACT_DIR}"/*  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output
+for f in  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output/*
+do
+  sed -i "s/uid:.*/uid: \"\"/" "${f}"
+done
 rm -r "${ARTIFACT_DIR}"

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   name: performance-manual
   ownerReferences:
-  - apiVersion: "performance.openshift.io/v2"
+  - apiVersion: performance.openshift.io/v2
     kind: PerformanceProfile
     name: manual
     uid: ""
@@ -25,8 +25,8 @@ spec:
       full-pcpus-only: "true"
     cpuManagerReconcilePeriod: 5s
     evictionHard:
-      memory.available: 100Mi
       imagefs.available: 15%
+      memory.available: 100Mi
       nodefs.available: 10%
       nodefs.inodesFree: 5%
     evictionPressureTransitionPeriod: 0s
@@ -47,9 +47,9 @@ spec:
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     reservedMemory:
-      - limits:
-          memory: 1100Mi
-        numaNode: 0
+    - limits:
+        memory: 1100Mi
+      numaNode: 0
     reservedSystemCPUs: "0"
     runtimeRequestTimeout: 0s
     shutdownGracePeriod: 0s

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
@@ -6,7 +6,7 @@ metadata:
     machineconfiguration.openshift.io/role: worker-cnf
   name: 50-performance-manual
   ownerReferences:
-  - apiVersion: "performance.openshift.io/v2"
+  - apiVersion: performance.openshift.io/v2
     kind: PerformanceProfile
     name: manual
     uid: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_runtimeclass.yaml
@@ -5,7 +5,7 @@ metadata:
   creationTimestamp: null
   name: performance-manual
   ownerReferences:
-  - apiVersion: "performance.openshift.io/v2"
+  - apiVersion: performance.openshift.io/v2
     kind: PerformanceProfile
     name: manual
     uid: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-node-performance-manual
   namespace: openshift-cluster-node-tuning-operator
   ownerReferences:
-  - apiVersion: "performance.openshift.io/v2"
+  - apiVersion: performance.openshift.io/v2
     kind: PerformanceProfile
     name: manual
     uid: ""
@@ -27,10 +27,10 @@ spec:
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_min_granularity_ns=10000000\nsched_migration_cost_ns=5000000\nnuma_balancing=0\n\nsched_rt_runtime_us=-1\n\n\ndefault_irq_smp_affinity
       = ignore\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
-      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and RealTimeHint
-      for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning and needs
-      to evacuate\n#> scheduled timers when starting a guaranteed workload (= 1)\nkernel.timer_migration=1\n#>
-      network-latency\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
+      RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
       ktune sysctl settings for rhel6 servers, maximizing i/o throughput\n#\n# Minimal
       preemption granularity for CPU-bound tasks:\n# (default: 1 msec#  (1 + ilog(ncpus)),
       units: nanoseconds)\n#> latency-performance\nkernel.sched_min_granularity_ns=10000000\n\n#


### PR DESCRIPTION
The render command is generating manifests with uid now. we don't need it to be part of the data for our render-expected-output so let's remove it