### PR TITLE
Add golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,32 @@
+run:
+  timeout: 5m
+  tests: false
+  skip-dirs:
+    - vendor
+    - test
+  modules-download-mode: vendor
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - bodyclose
+    - exportloopref
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - nosprintfhostport
+    - staticcheck
+    - tenv
+    - typecheck
+    - unconvert
+    - unused
+    - wastedassign
+    - whitespace
+linters-settings:
+  misspell:
+    locale: US
+    ignore-words:
+      - NTO
+      - nto

--- a/cmd/performance-profile-creator/cmd/root.go
+++ b/cmd/performance-profile-creator/cmd/root.go
@@ -114,8 +114,8 @@ func init() {
 // NewRootCommand returns entrypoint command to interact with all other commands
 func NewRootCommand() *cobra.Command {
 	pcArgs := &ProfileCreatorArgs{
-		UserLevelNetworking:   pointer.BoolPtr(false),
-		PerPodPowerManagement: pointer.BoolPtr(false),
+		UserLevelNetworking:   pointer.Bool(false),
+		PerPodPowerManagement: pointer.Bool(false),
 	}
 
 	var requiredFlags = []string{
@@ -464,7 +464,7 @@ func getProfileData(args ProfileCreatorArgs, cluster ClusterData) (*ProfileData,
 	for _, nodeHandler := range cluster[mcp] {
 		matchedNodeNames = append(matchedNodeNames, nodeHandler.Node.GetName())
 	}
-	log.Infof("Nodes targetted by %s MCP are: %v", args.MCPName, matchedNodeNames)
+	log.Infof("Nodes targeted by %s MCP are: %v", args.MCPName, matchedNodeNames)
 	err = profilecreator.EnsureNodesHaveTheSameHardware(cluster[mcp])
 	if err != nil {
 		return nil, fmt.Errorf("targeted nodes differ: %v", err)
@@ -511,16 +511,15 @@ func getProfileData(args ProfileCreatorArgs, cluster ClusterData) (*ProfileData,
 			)
 		}
 	case lowLatency:
-		profileData.realtimeHint = pointer.BoolPtr(true)
+		profileData.realtimeHint = pointer.Bool(true)
 	case ultraLowLatency:
-		profileData.realtimeHint = pointer.BoolPtr(true)
-		profileData.highPowerConsumptionHint = pointer.BoolPtr(true)
+		profileData.realtimeHint = pointer.Bool(true)
+		profileData.highPowerConsumptionHint = pointer.Bool(true)
 		if profileData.perPodPowerManagementHint != nil && *profileData.perPodPowerManagementHint {
 			return nil, fmt.Errorf(
 				"please use one of %v power consumption modes together with the perPodPowerManagement",
 				validPowerConsumptionModes[:2],
 			)
-
 		}
 	}
 	return profileData, nil
@@ -600,9 +599,9 @@ func createProfile(profileData ProfileData) error {
 
 	// configuring workload hints
 	profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
-		HighPowerConsumption:  pointer.BoolPtr(false),
-		RealTime:              pointer.BoolPtr(false),
-		PerPodPowerManagement: pointer.BoolPtr(false),
+		HighPowerConsumption:  pointer.Bool(false),
+		RealTime:              pointer.Bool(false),
+		PerPodPowerManagement: pointer.Bool(false),
 	}
 
 	if profileData.highPowerConsumptionHint != nil {

--- a/docs/performanceprofile/performance_profile.md
+++ b/docs/performanceprofile/performance_profile.md
@@ -3,7 +3,7 @@
 
 This document documents the PerformanceProfile API introduced by the Performance controller.
 
-> This document is generated from code comments on the `PerformanceProfile` struct.  
+> This document is generated from code comments on the `PerformanceProfile` struct.
 > When contributing a change to this document please do so by changing those code comments.
 
 ## Table of Contents
@@ -142,7 +142,7 @@ PerformanceProfileSpec defines the desired state of PerformanceProfile.
 | machineConfigPoolSelector | MachineConfigPoolSelector defines the MachineConfigPool label to use in the MachineConfigPoolSelector of resources like KubeletConfigs created by the operator. Defaults to \"machineconfiguration.openshift.io/role=&lt;same role as in NodeSelector label key&gt;\" | map[string]string | false |
 | nodeSelector | NodeSelector defines the Node label to use in the NodeSelectors of resources like Tuned created by the operator. It most likely should, but does not have to match the node label in the NodeSelector of the MachineConfigPool which targets this performance profile. In the case when machineConfigLabels or machineConfigPoolSelector are not set, we are expecting a certain NodeSelector format &lt;domain&gt;/&lt;role&gt;: \"\" in order to be able to calculate the default values for the former mentioned fields. | map[string]string | true |
 | realTimeKernel | RealTimeKernel defines a set of real time kernel related parameters. RT kernel won't be installed when not set. | *[RealTimeKernel](#realtimekernel) | false |
-| additionalKernelArgs | Addional kernel arguments. | []string | false |
+| additionalKernelArgs | Additional kernel arguments. | []string | false |
 | numa | NUMA defines options related to topology aware affinities | *[NUMA](#numa) | false |
 | net | Net defines a set of network related features | *[Net](#net) | false |
 | globallyDisableIrqLoadBalancing | GloballyDisableIrqLoadBalancing toggles whether IRQ load balancing will be disabled for the Isolated CPU set. When the option is set to \"true\" it disables IRQs load balancing for the Isolated CPU set. Setting the option to \"false\" allows the IRQs to be balanced across all CPUs, however the IRQs load balancing can be disabled per pod CPUs when using irq-load-balancing.crio.io/cpu-quota.crio.io annotations. Defaults to \"false\" | *bool | false |

--- a/examples/performanceprofile/crd/bases/performance.openshift.io_performanceprofiles.yaml
+++ b/examples/performanceprofile/crd/bases/performance.openshift.io_performanceprofiles.yaml
@@ -41,7 +41,7 @@ spec:
             description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
             properties:
               additionalKernelArgs:
-                description: Addional kernel arguments.
+                description: Additional kernel arguments.
                 items:
                   type: string
                 type: array
@@ -277,7 +277,7 @@ spec:
             description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
             properties:
               additionalKernelArgs:
-                description: Addional kernel arguments.
+                description: Additional kernel arguments.
                 items:
                   type: string
                 type: array
@@ -459,7 +459,7 @@ spec:
             description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
             properties:
               additionalKernelArgs:
-                description: Addional kernel arguments.
+                description: Additional kernel arguments.
                 items:
                   type: string
                 type: array

--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -54,7 +54,7 @@ spec:
             description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
             properties:
               additionalKernelArgs:
-                description: Addional kernel arguments.
+                description: Additional kernel arguments.
                 items:
                   type: string
                 type: array
@@ -314,7 +314,7 @@ spec:
             description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
             properties:
               additionalKernelArgs:
-                description: Addional kernel arguments.
+                description: Additional kernel arguments.
                 items:
                   type: string
                 type: array
@@ -496,7 +496,7 @@ spec:
             description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
             properties:
               additionalKernelArgs:
-                description: Addional kernel arguments.
+                description: Additional kernel arguments.
                 items:
                   type: string
                 type: array

--- a/pkg/apis/performanceprofile/v1/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v1/performanceprofile_types.go
@@ -54,7 +54,7 @@ type PerformanceProfileSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector"`
 	// RealTimeKernel defines a set of real time kernel related parameters. RT kernel won't be installed when not set.
 	RealTimeKernel *RealTimeKernel `json:"realTimeKernel,omitempty"`
-	// Addional kernel arguments.
+	// Additional kernel arguments.
 	// +optional
 	AdditionalKernelArgs []string `json:"additionalKernelArgs,omitempty"`
 	// NUMA defines options related to topology aware affinities

--- a/pkg/apis/performanceprofile/v1alpha1/performanceprofile_conversion.go
+++ b/pkg/apis/performanceprofile/v1alpha1/performanceprofile_conversion.go
@@ -29,7 +29,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.CPU.Isolated = &isolated
 		}
 		if curr.Spec.CPU.BalanceIsolated != nil {
-			dst.Spec.CPU.BalanceIsolated = pointer.BoolPtr(*curr.Spec.CPU.BalanceIsolated)
+			dst.Spec.CPU.BalanceIsolated = pointer.Bool(*curr.Spec.CPU.BalanceIsolated)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 					Size: v1.HugePageSize(p.Size), Count: p.Count,
 				}
 				if p.Node != nil {
-					dst.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+					dst.Spec.HugePages.Pages[i].Node = pointer.Int32(*p.Node)
 				}
 			}
 		}
@@ -80,7 +80,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.RealTimeKernel = new(v1.RealTimeKernel)
 
 		if curr.Spec.RealTimeKernel.Enabled != nil {
-			dst.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(*curr.Spec.RealTimeKernel.Enabled)
+			dst.Spec.RealTimeKernel.Enabled = pointer.Bool(*curr.Spec.RealTimeKernel.Enabled)
 		}
 	}
 
@@ -93,7 +93,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.NUMA = new(v1.NUMA)
 
 		if curr.Spec.NUMA.TopologyPolicy != nil {
-			dst.Spec.NUMA.TopologyPolicy = pointer.StringPtr(*curr.Spec.NUMA.TopologyPolicy)
+			dst.Spec.NUMA.TopologyPolicy = pointer.String(*curr.Spec.NUMA.TopologyPolicy)
 		}
 	}
 
@@ -104,11 +104,11 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	if curr.Status.Tuned != nil {
-		dst.Status.Tuned = pointer.StringPtr(*curr.Status.Tuned)
+		dst.Status.Tuned = pointer.String(*curr.Status.Tuned)
 	}
 
 	if curr.Status.RuntimeClass != nil {
-		dst.Status.RuntimeClass = pointer.StringPtr(*curr.Status.RuntimeClass)
+		dst.Status.RuntimeClass = pointer.String(*curr.Status.RuntimeClass)
 	}
 
 	// +kubebuilder:docs-gen:collapse=rote conversion
@@ -135,7 +135,7 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 			curr.Spec.CPU.Isolated = &isolated
 		}
 		if src.Spec.CPU.BalanceIsolated != nil {
-			curr.Spec.CPU.BalanceIsolated = pointer.BoolPtr(*src.Spec.CPU.BalanceIsolated)
+			curr.Spec.CPU.BalanceIsolated = pointer.Bool(*src.Spec.CPU.BalanceIsolated)
 		}
 	}
 
