### PR TITLE
OCPBUGS-10998: Fix updating nodeSelector test

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -378,8 +378,15 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				oldNodeSelector = profile.Spec.DeepCopy().NodeSelector
 			}
 			removeLabels = func(nodeSelector map[string]string, targetNode *corev1.Node) error {
+				patchNode := false
 				for l := range nodeSelector {
-					delete(targetNode.Labels, l)
+					if _, ok := targetNode.Labels[l]; ok {
+						patchNode = true
+						delete(targetNode.Labels, l)
+					}
+				}
+				if !patchNode {
+					return nil
 				}
 				label, err := json.Marshal(targetNode.Labels)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The node selector tests are using a utility function that removes labels from nodes.
When the function tries to patch nodes with updated labels it will wait for the matching mcp to be updated. In case no update to node labels where done the update will time out.

The fix is to only wait for mcp updates if there was actually one.