### PR TITLE
[release-4.13][manual] OCPBUGS-11851: render: remove uid from render-sync target (#594)

### DIFF
--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -9,4 +9,8 @@ _output/cluster-node-tuning-operator render \
 --asset-output-dir "${ARTIFACT_DIR}"
 
 cp "${ARTIFACT_DIR}"/*  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output
+for f in  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output/*
+do
+  sed -i "s/uid:.*/uid: \"\"/" "${f}"
+done
 rm -r "${ARTIFACT_DIR}"

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   name: performance-manual
   ownerReferences:
-  - apiVersion: "performance.openshift.io/v2"
+  - apiVersion: performance.openshift.io/v2
     kind: PerformanceProfile
     name: manual
     uid: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
@@ -6,7 +6,7 @@ metadata:
     machineconfiguration.openshift.io/role: worker-cnf
   name: 50-performance-manual
   ownerReferences:
-  - apiVersion: "performance.openshift.io/v2"
+  - apiVersion: performance.openshift.io/v2
     kind: PerformanceProfile
     name: manual
     uid: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_runtimeclass.yaml
@@ -5,7 +5,7 @@ metadata:
   creationTimestamp: null
   name: performance-manual
   ownerReferences:
-  - apiVersion: "performance.openshift.io/v2"
+  - apiVersion: performance.openshift.io/v2
     kind: PerformanceProfile
     name: manual
     uid: ""


### PR DESCRIPTION
The render command is generating manifests with uid now. we don't need it to be part of the data for our render-expected-output so let's remove it