### PR TITLE
OCPBUGS-11083: pao e2e: fix update test suit timeouts

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -615,9 +615,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -673,9 +673,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -730,9 +730,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -792,9 +792,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -909,9 +909,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -973,9 +973,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -1044,9 +1044,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -1109,9 +1109,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -397,6 +397,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		var oldMcpSelector, oldNodeSelector map[string]string
 
 		BeforeEach(func() {
+			testutils.KnownIssueJira("OCPBUGS-12836")
+
 			// initialize on every run
 			labelsDeletion = false
 			//fetch the latest profile
@@ -462,6 +464,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 
 		It("[test_id:28440]Verifies that nodeSelector can be updated in performance profile", func() {
+			testutils.KnownIssueJira("OCPBUGS-12836")
+
 			kubeletConfig, err := nodes.GetKubeletConfig(newCnfNode)
 			Expect(kubeletConfig.TopologyManagerPolicy).ToNot(BeEmpty())
 			cmdline, err := nodes.ExecCommandOnNode(chkCmdLine, newCnfNode)
@@ -471,6 +475,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 
 		It("[test_id:27484]Verifies that node is reverted to plain worker when the extra labels are removed", func() {
+			testutils.KnownIssueJira("OCPBUGS-12836")
+
 			By("Deleting cnf labels from the node")
 			removeLabels(profile.Spec.NodeSelector, newCnfNode)
 			labelsDeletion = true
@@ -502,6 +508,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 
 		AfterEach(func() {
+			testutils.KnownIssueJira("OCPBUGS-12836")
 
 			if labelsDeletion == false {
 				removeLabels(profile.Spec.NodeSelector, newCnfNode)

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -620,7 +620,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -677,7 +678,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -733,7 +735,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to NOT be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld should not running on node %q ", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -794,7 +797,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -910,7 +914,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -973,7 +978,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -1043,7 +1049,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -1107,7 +1114,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)


### PR DESCRIPTION
This PR comes to fix :
- stalld flaky tests the occur due to race conditions
- afterAll function should be skipped if tests are skipped to save testing time and irrelevant errors.
- skip flaky update test due to OCPBUGS-12836
