### PR TITLE
OCPBUGS-14622: Do not fail creating cgroups if they exist already

### DIFF
--- a/assets/performanceprofile/scripts/cpuset-configure.sh
+++ b/assets/performanceprofile/scripts/cpuset-configure.sh
@@ -32,7 +32,7 @@ done
 # Finally, a the `machine.slice` cgroup must be preconfigured. Podman will create containers and move them into the `machine.slice`, but there's
 # no way to tell podman to update machine.slice to not have the full set of cpus. Instead of disabling load balancing in it, we can pre-create it.
 # with the reserved CPUs set ahead of time, so when isolated processes begin, the cgroup does not have an overlapping cpuset between machine.slice and isolated containers.
-mkdir -p "$machine" || true
+mkdir -p "$machine"
 
 # It's unlikely, but possible, that this cpuset already existed. Iterate just in case.
 for file in $(find "$machine" -name cpuset.cpus | sort -r); do echo "$reserved_set" > "$file"; done


### PR DESCRIPTION
This `mkdir -p` to resolve the issue below: 
```
[root@itamae ~]# systemctl status cpuset-configure.service
× cpuset-configure.service - Move services to reserved cpuset
     Loaded: loaded (/etc/systemd/system/cpuset-configure.service; enabled; preset: disabled)
     Active: failed (Result: exit-code) since Tue 2023-06-06 13:51:43 UTC; 8s ago
    Process: 3927805 ExecStart=/usr/local/bin/cpuset-configure.sh (code=exited, status=1/FAILURE)
   Main PID: 3927805 (code=exited, status=1/FAILURE)
        CPU: 5ms

Jun 06 13:51:43 itamae systemd[1]: Starting Move services to reserved cpuset...
Jun 06 13:51:43 itamae cpuset-configure.sh[3927806]: mkdir: cannot create directory ‘/sys/fs/cgroup/cpuset/system’: File exists
Jun 06 13:51:43 itamae systemd[1]: cpuset-configure.service: Main process exited, code=exited, status=1/FAILURE
Jun 06 13:51:43 itamae systemd[1]: cpuset-configure.service: Failed with result 'exit-code'.
Jun 06 13:51:43 itamae systemd[1]: Failed to start Move services to reserved cpuset.
```