### PR TITLE
[test] [e2e] Check variables before reading them in the cleanup closures.

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/netqueues.go
+++ b/test/e2e/performanceprofile/functests/1_performance/netqueues.go
@@ -79,6 +79,11 @@ var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", Ordered, func() 
 	})
 
 	AfterEach(func() {
+		By("Checking the Profile")
+		if initialProfile == nil {
+			testlog.Error("unable to revert profile. Readed profile is nil")
+			return
+		}
 		By("Reverting the Profile")
 		spec, err := json.Marshal(initialProfile.Spec)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -762,6 +762,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			var globallyDisableIrqLoadBalancing bool
 
 			JustBeforeEach(func() {
+				//REVIEW - This is overwritting the "profile" var, is that ok?
 				key := types.NamespacedName{
 					Name:      profile.Name,
 					Namespace: profile.Namespace,
@@ -873,6 +874,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			}
 		})
 
+		// REVIEW - validateObject could be creating new objects that are never deleted.
 		validateObject := func(obj client.Object, message string) {
 			err := testclient.Client.Create(context.TODO(), obj)
 			Expect(err).To(HaveOccurred(), "expected the validation error")

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -49,7 +49,7 @@ type checkFunction func(*corev1.Node) (string, error)
 
 var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance profile", func() {
 	var workerRTNodes []corev1.Node
-	var profile, initialProfile *performancev2.PerformanceProfile
+	var profile *performancev2.PerformanceProfile
 	var performanceMCP string
 	var err error
 
@@ -112,6 +112,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 	Context("Verify hugepages count split on two NUMA nodes", Ordered, func() {
 		hpSize2M := performancev2.HugePageSize("2M")
 		skipTests := false
+		var initialProfile *performancev2.PerformanceProfile
 
 		testutils.CustomBeforeAll(func() {
 			for _, node := range workerRTNodes {
@@ -222,6 +223,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 
 	Context("Verify that all performance profile parameters can be updated", Ordered, func() {
 		var removedKernelArgs string
+		var initialProfile *performancev2.PerformanceProfile
 
 		hpSize2M := performancev2.HugePageSize("2M")
 		hpSize1G := performancev2.HugePageSize("1G")
@@ -579,6 +581,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 
 	Context("WorkloadHints", func() {
 		var testpod *corev1.Pod
+		var initialProfile *performancev2.PerformanceProfile
+
 		BeforeEach(func() {
 			By("Saving the old performance profile")
 			initialProfile = profile.DeepCopy()
@@ -1371,6 +1375,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 	})
 
 	Context("Offlined CPU API", func() {
+		var initialProfile *performancev2.PerformanceProfile
+
 		BeforeEach(func() {
 			//Saving the old performance profile
 			initialProfile = profile.DeepCopy()
@@ -1833,6 +1839,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 	})
 
 	Context("[rfe_id:54374][rps_mask] Network Stack Pinning", func() {
+		var initialProfile *performancev2.PerformanceProfile
 
 		BeforeEach(func() {
 			//Get Latest profile

--- a/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -92,6 +92,14 @@ var _ = AfterSuite(func() {
 		namespaces.WaitForDeletion(prePullNamespaceName, 5*time.Minute)
 	}
 
+	// check if profile variable has been populated.
+	// otherwise there is no need to try to restore it
+	// and it would panic
+	if profile == nil {
+		testlog.Error("could not restore the initial profile because it has not been read")
+		return
+	}
+
 	currentProfile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 	Expect(err).ToNot(HaveOccurred())
 	if reflect.DeepEqual(currentProfile.Spec, profile.Spec) != true {

--- a/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -88,8 +88,9 @@ var _ = AfterSuite(func() {
 	err := testclient.Client.Delete(context.TODO(), prePullNamespace)
 	if err != nil {
 		testlog.Errorf("namespace %q could not be deleted err=%v", prePullNamespace.Name, err)
+	} else {
+		namespaces.WaitForDeletion(prePullNamespaceName, 5*time.Minute)
 	}
-	namespaces.WaitForDeletion(prePullNamespaceName, 5*time.Minute)
 
 	currentProfile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
When a failure occurs in a `BeforeEach`, `JustBeforeEach`, or `It` closure Ginkgo halts execution of the current spec and cleans up by invoking any registered `AfterEach` or `JustAfterEach` closures (and any registered `DeferCleanup` closures if applicable). 

We need to check variables before reading them in the cleanup closures.