### PR TITLE
[release-4.11] OCPBUGS-14501: Fix updating numa core siblings map in GetCpuSiblings f…

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -840,7 +840,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				// Select the last core id
 				higherCoreIds := cores[len(cores)-1]
 				// Get cpu siblings from the selected cores and delete the selected cores  from the map
-				cpusiblings := nodes.GetCpuSiblings(numaCoreSiblings, higherCoreIds)
+				cpusiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, higherCoreIds)
 				offline = append(offline, cpusiblings...)
 			}
 			offlineCpus := strings.Join(offline, ",")
@@ -848,7 +848,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				cpusiblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				cpusiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, cpusiblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
@@ -856,7 +856,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			// numaCoreSiblings map is used in isolatedCpus
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					cpusiblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					cpusiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, cpusiblings...)
 				}
 			}
@@ -919,14 +919,14 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 				sort.Ints(cores)
 				middleCoreIds := cores[len(cores)/2]
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, middleCoreIds)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, middleCoreIds)
 				offline = append(offline, siblings...)
 			}
 			offlineCpus := strings.Join(offline, ",")
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, siblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
@@ -934,7 +934,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			// numaCoreSiblings map is used in isolatedCpus
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					siblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, siblings...)
 				}
 			}
@@ -986,23 +986,18 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 			}
 			for _, node := range workerRTNodes {
-				onlineCPUCount, err := nodes.ExecCommandOnNode([]string{"nproc", "--all"}, &node)
-				Expect(err).ToNot(HaveOccurred())
-				onlineCPUInt, err := strconv.Atoi(onlineCPUCount)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(onlineCPUInt).Should(BeNumerically(">=", 3))
-				if onlineCPUInt <= 8 {
-					Skip(fmt.Sprintf("This test needs more than 8 CPUs online to work correctly, current online CPUs are %s", onlineCPUCount))
-				}
-			}
-			for _, node := range workerRTNodes {
 				numaCoreSiblings, err = nodes.GetCoreSiblings(&node)
 			}
+
+			if len(numaCoreSiblings[0]) < 20 {
+				Skip(fmt.Sprintf("This test needs systems with at least 20 cores per socket"))
+			}
+
 			// Get reserved core siblings from 0, 1
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, siblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
@@ -1015,8 +1010,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 				sort.Ints(cores)
 				middleCoreIds := cores[len(cores)/2]
-				for i := middleCoreIds; i < middleCoreIds+10; i++ {
-					siblings := nodes.GetCpuSiblings(numaCoreSiblings, i)
+				for i := middleCoreIds; i < len(cores)/2; i++ {
+					siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, i)
 					offlined = append(offlined, siblings...)
 				}
 			}
@@ -1025,7 +1020,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			// map is used in isolatedCpus
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					siblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, siblings...)
 				}
 			}
@@ -1093,7 +1088,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, siblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
@@ -1101,7 +1096,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			// numaCoreSiblings map is used in isolatedCpus
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					siblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, siblings...)
 				}
 			}
@@ -1167,20 +1162,20 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
 				// from the map. Selected siblings of cores are saved in reservedCpus
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, reservedCores)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, reservedCores)
 				reserved = append(reserved, siblings...)
 			}
 			reservedCpus := strings.Join(reserved, ",")
 
 			discreteCores := []int{3, 13, 15, 24, 29}
 			for _, v := range discreteCores {
-				siblings := nodes.GetCpuSiblings(numaCoreSiblings, v)
+				siblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, v)
 				offlined = append(offlined, siblings...)
 			}
 			offlineCpus := strings.Join(offlined, ",")
 			for key := range numaCoreSiblings {
 				for k := range numaCoreSiblings[key] {
-					cpusiblings := nodes.GetCpuSiblings(numaCoreSiblings, k)
+					cpusiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, k)
 					isolated = append(isolated, cpusiblings...)
 				}
 			}

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -427,14 +427,21 @@ func GetByCpuCapacity(nodesList []corev1.Node, cpuQty int) []corev1.Node {
 	return nodesWithSufficientCpu
 }
 
-// GetCpuSiblings function returns the cpus siblings associated with core
+// GetAndRemoveCpuSiblingsFromMap function returns the cpus siblings associated with core
 // Also updates the map by deleting the cpu siblings returned
-func GetCpuSiblings(numaCoreSiblings map[int]map[int][]int, coreKey int) []string {
+func GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings map[int]map[int][]int, coreId int) []string {
 	var cpuSiblings []string
-	for key := range numaCoreSiblings {
-		for _, c := range numaCoreSiblings[key][coreKey] {
-			cpuSiblings = append(cpuSiblings, strconv.Itoa(c))
-			delete(numaCoreSiblings[key], c)
+	// Iterate over the  Numa node in the map
+	for node := range numaCoreSiblings {
+		// Check if the coreId exists in the Numa node
+		_, ok := numaCoreSiblings[node][coreId]
+		if ok {
+			// Iterate over the siblings of the coreId
+			for _, sibling := range numaCoreSiblings[node][coreId] {
+				cpuSiblings = append(cpuSiblings, strconv.Itoa(sibling))
+			}
+			// Delete the cpusiblings of that particular coreId
+			delete(numaCoreSiblings[node], coreId)
 		}
 	}
 	return cpuSiblings


### PR DESCRIPTION
…unction

Fix updating numa core siblings map in GetCpuSiblings function move the delete operation outside of for loop.

Also minor fixes to offline tests to check if the worker node has 20 cores earlier in the test function