### PR TITLE
OCPBUGS-12756: Add minLength restriction to Tuned CR

### DIFF
--- a/manifests/20-tuned.crd.yaml
+++ b/manifests/20-tuned.crd.yaml
@@ -61,6 +61,7 @@ spec:
                     name:
                       description: Name of the Tuned profile to be used in the recommend
                         section.
+                      minLength: 1
                       type: string
                   required:
                   - data
@@ -139,6 +140,7 @@ spec:
                       type: integer
                     profile:
                       description: Name of the Tuned profile to recommend.
+                      minLength: 1
                       type: string
                   required:
                   - priority

--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -71,6 +71,7 @@ type TunedSpec struct {
 // A Tuned profile.
 type TunedProfile struct {
 	// Name of the Tuned profile to be used in the recommend section.
+	// +kubebuilder:validation:MinLength=1
 	Name *string `json:"name"`
 	// Specification of the Tuned profile to be consumed by the Tuned daemon.
 	Data *string `json:"data"`
@@ -79,6 +80,7 @@ type TunedProfile struct {
 // Selection logic for a single Tuned profile.
 type TunedRecommend struct {
 	// Name of the Tuned profile to recommend.
+	// +kubebuilder:validation:MinLength=1
 	Profile *string `json:"profile"`
 
 	// Tuned profile priority. Highest priority is 0.


### PR DESCRIPTION
Add `minLength == 1` to Tuned `spec.profile[].name` and `spec.recommend[].profile`.  The profile name always has at least 1 character and this will also prevent `TuneD` daemon traceback when recommending an empty-string profile.

Also see: https://github.com/redhat-performance/tuned/issues/537