@@ -154,7 +154,7 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 					Size: HugePageSize(p.Size), Count: p.Count,
 				}
 				if p.Node != nil {
-					curr.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+					curr.Spec.HugePages.Pages[i].Node = pointer.Int32(*p.Node)
 				}
 			}
 		}
@@ -185,7 +185,7 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		curr.Spec.RealTimeKernel = new(RealTimeKernel)
 
 		if src.Spec.RealTimeKernel.Enabled != nil {
-			curr.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(*src.Spec.RealTimeKernel.Enabled)
+			curr.Spec.RealTimeKernel.Enabled = pointer.Bool(*src.Spec.RealTimeKernel.Enabled)
 		}
 	}
 
@@ -198,7 +198,7 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		curr.Spec.NUMA = new(NUMA)
 
 		if src.Spec.NUMA.TopologyPolicy != nil {
-			curr.Spec.NUMA.TopologyPolicy = pointer.StringPtr(*src.Spec.NUMA.TopologyPolicy)
+			curr.Spec.NUMA.TopologyPolicy = pointer.String(*src.Spec.NUMA.TopologyPolicy)
 		}
 	}
 
@@ -209,11 +209,11 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	if src.Status.Tuned != nil {
-		curr.Status.Tuned = pointer.StringPtr(*src.Status.Tuned)
+		curr.Status.Tuned = pointer.String(*src.Status.Tuned)
 	}
 
 	if src.Status.RuntimeClass != nil {
-		curr.Status.RuntimeClass = pointer.StringPtr(*src.Status.RuntimeClass)
+		curr.Status.RuntimeClass = pointer.String(*src.Status.RuntimeClass)
 	}
 
 	// +kubebuilder:docs-gen:collapse=rote conversion

