### PR TITLE
OCPBUGS-12883: Fixes segfault in hypershift node tuning logic

### DIFF
--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -256,18 +256,17 @@ func newConfigMapForMachineConfig(configMapName string, nodePoolName string, mc 
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: ntoconfig.OperatorNamespace(),
-			Labels:    generatedConfigMapLabels(nodePoolName),
-			Annotations: map[string]string{
-				GeneratedByControllerVersionAnnotationKey: version.Version,
-			},
+			Name:        configMapName,
+			Namespace:   ntoconfig.OperatorNamespace(),
+			Labels:      generatedConfigMapLabels(nodePoolName),
+			Annotations: generatedConfigMapAnnotations(nodePoolName),
 		},
 		Data: map[string]string{
 			mcConfigMapDataKey: string(mcManifest),
 		},
 	}
 
+	ret.Annotations[GeneratedByControllerVersionAnnotationKey] = version.Version
 	return ret, nil
 }
 


### PR DESCRIPTION
A segfault occurs due to the cluster node tuning operator attempting to retrieve a MachineConfigPool object when used with Hypershift.

see this line
```machineCount, err := c.pc.getMachineCountForMachineConfigPool(mc.Name[len(MachineConfigPrefix)+1:])```

With Hypershift, MachineConfigPools do not appear to be used. This logic appears like it might have been a copy and paste from the standard "non hypershift" code paths.

 It's a strange sequence of events, but At least for the KubeVirt hypershift platform, this code path that results in a segfault is common due to the annotations used when the mc's configmap is created not matching the expected annotations.

This PR addesses both the annotations issue, by adding the expected annotations during config map creation, and fixes the segfault by removing the MachineConfigPool client usage.

Related To: https://issues.redhat.com/browse/OCPBUGS-12883 
