### PR TITLE
e2e: latency: Add new env var for latency tools path

### DIFF
--- a/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -31,9 +31,6 @@ import (
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
-// TODO get commonly used variables from one shared file that defines constants
-const testExecutablePath = "../../../../../build/_output/bin/latency-e2e.test"
-
 var prePullNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "testing-prepull",
@@ -42,7 +39,7 @@ var prePullNamespace = &corev1.Namespace{
 var profile *performancev2.PerformanceProfile
 
 var _ = BeforeSuite(func() {
-	Expect(isTestExecutableFound()).To(BeTrue())
+	Expect(isTestExecutableFound(testutils.LatencyToolsPath)).To(BeTrue(), fmt.Sprintf("Unable to find latency tools at %s", testutils.LatencyToolsPath))
 	Expect(testclient.ClientsEnabled).To(BeTrue())
 
 	// update PP isolated CPUs. the new cpu set for isolated should have an even number of CPUs to avoid failing the pod on SMTAlignment error,
@@ -124,8 +121,9 @@ func createNamespace() error {
 	return err
 }
 
-func isTestExecutableFound() bool {
-	if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
+func isTestExecutableFound(path string) bool {
+	testlog.Infof("looking for tools at: %s", path)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return false
 	}
 	return true

--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -11,12 +11,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 )
 
 // TODO get commonly used variables from one shared file that defines constants
 const (
-	testExecutablePath = "../../../../../build/_output/bin/latency-e2e.test"
 	//tool to test
 	oslat       = "oslat"
 	cyclictest  = "cyclictest"
@@ -95,7 +96,7 @@ var _ = DescribeTable("Test latency measurement tools tests", func(testGroup []l
 		clearEnv()
 		testDescription := setEnvAndGetDescription(test)
 		By(testDescription)
-		output, err := exec.Command(testExecutablePath, "-ginkgo.v", "-ginkgo.focus", test.toolToTest).Output()
+		output, err := exec.Command(testutils.LatencyToolsPath, "-ginkgo.v", "-ginkgo.focus", test.toolToTest).Output()
 		if err != nil {
 			//we don't log Error level here because the test might be a negative check
 			testlog.Info(err.Error())

--- a/test/e2e/performanceprofile/functests/utils/consts.go
+++ b/test/e2e/performanceprofile/functests/utils/consts.go
@@ -8,6 +8,8 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
 )
 
+const defaultLatencyToolsPath = "../../../../../build/_output/bin/latency-e2e.test"
+
 // RoleWorkerCNF contains role name of cnf worker nodes
 var RoleWorkerCNF string
 
@@ -24,7 +26,16 @@ var NodesSelector string
 // ProfileNotFound is true when discovery mode is enabled and no valid profile was found
 var ProfileNotFound bool
 
+// Complete file name for the latency tools executable
+var LatencyToolsPath string
+
 func init() {
+
+	LatencyToolsPath = os.Getenv("LATENCY_TOOLS_PATH")
+	if LatencyToolsPath == "" {
+		LatencyToolsPath = defaultLatencyToolsPath
+	}
+
 	RoleWorkerCNF = os.Getenv("ROLE_WORKER_CNF")
 	if RoleWorkerCNF == "" {
 		RoleWorkerCNF = "worker-cnf"


### PR DESCRIPTION
Latency test suite uses an executable to run latency tests with different parameters.

This file's complete filename is hardcoded in the suite.

Being able to configure the path would make building cnf-test latency test image easier and, as if the variable is not set or empty default value would be used, this change is backward compatible.