### PR TITLE
OCPBUGS-13262: Add PerformanceProfiles to 'oc adm must-gather: REVERT

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -340,7 +340,6 @@ func getRelatedObjects() []configv1.ObjectReference {
 		{Group: "tuned.openshift.io", Resource: "profiles", Name: "", Namespace: tunedMf.Namespace},
 		{Group: "tuned.openshift.io", Resource: "tuneds", Name: "", Namespace: tunedMf.Namespace},
 		{Group: "apps", Resource: "daemonsets", Name: dsMf.Name, Namespace: dsMf.Namespace},
-		{Group: "performance.openshift.io", Resource: "performanceprofiles", Name: ""},
 	}
 }
 


### PR DESCRIPTION
Reverts openshift/cluster-node-tuning-operator#582

HyperShift conformance tests are failing.
