### PR TITLE
OCPNODE-1539: perf profile: add script for preparing cgroups for CPU load balance disabling

### DIFF
--- a/assets/performanceprofile/scripts/cpuset-configure.sh
+++ b/assets/performanceprofile/scripts/cpuset-configure.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# cpuset-configure.sh configures three cpusets in preparation for allowing containers to have cpu load balancing disabled.
+# To configure a cpuset to have load balance disabled (on cgroup v1), a cpuset cgroup must have `cpuset.sched_load_balance`
+# set to 0 (disable), and any cpuset that contains the same set as `cpuset.cpus` must also have `cpuset.sched_load_balance` set to disabled.
+
+set -euo pipefail
+
+root=/sys/fs/cgroup/cpuset
+system="$root"/system
+machine="$root"/machine.slice
+
+# As such, the root cgroup needs to have cpuset.sched_load_balance=0. 
+echo 0 > "$root"/cpuset.sched_load_balance
+
+# However, this would present a problem for system daemons, which should have load balancing enabled.
+# As such, a second cpuset must be created, here dubbed `system`, which will take all system daemons.
+# Since systemd starts its children with the cpuset it is in, moving systemd will ensure all processes systemd begins will be in the correct cgroup.
+mkdir "$system"
+# cpuset.mems must be initialized or processes will fail to be moved into it.
+cat "$root/cpuset.mems" > "$system"/cpuset.mems
+# Retrieve the cpuset of systemd, and write it to cpuset.cpus of the system cgroup.
+reserved_set=$(taskset -cp  1  | awk 'NF{ print $NF }')
+echo "$reserved_set" > "$system"/cpuset.cpus
+
+# And move the system processes into it.
+# Note, some kernel threads will fail to be moved with "Invalid Argument". This should be ignored.
+for process in $(cat "$root"/cgroup.procs | sort -r); do
+	echo $process > "$system"/cgroup.procs 2>&1 | grep -v "Invalid Argument" || true;
+done
+
+# Finally, a the `machine.slice` cgroup must be preconfigured. Podman will create containers and move them into the `machine.slice`, but there's
+# no way to tell podman to update machine.slice to not have the full set of cpus. Instead of disabling load balancing in it, we can pre-create it.
+# with the reserved CPUs set ahead of time, so when isolated processes begin, the cgroup does not have an overlapping cpuset between machine.slice and isolated containers.
+mkdir "$machine" || true
+
+# It's unlikely, but possible, that this cpuset already existed. Iterate just in case.
+for file in $(find "$machine" -name cpuset.cpus | sort -r); do echo "$reserved_set" > "$file"; done

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -60,6 +60,7 @@ const (
 	setCPUsOffline            = "set-cpus-offline"
 	setRPSMask                = "set-rps-mask"
 	clearIRQBalanceBannedCPUs = "clear-irqbalance-banned-cpus"
+	cpusetConfigure           = "cpuset-configure"
 )
 
 const (
@@ -76,11 +77,13 @@ const (
 )
 
 const (
-	systemdServiceIRQBalance  = "irqbalance.service"
-	systemdServiceKubelet     = "kubelet.service"
-	systemdServiceTypeOneshot = "oneshot"
-	systemdTargetMultiUser    = "multi-user.target"
-	systemdTrue               = "true"
+	systemdServiceIRQBalance   = "irqbalance.service"
+	systemdServiceKubelet      = "kubelet.service"
+	systemdServiceCrio         = "crio.service"
+	systemdServiceTypeOneshot  = "oneshot"
+	systemdTargetMultiUser     = "multi-user.target"
+	systemdTargetNetworkOnline = "network-online.target"
+	systemdTrue                = "true"
 )
 
 const (
@@ -259,6 +262,23 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, pinningMode *a
 			}
 			ocpPartitionDst := filepath.Join(kubernetesConfDir, ocpPartitioningConfig)
 			addContent(ignitionConfig, ocpPartitionFileData, ocpPartitionDst, &crioConfdRuntimesMode)
+			cpusetConfigureService, err := getSystemdContent(getCpusetConfigureServiceOptions())
+			if err != nil {
+				return nil, err
+			}
+
+			ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
+				Contents: &cpusetConfigureService,
+				Enabled:  pointer.BoolPtr(true),
+				Name:     getSystemdService(cpusetConfigure),
+			})
+
+			dst := getBashScriptPath(cpusetConfigure)
+			content, err := assets.Scripts.ReadFile(fmt.Sprintf("scripts/%s.sh", cpusetConfigure))
+			if err != nil {
+				return nil, err
+			}
+			addContent(ignitionConfig, content, dst, &mode)
 		}
 	}
 
