### PR TITLE
OCPBUGS-14756: [test] [e2e] Check ci lanes are executing the right test suites

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -6,13 +6,13 @@ OC_TOOL="${OC_TOOL:-oc}"
 
 which ginkgo
 if [ $? -ne 0 ]; then
-	echo "Downloading ginkgo tool"
-    go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
-    ginkgo version
+  echo "Downloading ginkgo tool"
+  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+  ginkgo version
 fi
 
 NO_COLOR=""
-if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
+if ! which tput &>/dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
   echo "Terminal does not seem to support colored output, disabling it"
   NO_COLOR="-noColor"
 fi
@@ -24,9 +24,9 @@ fi
 
 if [[ -z "${CNF_TESTS_IMAGE}" ]]; then
 
-    echo "autodetected cluster version: ${ocp_version}"
-    ocp_version=$(${OC_TOOL} get clusterversion -o jsonpath='{.items[].status.desired.version}{"\n"}' | awk -F "." '{print $1"."$2}')
-    export CNF_TESTS_IMAGE=cnf-tests:${ocp_version}
+  echo "autodetected cluster version: ${ocp_version}"
+  ocp_version=$(${OC_TOOL} get clusterversion -o jsonpath='{.items[].status.desired.version}{"\n"}' | awk -F "." '{print $1"."$2}')
+  export CNF_TESTS_IMAGE=cnf-tests:${ocp_version}
 fi
 
 echo "Running Functional Tests: ${GINKGO_SUITS}"

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GINKGO_SUITS=${GINKGO_SUITS:-"test/e2e/performanceprofile/functests"}
+GINKGO_SUITS=${GINKGO_SUITS:-"test/e2e/performanceprofile/functests/0_config test/e2e/performanceprofile/functests/1_performance test/e2e/performanceprofile/functests/6_mustgather_testing"}
 LATENCY_TEST_RUN=${LATENCY_TEST_RUN:-"false"}
 OC_TOOL="${OC_TOOL:-oc}"
 
@@ -35,4 +35,4 @@ echo "Running Functional Tests: ${GINKGO_SUITS}"
 # --fail-fast: ginkgo will stop the suite right after the first spec failure
 # --flake-attempts: rerun the test if it fails
 # --require-suite: fail if tests are not executed because of missing suite
-GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --fail-fast --skip-package="5_latency_testing,2_performance_update" --flake-attempts=2 --require-suite ${GINKGO_SUITS} --junit-report=report.xml
+GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --fail-fast --flake-attempts=2 --require-suite ${GINKGO_SUITS} --junit-report=report.xml

--- a/hack/run-update-testing.sh
+++ b/hack/run-update-testing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GINKGO_SUITS=${GINKGO_SUITS:-"test/e2e/performanceprofile/functests/0_config test/e2e/performanceprofile/functests/2_performance_update"}
+GINKGO_SUITS=${GINKGO_SUITS:-"test/e2e/performanceprofile/functests/0_config test/e2e/performanceprofile/functests/2_performance_update test/e2e/performanceprofile/functests/3_performance_status test/e2e/performanceprofile/functests/7_performance_kubelet_node test/e2e/performanceprofile/functests/8_reboot"}
 LATENCY_TEST_RUN=${LATENCY_TEST_RUN:-"false"}
 
 which ginkgo

--- a/hack/run-update-testing.sh
+++ b/hack/run-update-testing.sh
@@ -5,13 +5,13 @@ LATENCY_TEST_RUN=${LATENCY_TEST_RUN:-"false"}
 
 which ginkgo
 if [ $? -ne 0 ]; then
-	echo "Downloading ginkgo tool"
-    go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
-    ginkgo version
+  echo "Downloading ginkgo tool"
+  go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+  ginkgo version
 fi
 
 NO_COLOR=""
-if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
+if ! which tput &>/dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
   echo "Terminal does not seem to support colored output, disabling it"
   NO_COLOR="-noColor"
 fi
@@ -20,7 +20,6 @@ fi
 if [ -n "${IMAGE_FORMAT}" ]; then
   LATENCY_TEST_RUN="true"
 fi
-
 
 echo "Running Functional Tests: ${GINKGO_SUITS}"
 # -v: print out the text and location for each spec before running it and flush output to stdout in realtime


### PR DESCRIPTION
Some ci-lanes are running test-suites by mistake. 
