### PR TITLE
[release-4.13] [manual] OCPBUGS-11336: pao e2e: fix update test suit timeouts

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -579,9 +579,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -637,9 +637,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -694,9 +694,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -756,9 +756,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -873,9 +873,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -937,9 +937,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -1008,9 +1008,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)
@@ -1073,9 +1073,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
 					node := &workerRTNodes[i]
+					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
-						wg.Add(1)
 						defer wg.Done()
 
 						pod, err := utilstuned.GetPod(context.TODO(), node)

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -591,7 +591,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -648,7 +649,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -704,7 +706,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to NOT be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld should not be running on node %q ", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -765,7 +768,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -881,7 +885,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -944,7 +949,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -1014,7 +1020,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
@@ -1078,7 +1085,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 						Expect(err).ToNot(HaveOccurred())
 
 						By(fmt.Sprintf("Waiting for stalld to be running on %q", node.Name))
-						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred())
+						Expect(utilstuned.WaitForStalldTo(stalldEnabled, 10*time.Second, 1*time.Minute, node)).ToNot(HaveOccurred(),
+							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						utilstuned.CheckParameters(node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)


### PR DESCRIPTION
This is partial manual cherry-pick of https://github.com/openshift/cluster-node-tuning-operator/pull/626
covering stalld and workload hints flaky tests that occur due to race conditions