--- a/pkg/apis/performanceprofile/v1alpha1/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v1alpha1/performanceprofile_types.go
@@ -52,7 +52,7 @@ type PerformanceProfileSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// RealTimeKernel defines a set of real time kernel related parameters. RT kernel won't be installed when not set.
 	RealTimeKernel *RealTimeKernel `json:"realTimeKernel,omitempty"`
-	// Addional kernel arguments.
+	// Additional kernel arguments.
 	// +optional
 	AdditionalKernelArgs []string `json:"additionalKernelArgs,omitempty"`
 	// NUMA defines options related to topology aware affinities

--- a/pkg/apis/performanceprofile/v2/performanceprofile_conversion.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_conversion.go
@@ -29,7 +29,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.CPU.Isolated = &isolated
 		}
 		if curr.Spec.CPU.BalanceIsolated != nil {
-			dst.Spec.CPU.BalanceIsolated = pointer.BoolPtr(*curr.Spec.CPU.BalanceIsolated)
+			dst.Spec.CPU.BalanceIsolated = pointer.Bool(*curr.Spec.CPU.BalanceIsolated)
 		}
 	}
 
@@ -49,7 +49,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 					Size: v1.HugePageSize(p.Size), Count: p.Count,
 				}
 				if p.Node != nil {
-					dst.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+					dst.Spec.HugePages.Pages[i].Node = pointer.Int32(*p.Node)
 				}
 			}
 		}
@@ -80,7 +80,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.RealTimeKernel = new(v1.RealTimeKernel)
 
 		if curr.Spec.RealTimeKernel.Enabled != nil {
-			dst.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(*curr.Spec.RealTimeKernel.Enabled)
+			dst.Spec.RealTimeKernel.Enabled = pointer.Bool(*curr.Spec.RealTimeKernel.Enabled)
 		}
 	}
 
@@ -93,7 +93,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.NUMA = new(v1.NUMA)
 
 		if curr.Spec.NUMA.TopologyPolicy != nil {
-			dst.Spec.NUMA.TopologyPolicy = pointer.StringPtr(*curr.Spec.NUMA.TopologyPolicy)
+			dst.Spec.NUMA.TopologyPolicy = pointer.String(*curr.Spec.NUMA.TopologyPolicy)
 		}
 	}
 
@@ -102,7 +102,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.Net = new(v1.Net)
 
 		if curr.Spec.Net.UserLevelNetworking != nil {
-			dst.Spec.Net.UserLevelNetworking = pointer.BoolPtr(*curr.Spec.Net.UserLevelNetworking)
+			dst.Spec.Net.UserLevelNetworking = pointer.Bool(*curr.Spec.Net.UserLevelNetworking)
 		}
 
 		if curr.Spec.Net.Devices != nil {
@@ -112,15 +112,15 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 				device := v1.Device{}
 
 				if d.VendorID != nil {
-					device.VendorID = pointer.StringPtr(*d.VendorID)
+					device.VendorID = pointer.String(*d.VendorID)
 				}
 
 				if d.DeviceID != nil {
-					device.DeviceID = pointer.StringPtr(*d.DeviceID)
+					device.DeviceID = pointer.String(*d.DeviceID)
 				}
 
 				if d.InterfaceName != nil {
-					device.InterfaceName = pointer.StringPtr(*d.InterfaceName)
+					device.InterfaceName = pointer.String(*d.InterfaceName)
 				}
 
 				dst.Spec.Net.Devices = append(dst.Spec.Net.Devices, device)
@@ -129,7 +129,7 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	if curr.Spec.GloballyDisableIrqLoadBalancing != nil {
-		dst.Spec.GloballyDisableIrqLoadBalancing = pointer.BoolPtr(*curr.Spec.GloballyDisableIrqLoadBalancing)
+		dst.Spec.GloballyDisableIrqLoadBalancing = pointer.Bool(*curr.Spec.GloballyDisableIrqLoadBalancing)
 	}
 
 	// Status
@@ -139,11 +139,11 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	if curr.Status.Tuned != nil {
-		dst.Status.Tuned = pointer.StringPtr(*curr.Status.Tuned)
+		dst.Status.Tuned = pointer.String(*curr.Status.Tuned)
 	}
 
 	if curr.Status.RuntimeClass != nil {
-		dst.Status.RuntimeClass = pointer.StringPtr(*curr.Status.RuntimeClass)
+		dst.Status.RuntimeClass = pointer.String(*curr.Status.RuntimeClass)
 	}
 
 	// +kubebuilder:docs-gen:collapse=rote conversion
@@ -170,7 +170,7 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 			curr.Spec.CPU.Isolated = &isolated
 		}
 		if src.Spec.CPU.BalanceIsolated != nil {
-			curr.Spec.CPU.BalanceIsolated = pointer.BoolPtr(*src.Spec.CPU.BalanceIsolated)
+			curr.Spec.CPU.BalanceIsolated = pointer.Bool(*src.Spec.CPU.BalanceIsolated)
 		}
 	}
 
