### PR TITLE
OCPBUGS-10424: e2e: Fix RPS test for multi-worker cluster

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -303,8 +303,9 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			count := 0
 			expectedRPSCPUs, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 			Expect(err).ToNot(HaveOccurred())
-			var vethInterfaces = []string{}
+
 			for _, node := range workerRTNodes {
+				var vethInterfaces = []string{}
 				allInterfaces, err := nodes.GetNodeInterfaces(node)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(allInterfaces).ToNot(BeNil())


### PR DESCRIPTION
Fix `[test_id: 59572] Check RPS Mask is applied to atleast one single rx queue on all veth interface` test bug that occurs when running against a cluster with multiple worker nodes.

@mrniranjan @jlojosnegros Please, take a look.