### PR TITLE
OCPBUGS-14247: Remove setting ip forwarding via openshift profile

### DIFF
--- a/assets/tuned/daemon/profiles/openshift/tuned.conf
+++ b/assets/tuned/daemon/profiles/openshift/tuned.conf
@@ -13,7 +13,6 @@ avc_cache_threshold=8192
 nf_conntrack_hashsize=1048576
 
 [sysctl]
-net.ipv4.ip_forward=1
 kernel.pid_max=>4194304
 fs.aio-max-nr=>1048576
 net.netfilter.nf_conntrack_max=1048576


### PR DESCRIPTION
With https://github.com/openshift/machine-config-operator/pull/3676 we removed globally setting ip forwarding in MCO. We should not be setting it in the default profile for OpenShift. We now set it on a per interface basis as needed. However, by setting proc/sys/net/ipv4/forward rather than (forwarding) it will reset all the values:

"This variable is special, its change resets all configuration parameters to their default state (RFC1122 for hosts, RFC1812 for routers)"

We suspect this causes upgrade to fail. NTO sets this to 1, which then resets all the per interface config that OVNK wrote. Then during upgrade when there is a tuned profile change, the config change is rolled back so forward is 0, and now there is no connectivity to kapi and upgrade fails.