### PR TITLE
OCPBUGS-12978: use WatchNamespace() when deleting Profiles

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -622,7 +622,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 		// Remove Profiles for Nodes which no longer exist.
 		if errors.IsNotFound(err) {
 			klog.V(2).Infof("syncProfile(): deleting Profile %s", nodeName)
-			err = c.clients.Tuned.TunedV1().Profiles(ntoconfig.OperatorNamespace()).Delete(context.TODO(), nodeName, metav1.DeleteOptions{})
+			err = c.clients.Tuned.TunedV1().Profiles(ntoconfig.WatchNamespace()).Delete(context.TODO(), nodeName, metav1.DeleteOptions{})
 			if err != nil && errors.IsNotFound(err) {
 				err = nil
 			}


### PR DESCRIPTION
In HyperShift, WatchNamespace() is the namespace in hosted cluster where Profile and Tuned objects exist, which is distinct from the OperatorNamespace() which is named based on the name of the HostedCluster. 

In standalone OCP, these will be the same namespace (`openshift-cluster-node-tuning-operator`) (by default, at least...)