### PR TITLE
OCPBUGS-15736: Do not rollback settings on TuneD exit

### DIFF
--- a/assets/bin/run
+++ b/assets/bin/run
@@ -2,6 +2,14 @@
 
 export SYSTEMD_IGNORE_CHROOT=1
 
+set_tuned_main_opt() {
+  local key=$1
+  local val=$2
+  local tuned_main_conf=/etc/tuned/tuned-main.conf
+
+  sed -Ei 's|^#?\s*'"$key"'\s*=.*$|'"$key"' = '"$val"'|' $tuned_main_conf
+}
+
 start() {
   # Tuned can take ~20s to reload/start when "ulimit -Sn == 1048576".
   # See:
@@ -9,6 +17,8 @@ start() {
   # - https://www.python.org/dev/peps/pep-0446/#closing-all-open-file-descriptors
   # - http://bugs.python.org/issue1663329
   ulimit -Sn 1024	# workaround for the issue above
+
+  set_tuned_main_opt rollback not_on_exit
 
   exec /usr/bin/openshift-tuned \
     -v=0

--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -10,7 +10,8 @@ spec:
       summary=Custom OpenShift ingress profile
       include=openshift-control-plane
       [sysctl]
-      net.ipv4.ip_local_port_range="1024 65535"
+      # Comments start with '#' and run till the end of the line.
+      # net.ipv4.ip_local_port_range="1024 65535"
       net.ipv4.tcp_tw_reuse=1
     name: openshift-ingress
   recommend:

--- a/test/e2e/basic/rollback.go
+++ b/test/e2e/basic/rollback.go
@@ -92,6 +92,14 @@ var _ = ginkgo.Describe("[basic][rollback] Node Tuning Operator settings rollbac
 			})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), explain)
 
+			// rollback = not_on_exit in tuned-main.conf file prevents settings rollback at TuneD exit
+			ginkgo.By(fmt.Sprintf("ensuring the custom %s value (%s) is still set in Pod %s", sysctlVar, "1", pod.Name))
+			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, "1")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			_, err = util.ExecCmdInPod(pod, "sysctl", fmt.Sprintf("%s=%s", sysctlVar, sysctlValDef))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred()) // sysctl exits 1 when it fails to configure a kernel parameter at runtime
+
 			ginkgo.By(fmt.Sprintf("ensuring the default %s value (%s) is set in Pod %s", sysctlVar, sysctlValDef, pod.Name))
 			_, err = util.WaitForSysctlValueInPod(pollInterval, waitDuration, pod, sysctlVar, sysctlValDef)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
Settings rollbacks on TuneD exit in the OCP environment are generally a bad idea.  They can cause issues ranging from latency spikes to a complete loss of service (see OCPBUGS-13065).  Do not perform rollbacks apart from when switching Profiles.

Other changes:
  - Changed "rollback.go" e2e tests to reflect the new "rollback=not_on_exit" behaviour.

Resolves: OCPBUGS-15736