### PR TITLE
OCPBUGS-13148: Configure cpu balancing cpu sets for all clusters

### DIFF
--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
@@ -67,6 +67,13 @@ spec:
         mode: 420
         path: /etc/udev/rules.d/99-netdev-rps.rules
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCiMgY3B1c2V0LWNvbmZpZ3VyZS5zaCBjb25maWd1cmVzIHRocmVlIGNwdXNldHMgaW4gcHJlcGFyYXRpb24gZm9yIGFsbG93aW5nIGNvbnRhaW5lcnMgdG8gaGF2ZSBjcHUgbG9hZCBiYWxhbmNpbmcgZGlzYWJsZWQuCiMgVG8gY29uZmlndXJlIGEgY3B1c2V0IHRvIGhhdmUgbG9hZCBiYWxhbmNlIGRpc2FibGVkIChvbiBjZ3JvdXAgdjEpLCBhIGNwdXNldCBjZ3JvdXAgbXVzdCBoYXZlIGBjcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlYAojIHNldCB0byAwIChkaXNhYmxlKSwgYW5kIGFueSBjcHVzZXQgdGhhdCBjb250YWlucyB0aGUgc2FtZSBzZXQgYXMgYGNwdXNldC5jcHVzYCBtdXN0IGFsc28gaGF2ZSBgY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZWAgc2V0IHRvIGRpc2FibGVkLgoKc2V0IC1ldW8gcGlwZWZhaWwKCnJvb3Q9L3N5cy9mcy9jZ3JvdXAvY3B1c2V0CnN5c3RlbT0iJHJvb3QiL3N5c3RlbQptYWNoaW5lPSIkcm9vdCIvbWFjaGluZS5zbGljZQoKIyBBcyBzdWNoLCB0aGUgcm9vdCBjZ3JvdXAgbmVlZHMgdG8gaGF2ZSBjcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlPTAuIAplY2hvIDAgPiAiJHJvb3QiL2NwdXNldC5zY2hlZF9sb2FkX2JhbGFuY2UKCiMgSG93ZXZlciwgdGhpcyB3b3VsZCBwcmVzZW50IGEgcHJvYmxlbSBmb3Igc3lzdGVtIGRhZW1vbnMsIHdoaWNoIHNob3VsZCBoYXZlIGxvYWQgYmFsYW5jaW5nIGVuYWJsZWQuCiMgQXMgc3VjaCwgYSBzZWNvbmQgY3B1c2V0IG11c3QgYmUgY3JlYXRlZCwgaGVyZSBkdWJiZWQgYHN5c3RlbWAsIHdoaWNoIHdpbGwgdGFrZSBhbGwgc3lzdGVtIGRhZW1vbnMuCiMgU2luY2Ugc3lzdGVtZCBzdGFydHMgaXRzIGNoaWxkcmVuIHdpdGggdGhlIGNwdXNldCBpdCBpcyBpbiwgbW92aW5nIHN5c3RlbWQgd2lsbCBlbnN1cmUgYWxsIHByb2Nlc3NlcyBzeXN0ZW1kIGJlZ2lucyB3aWxsIGJlIGluIHRoZSBjb3JyZWN0IGNncm91cC4KbWtkaXIgIiRzeXN0ZW0iCiMgY3B1c2V0Lm1lbXMgbXVzdCBiZSBpbml0aWFsaXplZCBvciBwcm9jZXNzZXMgd2lsbCBmYWlsIHRvIGJlIG1vdmVkIGludG8gaXQuCmNhdCAiJHJvb3QvY3B1c2V0Lm1lbXMiID4gIiRzeXN0ZW0iL2NwdXNldC5tZW1zCiMgUmV0cmlldmUgdGhlIGNwdXNldCBvZiBzeXN0ZW1kLCBhbmQgd3JpdGUgaXQgdG8gY3B1c2V0LmNwdXMgb2YgdGhlIHN5c3RlbSBjZ3JvdXAuCnJlc2VydmVkX3NldD0kKHRhc2tzZXQgLWNwICAxICB8IGF3ayAnTkZ7IHByaW50ICRORiB9JykKZWNobyAiJHJlc2VydmVkX3NldCIgPiAiJHN5c3RlbSIvY3B1c2V0LmNwdXMKCiMgQW5kIG1vdmUgdGhlIHN5c3RlbSBwcm9jZXNzZXMgaW50byBpdC4KIyBOb3RlLCBzb21lIGtlcm5lbCB0aHJlYWRzIHdpbGwgZmFpbCB0byBiZSBtb3ZlZCB3aXRoICJJbnZhbGlkIEFyZ3VtZW50Ii4gVGhpcyBzaG91bGQgYmUgaWdub3JlZC4KZm9yIHByb2Nlc3MgaW4gJChjYXQgIiRyb290Ii9jZ3JvdXAucHJvY3MgfCBzb3J0IC1yKTsgZG8KCWVjaG8gJHByb2Nlc3MgPiAiJHN5c3RlbSIvY2dyb3VwLnByb2NzIDI+JjEgfCBncmVwIC12ICJJbnZhbGlkIEFyZ3VtZW50IiB8fCB0cnVlOwpkb25lCgojIEZpbmFsbHksIGEgdGhlIGBtYWNoaW5lLnNsaWNlYCBjZ3JvdXAgbXVzdCBiZSBwcmVjb25maWd1cmVkLiBQb2RtYW4gd2lsbCBjcmVhdGUgY29udGFpbmVycyBhbmQgbW92ZSB0aGVtIGludG8gdGhlIGBtYWNoaW5lLnNsaWNlYCwgYnV0IHRoZXJlJ3MKIyBubyB3YXkgdG8gdGVsbCBwb2RtYW4gdG8gdXBkYXRlIG1hY2hpbmUuc2xpY2UgdG8gbm90IGhhdmUgdGhlIGZ1bGwgc2V0IG9mIGNwdXMuIEluc3RlYWQgb2YgZGlzYWJsaW5nIGxvYWQgYmFsYW5jaW5nIGluIGl0LCB3ZSBjYW4gcHJlLWNyZWF0ZSBpdC4KIyB3aXRoIHRoZSByZXNlcnZlZCBDUFVzIHNldCBhaGVhZCBvZiB0aW1lLCBzbyB3aGVuIGlzb2xhdGVkIHByb2Nlc3NlcyBiZWdpbiwgdGhlIGNncm91cCBkb2VzIG5vdCBoYXZlIGFuIG92ZXJsYXBwaW5nIGNwdXNldCBiZXR3ZWVuIG1hY2hpbmUuc2xpY2UgYW5kIGlzb2xhdGVkIGNvbnRhaW5lcnMuCm1rZGlyICIkbWFjaGluZSIgfHwgdHJ1ZQoKIyBJdCdzIHVubGlrZWx5LCBidXQgcG9zc2libGUsIHRoYXQgdGhpcyBjcHVzZXQgYWxyZWFkeSBleGlzdGVkLiBJdGVyYXRlIGp1c3QgaW4gY2FzZS4KZm9yIGZpbGUgaW4gJChmaW5kICIkbWFjaGluZSIgLW5hbWUgY3B1c2V0LmNwdXMgfCBzb3J0IC1yKTsgZG8gZWNobyAiJHJlc2VydmVkX3NldCIgPiAiJGZpbGUiOyBkb25lCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/cpuset-configure.sh
+        user: {}
     systemd:
       units:
       - contents: |
@@ -94,6 +101,19 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: hugepages-allocation-1048576kB-NUMA0.service
+      - contents: |
+          [Unit]
+          Description=Move services to reserved cpuset
+          Before=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/cpuset-configure.sh
+
+          [Install]
+          WantedBy=multi-user.target crio.service
+        enabled: true
+        name: cpuset-configure.service
       - contents: |
           [Unit]
           Description=Set cpus offline: 2,3


### PR DESCRIPTION
The current code configures the cpu balancing management cpuset cgroup structure only when Workload partitioning is enabled.

That is wrong as even standard clusters use that feature.