### PR TITLE
e2e: memorymanager fix: check the hugepage size condition

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/memorymanager.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/memorymanager.go
@@ -837,7 +837,7 @@ func GetMemoryNodes(testPod *corev1.Pod, targetNode *corev1.Node) (string, error
 
 // CreateHugePagesVolumeMounts create Huge pages volume mounts
 func (mm MMPod) CreateHugePagesVolumeMounts() *corev1.VolumeMount {
-	if mm.hpgSize == "2Mi" {
+	if (fmt.Sprintf("hugepages-%si", mm.hpgSize)) == "hugepages-2Mi" {
 		return &corev1.VolumeMount{
 			Name:      "hugepage-2mi",
 			MountPath: "/hugepages-2Mi",


### PR DESCRIPTION
Minor if condition fix, earlier it was checking the string "2mi", but the test cases are setting hugepages requried in field called hpgSize, which was not used . hence pod was not getting the right hugepages mounted.