### PR TITLE
OCPBUGS-12836: [pao] [e2e] flaky test test_id:28440 Updating of nodeSelector

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -379,8 +379,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		var oldMcpSelector, oldNodeSelector map[string]string
 
 		BeforeEach(func() {
-			testutils.KnownIssueJira("OCPBUGS-12836")
-
 			// initialize on every run
 			labelsDeletion = false
 			//fetch the latest profile
@@ -446,8 +444,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 
 		It("[test_id:28440]Verifies that nodeSelector can be updated in performance profile", func() {
-			testutils.KnownIssueJira("OCPBUGS-12836")
-
 			kubeletConfig, err := nodes.GetKubeletConfig(newCnfNode)
 			Expect(kubeletConfig.TopologyManagerPolicy).ToNot(BeEmpty())
 			cmdline, err := nodes.ExecCommandOnNode(chkCmdLine, newCnfNode)
@@ -457,8 +453,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 
 		It("[test_id:27484]Verifies that node is reverted to plain worker when the extra labels are removed", func() {
-			testutils.KnownIssueJira("OCPBUGS-12836")
-
 			By("Deleting cnf labels from the node")
 			removeLabels(profile.Spec.NodeSelector, newCnfNode)
 			labelsDeletion = true
@@ -490,8 +484,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 
 		AfterEach(func() {
-			testutils.KnownIssueJira("OCPBUGS-12836")
-
 			if labelsDeletion == false {
 				removeLabels(profile.Spec.NodeSelector, newCnfNode)
 			}


### PR DESCRIPTION
Just enable the tests to check if, after the ci-lane split they work, as the lastest errors were due to timeout issues.