### PR TITLE
[release-4.13] OCPBUGS-11709: pao e2e: skip hugepages and numa tests properly

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -107,7 +107,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		}
 	})
 
-	Context("Verify hugepages count split on two NUMA nodes", func() {
+	Context("Verify hugepages count split on two NUMA nodes", Ordered, func() {
 		hpSize2M := performancev2.HugePageSize("2M")
 		skipTests := false
 


### PR DESCRIPTION
- pao e2e: skip hugepages and numa tests properly
- afterAll function should be skipped if tests are skipped  to save testing time and irrelevant errors.
 
