### PR TITLE
e2e: config: always add MCP to the perfprof

### DIFF
--- a/test/e2e/performanceprofile/functests/0_config/config.go
+++ b/test/e2e/performanceprofile/functests/0_config/config.go
@@ -204,10 +204,8 @@ func testProfile() *performancev2.PerformanceProfile {
 	// If the machineConfigPool is master, the automatic selector from PAO won't work
 	// since the machineconfiguration.openshift.io/role label is not applied to the
 	// master pool, hence we put an explicit selector here.
-	if utils.RoleWorkerCNF == "master" {
-		profile.Spec.MachineConfigPoolSelector = map[string]string{
-			"pools.operator.machineconfiguration.openshift.io/master": "",
-		}
+	profile.Spec.MachineConfigPoolSelector = map[string]string{
+		"pools.operator.machineconfiguration.openshift.io/" + utils.RoleWorkerCNF: "",
 	}
 	return profile
 }


### PR DESCRIPTION
If we create a performance profile for the tests,
let's always add the MCP: it's the recommended path anyway, if nodeselector takes precedence (but it should not) it's harmless, and some tests, most notably the ones depending on ContainerRuntimeConfig, require this field anyway.