### PR TITLE
OCPBUGS-11417:  [release-4.13] check scheduler settings under /sys/kernel/debug/sched/

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -85,12 +85,7 @@ net.core.busy_read=50
 net.core.busy_poll=50
 net.ipv4.tcp_fastopen=3
 
-# ktune sysctl settings for rhel6 servers, maximizing i/o throughput
-#
-# Minimal preemption granularity for CPU-bound tasks:
-# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-#> latency-performance
-kernel.sched_min_granularity_ns=10000000
+
 
 # If a workload mostly uses anonymous memory and it hits this limit, the entire
 # working set is buffered for I/O, and any more write buffering would require
@@ -116,11 +111,7 @@ vm.dirty_background_ratio=3
 #> latency-performance
 vm.swappiness=10
 
-# The total time the scheduler will consider a migrated process
-# "cache hot" and thus less likely to be re-migrated
-# (system default is 500000, i.e. 0.5 ms)
-#> latency-performance
-kernel.sched_migration_cost_ns=5000000
+
 
 [selinux]
 #> Custom (atomic host)

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -396,13 +396,16 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 	Context("Network latency parameters adjusted by the Node Tuning Operator", func() {
 		It("[test_id:28467][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Should contain configuration injected through the openshift-node-performance profile", func() {
 			sysctlMap := map[string]string{
-				"net.ipv4.tcp_fastopen":           "3",
-				"kernel.sched_min_granularity_ns": "10000000",
-				"vm.dirty_ratio":                  "10",
-				"vm.dirty_background_ratio":       "3",
-				"vm.swappiness":                   "10",
-				"kernel.sched_migration_cost_ns":  "5000000",
+				"net.ipv4.tcp_fastopen":     "3",
+				"vm.dirty_ratio":            "10",
+				"vm.dirty_background_ratio": "3",
+				"vm.swappiness":             "10",
 			}
+			schedulerKnobs := map[string]string{
+				"min_granularity_ns": "10000000",
+				"migration_cost_ns":  "5000000",
+			}
+
 			key := types.NamespacedName{
 				Name:      components.GetComponentName(testutils.PerformanceProfileName, components.ProfileNamePerformance),
 				Namespace: components.NamespaceNodeTuningOperator,
@@ -412,6 +415,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator object "+components.ProfileNamePerformance)
 			validateTunedActiveProfile(workerRTNodes)
 			execSysctlOnWorkers(workerRTNodes, sysctlMap)
+			checkSchedKnobs(workerRTNodes, schedulerKnobs)
 		})
 	})
 
@@ -1381,5 +1385,20 @@ func validateTunedActiveProfile(wrknodes []corev1.Node) {
 			return strings.TrimSpace(string(out))
 		}, cluster.ComputeTestTimeout(testTimeout*time.Second, RunningOnSingleNode), testPollInterval*time.Second).Should(Equal(activeProfileName),
 			fmt.Sprintf("active_profile is not set to %s. %v", activeProfileName, err))
+	}
+}
+
+// check scheduler settings. on RHCOS9.2 all scheduler settings are moved to /sys/kernel/debug/sched/
+func checkSchedKnobs(workerNodes []corev1.Node, schedKnobs map[string]string) {
+	var err error
+	var out []byte
+	for _, node := range workerNodes {
+		for param, expected := range schedKnobs {
+			By(fmt.Sprintf("Checking scheduler knob %s", param))
+			knob := fmt.Sprintf("/rootfs/sys/kernel/debug/sched/%s", param)
+			out, err = nodes.ExecCommandOnMachineConfigDaemon(&node, []string{"cat", knob})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(strings.TrimSpace(string(out))).Should(Equal(expected), "parameter %s value is not %s.", param, expected)
+		}
 	}
 }

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
@@ -25,8 +25,8 @@ spec:
       full-pcpus-only: "true"
     cpuManagerReconcilePeriod: 5s
     evictionHard:
-      memory.available: 100Mi
       imagefs.available: 15%
+      memory.available: 100Mi
       nodefs.available: 10%
       nodefs.inodesFree: 5%
     evictionPressureTransitionPeriod: 0s
@@ -47,9 +47,9 @@ spec:
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     reservedMemory:
-      - limits:
-          memory: 1100Mi
-        numaNode: 0
+    - limits:
+        memory: 1100Mi
+      numaNode: 0
     reservedSystemCPUs: "0"
     runtimeRequestTimeout: 0s
     shutdownGracePeriod: 0s

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-node-performance-manual
   namespace: openshift-cluster-node-tuning-operator
   ownerReferences:
-  - apiVersion: "performance.openshift.io/v2"
+  - apiVersion: performance.openshift.io/v2
     kind: PerformanceProfile
     name: manual
     uid: ""
@@ -27,13 +27,10 @@ spec:
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_min_granularity_ns=10000000\nsched_migration_cost_ns=5000000\nnuma_balancing=0\n\nsched_rt_runtime_us=-1\n\n\ndefault_irq_smp_affinity
       = ignore\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
-      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and RealTimeHint
-      for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning and needs
-      to evacuate\n#> scheduled timers when starting a guaranteed workload (= 1)\nkernel.timer_migration=1\n#>
-      network-latency\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
-      ktune sysctl settings for rhel6 servers, maximizing i/o throughput\n#\n# Minimal
-      preemption granularity for CPU-bound tasks:\n# (default: 1 msec#  (1 + ilog(ncpus)),
-      units: nanoseconds)\n#> latency-performance\nkernel.sched_min_granularity_ns=10000000\n\n#
+      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
+      RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -45,10 +42,7 @@ spec:
       out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
       swapping processes out of physical memory\n# for as long as possible\n# 100
       tells the kernel to aggressively swap processes out of physical memory\n# and
-      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# The total
-      time the scheduler will consider a migrated process\n# \"cache hot\" and thus
-      less likely to be re-migrated\n# (system default is 500000, i.e. 0.5 ms)\n#>
-      latency-performance\nkernel.sched_migration_cost_ns=5000000\n\n[selinux]\n#>
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}


### PR DESCRIPTION
 moved some of the scheduler knobs like min_granularity_ns and migration_cost_ns
 from sysctl to debugfs. Moving these knobs out of sysctl

 check scheduler settings under /sys/kernel/debug/sched/ instead of sysctl
 Render updated tuned.yaml