### PR TITLE
e2e: perf-prof: disable truncating gomega output

### DIFF
--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 )
 
@@ -91,6 +92,7 @@ type latencyTest struct {
 }
 
 var _ = DescribeTable("Test latency measurement tools tests", func(testGroup []latencyTest, isPositiveTest bool) {
+	format.MaxLength = 0
 	for _, test := range testGroup {
 		clearEnv()
 		testDescription := setEnvAndGetDescription(test)


### PR DESCRIPTION
When the tests fail, we want to have a clear full log of the output of the executed latency tool. The default format.MaxLength is 4000 but it isn't always sufficient to display the full string presentation especially when there is a failure.

Disable this limitation by setting the format.MaxLength to 0, to help with better troubleshooting of the failure.

For more info: https://onsi.github.io/gomega/#adjusting-output