### PR TITLE
pao e2e: fix stalld enablement checks

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -611,7 +611,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -668,7 +669,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -724,7 +726,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to NOT be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld should not running on node %q ", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -785,7 +788,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -901,7 +905,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -964,7 +969,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -1034,7 +1040,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -1098,7 +1105,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)


### PR DESCRIPTION
util functions for checking stalld proccess existance fixed since they were existing the check too early due to hidden errors.