### PR TITLE
OCPBUGS-11150: Revert #567 and cleanup PPC-generated TuneD config

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -59,10 +59,6 @@ group.rcuc=0:f:11:*:rcuc.*
 group.ktimers=0:f:11:*:ktimers.*
 sched_min_granularity_ns=10000000
 sched_migration_cost_ns=5000000
-numa_balancing=0
-{{if .RealTimeHint}}
-sched_rt_runtime_us=-1
-{{end}}
 {{if not .GloballyDisableIrqLoadBalancing}}
 default_irq_smp_affinity = ignore
 {{end}}
@@ -83,6 +79,7 @@ vm.stat_interval=10
 #> scheduled timers when starting a guaranteed workload (= 1)
 kernel.timer_migration=1
 #> network-latency
+# TODO once rhbz#2120328 is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll do not exist on RT kernels
 kernel.numa_balancing=0
 net.core.busy_read=50
 net.core.busy_poll=50

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -84,7 +84,6 @@ var _ = Describe("Tuned", func() {
 
 			schedulerSection, err := tunedData.GetSection("scheduler")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(schedulerSection.Key("sched_rt_runtime_us").String()).To(Equal("-1"))
 			Expect(schedulerSection.Key("group.ksoftirqd").String()).To(Equal("0:f:11:*:ksoftirqd.*"))
 			Expect(schedulerSection.Key("group.rcuc").String()).To(Equal("0:f:11:*:rcuc.*"))
 			Expect(schedulerSection.Key("group.ktimers").String()).To(Equal("0:f:11:*:ktimers.*"))
@@ -145,9 +144,6 @@ var _ = Describe("Tuned", func() {
 				service, err := tunedData.GetSection("service")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(service.Key("service.stalld").String()).To(Equal("start,enable"))
-				scheduler, err := tunedData.GetSection("scheduler")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(scheduler.Key("sched_rt_runtime_us").String()).To(Equal("-1"))
 				sysctl, err := tunedData.GetSection("sysctl")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(sysctl.Key("kernel.hung_task_timeout_secs").String()).To(Equal("600"))

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -1004,6 +1004,16 @@ func (c *Controller) informerEventHandler(workqueueKey wqKey) cache.ResourceEven
 				klog.Errorf("unable to get accessor for new object: %s", err)
 				return
 			}
+			oldAccessor, err := kmeta.Accessor(o)
+			if err != nil {
+				klog.Errorf("unable to get accessor for old object: %s", err)
+				return
+			}
+			if newAccessor.GetResourceVersion() == oldAccessor.GetResourceVersion() {
+				// Periodic resync will send update events for all known resources.
+				// Two different versions of the same resource will always have different RVs.
+				return
+			}
 			klog.V(2).Infof("add event to workqueue due to %s (update)", util.ObjectInfo(n))
 			c.wqKube.Add(wqKey{kind: workqueueKey.kind, name: newAccessor.GetName()})
 		},

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -24,13 +24,15 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_min_granularity_ns=10000000\nsched_migration_cost_ns=5000000\nnuma_balancing=0\n\nsched_rt_runtime_us=-1\n\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_min_granularity_ns=10000000\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
       = ignore\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
+      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
+      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#


### PR DESCRIPTION
PerformanceProfile Controller (PPC) generates TuneD configuration out of template file `assets/performanceprofile/tuned/openshift-node-performance`.

This PR fixes several issues with this file:
  - Remove `TuneD [scheduler]` plug-in options that do not exist.
  - Add a note about sysctl existing only in non-rt kernels.

Also, as a temporary fix we revert the removal of optimizations done in #567 as a way of addressing OCPBUGS-7384.  However, we later found OCPBUGS-7384 was a user configuration issue so the change is not really needed at this point as we ran with it since OCP 4.5 with no issues.