@@ -348,6 +368,23 @@ func GetHugepagesSizeKilobytes(hugepagesSize performancev2.HugePageSize) (string
 		return "2048", nil
 	default:
 		return "", fmt.Errorf("can not convert size %q to kilobytes", hugepagesSize)
+	}
+}
+
+func getCpusetConfigureServiceOptions() []*unit.UnitOption {
+	return []*unit.UnitOption{
+		// [Unit]
+		// Description
+		unit.NewUnitOption(systemdSectionUnit, systemdDescription, "Move services to reserved cpuset"),
+		// Before
+		unit.NewUnitOption(systemdSectionUnit, systemdBefore, systemdTargetNetworkOnline),
+		// Type
+		unit.NewUnitOption(systemdSectionService, systemdType, systemdServiceTypeOneshot),
+		// ExecStart
+		unit.NewUnitOption(systemdSectionService, systemdExecStart, getBashScriptPath(cpusetConfigure)),
+		// [Install]
+		// WantedBy
+		unit.NewUnitOption(systemdSectionInstall, systemdWantedBy, systemdTargetMultiUser+" "+systemdServiceCrio),
 	}
 }
 

--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -300,8 +300,6 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		})
 
 		It("[test_id:32646] should disable CPU load balancing for CPU's used by the pod", func() {
-			testutils.KnownIssueJira("OCPNODE-1538")
-
 			var err error
 			By("Starting the pod")
 			err = testclient.Client.Create(context.TODO(), testpod)

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -165,8 +165,6 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 				Skip("this test needs dynamic IRQ balancing")
 			}
 
-			testutils.KnownIssueJira("OCPNODE-1538")
-
 			targetNodeIdx := pickNodeIdx(workerRTNodes)
 			targetNode = &workerRTNodes[targetNodeIdx]
 			Expect(targetNode).ToNot(BeNil(), "missing target node")
@@ -267,8 +265,6 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 			// This _likely_ means the first time the provisioned node boots, and in this case is _likely_ the node
 			// has not any IRQ pinning, thus the saved CPU ban list is the empty list. But we don't control nor declare this state.
 			// It's all best effort.
-
-			testutils.KnownIssueJira("OCPNODE-1538")
 
 			nodeIdx := pickNodeIdx(workerRTNodes)
 			node := &workerRTNodes[nodeIdx]


### PR DESCRIPTION
on RHEL 9 and newer kernels, the sysfs previously relied on to disable CPU load balancing is no longer available. Instead, cpu load balancing must be configured through cgroups.

To configure a cpuset to have load balance disabled (on cgroup v1), a cpuset cgroup must have `cpuset.sched_load_balance` set to 0 (disable), and any cpuset that contains the same set as `cpuset.cpus` must also have `cpuset.sched_load_balance` set to disabled.

To do this, we must move systemd and all host processes to a separate cpuset off of the root cgroup, and manually configure it to use the reserved cpus set by set_cpuaffinity. This won't have any effect on the actual processes themselves, but will open the opportunity for the root cgroup to have load balance disabled.

Also, preconfigure the machine.slice (which will later be created by podman).

This PR adds a script to do these things and a systemd unit to enable it, which is created when there are reserved cpus in the performance profile.