@@ -189,7 +189,7 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 					Size: HugePageSize(p.Size), Count: p.Count,
 				}
 				if p.Node != nil {
-					curr.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+					curr.Spec.HugePages.Pages[i].Node = pointer.Int32(*p.Node)
 				}
 			}
 		}
@@ -220,7 +220,7 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		curr.Spec.RealTimeKernel = new(RealTimeKernel)
 
 		if src.Spec.RealTimeKernel.Enabled != nil {
-			curr.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(*src.Spec.RealTimeKernel.Enabled)
+			curr.Spec.RealTimeKernel.Enabled = pointer.Bool(*src.Spec.RealTimeKernel.Enabled)
 		}
 	}
 
@@ -233,7 +233,7 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		curr.Spec.NUMA = new(NUMA)
 
 		if src.Spec.NUMA.TopologyPolicy != nil {
-			curr.Spec.NUMA.TopologyPolicy = pointer.StringPtr(*src.Spec.NUMA.TopologyPolicy)
+			curr.Spec.NUMA.TopologyPolicy = pointer.String(*src.Spec.NUMA.TopologyPolicy)
 		}
 	}
 
@@ -242,7 +242,7 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		curr.Spec.Net = new(Net)
 
 		if src.Spec.Net.UserLevelNetworking != nil {
-			curr.Spec.Net.UserLevelNetworking = pointer.BoolPtr(*src.Spec.Net.UserLevelNetworking)
+			curr.Spec.Net.UserLevelNetworking = pointer.Bool(*src.Spec.Net.UserLevelNetworking)
 		}
 
 		if src.Spec.Net.Devices != nil {
@@ -252,15 +252,15 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 				device := Device{}
 
 				if d.VendorID != nil {
-					device.VendorID = pointer.StringPtr(*d.VendorID)
+					device.VendorID = pointer.String(*d.VendorID)
 				}
 
 				if d.DeviceID != nil {
-					device.DeviceID = pointer.StringPtr(*d.DeviceID)
+					device.DeviceID = pointer.String(*d.DeviceID)
 				}
 
 				if d.InterfaceName != nil {
-					device.InterfaceName = pointer.StringPtr(*d.InterfaceName)
+					device.InterfaceName = pointer.String(*d.InterfaceName)
 				}
 
 				curr.Spec.Net.Devices = append(curr.Spec.Net.Devices, device)
@@ -269,9 +269,9 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	if src.Spec.GloballyDisableIrqLoadBalancing != nil {
-		curr.Spec.GloballyDisableIrqLoadBalancing = pointer.BoolPtr(*src.Spec.GloballyDisableIrqLoadBalancing)
+		curr.Spec.GloballyDisableIrqLoadBalancing = pointer.Bool(*src.Spec.GloballyDisableIrqLoadBalancing)
 	} else { // set to true by default
-		curr.Spec.GloballyDisableIrqLoadBalancing = pointer.BoolPtr(true)
+		curr.Spec.GloballyDisableIrqLoadBalancing = pointer.Bool(true)
 	}
 
 	// Status
@@ -281,11 +281,11 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	if src.Status.Tuned != nil {
-		curr.Status.Tuned = pointer.StringPtr(*src.Status.Tuned)
+		curr.Status.Tuned = pointer.String(*src.Status.Tuned)
 	}
 
 	if src.Status.RuntimeClass != nil {
-		curr.Status.RuntimeClass = pointer.StringPtr(*src.Status.RuntimeClass)
+		curr.Status.RuntimeClass = pointer.String(*src.Status.RuntimeClass)
 	}
 
 	// +kubebuilder:docs-gen:collapse=rote conversion

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -62,7 +62,7 @@ type PerformanceProfileSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector"`
 	// RealTimeKernel defines a set of real time kernel related parameters. RT kernel won't be installed when not set.
 	RealTimeKernel *RealTimeKernel `json:"realTimeKernel,omitempty"`
-	// Addional kernel arguments.
+	// Additional kernel arguments.
 	// +optional
 	AdditionalKernelArgs []string `json:"additionalKernelArgs,omitempty"`
 	// NUMA defines options related to topology aware affinities

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -285,7 +285,7 @@ func (r *PerformanceProfile) validateNet() field.ErrorList {
 	}
 
 	if r.Spec.Net.UserLevelNetworking != nil && *r.Spec.Net.UserLevelNetworking && r.Spec.CPU.Reserved == nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec.net"), r.Spec.Net, "can not set network devices queues count without specifiying spec.cpu.reserved"))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec.net"), r.Spec.Net, "can not set network devices queues count without specifying spec.cpu.reserved"))
 	}
 
 	for _, device := range r.Spec.Net.Devices {

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -70,7 +69,7 @@ func buildServer(port int) *http.Server {
 	)
 
 	tlsConfig := &tls.Config{}
-	caCert, err := ioutil.ReadFile(authCAFile)
+	caCert, err := os.ReadFile(authCAFile)
 	if err == nil {
 		caCertPool := x509.NewCertPool()
 		if caCertPool.AppendCertsFromPEM(caCert) {
@@ -149,6 +148,7 @@ func RunServer(port int, ctx context.Context) error {
 					klog.V(2).Infof("event from filewatcher on file: %v, event: %v", event.Name, event.Op)
 
 					if event.Name == authCAFile {
+						//nolint:staticcheck
 						if ok, _ := fileExistsAndNotEmpty(authCAFile); ok {
 							// authCAFile is now created and is not empty.
 							break

--- a/pkg/performanceprofile/cmd/render/cmd.go
+++ b/pkg/performanceprofile/cmd/render/cmd.go
@@ -44,7 +44,6 @@ func NewRenderCommand() *cobra.Command {
 		Use:   "render",
 		Short: "Render performance-addon-operator manifests",
 		Run: func(cmd *cobra.Command, args []string) {
-
 			if err := renderOpts.Validate(); err != nil {
 				klog.Fatal(err)
 			}

--- a/pkg/performanceprofile/cmd/render/manifests.go
+++ b/pkg/performanceprofile/cmd/render/manifests.go
@@ -37,7 +37,7 @@ func (m *manifest) UnmarshalJSON(in []byte) error {
 		return errors.New("manifest: UnmarshalJSON on nil pointer")
 	}
 
-	// This happens when marshalling
+	// This happens when marshaling
 	// <yaml>
 	// ---	(this between two `---`)
 	// ---

--- a/pkg/performanceprofile/cmd/render/render.go
+++ b/pkg/performanceprofile/cmd/render/render.go
@@ -69,7 +69,6 @@ func init() {
 // Render will traverse the input directory and generate the proper performance profile files
 // in to the output dir based on PerformanceProfile manifests contained in the input directory.
 func render(inputDir, outputDir string) error {
-
 	klog.Info("Rendering files into: ", outputDir)
 
 	// Read asset directory fileInfo

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -5,8 +5,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"path/filepath"
 	"text/template"
 
@@ -195,7 +195,6 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, pinningMode *a
 	// do not add RPS handling when realtime is explicitly disabled by workload hint
 	if profileutil.IsRpsEnabled(profile) || profile.Spec.WorkloadHints == nil ||
 		profile.Spec.WorkloadHints.RealTime == nil || *profile.Spec.WorkloadHints.RealTime {
-
 		// configure default rps mask applied to all network devices
 		sysctlConfContent, err := renderSysctlConf(profile, filepath.Join("configs", defaultRPSMaskConfig))
 		if err != nil {
@@ -253,7 +252,7 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, pinningMode *a
 
 			ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
 				Contents: &hugepagesService,
-				Enabled:  pointer.BoolPtr(true),
+				Enabled:  pointer.Bool(true),
 				Name:     getSystemdService(fmt.Sprintf("%s-%skB-NUMA%d", hugepagesAllocation, hugepagesSize, *page.Node)),
 			})
 		}
@@ -286,7 +285,7 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, pinningMode *a
 
 		ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
 			Contents: &cpusetConfigureService,
-			Enabled:  pointer.BoolPtr(true),
+			Enabled:  pointer.Bool(true),
 			Name:     getSystemdService(cpusetConfigure),
 		})
 
@@ -311,7 +310,7 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, pinningMode *a
 
 		ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
 			Contents: &offlineCPUsService,
-			Enabled:  pointer.BoolPtr(true),
+			Enabled:  pointer.Bool(true),
 			Name:     getSystemdService(setCPUsOffline),
 		})
 	}
@@ -323,7 +322,7 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, pinningMode *a
 
 	ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
 		Contents: &clearIRQBalanceBannedCPUsService,
-		Enabled:  pointer.BoolPtr(true),
+		Enabled:  pointer.Bool(true),
 		Name:     getSystemdService(clearIRQBalanceBannedCPUs),
 	})
 
@@ -386,7 +385,7 @@ func getSystemdService(serviceName string) string {
 
 func getSystemdContent(options []*unit.UnitOption) (string, error) {
 	outReader := unit.Serialize(options)
-	outBytes, err := ioutil.ReadAll(outReader)
+	outBytes, err := io.ReadAll(outReader)
 	if err != nil {
 		return "", err
 	}
@@ -535,7 +534,7 @@ func addContent(ignitionConfig *igntypes.Config, content []byte, dst string, mod
 		},
 		FileEmbedded1: igntypes.FileEmbedded1{
 			Contents: igntypes.Resource{
-				Source: pointer.StringPtr(fmt.Sprintf("%s,%s", defaultIgnitionContentSource, contentBase64)),
+				Source: pointer.String(fmt.Sprintf("%s,%s", defaultIgnitionContentSource, contentBase64)),
 			},
 			Mode: mode,
 		},

--- a/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
@@ -9,7 +9,7 @@ import (
 
 // GetMachineConfigPoolSelector returns the MachineConfigPoolSelector from the CR or a default value calculated based on NodeSelector
 func GetMachineConfigPoolSelector(profile *performancev2.PerformanceProfile, profileMCP *mcov1.MachineConfigPool) map[string]string {
-	// we do not really need profile.spec.machineConfigPoolSelector anymore, but we should use it for backward compatability
+	// we do not really need profile.spec.machineConfigPoolSelector anymore, but we should use it for backward compatibility
 	if profile.Spec.MachineConfigPoolSelector != nil {
 		return profile.Spec.MachineConfigPoolSelector
 	}

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
@@ -77,7 +77,7 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 				// a user requested to allocate 2M huge pages on the specific NUMA node,
 				// append dummy kernel arguments
 				if page.Size == components.HugepagesSize2M && is2MHugepagesRequested == nil {
-					is2MHugepagesRequested = pointer.BoolPtr(true)
+					is2MHugepagesRequested = pointer.Bool(true)
 				}
 				continue
 			}
@@ -86,7 +86,7 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 			// we need to append 2M hugepages kernel arguments anyway, no need to add dummy
 			// kernel arguments
 			if page.Size == components.HugepagesSize2M {
-				is2MHugepagesRequested = pointer.BoolPtr(false)
+				is2MHugepagesRequested = pointer.Bool(false)
 			}
 
 			hugepages = append(hugepages, fmt.Sprintf("hugepagesz=%s", string(page.Size)))
@@ -118,7 +118,6 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 	templateArgs[templateNetDevices] = fmt.Sprintf("[net]\n%s", nfConntrackHashsize)
 	if profile.Spec.Net != nil && profile.Spec.Net.UserLevelNetworking != nil &&
 		*profile.Spec.Net.UserLevelNetworking && profile.Spec.CPU.Reserved != nil {
-
 		reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 		if err != nil {
 			return nil, err

--- a/pkg/performanceprofile/controller/performanceprofile/components/utils.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/utils.go
@@ -51,7 +51,7 @@ func CPUListToHexMask(cpulist string) (hexMask string, err error) {
 }
 
 // CPUListToMaskList converts a list of cpus into a cpu mask represented
-// in a list of hexadecimal mask devided by a delimiter ","
+// in a list of hexadecimal mask divided by a delimiter ","
 func CPUListToMaskList(cpulist string) (hexMask string, err error) {
 	maskStr, err := CPUListToHexMask(cpulist)
 	if err != nil {
@@ -100,7 +100,7 @@ func (c *CPULists) GetOfflined() cpuset.CPUSet {
 	return c.offlined
 }
 
-// NewCPULists parse text representations of reserved and isolated cpusets definiton and returns a CPULists object
+// NewCPULists parse text representations of reserved and isolated cpusets definition and returns a CPULists object
 func NewCPULists(reservedList, isolatedList, offlinedList string) (*CPULists, error) {
 	var err error
 	reserved, err := cpuset.Parse(reservedList)

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -70,7 +70,6 @@ type PerformanceProfileReconciler struct {
 // SetupWithManager creates a new PerformanceProfile Controller and adds it to the Manager.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
 func (r *PerformanceProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
 	// we want to initate reconcile loop only on change under labels or spec of the object
 	p := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -667,7 +666,6 @@ func (r *PerformanceProfileReconciler) deleteComponents(profile *performancev2.P
 	}
 
 	return nil
-
 }
 
 func (r *PerformanceProfileReconciler) isComponentsExist(profile *performancev2.PerformanceProfile) bool {

--- a/pkg/performanceprofile/controller/resources.go
+++ b/pkg/performanceprofile/controller/resources.go
@@ -222,7 +222,6 @@ func (r *PerformanceProfileReconciler) getMutatedTuned(tuned *tunedv1.Tuned) (*t
 }
 
 func (r *PerformanceProfileReconciler) createOrUpdateTuned(tuned *tunedv1.Tuned, profileName string) error {
-
 	if err := r.removeOutdatedTuned(tuned, profileName); err != nil {
 		return err
 	}

--- a/pkg/performanceprofile/controller/status.go
+++ b/pkg/performanceprofile/controller/status.go
@@ -53,7 +53,6 @@ func (r *PerformanceProfileReconciler) updateStatus(profile *performancev2.Perfo
 		if oldCondition.Status != newCondition.Status ||
 			oldCondition.Reason != newCondition.Reason ||
 			oldCondition.Message != newCondition.Message {
-
 			modified = true
 			break
 		}
@@ -233,7 +232,7 @@ func (r *PerformanceProfileReconciler) getTunedConditionsByProfile(profile *perf
 		return nil, err
 	}
 
-	// remove Tuned profiles that are not associate with this perfomance profile
+	// remove Tuned profiles that are not associate with this performance profile
 	// Tuned profile's name and node's name should be equal
 	filtered := removeUnMatchedTunedProfiles(nodes.Items, tunedProfileList.Items)
 	message := bytes.Buffer{}

--- a/pkg/performanceprofile/profilecreator/profilecreator.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator.go
@@ -18,6 +18,7 @@ package profilecreator
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path"
@@ -64,11 +65,11 @@ const (
 var (
 	// This filter is used to avoid offlining the first logical processor of each core.
 	// LogicalProcessors is a slice of integers representing the logical processor IDs assigned to
-	// a processing unit for a core. GHW API gurantees that the logicalProcessors correspond
+	// a processing unit for a core. GHW API guarantees that the logicalProcessors correspond
 	// to hyperthread pairs and in the code below we select only the first hyperthread (id=0)
 	// of the available logical processors.
 	// Please refer to https://www.kernel.org/doc/Documentation/x86/topology.txt for more information on
-	// x86 hardware topology. This document clarifies the main aspects of x86 topology modelling and
+	// x86 hardware topology. This document clarifies the main aspects of x86 topology modeling and
 	// representation in the linux kernel and explains why we select id=0 for obtaining the first
 	// hyperthread (logical core).
 	filterFirstLogicalProcessorInCore = func(index, lpID int) bool { return index != 0 }
@@ -89,10 +90,8 @@ func getMustGatherFullPathsWithFilter(mustGatherPath string, suffix string, filt
 	if err != nil {
 		return "", fmt.Errorf("failed to get the path mustGatherPath:%s, suffix:%s %v", mustGatherPath, suffix, err)
 	}
-
 	if len(paths) == 0 {
 		return "", fmt.Errorf("no match for the specified must gather directory path: %s and suffix: %s", mustGatherPath, suffix)
-
 	}
 	if len(paths) > 1 {
 		log.Infof("Multiple matches for the specified must gather directory path: %s and suffix: %s", mustGatherPath, suffix)
@@ -140,11 +139,20 @@ func GetNodeList(mustGatherDirPath string) ([]*v1.Node, error) {
 		return nil, fmt.Errorf("failed to get Nodes from must gather directory: %v", err)
 	}
 
-	nodes, err := ioutil.ReadDir(nodePath)
+	nodes, err := os.ReadDir(nodePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list mustGatherPath directories: %v", err)
 	}
+	nodeInfos := make([]fs.FileInfo, len(nodes))
 	for _, node := range nodes {
+		nodeName := node.Name()
+		info, err := node.Info()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Nodes %s: %v", nodeName, err)
+		}
+		nodeInfos = append(nodeInfos, info)
+	}
+	for _, node := range nodeInfos {
 		nodeName := node.Name()
 		node, err := getNode(mustGatherDirPath, nodeName)
 		if err != nil {
@@ -289,7 +297,7 @@ func (ghwHandler GHWHandler) SortedTopology() (*topology.Info, error) {
 
 // topologyHTDisabled returns topologyinfo in case Hyperthreading needs to be disabled.
 // It receives a pointer to Topology.Info and deletes logicalprocessors from individual cores.
-// The behaviour of this function depends on ghw data representation.
+// The behavior of this function depends on ghw data representation.
 func topologyHTDisabled(info *topology.Info) *topology.Info {
 	disabledHTTopology := &topology.Info{
 		Architecture: info.Architecture,
@@ -304,12 +312,12 @@ func topologyHTDisabled(info *topology.Info) *topology.Info {
 				NumThreads: 1,
 			}
 			// LogicalProcessors is a slice of ints representing the logical processor IDs assigned to
-			// a processing unit for a core. GHW API gurantees that the logicalProcessors correspond
+			// a processing unit for a core. GHW API guarantees that the logicalProcessors correspond
 			// to hyperthread pairs and in the code below we select only the first hyperthread (id=0)
 			// of the available logical processors.
 			for id, logicalProcessor := range processorCore.LogicalProcessors {
 				// Please refer to https://www.kernel.org/doc/Documentation/x86/topology.txt for more information on
-				// x86 hardware topology. This document clarifies the main aspects of x86 topology modelling and
+				// x86 hardware topology. This document clarifies the main aspects of x86 topology modeling and
 				// representation in the linux kernel and explains why we select id=0 for obtaining the first
 				// hyperthread (logical core).
 				if id == 0 {
@@ -369,7 +377,6 @@ func (ghwHandler GHWHandler) GatherSystemInfo() (*systemInfo, error) {
 
 // Calculates the resevered, isolated and offlined cpuSets.
 func CalculateCPUSets(systemInfo *systemInfo, reservedCPUCount int, offlinedCPUCount int, splitReservedCPUsAcrossNUMA bool, disableHTFlag bool, highPowerConsumptionMode bool) (cpuset.CPUSet, cpuset.CPUSet, cpuset.CPUSet, error) {
-
 	topologyInfo := systemInfo.TopologyInfo
 	htEnabled := systemInfo.HtEnabled
 
@@ -427,7 +434,7 @@ func CalculateCPUSets(systemInfo *systemInfo, reservedCPUCount int, offlinedCPUC
 	return reserved, isolated, offlined, nil
 }
 
-// Calculates Isolated cpuSet as the difference between all the cpus in the topology and those already choosen as reserved or offlined.
+// Calculates Isolated cpuSet as the difference between all the cpus in the topology and those already chosen as reserved or offlined.
 // all cpus thar are not offlined or reserved belongs to the isolated cpuSet
 func getIsolatedCPUs(topologyInfoNodes []*topology.Node, reserved, offlined cpuset.CPUSet) (cpuset.CPUSet, error) {
 	total, err := totalCPUSetFromTopology(topologyInfoNodes)
@@ -446,7 +453,6 @@ func AreAllLogicalProcessorsFromSocketUnused(extCpuInfo *extendedCPUInfo, socket
 }
 
 func getOfflinedCPUs(extCpuInfo *extendedCPUInfo, offlinedCPUCount int, disableHTFlag bool, htEnabled bool, highPowerConsumption bool) (cpuset.CPUSet, error) {
-
 	offlined := newCPUAccumulator()
 	lpOfflined := 0
 
@@ -505,7 +511,6 @@ func getOfflinedCPUs(extCpuInfo *extendedCPUInfo, offlinedCPUCount int, disableH
 		log.Warnf("could not offline enough logical processors (required:%d, offlined:%d)", offlinedCPUCount, lpOfflined)
 	}
 	return offlined.Result(), nil
-
 }
 
 func updateTopologyInfo(topoInfo *topology.Info, disableHTFlag bool, htEnabled bool) (*topology.Info, error) {
@@ -519,7 +524,6 @@ func updateTopologyInfo(topoInfo *topology.Info, disableHTFlag bool, htEnabled b
 }
 
 func getReservedCPUs(topologyInfo *topology.Info, reservedCPUCount int, splitReservedCPUsAcrossNUMA bool, disableHTFlag bool, htEnabled bool) (cpuset.CPUSet, error) {
-
 	if htEnabled && disableHTFlag {
 		log.Infof("Currently hyperthreading is enabled and the performance profile will disable it")
 		htEnabled = false
@@ -646,7 +650,6 @@ func getCPUsSequentially(reservedCPUCount int, htEnabled bool, topologyInfoNodes
 		if _, err := reservedCPUs.AddCores(reservedCPUCount, node.Cores); err != nil {
 			return cpuset.CPUSet{}, err
 		}
-
 	}
 	return reservedCPUs.Result(), nil
 }
@@ -757,7 +760,6 @@ func GetAdditionalKernelArgs(disableHT bool) []string {
 }
 
 func updateExtendedCPUInfo(extCpuInfo *extendedCPUInfo, used cpuset.CPUSet, disableHT, htEnabled bool) (*extendedCPUInfo, error) {
-
 	retCpuInfo := &cpu.Info{
 		TotalCores:   0,
 		TotalThreads: 0,
@@ -777,7 +779,6 @@ func updateExtendedCPUInfo(extCpuInfo *extendedCPUInfo, used cpuset.CPUSet, disa
 
 	cpuInfo := extCpuInfo.CpuInfo
 	for _, socket := range cpuInfo.Processors {
-
 		s := &cpu.Processor{
 			ID:           socket.ID,
 			Vendor:       socket.Vendor,

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -1,20 +1,19 @@
 package tuned
 
 import (
-	"bufio"     // scanner
-	"bytes"     // bytes.Buffer
-	"context"   // context.TODO()
-	"flag"      // command-line options parsing
-	"fmt"       // Printf()
-	"io/ioutil" // ioutil.ReadFile()
-	"math"      // math.Pow()
-	"net"       // net.Conn
-	"os"        // os.Exit(), os.Stderr, ...
-	"os/exec"   // os.Exec()
-	"strconv"   // strconv
-	"strings"   // strings.Join()
-	"syscall"   // syscall.SIGHUP, ...
-	"time"      // time.Second, ...
+	"bufio"   // scanner
+	"bytes"   // bytes.Buffer
+	"context" // context.TODO()
+	"flag"    // command-line options parsing
+	"fmt"     // Printf()
+	"math"    // math.Pow()
+	"net"     // net.Conn
+	"os"      // os.Exit(), os.Stderr, ...
+	"os/exec" // os.Exec()
+	"strconv" // strconv
+	"strings" // strings.Join()
+	"syscall" // syscall.SIGHUP, ...
+	"time"    // time.Second, ...
 
 	fsnotify "gopkg.in/fsnotify.v1"
 	"gopkg.in/ini.v1"
@@ -371,7 +370,7 @@ func disableSystemTuned() {
 }
 
 func profilesEqual(profileFile string, profileData string) bool {
-	content, err := ioutil.ReadFile(profileFile)
+	content, err := os.ReadFile(profileFile)
 	if err != nil {
 		content = []byte{}
 	}
@@ -912,7 +911,6 @@ func (c *Controller) eventProcessorTuneD() {
 			// Successful processing.
 			c.wqTuneD.Forget(obj)
 		}()
-
 	}
 }
 

--- a/pkg/tuned/tuned_parser.go
+++ b/pkg/tuned/tuned_parser.go
@@ -1,15 +1,14 @@
 package tuned
 
 import (
-	"errors"    // errors.Is()
-	"fmt"       // Printf()
-	"io"        // io.EOF
-	"io/ioutil" // ioutil.ReadFile()
-	"os"        // os.Stat()
-	"os/exec"   // os.Exec()
-	"strings"   // strings.Split()
-	"syscall"   // syscall.SIGHUP, ...
-	"time"      // time.Second, ...
+	"errors"  // errors.Is()
+	"fmt"     // Printf()
+	"io"      // io.EOF
+	"os"      // os.Stat()
+	"os/exec" // os.Exec()
+	"strings" // strings.Split()
+	"syscall" // syscall.SIGHUP, ...
+	"time"    // time.Second, ...
 
 	"gopkg.in/ini.v1"
 	"k8s.io/klog/v2"
@@ -22,7 +21,7 @@ func iniFileLoad(iniFile string) (*ini.File, error) {
 		err error
 	)
 
-	content, err := ioutil.ReadFile(iniFile)
+	content, err := os.ReadFile(iniFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %s: %v", iniFile, err)
 	}
@@ -113,7 +112,7 @@ func getIniFileSectionSlice(data *string, section, key, separator string) []stri
 func profileIncludesRaw(profileName string, tunedProfilesDir string) []string {
 	profileFile := fmt.Sprintf("%s/%s/%s", tunedProfilesDir, profileName, tunedConfFile)
 
-	content, err := ioutil.ReadFile(profileFile)
+	content, err := os.ReadFile(profileFile)
 	if err != nil {
 		content = []byte{}
 	}

--- a/pkg/util/leaderelection.go
+++ b/pkg/util/leaderelection.go
@@ -12,7 +12,6 @@ import (
 
 // GetLeaderElectionConfig returns leader election configs defaults based on the cluster topology
 func GetLeaderElectionConfig(restcfg *rest.Config, enabled bool) configv1.LeaderElection {
-
 	// Defaults follow conventions
 	// https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#high-availability
 	defaultLeaderElection := leaderelection.LeaderElectionDefaulting(


### PR DESCRIPTION
This commit adds a new golangci-lint target to the makefile and sets up
a common config along the lines of other openshift operators.

- Address misspell violations
- Address staticheck violations

Signed-off-by: Daniel Mellado <dmellado@redhat.com>
