### PR TITLE
OCPBUGS-15800:e2e: latency testing: increase the expected threshold and fix gomega truncating output

### DIFF
--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 )
 
@@ -95,6 +96,7 @@ type latencyTest struct {
 }
 
 var _ = table.DescribeTable("Test latency measurement tools tests", func(testGroup []latencyTest, isPositiveTest bool) {
+	format.MaxLength = 0
 	for _, test := range testGroup {
 		clearEnv()
 		testDescription := setEnvAndGetDescription(test)

--- a/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/latency_testing.go
@@ -72,7 +72,10 @@ const (
 	skipOddCpuNumber    = `Skip the test, the requested number of CPUs should be even to avoid noisy neighbor situation`
 
 	//used values parameters
-	guaranteedLatency = "20000"
+
+	// we do not care about the actual system latency because CI systems are not tuned well enough to be an example for
+	// latency measuring, besides this suite only cares about testing the test executable with different values of env vars.
+	guaranteedLatency = "900000"
 	negativeTesting   = false
 	positiveTesting   = true
 )


### PR DESCRIPTION
lately some of the latency tests were failing and it turned out that the failure is due to that the maximum latency found was greater than anticipated. The tests in this suite do not care about the measured latency because we do not care to tune the systems in the first place. Its only goal is to run the tests of the latency tools with different values of environment variables and validate that the tool actually runs with these parameters.

Increase the maximum latency threshold so that the test doesn't fail in case of a high latency result.