### PR TITLE
OCPBUGS-12883: Revert PR558 and PR585 partially

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -869,11 +869,7 @@ func (c *Controller) syncMachineConfigHyperShift(nodePoolName string, profile *t
 	bootcmdline := profile.Status.Bootcmdline
 	kernelArguments = util.SplitKernelArguments(bootcmdline)
 
-	annotations := map[string]string{
-		GeneratedByControllerVersionAnnotationKey:   version.Version,
-		tunedv1.RendredTunedGenerationAnnotationKey: profile.ObjectMeta.Annotations[tunedv1.RendredTunedGenerationAnnotationKey],
-		tunedv1.TunedProfileAnnotationKey:           profile.Status.TunedProfile,
-	}
+	annotations := map[string]string{GeneratedByControllerVersionAnnotationKey: version.Version}
 
 	mcConfigMap, err := c.clients.ManagementKube.CoreV1().ConfigMaps(ntoconfig.OperatorNamespace()).Get(context.TODO(), configMapName, metav1.GetOptions{})
 	if err != nil {
@@ -928,17 +924,6 @@ func (c *Controller) syncMachineConfigHyperShift(nodePoolName string, profile *t
 		// No update needed
 		klog.V(2).Infof("syncMachineConfig(): MachineConfig %s doesn't need updating", mc.ObjectMeta.Name)
 		return nil
-	} else if mcAnnotationsMatch(mc.ObjectMeta.Annotations, annotations) {
-		// Kernel arguments differ and they were generated based on the same TuneD profile and Tuned/rendered CR.
-		machineCount, err := c.pc.getMachineCountForMachineConfigPool(mc.Name[len(MachineConfigPrefix)+1:])
-		if err != nil {
-			return err
-		} else if machineCount > 1 {
-			klog.Warningf("refusing to update MachineConfig %s for %s due to kernel arguments change with unchanged input configuration (%s/%s). Node(s) with different (CPU) topology in the same MCP?",
-				mc.Name, profile.Name, annotations[tunedv1.RendredTunedGenerationAnnotationKey], annotations[tunedv1.TunedProfileAnnotationKey])
-			c.bootcmdlineConflict[profile.Name] = true
-			return nil
-		}
 	}
 
 	// If mcfgs are not equivalent do update


### PR DESCRIPTION
This is a partial revert of
https://github.com/openshift/cluster-node-tuning-operator/pull/558 and https://github.com/openshift/cluster-node-tuning-operator/pull/585

that handle different topology of machines in the same MCP.  The code was not properly tested on HyperShift and causes a SEGV there.

