### PR TITLE
Expose TuneD socket to host.

### DIFF
--- a/assets/bin/run
+++ b/assets/bin/run
@@ -2,6 +2,10 @@
 
 export SYSTEMD_IGNORE_CHROOT=1
 
+enable_tuned_unix_socket() {
+  sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|' /etc/tuned/tuned-main.conf
+}
+
 start() {
   # Tuned can take ~20s to reload/start when "ulimit -Sn == 1048576".
   # See:
@@ -9,6 +13,8 @@ start() {
   # - https://www.python.org/dev/peps/pep-0446/#closing-all-open-file-descriptors
   # - http://bugs.python.org/issue1663329
   ulimit -Sn 1024	# workaround for the issue above
+
+  enable_tuned_unix_socket
 
   exec /usr/bin/openshift-tuned \
     -v=0

--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -49,14 +49,10 @@ spec:
           readOnly: true
         - mountPath: /etc/systemd
           name: etc-systemd
+        - mountPath: /run
+          name: run
         - mountPath: /sys
           name: sys
-        - mountPath: /var/run/dbus
-          name: var-run-dbus
-          readOnly: true
-        - mountPath: /run/systemd/system
-          name: run-systemd-system
-          readOnly: true
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
@@ -99,17 +95,13 @@ spec:
           type: Directory
         name: etc-systemd
       - hostPath:
+          path: /run
+          type: Directory
+        name: run
+      - hostPath:
           path: /sys
           type: Directory
         name: sys
-      - hostPath:
-          path: /var/run/dbus
-          type: Directory
-        name: var-run-dbus
-      - hostPath:
-          path: /run/systemd/system
-          type: Directory
-        name: run-systemd-system
       - hostPath:
           path: /lib/modules
           type: Directory


### PR DESCRIPTION
This change exposes `TuneD` socket interface to the host OS.  This will, for example, allow to query and/or change a `TuneD` profile by using `TuneD` socket API.  For example, issuing the following (by the root user) from the host will return the active `TuneD` profile.

```
printf '{"jsonrpc": "2.0", "method": "active_profile", "id": 1}' | nc -U /run/tuned/tuned.sock
{"jsonrpc": "2.0", "id": 1, "result": "openshift-node"}
```