### PR TITLE
e2e: add missing test id

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -349,7 +349,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				}
 			}
 		})
-		It("Should not have RPS configuration set when realtime workload hint is explicitly set", func() {
+		It("[test_id:54190] Should not have RPS configuration set when realtime workload hint is explicitly set", func() {
 
 			if profile.Spec.WorkloadHints != nil && profile.Spec.WorkloadHints.RealTime != nil &&
 				!*profile.Spec.WorkloadHints.RealTime && !profileutil.IsRpsEnabled(profile) {


### PR DESCRIPTION
Add missing PAO test id to enble proper reporting of the test's result.