### PR TITLE
 Build gather-sysinfo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN INSTALL_PKGS=" \
 FROM quay.io/centos/centos:stream9
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/gather-sysinfo /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/
 ENV APP_ROOT=/var/lib/tuned
 ENV PATH=${APP_ROOT}/bin:${PATH}
@@ -28,7 +29,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=tuned   /root/assets ${APP_ROOT}
 COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
-      nmap-ncat procps-ng \
+      nmap-ncat procps-ng pciutils \
       " && \
     mkdir -p /etc/grub.d/ /boot && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -6,6 +6,7 @@ RUN make build
 FROM registry.ci.openshift.org/ocp/4.14:base
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/gather-sysinfo /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/
 ENV APP_ROOT=/var/lib/tuned
 ENV PATH=${APP_ROOT}/bin:${PATH}
@@ -17,7 +18,7 @@ RUN INSTALL_PKGS=" \
       tuned tuned-profiles-atomic tuned-profiles-cpu-partitioning tuned-profiles-mssql tuned-profiles-nfv tuned-profiles-nfv-guest \
       tuned-profiles-nfv-host tuned-profiles-openshift tuned-profiles-oracle tuned-profiles-postgresql tuned-profiles-realtime \
       tuned-profiles-sap tuned-profiles-sap-hana tuned-profiles-spectrumscale \
-      nmap-ncat procps-ng" && \
+      nmap-ncat procps-ng pciutils" && \
     mkdir -p /etc/grub.d/ /boot && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rm -rf /var/lib/tuned/tuned && \

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -6,6 +6,7 @@ RUN make build
 FROM registry.ci.openshift.org/ocp/4.14:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/gather-sysinfo /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/
 ENV APP_ROOT=/var/lib/tuned
 ENV PATH=${APP_ROOT}/bin:${PATH}
@@ -17,7 +18,7 @@ RUN INSTALL_PKGS=" \
       tuned tuned-profiles-atomic tuned-profiles-cpu-partitioning tuned-profiles-mssql tuned-profiles-nfv tuned-profiles-nfv-guest \
       tuned-profiles-nfv-host tuned-profiles-openshift tuned-profiles-oracle tuned-profiles-postgresql tuned-profiles-realtime \
       tuned-profiles-sap tuned-profiles-sap-hana tuned-profiles-spectrumscale \
-      nmap-ncat procps-ng" && \
+      nmap-ncat procps-ng pciutils" && \
     mkdir -p /etc/grub.d/ /boot && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rm -rf /var/lib/tuned/tuned && \

--- a/cmd/gather-sysinfo/.gitignore
+++ b/cmd/gather-sysinfo/.gitignore
@@ -1,0 +1,2 @@
+output
+testSnapshot.tgz

--- a/cmd/gather-sysinfo/gather-sysinfo.go
+++ b/cmd/gather-sysinfo/gather-sysinfo.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"fmt"
+	"github.com/jaypipes/ghw/pkg/snapshot"
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s"
+	"github.com/openshift-kni/debug-tools/pkg/machineinformer"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+const machineInfoFilePath string = "machineinfo.json"
+
+type snapshotOptions struct {
+	dumpList bool
+	output   string
+	rootDir  string
+}
+
+func main() {
+	root := cmd.NewRootCommand(newSnapshotCommand,
+		k8s.NewPodResourcesCommand,
+		k8s.NewPodInfoCommand,
+	)
+
+	if err := root.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func newSnapshotCommand(knitOpts *cmd.KnitOptions) *cobra.Command {
+	opts := &snapshotOptions{}
+	snap := &cobra.Command{
+		Use:   "snapshot",
+		Short: "snapshot pseudofilesystems for offline analysis",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return makeSnapshot(cmd, knitOpts, opts, args)
+		},
+		Args: cobra.NoArgs,
+	}
+	snap.Flags().StringVar(&opts.rootDir, "root", "", "pseudofs root - use this if running inside a container")
+	snap.Flags().StringVar(&opts.output, "output", "", "path to clone system information into")
+	snap.Flags().BoolVar(&opts.dumpList, "dump", false, "just dump the glob list of expected content and exit")
+
+	return snap
+}
+
+func collectMachineinfo(knitOpts *cmd.KnitOptions, destPath string) error {
+	outfile, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+
+	mih := machineinformer.Handle{
+		RootDirectory: knitOpts.SysFSRoot,
+		Out:           outfile,
+	}
+	mih.Run()
+
+	return nil
+}
+
+func makeSnapshot(cmd *cobra.Command, knitOpts *cmd.KnitOptions, opts *snapshotOptions, args []string) error {
+	// ghw can't handle duplicates in CopyFilesInto, the operation will fail.
+	// Hence we need to make sure we just don't feed duplicates.
+	fileSpecs := dedupExpectedContent(kniExpectedCloneContent(), snapshot.ExpectedCloneContent())
+	if opts.dumpList {
+		for _, fileSpec := range fileSpecs {
+			fmt.Printf("%s\n", fileSpec)
+		}
+		return nil
+	}
+
+	if opts.output == "" {
+		return fmt.Errorf("--output is required")
+	}
+
+	if knitOpts.Debug {
+		snapshot.SetTraceFunction(func(msg string, args ...interface{}) {
+			knitOpts.Log.Printf(msg, args...)
+		})
+	}
+
+	scratchDir, err := ioutil.TempDir("", "perf-must-gather-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(scratchDir)
+
+	if opts.rootDir != "" {
+		fileSpecs = chrootFileSpecs(fileSpecs, opts.rootDir)
+	}
+
+	if err := snapshot.CopyFilesInto(fileSpecs, scratchDir, nil); err != nil {
+		return fmt.Errorf("error cloning extra files into %q: %v", scratchDir, err)
+	}
+
+	if opts.rootDir != "" {
+		scratchDir = filepath.Join(scratchDir, opts.rootDir)
+	}
+
+	// intentionally ignore errors, keep collecting data
+	// machineinfo data is accessory, if we fail to collect
+	// we want to keep going and try to collect /proc and /sys data,
+	// which is more important
+	localPath := filepath.Join(scratchDir, machineInfoFilePath)
+	err = collectMachineinfo(knitOpts, localPath)
+	if err != nil {
+		log.Printf("error collecting machineinfo data: %v - continuing", err)
+	}
+
+	dest := opts.output
+	if dest == "-" {
+		err = snapshot.PackWithWriter(os.Stdout, scratchDir)
+		dest = "stdout"
+	} else {
+		err = snapshot.PackFrom(dest, scratchDir)
+	}
+	if err != nil {
+		return fmt.Errorf("error packing %q to %q: %v", scratchDir, dest, err)
+	}
+
+	return nil
+}
+
+func chrootFileSpecs(fileSpecs []string, root string) []string {
+	var entries []string
+	for _, fileSpec := range fileSpecs {
+		entries = append(entries, filepath.Join(root, fileSpec))
+	}
+	return entries
+}
+
+func dedupExpectedContent(fileSpecs, extraFileSpecs []string) []string {
+	specSet := make(map[string]int)
+	for _, fileSpec := range fileSpecs {
+		specSet[fileSpec]++
+	}
+	for _, extraFileSpec := range extraFileSpecs {
+		specSet[extraFileSpec]++
+	}
+
+	var retSpecs []string
+	for retSpec := range specSet {
+		retSpecs = append(retSpecs, retSpec)
+	}
+	return retSpecs
+}
+
+func kniExpectedCloneContent() []string {
+	return []string{
+		// generic information
+		"/proc/cmdline",
+		// IRQ affinities
+		"/proc/interrupts",
+		"/proc/irq/default_smp_affinity",
+		"/proc/irq/*/*affinity_list",
+		"/proc/irq/*/node",
+		// softirqs counters
+		"/proc/softirqs",
+		// KNI-specific CPU infos:
+		"/sys/devices/system/cpu/smt/active",
+		"/proc/sys/kernel/sched_domain/cpu*/domain*/flags",
+		"/sys/devices/system/cpu/offline",
+		// BIOS/firmware versions
+		"/sys/class/dmi/id/bios*",
+		"/sys/class/dmi/id/product_family",
+		"/sys/class/dmi/id/product_name",
+		"/sys/class/dmi/id/product_sku",
+		"/sys/class/dmi/id/product_version",
+	}
+}

--- a/cmd/gather-sysinfo/gather-sysinfo_test.go
+++ b/cmd/gather-sysinfo/gather-sysinfo_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
+	"github.com/spf13/cobra"
+	"k8s.io/utils/strings/slices"
+)
+
+var kniEntries = []string{
+	"/host/proc/cmdline",
+	"/host/proc/interrupts",
+	"/host/proc/irq/default_smp_affinity",
+	"/host/proc/irq/*/*affinity_list",
+	"/host/proc/irq/*/node",
+	"/host/proc/softirqs",
+	"/host/sys/devices/system/cpu/smt/active",
+	"/host/proc/sys/kernel/sched_domain/cpu*/domain*/flags",
+	"/host/sys/devices/system/cpu/offline",
+	"/host/sys/class/dmi/id/bios*",
+	"/host/sys/class/dmi/id/product_family",
+	"/host/sys/class/dmi/id/product_name",
+	"/host/sys/class/dmi/id/product_sku",
+	"/host/sys/class/dmi/id/product_version",
+}
+
+var snapshotEntries = []string{"/host/proc/cmdline", "/host/sys/devices/system/node/online"}
+
+var expectedEntries = []string{
+	"/host/proc/cmdline",
+	"/host/proc/interrupts",
+	"/host/proc/irq/default_smp_affinity",
+	"/host/proc/irq/*/*affinity_list",
+	"/host/proc/irq/*/node",
+	"/host/proc/softirqs",
+	"/host/sys/devices/system/cpu/smt/active",
+	"/host/proc/sys/kernel/sched_domain/cpu*/domain*/flags",
+	"/host/sys/devices/system/cpu/offline",
+	"/host/sys/class/dmi/id/bios*",
+	"/host/sys/class/dmi/id/product_family",
+	"/host/sys/class/dmi/id/product_name",
+	"/host/sys/class/dmi/id/product_sku",
+	"/host/sys/class/dmi/id/product_version",
+	"/host/sys/devices/system/node/online",
+}
+
+func TestCollectMachineInfo(t *testing.T) {
+	//Check if collect machine info file is created correctly
+	knitOpts := &cmd.KnitOptions{}
+	knitOpts.SysFSRoot = "/host/sys"
+
+	destFile := "./output"
+
+	// Delete the file after the test
+	defer os.Remove(destFile) // ignore error
+
+	err := collectMachineinfo(knitOpts, destFile)
+	if err != nil {
+		t.Errorf("Collection of machine info failed: %v", err)
+	}
+
+	content, err := ioutil.ReadFile(destFile)
+	if err != nil {
+		t.Errorf("Reading of generated output failed: %v", err)
+	}
+
+	output := string(content)
+	if !strings.Contains(output, "timestamp") {
+		t.Errorf("The generated output is not valid.")
+	}
+}
+
+func TestChroot(t *testing.T) {
+	entries := chrootFileSpecs(kniExpectedCloneContent(), "/host")
+	if !slices.Equal(entries, kniEntries) {
+		t.Errorf("The chroot file list does not match the expected value.")
+	}
+}
+
+func TestDeduplication(t *testing.T) {
+	resultEntries := dedupExpectedContent(kniEntries, snapshotEntries)
+	if len(expectedEntries) != len(resultEntries) {
+		t.Errorf("The deduplication did not work.")
+	}
+}
+
+func TestSnapshot(t *testing.T) {
+	knitOpts := &cmd.KnitOptions{}
+
+	opts := &snapshotOptions{}
+	cmd := &cobra.Command{}
+	args := []string{}
+
+	err := makeSnapshot(cmd, knitOpts, opts, args)
+	if err == nil {
+		t.Errorf("Failure was expected when running without --output argument.")
+	}
+	t.Log(err)
+
+	opts.output = "testSnapshot.tgz"
+
+	// Delete the snapshot after the test
+	defer os.Remove(opts.output) // ignore error
+
+	err = makeSnapshot(cmd, knitOpts, opts, args)
+	if err != nil {
+		t.Errorf("Failed to collect snapshot: %v", err)
+	}
+
+	_, err = os.Stat(opts.output)
+	if err != nil {
+		t.Errorf("Snapshot file should have been created: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/kevinburke/go-bindata v3.16.0+incompatible
 	github.com/onsi/ginkgo/v2 v2.6.1
 	github.com/onsi/gomega v1.24.2
+	github.com/openshift-kni/debug-tools v0.1.11
 	github.com/openshift/api v0.0.0-20230223193310-d964c7a58d75
 	github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084

--- a/go.sum
+++ b/go.sum
@@ -628,6 +628,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
+github.com/openshift-kni/debug-tools v0.1.11 h1:FlcRlL5XQcfWrtzzzpeld9HOEBZqNKc8hipNbBM6plc=
+github.com/openshift-kni/debug-tools v0.1.11/go.mod h1:O3tmG9+vhUW0Fej5xj3ZbslNUigjwYVEACG5AbHMLis=
 github.com/openshift/api v0.0.0-20230223193310-d964c7a58d75 h1:OQJsfiach1cKBI1xUSNXKzuqi8nTpDRccR8gMGFkTIU=
 github.com/openshift/api v0.0.0-20230223193310-d964c7a58d75/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533 h1:mh3ZYs7kPIIe3UUY6tJcTExmtjnXXUu0MrBuK2W/Qvw=

--- a/vendor/github.com/openshift-kni/debug-tools/LICENSE
+++ b/vendor/github.com/openshift-kni/debug-tools/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/fswrap/fswrap.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/fswrap/fswrap.go
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package fswrap
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+type FSWrapper struct {
+	Log *log.Logger
+}
+
+func (fs FSWrapper) Open(name string) (*os.File, error) {
+	fs.Log.Printf("fswrap %-8s %q", "Open", name)
+	return os.Open(name)
+}
+
+func (fs FSWrapper) ReadFile(filename string) ([]byte, error) {
+	fs.Log.Printf("fswrap %-8s %q", "ReadFile", filename)
+	return ioutil.ReadFile(filename)
+}
+
+func (fs FSWrapper) ReadDir(dirname string) ([]os.FileInfo, error) {
+	fs.Log.Printf("fswrap %-8s %q", "ReadDir", dirname)
+	return ioutil.ReadDir(dirname)
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/irqs/info.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/irqs/info.go
@@ -1,0 +1,230 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package irqs
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/openshift-kni/debug-tools/pkg/fswrap"
+	cpuset "github.com/openshift-kni/debug-tools/pkg/k8s_imported"
+)
+
+const (
+	EffectiveAffinity = 1 << iota
+)
+
+// the IRQ name is not always a number, can be like "NMI", "TLB"...
+type Counter map[string]uint64
+
+// assume x is fresher than x. IRQ (all stems by how the kernel does the accounting):
+// if a irq is counted in both c and x, then val(x) >= val(x)
+// x is always a superset of c
+func (C Counter) Delta(X Counter) Counter {
+	R := make(Counter)
+	for name, amount := range X {
+		if delta := amount - C[name]; delta > 0 {
+			R[name] = delta
+		}
+	}
+	return R
+}
+
+func (C Counter) Clone() Counter {
+	R := make(Counter)
+	for k, v := range C {
+		R[k] = v
+	}
+	return R
+}
+
+// CPUid -> counter
+type Stats map[int]Counter
+
+func (S Stats) Delta(X Stats) Stats {
+	R := make(Stats)
+	for cpuid, counter := range X {
+		R[cpuid] = S[cpuid].Delta(counter)
+	}
+	return R
+}
+
+func (S Stats) Clone() Stats {
+	R := make(Stats)
+	for k, v := range S {
+		R[k] = v.Clone()
+	}
+	return R
+}
+
+type Info struct {
+	Source string
+	IRQ    int
+	CPUs   cpuset.CPUSet
+}
+
+type Handler struct {
+	log        *log.Logger
+	procfsRoot string
+	fs         fswrap.FSWrapper
+}
+
+func New(logger *log.Logger, procfsRoot string) *Handler {
+	return &Handler{
+		log:        logger,
+		procfsRoot: procfsRoot,
+		fs:         fswrap.FSWrapper{Log: logger},
+	}
+}
+
+func (handler *Handler) ReadInfo(flags uint) ([]Info, error) {
+	// the best source of information here is man 5 procfs
+	// and https://www.kernel.org/doc/Documentation/IRQ-affinity.txt
+	irqRoot := filepath.Join(handler.procfsRoot, "irq")
+
+	files, err := handler.fs.ReadDir(irqRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var irqs []int
+	for _, file := range files {
+		irq, err := strconv.Atoi(file.Name())
+		if err != nil {
+			continue // just skip not-irq-looking dirs
+		}
+		irqs = append(irqs, irq)
+	}
+
+	sort.Ints(irqs)
+
+	affinityListFile := "smp_affinity_list"
+	if (flags & EffectiveAffinity) == EffectiveAffinity {
+		affinityListFile = "effective_affinity_list"
+	}
+
+	irqInfos := make([]Info, len(irqs))
+	for _, irq := range irqs {
+		irqDir := filepath.Join(irqRoot, fmt.Sprintf("%d", irq))
+
+		irqCpuList, err := handler.fs.ReadFile(filepath.Join(irqDir, affinityListFile))
+		if err != nil {
+			return nil, err
+		}
+
+		irqCpus, err := cpuset.Parse(strings.TrimSpace(string(irqCpuList)))
+		if err != nil {
+			handler.log.Printf("Error parsing cpulist in %q: %v", irqCpuList, err)
+			continue // keep running
+		}
+
+		irqInfos = append(irqInfos, Info{
+			CPUs:   irqCpus,
+			IRQ:    irq,
+			Source: handler.findSourceForIRQ(irq),
+		})
+	}
+	return irqInfos, nil
+}
+
+func (handler *Handler) ReadStats() (Stats, error) {
+	src, err := handler.fs.Open(filepath.Join(handler.procfsRoot, "interrupts"))
+	if err != nil {
+		return nil, fmt.Errorf("error reading interrupts from %q: %v", handler.procfsRoot, err)
+	}
+	defer src.Close()
+	return parseInterrupts(handler.log, src)
+}
+
+func parseInterrupts(logger *log.Logger, rd io.Reader) (Stats, error) {
+	src := bufio.NewScanner(rd)
+	src.Scan()
+	cpus := strings.Fields(src.Text())
+
+	// we should never assume columnid == cpuid, because we will need to handle offlined cpus
+	// - aka holes in the sequence. Hence we use a mapping.
+	col2cpu := make(map[int]int)
+
+	stats := make(Stats)
+	// we split the line using whitespaces as separator. So the first line is something like
+	// "            CPU0       CPU1       CPU2       CPU3" (all spaces, no tabs)
+	// and the `cpus` slice is something like ["CPU0" "CPU1" "CPU2" "CPU3"]
+	for colIdx, cpu := range cpus {
+		var cpuid int
+		n, err := fmt.Sscanf(cpu, "CPU%d", &cpuid)
+		if n != 1 || err != nil {
+			return nil, fmt.Errorf("cannot parse cpu name %q: err=%v", cpu, err)
+		}
+		stats[cpuid] = make(Counter)
+		// if all the cpus are online, this is the trivial mapping 0:0, 1:1, ...
+		col2cpu[colIdx] = cpuid
+	}
+
+	// format:
+	// IRQ: cpu0_counter ... cpuN_counter [stuff we dont care]
+	// so we need to scan only the first len(cpus) + 1 columns
+	maxCols := 1 + len(cpus)
+	for src.Scan() {
+		items := strings.Fields(src.Text())
+		if len(items) < maxCols {
+			// irq name == MIS
+			continue
+		}
+		irqName := strings.TrimSuffix(items[0], ":")
+		// so from now on we consider only len(cpus) columns, shifted by one to the left
+		//                [ "0:" "13" "0" "0" "0" "IR-IO-APIC" "2-edge" "timer"]
+		// column index:    0    1    2   3   4   5            6        7
+		//                  |----+                ============================ we don't care about this
+		//                       |----|---|---|
+		//                                    `- we only care about 1 + len(cpus) = 4 = 5 columns
+		// `cpuColIdx`:    {skip} 0   1   2   3
+		for cpuColIdx, item := range items[1:maxCols] {
+			count, err := strconv.ParseUint(item, 10, 64)
+			if err != nil {
+				log.Printf("Error parsing interrupts info from %q: %v", item, err)
+				continue
+			}
+
+			cpuId := col2cpu[cpuColIdx]
+			stats[cpuId][irqName] = count
+		}
+	}
+	return stats, nil
+}
+
+// TODO: we may want to crosscorrelate with `/proc/interrupts, which always give a valid (!= "") source
+func (handler *Handler) findSourceForIRQ(irq int) string {
+	irqDir := filepath.Join(handler.procfsRoot, "irq", fmt.Sprintf("%d", irq))
+	files, err := handler.fs.ReadDir(irqDir)
+	if err != nil {
+		handler.log.Printf("Error reading %q: %v", irqDir, err)
+		return "MISSING"
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			return file.Name()
+		}
+	}
+	handler.log.Printf("Cannot find source for irq %d", irq)
+	return ""
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/irqs/reporter.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/irqs/reporter.go
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package irqs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	cpuset "github.com/openshift-kni/debug-tools/pkg/k8s_imported"
+)
+
+type Reporter interface {
+	Delta(ts time.Time, prevStats, lastStats Stats)
+	Summary(initTs time.Time, prevStats, lastStats Stats)
+}
+
+func NewReporter(sink io.Writer, jsonOutput bool, verbose int, cpus cpuset.CPUSet) Reporter {
+	if jsonOutput {
+		return &reporterJSON{
+			verbose: verbose,
+			cpus:    cpus,
+			sink:    sink,
+		}
+	}
+	return &reporterText{
+		verbose: verbose,
+		cpus:    cpus,
+		sink:    sink,
+	}
+
+}
+
+type reporterText struct {
+	verbose int
+	cpus    cpuset.CPUSet
+	sink    io.Writer
+}
+
+func (rt *reporterText) Delta(ts time.Time, prevStats, lastStats Stats) {
+	if rt.verbose < 2 {
+		return
+	}
+	delta := prevStats.Delta(lastStats)
+	cpuids := rt.cpus.ToSlice()
+	for _, cpuid := range cpuids {
+		counter, ok := delta[cpuid]
+		if !ok {
+			continue
+		}
+		for irqName, val := range counter {
+			if val == 0 {
+				continue
+			}
+			fmt.Fprintf(rt.sink, "%v CPU=%d IRQ=%s +%d\n", ts, cpuid, irqName, val)
+		}
+	}
+}
+
+func (rt *reporterText) Summary(initTs time.Time, prevStats, lastStats Stats) {
+	if rt.verbose < 1 {
+		return
+	}
+	timeDelta := time.Now().Sub(initTs)
+	delta := prevStats.Delta(lastStats)
+	cpuids := rt.cpus.ToSlice()
+
+	fmt.Fprintf(rt.sink, "\nIRQ summary on cpus %v after %v\n", rt.cpus, timeDelta)
+	for _, cpuid := range cpuids {
+		counter, ok := delta[cpuid]
+		if !ok {
+			continue
+		}
+		for irqName, val := range counter {
+			if val == 0 {
+				continue
+			}
+			fmt.Fprintf(rt.sink, "CPU=%d IRQ=%s +%d\n", cpuid, irqName, val)
+		}
+	}
+}
+
+type reporterJSON struct {
+	verbose int
+	cpus    cpuset.CPUSet
+	sink    io.Writer
+}
+
+type irqDelta struct {
+	Timestamp time.Time `json:"timestamp"`
+	Counters  Stats     `json:"counters"`
+}
+
+func (rj *reporterJSON) Delta(ts time.Time, prevStats, lastStats Stats) {
+	if rj.verbose < 2 {
+		return
+	}
+	res := irqDelta{
+		Timestamp: ts,
+		Counters:  countersForCPUs(rj.cpus, prevStats.Delta(lastStats)),
+	}
+	json.NewEncoder(rj.sink).Encode(res)
+}
+
+type irqwatchDuration struct {
+	d time.Duration
+}
+
+type irqSummary struct {
+	Elapsed  irqwatchDuration `json:"elapsed"`
+	Counters Stats            `json:"counters"`
+}
+
+func (rj *reporterJSON) Summary(initTs time.Time, prevStats, lastStats Stats) {
+	if rj.verbose < 1 {
+		return
+	}
+	res := irqSummary{
+		Elapsed: irqwatchDuration{
+			d: time.Now().Sub(initTs),
+		},
+		Counters: countersForCPUs(rj.cpus, prevStats.Delta(lastStats)),
+	}
+	json.NewEncoder(rj.sink).Encode(res)
+}
+
+func countersForCPUs(cpus cpuset.CPUSet, stats Stats) Stats {
+	res := make(Stats)
+	cpuids := cpus.ToSlice()
+
+	for _, cpuid := range cpuids {
+		counter, ok := stats[cpuid]
+		if !ok || len(counter) == 0 {
+			continue
+		}
+		res[cpuid] = counter
+	}
+
+	return res
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/irqs/soft/info.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/irqs/soft/info.go
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package soft
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/openshift-kni/debug-tools/pkg/fswrap"
+)
+
+// presented in kernel order
+func Names() []string {
+	// keys found in /proc/softirqs (first column)
+	return []string{"HI", "TIMER", "NET_TX", "NET_RX", "BLOCK", "IRQ_POLL", "TASKLET", "SCHED", "HRTIMER", "RCU"}
+}
+
+type Info struct {
+	CPUs int
+	// softirq -> percpu count
+	Counters map[string][]uint64
+}
+
+type Handler struct {
+	log        *log.Logger
+	procfsRoot string
+	fs         fswrap.FSWrapper
+}
+
+func New(logger *log.Logger, procfsRoot string) *Handler {
+	return &Handler{
+		log:        logger,
+		procfsRoot: procfsRoot,
+		fs:         fswrap.FSWrapper{Log: logger},
+	}
+}
+
+func (handler *Handler) ReadInfo() (*Info, error) {
+	src, err := handler.fs.Open(filepath.Join(handler.procfsRoot, "softirqs"))
+	if err != nil {
+		return nil, fmt.Errorf("error reading softirqs from %q: %v", handler.procfsRoot, err)
+	}
+	defer src.Close()
+	return parseSoftirqs(handler.log, src)
+}
+
+func parseSoftirqs(logger *log.Logger, rd io.Reader) (*Info, error) {
+	src := bufio.NewScanner(rd)
+	src.Scan()
+	cpus := strings.Fields(src.Text())
+	ret := Info{
+		CPUs:     len(cpus),
+		Counters: make(map[string][]uint64),
+	}
+
+	for src.Scan() {
+		items := strings.Fields(src.Text())
+		var vals []uint64
+		for _, item := range items[1:] {
+			v, err := strconv.ParseUint(item, 10, 64)
+			if err != nil {
+				log.Printf("Error parsing softirqs info from %q: %v", item, err)
+				continue
+			}
+			vals = append(vals, v)
+		}
+		ret.Counters[strings.TrimSuffix(items[0], ":")] = vals
+	}
+	return &ret, nil
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/k8s_imported/cpuset.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/k8s_imported/cpuset.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+This was copied out of kubernetes source to avoid pulling too
+many dependencies with the full kubernetes source code.
+
+This is based on the following kubernetes file:
+
+https://github.com/kubernetes/kubernetes/blob/759e043136b249f9e19355d3b2c9261b3ac82a70/pkg/kubelet/cm/cpuset/cpuset.go
+
+And will be replaced by https://pkg.go.dev/k8s.io/utils/cpuset once
+it is released as a stable version.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpuset
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Builder is a mutable builder for CPUSet. Functions that mutate instances
+// of this type are not thread-safe.
+type Builder struct {
+	result CPUSet
+	done   bool
+}
+
+// NewBuilder returns a mutable CPUSet builder.
+func NewBuilder() *Builder {
+	return &Builder{
+		result: CPUSet{
+			elems: map[int]struct{}{},
+		},
+	}
+}
+
+// Add adds the supplied elements to the result. Calling Add after calling
+// Result has no effect.
+func (b *Builder) Add(elems ...int) {
+	if b.done {
+		return
+	}
+	for _, elem := range elems {
+		b.result.elems[elem] = struct{}{}
+	}
+}
+
+// Result returns the result CPUSet containing all elements that were
+// previously added to this builder. Subsequent calls to Add have no effect.
+func (b *Builder) Result() CPUSet {
+	b.done = true
+	return b.result
+}
+
+// CPUSet is a thread-safe, immutable set-like data structure for CPU IDs.
+type CPUSet struct {
+	elems map[int]struct{}
+}
+
+// NewCPUSet returns a new CPUSet containing the supplied elements.
+func NewCPUSet(cpus ...int) CPUSet {
+	b := NewBuilder()
+	for _, c := range cpus {
+		b.Add(c)
+	}
+	return b.Result()
+}
+
+// NewCPUSetInt64 returns a new CPUSet containing the supplied elements, as slice of int64.
+func NewCPUSetInt64(cpus ...int64) CPUSet {
+	b := NewBuilder()
+	for _, c := range cpus {
+		b.Add(int(c))
+	}
+	return b.Result()
+}
+
+// Size returns the number of elements in this set.
+func (s CPUSet) Size() int {
+	return len(s.elems)
+}
+
+// IsEmpty returns true if there are zero elements in this set.
+func (s CPUSet) IsEmpty() bool {
+	return s.Size() == 0
+}
+
+// Contains returns true if the supplied element is present in this set.
+func (s CPUSet) Contains(cpu int) bool {
+	_, found := s.elems[cpu]
+	return found
+}
+
+// Equals returns true if the supplied set contains exactly the same elements
+// as this set (s IsSubsetOf s2 and s2 IsSubsetOf s).
+func (s CPUSet) Equals(s2 CPUSet) bool {
+	return reflect.DeepEqual(s.elems, s2.elems)
+}
+
+// Filter returns a new CPU set that contains all of the elements from this
+// set that match the supplied predicate, without mutating the source set.
+func (s CPUSet) Filter(predicate func(int) bool) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		if predicate(cpu) {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// FilterNot returns a new CPU set that contains all of the elements from this
+// set that do not match the supplied predicate, without mutating the source
+// set.
+func (s CPUSet) FilterNot(predicate func(int) bool) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		if !predicate(cpu) {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// IsSubsetOf returns true if the supplied set contains all the elements
+func (s CPUSet) IsSubsetOf(s2 CPUSet) bool {
+	result := true
+	for cpu := range s.elems {
+		if !s2.Contains(cpu) {
+			result = false
+			break
+		}
+	}
+	return result
+}
+
+// Union returns a new CPU set that contains all of the elements from this
+// set and all of the elements from the supplied set, without mutating
+// either source set.
+func (s CPUSet) Union(s2 CPUSet) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		b.Add(cpu)
+	}
+	for cpu := range s2.elems {
+		b.Add(cpu)
+	}
+	return b.Result()
+}
+
+// UnionAll returns a new CPU set that contains all of the elements from this
+// set and all of the elements from the supplied sets, without mutating
+// either source set.
+func (s CPUSet) UnionAll(s2 []CPUSet) CPUSet {
+	b := NewBuilder()
+	for cpu := range s.elems {
+		b.Add(cpu)
+	}
+	for _, cs := range s2 {
+		for cpu := range cs.elems {
+			b.Add(cpu)
+		}
+	}
+	return b.Result()
+}
+
+// Intersection returns a new CPU set that contains all of the elements
+// that are present in both this set and the supplied set, without mutating
+// either source set.
+func (s CPUSet) Intersection(s2 CPUSet) CPUSet {
+	return s.Filter(func(cpu int) bool { return s2.Contains(cpu) })
+}
+
+// Difference returns a new CPU set that contains all of the elements that
+// are present in this set and not the supplied set, without mutating either
+// source set.
+func (s CPUSet) Difference(s2 CPUSet) CPUSet {
+	return s.FilterNot(func(cpu int) bool { return s2.Contains(cpu) })
+}
+
+// ToSlice returns a slice of integers that contains all elements from
+// this set.
+func (s CPUSet) ToSlice() []int {
+	result := []int{}
+	for cpu := range s.elems {
+		result = append(result, cpu)
+	}
+	sort.Ints(result)
+	return result
+}
+
+// ToSliceNoSort returns a slice of integers that contains all elements from
+// this set.
+func (s CPUSet) ToSliceNoSort() []int {
+	result := []int{}
+	for cpu := range s.elems {
+		result = append(result, cpu)
+	}
+	return result
+}
+
+// ToSliceInt64 returns an ordered slice of int64 that contains all elements from
+// this set
+func (s CPUSet) ToSliceInt64() []int64 {
+	var result []int64
+	for cpu := range s.elems {
+		result = append(result, int64(cpu))
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	return result
+}
+
+// ToSliceNoSortInt64 returns a slice of int64 that contains all elements from
+// this set.
+func (s CPUSet) ToSliceNoSortInt64() []int64 {
+	var result []int64
+	for cpu := range s.elems {
+		result = append(result, int64(cpu))
+	}
+	return result
+}
+
+// String returns a new string representation of the elements in this CPU set
+// in canonical linux CPU list format.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func (s CPUSet) String() string {
+	if s.IsEmpty() {
+		return ""
+	}
+
+	elems := s.ToSlice()
+
+	type rng struct {
+		start int
+		end   int
+	}
+
+	ranges := []rng{{elems[0], elems[0]}}
+
+	for i := 1; i < len(elems); i++ {
+		lastRange := &ranges[len(ranges)-1]
+		// if this element is adjacent to the high end of the last range
+		if elems[i] == lastRange.end+1 {
+			// then extend the last range to include this element
+			lastRange.end = elems[i]
+			continue
+		}
+		// otherwise, start a new range beginning with this element
+		ranges = append(ranges, rng{elems[i], elems[i]})
+	}
+
+	// construct string from ranges
+	var result bytes.Buffer
+	for _, r := range ranges {
+		if r.start == r.end {
+			result.WriteString(strconv.Itoa(r.start))
+		} else {
+			result.WriteString(fmt.Sprintf("%d-%d", r.start, r.end))
+		}
+		result.WriteString(",")
+	}
+	return strings.TrimRight(result.String(), ",")
+}
+
+// MustParse CPUSet constructs a new CPU set from a Linux CPU list formatted
+// string. Unlike Parse, it does not return an error but rather panics if the
+// input cannot be used to construct a CPU set.
+func MustParse(s string) CPUSet {
+	res, err := Parse(s)
+	if err != nil {
+		log.Printf("Failed to parse input '%s' as CPUSet: %v", s, err)
+		os.Exit(1)
+	}
+	return res
+}
+
+// Parse CPUSet constructs a new CPU set from a Linux CPU list formatted string.
+//
+// See: http://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS
+func Parse(s string) (CPUSet, error) {
+	b := NewBuilder()
+
+	// Handle empty string.
+	if s == "" {
+		return b.Result(), nil
+	}
+
+	// Split CPU list string:
+	// "0-5,34,46-48" => ["0-5", "34", "46-48"]
+	ranges := strings.Split(s, ",")
+
+	for _, r := range ranges {
+		boundaries := strings.SplitN(r, "-", 2)
+		if len(boundaries) == 1 {
+			// Handle ranges that consist of only one element like "34".
+			elem, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			b.Add(elem)
+		} else if len(boundaries) == 2 {
+			// Handle multi-element ranges like "0-5".
+			start, err := strconv.Atoi(boundaries[0])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			end, err := strconv.Atoi(boundaries[1])
+			if err != nil {
+				return NewCPUSet(), err
+			}
+			if start > end {
+				return NewCPUSet(), fmt.Errorf("invalid range %q (%d >= %d)", r, start, end)
+			}
+			// start == end is acceptable (1-1 -> 1)
+
+			// Add all elements to the result.
+			// e.g. "0-5", "46-48" => [0, 1, 2, 3, 4, 5, 46, 47, 48].
+			for e := start; e <= end; e++ {
+				b.Add(e)
+			}
+		}
+	}
+	return b.Result(), nil
+}
+
+// Clone returns a copy of this CPU set.
+func (s CPUSet) Clone() CPUSet {
+	b := NewBuilder()
+	for elem := range s.elems {
+		b.Add(elem)
+	}
+	return b.Result()
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/k8s_imported/podresources_client.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/k8s_imported/podresources_client.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+This was copied out of kubernetes source to avoid pulling too
+many dependencies with the full kubernetes source code.
+
+This is based on the following kubernetes file:
+https://github.com/kubernetes/kubernetes/blob/52457842d155743f0e3fc57ade87251cca37d375/pkg/kubelet/apis/podresources/client.go#L56
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpuset
+
+import (
+	"context"
+	"fmt"
+	"google.golang.org/grpc"
+	"k8s.io/klog/v2"
+	"k8s.io/kubelet/pkg/apis/podresources/v1"
+	"net"
+	"net/url"
+	"time"
+)
+
+// GetV1Client returns a client for the PodResourcesLister grpc service
+// This was copied from kubelet sources as per the comment there:
+//
+// Quote:
+// https://github.com/kubernetes/kubernetes/blob/52457842d155743f0e3fc57ade87251cca37d375/pkg/kubelet/apis/podresources/client.go#L32
+// Note: Consumers of the pod resources API should not be importing this package.
+// They should copy paste the function in their project.
+func GetV1Client(socket string, connectionTimeout time.Duration, maxMsgSize int) (v1.PodResourcesListerClient, *grpc.ClientConn, error) {
+	addr, dialer, err := getAddressAndDialer(socket)
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	if err != nil {
+		return nil, nil, fmt.Errorf("error dialing socket %s: %v", socket, err)
+	}
+	return v1.NewPodResourcesListerClient(conn), conn, nil
+}
+
+// GetAddressAndDialer returns the address parsed from the given endpoint and a context dialer.
+func getAddressAndDialer(endpoint string) (string, func(ctx context.Context, addr string) (net.Conn, error), error) {
+	protocol, addr, err := parseEndpointWithFallbackProtocol(endpoint, "unix")
+	if err != nil {
+		return "", nil, err
+	}
+	if protocol != "unix" {
+		return "", nil, fmt.Errorf("only support unix socket endpoint")
+	}
+
+	return addr, dial, nil
+}
+
+func dial(ctx context.Context, addr string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, "unix", addr)
+}
+
+func parseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string) (protocol string, addr string, err error) {
+	if protocol, addr, err = parseEndpoint(endpoint); err != nil && protocol == "" {
+		fallbackEndpoint := fallbackProtocol + "://" + endpoint
+		protocol, addr, err = parseEndpoint(fallbackEndpoint)
+		if err == nil {
+			klog.InfoS("Using this endpoint is deprecated, please consider using full URL format", "endpoint", endpoint, "URL", fallbackEndpoint)
+		}
+	}
+	return
+}
+
+func parseEndpoint(endpoint string) (string, string, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", "", err
+	}
+
+	switch u.Scheme {
+	case "tcp":
+		return "tcp", u.Host, nil
+
+	case "unix":
+		return "unix", u.Path, nil
+
+	case "":
+		return "", "", fmt.Errorf("using %q as endpoint is deprecated, please consider using full url format", endpoint)
+
+	default:
+		return u.Scheme, "", fmt.Errorf("protocol %q not supported", u.Scheme)
+	}
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/cpuaff.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/cpuaff.go
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	cpuset "github.com/openshift-kni/debug-tools/pkg/k8s_imported"
+	"github.com/openshift-kni/debug-tools/pkg/procs"
+)
+
+type cpuAffOptions struct {
+	pidIdent string
+}
+
+func NewCPUAffinityCommand(knitOpts *KnitOptions) *cobra.Command {
+	opts := &cpuAffOptions{}
+	cpuAff := &cobra.Command{
+		Use:   "cpuaff",
+		Short: "show cpu thread affinities",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showCPUAffinity(cmd, knitOpts, opts, args)
+		},
+		Args: cobra.NoArgs,
+	}
+	cpuAff.Flags().StringVarP(&opts.pidIdent, "pid", "p", "", "monitor only threads belonging to this pid (default is all).")
+	return cpuAff
+}
+
+type runnable struct {
+	PID         int    `json:"pid"`
+	TID         int    `json:"tid"`
+	ProcessName string `json:"process"`
+	ThreadName  string `json:"thread"`
+	CPUAffinity []int  `json:"affinity"`
+}
+
+func (ru runnable) String() string {
+	// see: https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html
+	// "The thread name is a meaningful C language string, whose length is restricted to 16 characters,
+	// including the terminating null byte"
+	// for process names howevwver we just pick a "usually long enough" format value
+	return fmt.Sprintf("PID %6d (%-32s) TID %6d (%-16s) can run on %v", ru.PID, ru.ProcessName, ru.TID, ru.ThreadName, ru.CPUAffinity)
+}
+
+func showCPUAffinity(cmd *cobra.Command, knitOpts *KnitOptions, opts *cpuAffOptions, args []string) error {
+	ph := procs.New(knitOpts.Log, knitOpts.ProcFSRoot)
+
+	if opts.pidIdent != "" {
+		pid, err := strconv.Atoi(opts.pidIdent)
+		if err != nil {
+			return fmt.Errorf("error parsing %q: %v", opts.pidIdent, err)
+		}
+		procInfo, err := ph.FromPID(pid)
+		for tid, tidInfo := range procInfo.TIDs {
+			threadCpus := cpuset.NewCPUSet(tidInfo.Affinity...)
+
+			cpus := threadCpus.Intersection(knitOpts.Cpus)
+			if cpus.Size() != 0 {
+				fmt.Printf("PID %6d TID %6d can run on %v\n", pid, tid, cpus.String())
+			}
+		}
+		return nil
+	}
+
+	procInfos, err := ph.ListAll()
+	if err != nil {
+		return fmt.Errorf("error getting process infos from %q: %v", knitOpts.ProcFSRoot, err)
+	}
+
+	var runnables []runnable
+	for _, pid := range sortedPids(procInfos) {
+		procInfo := procInfos[pid]
+
+		for _, tid := range sortedTids(procInfo.TIDs) {
+			tidInfo := procInfo.TIDs[tid]
+
+			threadCpus := cpuset.NewCPUSet(tidInfo.Affinity...)
+			cpus := threadCpus.Intersection(knitOpts.Cpus)
+			if cpus.Size() == 0 {
+				continue
+			}
+			runnables = append(runnables, runnable{
+				PID:         pid,
+				TID:         tid,
+				ProcessName: procInfo.Name,
+				ThreadName:  tidInfo.Name,
+				CPUAffinity: cpus.ToSlice(),
+			})
+		}
+	}
+
+	if knitOpts.JsonOutput {
+		json.NewEncoder(os.Stdout).Encode(runnables)
+	} else {
+		for _, runnable := range runnables {
+			fmt.Println(runnable.String())
+		}
+	}
+	return nil
+}
+
+func sortedPids(procInfos map[int]procs.PIDInfo) []int {
+	pids := make([]int, len(procInfos))
+	for pid := range procInfos {
+		pids = append(pids, pid)
+	}
+	sort.Ints(pids)
+	return pids
+}
+
+func sortedTids(tidInfos map[int]procs.TIDInfo) []int {
+	tids := make([]int, len(tidInfos))
+	for tid := range tidInfos {
+		tids = append(tids, tid)
+	}
+	sort.Ints(tids)
+	return tids
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/irqaff.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/irqaff.go
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-kni/debug-tools/pkg/irqs"
+	softirqs "github.com/openshift-kni/debug-tools/pkg/irqs/soft"
+	cpuset "github.com/openshift-kni/debug-tools/pkg/k8s_imported"
+)
+
+type irqAffOptions struct {
+	checkEffective  bool
+	checkSoftirqs   bool
+	showEmptySource bool
+}
+
+func NewIRQAffinityCommand(knitOpts *KnitOptions) *cobra.Command {
+	opts := &irqAffOptions{}
+	irqAff := &cobra.Command{
+		Use:   "irqaff",
+		Short: "show IRQ/softirq thread affinities",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.checkSoftirqs {
+				return showSoftIRQAffinity(cmd, knitOpts, opts, args)
+			} else {
+				return showIRQAffinity(cmd, knitOpts, opts, args)
+			}
+		},
+		Args: cobra.NoArgs,
+	}
+	irqAff.Flags().BoolVarP(&opts.checkEffective, "effective-affinity", "E", false, "check effective affinity.")
+	irqAff.Flags().BoolVarP(&opts.checkSoftirqs, "softirqs", "s", false, "check softirqs counters.")
+	irqAff.Flags().BoolVarP(&opts.showEmptySource, "show-empty-source", "e", false, "show infos if IRQ source is not reported.")
+	return irqAff
+}
+
+type irqAffinity struct {
+	IRQ         int    `json:"irq"`
+	Source      string `json:"source"`
+	CPUAffinity []int  `json:"affinity"`
+}
+
+func (ia irqAffinity) String() string {
+	return fmt.Sprintf("IRQ %3d [%24s]: can run on %v", ia.IRQ, ia.Source, ia.CPUAffinity)
+}
+
+type softirqAffinity struct {
+	SoftIRQ     string `json:"softirq"`
+	CPUAffinity []int  `json:"affinity"`
+}
+
+func (sa softirqAffinity) String() string {
+	return fmt.Sprintf("%8s = %v", sa.SoftIRQ, sa.CPUAffinity)
+}
+
+func showIRQAffinity(cmd *cobra.Command, knitOpts *KnitOptions, opts *irqAffOptions, args []string) error {
+	ih := irqs.New(knitOpts.Log, knitOpts.ProcFSRoot)
+
+	flags := uint(0)
+	if opts.checkEffective {
+		flags |= irqs.EffectiveAffinity
+	}
+
+	irqInfos, err := ih.ReadInfo(flags)
+	if err != nil {
+		return fmt.Errorf("error parsing irqs from %q: %v", knitOpts.ProcFSRoot, err)
+	}
+
+	var irqAffinities []irqAffinity
+	for _, irqInfo := range irqInfos {
+		cpus := irqInfo.CPUs.Intersection(knitOpts.Cpus)
+		if cpus.Size() == 0 {
+			continue
+		}
+		if irqInfo.Source == "" && !opts.showEmptySource {
+			continue
+		}
+		irqAffinities = append(irqAffinities, irqAffinity{
+			IRQ:         irqInfo.IRQ,
+			Source:      irqInfo.Source,
+			CPUAffinity: cpus.ToSlice(),
+		})
+	}
+
+	if knitOpts.JsonOutput {
+		json.NewEncoder(os.Stdout).Encode(irqAffinities)
+	} else {
+		for _, irqAffinity := range irqAffinities {
+			fmt.Println(irqAffinity.String())
+		}
+	}
+	return nil
+}
+
+func showSoftIRQAffinity(cmd *cobra.Command, knitOpts *KnitOptions, opts *irqAffOptions, args []string) error {
+	sh := softirqs.New(knitOpts.Log, knitOpts.ProcFSRoot)
+	info, err := sh.ReadInfo()
+
+	if err != nil {
+		return fmt.Errorf("error parsing softirqs from %q: %v", knitOpts.ProcFSRoot, err)
+	}
+
+	var softirqAffinities []softirqAffinity
+	keys := softirqs.Names()
+	for _, key := range keys {
+		counters := info.Counters[key]
+		cb := cpuset.NewBuilder()
+		for idx, counter := range counters {
+			if counter > 0 {
+				cb.Add(idx)
+			}
+		}
+		usedCPUs := knitOpts.Cpus.Intersection(cb.Result())
+
+		softirqAffinities = append(softirqAffinities, softirqAffinity{
+			SoftIRQ:     key,
+			CPUAffinity: usedCPUs.ToSlice(),
+		})
+	}
+
+	if knitOpts.JsonOutput {
+		json.NewEncoder(os.Stdout).Encode(softirqAffinities)
+	} else {
+		for _, softirqAffinity := range softirqAffinities {
+			fmt.Println(softirqAffinity.String())
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/irqwatch.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/irqwatch.go
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package cmd
+
+import (
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-kni/debug-tools/pkg/irqs"
+)
+
+type irqWatchOptions struct {
+	period  string
+	maxRuns int
+	verbose int
+}
+
+func NewIRQWatchCommand(knitOpts *KnitOptions) *cobra.Command {
+	opts := &irqWatchOptions{}
+	irqWatch := &cobra.Command{
+		Use:   "irqwatch",
+		Short: "watch IRQ counters",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return watchIRQs(cmd, knitOpts, opts, args)
+		},
+		Args: cobra.NoArgs,
+	}
+	irqWatch.Flags().IntVarP(&opts.maxRuns, "watch-times", "T", -1, "number of watch loops to perform, each every `watch-period`. Use -1 to run forever.")
+	irqWatch.Flags().StringVarP(&opts.period, "watch-period", "W", "1s", "period to poll IRQ counters.")
+	irqWatch.Flags().IntVarP(&opts.verbose, "verbose", "v", 1, "verbosiness amount.")
+	return irqWatch
+}
+
+func watchIRQs(cmd *cobra.Command, knitOpts *KnitOptions, opts *irqWatchOptions, args []string) error {
+	if opts.maxRuns == 0 {
+		return nil
+	}
+
+	var err error
+	period, err := time.ParseDuration(opts.period)
+	if err != nil {
+		return err
+	}
+
+	var initStats irqs.Stats
+	var prevStats irqs.Stats
+	var lastStats irqs.Stats
+
+	ih := irqs.New(knitOpts.Log, knitOpts.ProcFSRoot)
+
+	initTs := time.Now()
+	initStats, err = ih.ReadStats()
+	if err != nil {
+		return err
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	prevStats = initStats.Clone()
+	ticker := time.NewTicker(period)
+	reporter := irqs.NewReporter(os.Stdout, knitOpts.JsonOutput, opts.verbose, knitOpts.Cpus)
+
+	done := false
+	iterCount := 1
+	for {
+		select {
+		case <-c:
+			done = true
+		case t := <-ticker.C:
+			lastStats, err = ih.ReadStats()
+			if err != nil {
+				return err
+			}
+			reporter.Delta(t, prevStats, lastStats)
+			prevStats = lastStats
+		}
+
+		if done {
+			break
+		}
+		if opts.maxRuns > 0 && iterCount >= opts.maxRuns {
+			break
+		}
+		iterCount++
+	}
+
+	reporter.Summary(initTs, initStats, lastStats)
+	return nil
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s/podinfo.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s/podinfo.go
@@ -1,0 +1,210 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ */
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"text/template"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
+	"github.com/spf13/cobra"
+)
+
+type podInfoOptions struct {
+	nodeName string
+}
+
+//Only need some info about the pod.
+// Right now is:
+// - pod name
+// - pod namespace
+// - node name
+// - status.qosClass
+// - containers
+//   - requests cpu
+//   - limits cpu
+// Note this output format could change but it would be parsed on insight rules
+// so the change should be sync with it.
+// Caution: We filter the data from pods to avoid exposing sensible information
+// (like environment variables or input parameters which can contain passwords)
+// so take care of that when changing this template.
+const defaultTemplate string = `
+[
+	{{- range $idx, $item := .Items}}
+	{{- if (ne $idx 0)}},{{end}}
+	{
+		"namespace":"{{.ObjectMeta.Namespace}}", 
+		"name":"{{.ObjectMeta.Name}}", 
+		"nodeName":"{{.Spec.NodeName}}", 
+		"qosClass": "{{.Status.QOSClass}}", 
+		{{- if .Spec.Containers }}
+		"containers": [
+		{{- range $cdx, $cont := .Spec.Containers -}}
+			{{- if (ne $cdx 0) }},{{ end }} 
+			{
+				"name":"{{.Name}}"
+				{{- if or .Resources.Requests .Resources.Limits -}}
+				,
+				"resources": {
+					{{- if .Resources.Limits}} {{if .Resources.Limits.Cpu}} 
+					"limits": {
+						"cpu": "{{.Resources.Limits.Cpu}}"
+					}
+					{{- end -}}{{end}}
+					{{- if and .Resources.Requests .Resources.Limits .Resources.Requests.Cpu .Resources.Limits.Cpu -}}
+					,
+					{{- end -}}
+					{{- if .Resources.Requests}}{{if .Resources.Requests.Cpu }}
+					"requests": {
+						"cpu": "{{.Resources.Requests.Cpu}}"
+					}
+					{{- end }}{{end}}
+				} 
+				{{- end }} 
+			} 
+		{{- end }} 
+		]
+		{{- end }} 
+	}
+	{{- end }}
+]`
+
+func NewPodInfoCommand(knitOpts *cmd.KnitOptions) *cobra.Command {
+
+	opts := &podInfoOptions{}
+	podInfo := &cobra.Command{
+		Use:   "podinfo",
+		Short: "get pod information complementing podresources data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			clientset, err := getClientSetFromClusterConfig()
+			if err != nil {
+				return fmt.Errorf("unable to get clientset: %w", err)
+			}
+
+			podInfoTemplate, err := createOutputTemplate("pod_info", defaultTemplate)
+			if err != nil {
+				return fmt.Errorf("unable to get output template: %w", err)
+			}
+
+			nodeFieldSelector := buildNodeFieldSelector(opts.nodeName)
+
+			return showPodInfo(nodeFieldSelector, clientset, podInfoTemplate, os.Stdout)
+		},
+	}
+
+	podInfo.Flags().StringVar(&opts.nodeName, "node-name", "", "node name to get pod info from.")
+
+	return podInfo
+}
+
+// getKubeConfig creates a *rest.Config for talking to a Kubernetes apiserver.
+//
+// Config precedence:
+// - KUBECONFIG environment variable pointing at a file
+// - In-cluster config if running in cluster
+// - $HOME/.kube/config if exists
+//
+// note: Use same precedence as controller-runtime GetConfig.
+// see: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/client/config#GetConfig
+func getKubeConfig() (*rest.Config, error) {
+	kubeconfigFromFilePath := func(kubeConfigFilePath string) (*rest.Config, error) {
+		if _, err := os.Stat(kubeConfigFilePath); err != nil {
+			return nil, fmt.Errorf("cannot stat kubeconfig '%s'", kubeConfigFilePath)
+		}
+		return clientcmd.BuildConfigFromFlags("", kubeConfigFilePath)
+	}
+
+	// If an env variable is specified with the config location, use that
+	kubeConfig := os.Getenv("KUBECONFIG")
+	if len(kubeConfig) > 0 {
+		return kubeconfigFromFilePath(kubeConfig)
+	}
+
+	// try the in-cluster config
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+
+	// try the default location in the user's home directory
+	if usr, err := user.Current(); err == nil {
+		kubeConfig := filepath.Join(usr.HomeDir, ".kube", "config")
+		return kubeconfigFromFilePath(kubeConfig)
+	}
+
+	return nil, fmt.Errorf("could not locate a kubeconfig")
+}
+
+func getClientSetFromClusterConfig() (kubernetes.Interface, error) {
+
+	config, err := getKubeConfig()
+	if err != nil {
+		return nil, err
+	}
+	// creates the clientset
+	return kubernetes.NewForConfig(config)
+}
+
+func createOutputTemplate(name string, tmplStr string) (*template.Template, error) {
+	podInfoTemplate, err := template.New(name).Parse(tmplStr)
+	if err != nil {
+		return nil, err
+	}
+	return podInfoTemplate, nil
+}
+
+func buildNodeFieldSelector(nodeName string) string {
+	fieldSelector := ""
+	if len(nodeName) != 0 {
+		fieldSelector = fmt.Sprintf("spec.nodeName=%s,", nodeName)
+	}
+	fieldSelector += "status.phase=Running"
+
+	return fieldSelector
+}
+
+func showPodInfo(nodeFieldSelector string, clientset kubernetes.Interface, podInfoTemplate *template.Template, output io.Writer) error {
+
+	if nil == podInfoTemplate {
+		return fmt.Errorf("wrong incoming params: need an output template")
+	}
+
+	listOptions := metav1.ListOptions{
+		FieldSelector: nodeFieldSelector,
+	}
+	// get pods in all the namespaces by omitting namespace
+	// Or specify namespace to get pods in particular namespace
+	pods, err := clientset.CoreV1().Pods("").List(context.TODO(), listOptions)
+	if err != nil {
+		return fmt.Errorf("error while getting pods list: %w", err)
+	}
+
+	if err := podInfoTemplate.Execute(output, pods); err != nil {
+		return fmt.Errorf("error while trying to format output: %w", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s/podres.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s/podres.go
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	kube "github.com/openshift-kni/debug-tools/pkg/k8s_imported"
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
+	"github.com/spf13/cobra"
+	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+)
+
+// see k/k/test/e2e_node/util.go
+// TODO: make these options
+const (
+	defaultSocketPath = "unix:///var/lib/kubelet/pod-resources/kubelet.sock"
+
+	defaultPodResourcesTimeout = 10 * time.Second
+	defaultPodResourcesMaxSize = 1024 * 1024 * 16 // 16 Mb
+)
+
+const (
+	apiCallList           = "list"
+	apiCallGetAllocatable = "get-allocatable"
+)
+
+type podResOptions struct {
+	socketPath string
+}
+
+func NewPodResourcesCommand(knitOpts *cmd.KnitOptions) *cobra.Command {
+	opts := &podResOptions{}
+	podRes := &cobra.Command{
+		Use:   "podres",
+		Short: "show currently allocated pod resources",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showPodResources(cmd, opts, args)
+		},
+		Args: cobra.MaximumNArgs(1),
+	}
+	podRes.Flags().StringVarP(&opts.socketPath, "socket-path", "R", defaultSocketPath, "podresources API socket path.")
+	return podRes
+}
+
+// we fill our own structs to avoid the problem when default int value(0) removed from the json
+func selectAction(apiName string) (func(cli kubeletpodresourcesv1.PodResourcesListerClient) error, error) {
+	if apiName == apiCallList {
+		return func(cli kubeletpodresourcesv1.PodResourcesListerClient) error {
+			resp, err := cli.List(context.TODO(), &kubeletpodresourcesv1.ListPodResourcesRequest{})
+			if err != nil {
+				return err
+			}
+
+			listPodResourcesResp := getListPodResourcesResponse(resp)
+			if err := json.NewEncoder(os.Stdout).Encode(listPodResourcesResp); err != nil {
+				return err
+			}
+
+			return nil
+		}, nil
+	}
+	if apiName == apiCallGetAllocatable {
+		return func(cli kubeletpodresourcesv1.PodResourcesListerClient) error {
+			resp, err := cli.GetAllocatableResources(context.TODO(), &kubeletpodresourcesv1.AllocatableResourcesRequest{})
+			if err != nil {
+				return err
+			}
+
+			allocatableResourcesResponse := getAllocatableResourcesResponse(resp)
+			if err := json.NewEncoder(os.Stdout).Encode(allocatableResourcesResponse); err != nil {
+				return err
+			}
+
+			return nil
+		}, nil
+	}
+	return func(cli kubeletpodresourcesv1.PodResourcesListerClient) error {
+		return nil
+	}, fmt.Errorf("unknown API %q", apiName)
+}
+
+func showPodResources(cmd *cobra.Command, opts *podResOptions, args []string) error {
+	apiName := "list"
+	if len(args) == 1 {
+		apiName = args[0]
+	}
+
+	action, err := selectAction(apiName)
+	if err != nil {
+		return err
+	}
+
+	cli, conn, err := kube.GetV1Client(opts.socketPath, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	return action(cli)
+}
+
+func getListPodResourcesResponse(resp *kubeletpodresourcesv1.ListPodResourcesResponse) *ListPodResourcesResponse {
+	var podResources []*PodResources
+	for _, podRes := range resp.PodResources {
+		var podResContainers []*ContainerResources
+		for _, c := range podRes.Containers {
+			podResContainers = append(podResContainers, &ContainerResources{
+				Name:    c.Name,
+				CpuIds:  c.CpuIds,
+				Devices: getDevices(c.Devices),
+				Memory:  getMemory(c.Memory),
+			})
+		}
+
+		podResources = append(podResources, &PodResources{
+			Name:       podRes.Name,
+			Namespace:  podRes.Namespace,
+			Containers: podResContainers,
+		})
+	}
+
+	return &ListPodResourcesResponse{
+		PodResources: podResources,
+	}
+}
+
+func getAllocatableResourcesResponse(resp *kubeletpodresourcesv1.AllocatableResourcesResponse) *AllocatableResourcesResponse {
+	return &AllocatableResourcesResponse{
+		CpuIds:  resp.CpuIds,
+		Devices: getDevices(resp.Devices),
+		Memory:  getMemory(resp.Memory),
+	}
+}
+
+func getDevices(containerDevices []*kubeletpodresourcesv1.ContainerDevices) []*ContainerDevices {
+	var cDevices []*ContainerDevices
+	for _, d := range containerDevices {
+		deviceTopologyInfo := getTopologyInfo(d.Topology)
+		cDevices = append(cDevices, &ContainerDevices{
+			ResourceName: d.ResourceName,
+			DeviceIds:    d.DeviceIds,
+			Topology:     deviceTopologyInfo,
+		})
+	}
+
+	return cDevices
+}
+
+func getMemory(containerMemory []*kubeletpodresourcesv1.ContainerMemory) []*ContainerMemory {
+	var cMemory []*ContainerMemory
+	for _, m := range containerMemory {
+		memoryTopologyInfo := getTopologyInfo(m.Topology)
+		cMemory = append(cMemory, &ContainerMemory{
+			MemoryType: m.MemoryType,
+			Size_:      m.Size_,
+			Topology:   memoryTopologyInfo,
+		})
+	}
+
+	return cMemory
+}
+
+func getTopologyInfo(topologyInfo *kubeletpodresourcesv1.TopologyInfo) *TopologyInfo {
+	if topologyInfo == nil {
+		return nil
+	}
+
+	var numaNodes []*NUMANode
+	for _, numaNode := range topologyInfo.Nodes {
+		numaNodeID := numaNode.ID
+		numaNodes = append(numaNodes, &NUMANode{
+			ID: &numaNodeID,
+		})
+	}
+
+	return &TopologyInfo{
+		Nodes: numaNodes,
+	}
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s/types.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s/types.go
@@ -1,0 +1,54 @@
+package k8s
+
+// The structs are copied from k8s.io/kubelet/pkg/apis/podresources/v1/api.pb.go and should be in sync with it.
+// Should not be a big problem because it is v1 API and should not have a lot of changes.
+
+// ListPodResourcesResponse is the response returned by List function
+type ListPodResourcesResponse struct {
+	PodResources []*PodResources `json:"pod_resources,omitempty"`
+}
+
+// PodResources contains information about the node resources assigned to a pod
+type PodResources struct {
+	Name       string                `json:"name,omitempty"`
+	Namespace  string                `json:"namespace,omitempty"`
+	Containers []*ContainerResources `json:"containers,omitempty"`
+}
+
+// ContainerResources contains information about the resources assigned to a container
+type ContainerResources struct {
+	Name    string              `json:"name,omitempty"`
+	Devices []*ContainerDevices `json:"devices,omitempty"`
+	CpuIds  []int64             `json:"cpu_ids,omitempty"`
+	Memory  []*ContainerMemory  `json:"memory,omitempty"`
+}
+
+// AllocatableResourcesResponse contains information about all the devices known by the kubelet
+type AllocatableResourcesResponse struct {
+	Devices []*ContainerDevices `json:"devices,omitempty"`
+	CpuIds  []int64             `json:"cpu_ids,omitempty"`
+	Memory  []*ContainerMemory  `json:"memory,omitempty"`
+}
+
+// ContainerDevices contains information about the devices assigned to a container
+type ContainerDevices struct {
+	ResourceName string        `json:"resource_name,omitempty"`
+	DeviceIds    []string      `json:"device_ids,omitempty"`
+	Topology     *TopologyInfo `json:"topology,omitempty"`
+}
+
+// ContainerMemory contains information about memory and hugepages assigned to a container
+type ContainerMemory struct {
+	MemoryType string        `json:"memory_type,omitempty"`
+	Size_      uint64        `json:"size,omitempty"`
+	Topology   *TopologyInfo `json:"topology,omitempty"`
+}
+
+type TopologyInfo struct {
+	Nodes []*NUMANode `json:"nodes,omitempty"`
+}
+
+// NUMANode contains NUMA nodes information
+type NUMANode struct {
+	ID *int64 `json:"ID,omitempty"`
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/root.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/root.go
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	cpuset "github.com/openshift-kni/debug-tools/pkg/k8s_imported"
+)
+
+type KnitOptions struct {
+	Cpus       cpuset.CPUSet
+	ProcFSRoot string
+	SysFSRoot  string
+	JsonOutput bool
+	Debug      bool
+	Log        *log.Logger
+	cpuList    string
+}
+
+func ShowHelp(cmd *cobra.Command, args []string) error {
+	fmt.Fprint(cmd.OutOrStderr(), cmd.UsageString())
+	return nil
+}
+
+type NewCommandFunc func(ko *KnitOptions) *cobra.Command
+
+// NewRootCommand returns entrypoint command to interact with all other commands
+func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
+	knitOpts := &KnitOptions{}
+
+	root := &cobra.Command{
+		Use:   "knit",
+		Short: "knit allows to check system settings for low-latency workload",
+
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			knitOpts.Cpus, err = cpuset.Parse(knitOpts.cpuList)
+			if err != nil {
+				return fmt.Errorf("error parsing %q: %v", knitOpts.cpuList, err)
+			}
+
+			if knitOpts.Debug {
+				knitOpts.Log = log.New(os.Stderr, "knit ", log.LstdFlags)
+			} else {
+				knitOpts.Log = log.New(ioutil.Discard, "", 0)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ShowHelp(cmd, args)
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	// see https://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS for more details
+	root.PersistentFlags().StringVarP(&knitOpts.cpuList, "cpulist", "C", "0-16383", "isolated cpu set to check (see man (7) cpuset - List format")
+	root.PersistentFlags().StringVarP(&knitOpts.ProcFSRoot, "procfs", "P", "/proc", "procfs root")
+	root.PersistentFlags().StringVarP(&knitOpts.SysFSRoot, "sysfs", "S", "/sys", "sysfs root")
+	root.PersistentFlags().BoolVarP(&knitOpts.Debug, "debug", "D", false, "enable debug log")
+	root.PersistentFlags().BoolVarP(&knitOpts.JsonOutput, "json", "J", false, "output as JSON")
+
+	root.AddCommand(
+		NewCPUAffinityCommand(knitOpts),
+		NewIRQAffinityCommand(knitOpts),
+		NewIRQWatchCommand(knitOpts),
+		NewWaitCommand(knitOpts),
+	)
+	for _, extraCmd := range extraCmds {
+		root.AddCommand(extraCmd(knitOpts))
+	}
+
+	return root
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/wait.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/wait.go
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+type waitOpts struct {
+	healthFile string
+}
+
+func waitForever(dwOpts *waitOpts) error {
+	if dwOpts.healthFile != "" {
+		message := []byte("ok")
+		ioutil.WriteFile(dwOpts.healthFile, message, 0644) // intentionally ignore error
+	}
+
+	exitSignal := make(chan os.Signal)
+	signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
+	<-exitSignal
+	return nil
+}
+
+func NewWaitCommand(_ *KnitOptions) *cobra.Command {
+	flags := &waitOpts{}
+	show := &cobra.Command{
+		Use:   "wait",
+		Short: "wait forever, or until a UNIX signal (SIGINT, SIGTERM) arrives",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return waitForever(flags)
+		},
+		Args: cobra.NoArgs,
+	}
+	show.Flags().StringVarP(&flags.healthFile, "health-file", "H", "", "health file full path. Use \"\" to disable.")
+	return show
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/machineinformer/fakefsinfo.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/machineinformer/fakefsinfo.go
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package machineinformer
+
+import (
+	"fmt"
+
+	"github.com/google/cadvisor/fs"
+)
+
+type fakeFsInfo struct {
+	notImplemented error
+}
+
+func newFakeFsInfo() fs.FsInfo {
+	return fakeFsInfo{
+		notImplemented: fmt.Errorf("not implemented"),
+	}
+}
+
+func (ffi fakeFsInfo) GetGlobalFsInfo() ([]fs.Fs, error) {
+	return nil, ffi.notImplemented
+}
+
+func (ffi fakeFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]fs.Fs, error) {
+	return nil, ffi.notImplemented
+}
+
+func (ffi fakeFsInfo) GetDirUsage(dir string) (fs.UsageInfo, error) {
+	return fs.UsageInfo{}, ffi.notImplemented
+}
+
+func (ffi fakeFsInfo) GetDeviceInfoByFsUUID(uuid string) (*fs.DeviceInfo, error) {
+	return nil, ffi.notImplemented
+}
+
+func (ffi fakeFsInfo) GetDirFsDevice(dir string) (*fs.DeviceInfo, error) {
+	return nil, ffi.notImplemented
+}
+
+func (ffi fakeFsInfo) GetDeviceForLabel(label string) (string, error) {
+	return "", ffi.notImplemented
+}
+
+func (ffi fakeFsInfo) GetLabelsForDevice(device string) ([]string, error) {
+	return nil, ffi.notImplemented
+}
+
+func (ffi fakeFsInfo) GetMountpointForDevice(device string) (string, error) {
+	return "", ffi.notImplemented
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/machineinformer/informer.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/machineinformer/informer.go
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ */
+
+package machineinformer
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	infov1 "github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/machine"
+	"k8s.io/klog/v2"
+)
+
+type Handle struct {
+	RootDirectory   string
+	RawOutput       bool
+	CleanTimestamp  bool
+	CleanProcfsInfo bool
+	Out             io.Writer
+}
+
+func (handle *Handle) Run() {
+	var err error
+	var info *infov1.MachineInfo
+
+	info, err = GetRaw(handle.RootDirectory)
+	if err != nil {
+		klog.Fatalf("Cannot get machine info: %v")
+	}
+
+	if !handle.RawOutput {
+		info = cleanInfo(info)
+	}
+	if handle.CleanProcfsInfo {
+		info.NumPhysicalCores = 0
+		info.CpuFrequency = 0
+		info.MemoryCapacity = 0
+	}
+	if handle.CleanTimestamp {
+		info.Timestamp = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}
+
+	json.NewEncoder(handle.Out).Encode(info)
+}
+
+func GetRaw(root string) (*infov1.MachineInfo, error) {
+	fsInfo := newFakeFsInfo()
+	sysFs := NewRelocatableSysFs(root)
+	inHostNamespace := true
+
+	return machine.Info(sysFs, fsInfo, inHostNamespace)
+}
+
+func Get(root string) (*infov1.MachineInfo, error) {
+	info, err := GetRaw(root)
+	if err != nil {
+		return nil, err
+	}
+	return cleanInfo(info), nil
+}
+
+func cleanInfo(in *infov1.MachineInfo) *infov1.MachineInfo {
+	out := in.Clone()
+	out.MachineID = ""
+	out.SystemUUID = ""
+	out.BootID = ""
+	for i := 0; i < len(out.NetworkDevices); i++ {
+		out.NetworkDevices[i].MacAddress = ""
+	}
+	out.CloudProvider = infov1.UnknownProvider
+	out.InstanceType = infov1.UnknownInstance
+	out.InstanceID = infov1.UnNamedInstance
+	return out
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/machineinformer/relocatablesysfs.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/machineinformer/relocatablesysfs.go
@@ -1,0 +1,389 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// derived from https://github.com/google/cadvisor/blob/master/utils/sysfs/sysfs.go @ ef7e64f9
+// as Apache 2.0 license allows.
+
+package machineinformer
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"github.com/google/cadvisor/utils/sysfs"
+
+	cpuset "github.com/openshift-kni/debug-tools/pkg/k8s_imported"
+)
+
+const (
+	blockDir     = "/block"
+	cacheDir     = "/devices/system/cpu/cpu"
+	netDir       = "/class/net"
+	dmiDir       = "/class/dmi"
+	ppcDevTree   = "/proc/device-tree"
+	s390xDevTree = "/etc" // s390/s390x changes
+
+	meminfoFile = "meminfo"
+
+	sysFsCPUTopology = "topology"
+
+	// CPUPhysicalPackageID is a physical package id of cpu#. Typically corresponds to a physical socket number,
+	// but the actual value is architecture and platform dependent.
+	CPUPhysicalPackageID = "physical_package_id"
+	// CPUCoreID is the CPU core ID of cpu#. Typically it is the hardware platform's identifier
+	// (rather than the kernel's). The actual value is architecture and platform dependent.
+	CPUCoreID = "core_id"
+
+	coreIDFilePath    = "/" + sysFsCPUTopology + "/core_id"
+	packageIDFilePath = "/" + sysFsCPUTopology + "/physical_package_id"
+
+	// memory size calculations
+
+	cpuDirPattern  = "cpu*[0-9]"
+	nodeDirPattern = "node*[0-9]"
+
+	nodeDistance = "distance"
+
+	//HugePagesNrFile name of nr_hugepages file in sysfs
+	HugePagesNrFile = "nr_hugepages"
+
+	nodeDir = "/devices/system/node/"
+)
+
+// RelocatableSysFs allows to consume a sysfs tree whose root is not `/sys`.
+// this means we can easily consume a syfs snapshot from another node, for troubleshoot
+// and debugging purposes, without complex/cumbersome chroot dances or even more complicated,
+// without containerizing the test session.
+// the cadvisor's SysFS interface is not formalized nor very clean, so we add the prefix
+// in few key place discovered using tests and reviewing how the API is used.
+type RelocatableSysFs struct {
+	root string
+}
+
+func NewRelocatableSysFs(root string) sysfs.SysFs {
+	return RelocatableSysFs{
+		root: root,
+	}
+}
+
+func (fs RelocatableSysFs) GetDistances(nodePath string) (string, error) {
+	path := filepath.Join(fs.root, nodePath, nodeDistance)
+	nodeDistances, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(nodeDistances)), err
+}
+
+func (fs RelocatableSysFs) GetNodesPaths() ([]string, error) {
+	pathPattern := filepath.Join(fs.root, nodeDir, nodeDirPattern)
+	return filepath.Glob(pathPattern)
+}
+
+func (fs RelocatableSysFs) GetCPUsPaths(cpusPath string) ([]string, error) {
+	pathPattern := filepath.Join(cpusPath, cpuDirPattern)
+	return filepath.Glob(pathPattern)
+}
+
+func (fs RelocatableSysFs) GetCoreID(cpuPath string) (string, error) {
+	// intentionally not prepending fs.root, because this function
+	// is expected to be used with `cpuPath` as returned by
+	// GetCPUsPaths
+	coreIDFilePath := filepath.Join(cpuPath, coreIDFilePath)
+	coreID, err := ioutil.ReadFile(coreIDFilePath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(coreID)), err
+}
+
+func (fs RelocatableSysFs) GetCPUPhysicalPackageID(cpuPath string) (string, error) {
+	// intentionally not prepending fs.root, because this function
+	// is expected to be used with `cpuPath` as returned by
+	// GetCPUsPaths
+	packageIDFilePath := filepath.Join(cpuPath, packageIDFilePath)
+	packageID, err := ioutil.ReadFile(packageIDFilePath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(packageID)), err
+}
+
+func (fs RelocatableSysFs) GetMemInfo(nodePath string) (string, error) {
+	meminfoPath := filepath.Join(nodePath, meminfoFile)
+	meminfo, err := ioutil.ReadFile(meminfoPath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(meminfo)), err
+}
+
+func (fs RelocatableSysFs) GetHugePagesInfo(hugePagesDirectory string) ([]os.FileInfo, error) {
+	return ioutil.ReadDir(filepath.Join(fs.root, hugePagesDirectory))
+}
+
+func (fs RelocatableSysFs) GetHugePagesNr(hugepagesDirectory string, hugePageName string) (string, error) {
+	hugePageFilePath := filepath.Join(fs.root, hugepagesDirectory, hugePageName, HugePagesNrFile)
+	hugePageFile, err := ioutil.ReadFile(hugePageFilePath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(hugePageFile)), err
+}
+
+func (fs RelocatableSysFs) GetBlockDevices() ([]os.FileInfo, error) {
+	return ioutil.ReadDir(filepath.Join(fs.root, blockDir))
+}
+
+func (fs RelocatableSysFs) GetBlockDeviceNumbers(name string) (string, error) {
+	dev, err := ioutil.ReadFile(filepath.Join(fs.root, blockDir, name, "/dev"))
+	if err != nil {
+		return "", err
+	}
+	return string(dev), nil
+}
+
+func (fs RelocatableSysFs) GetBlockDeviceScheduler(name string) (string, error) {
+	sched, err := ioutil.ReadFile(filepath.Join(fs.root, blockDir, name, "/queue/scheduler"))
+	if err != nil {
+		return "", err
+	}
+	return string(sched), nil
+}
+
+func (fs RelocatableSysFs) GetBlockDeviceSize(name string) (string, error) {
+	size, err := ioutil.ReadFile(filepath.Join(fs.root, blockDir, name, "/size"))
+	if err != nil {
+		return "", err
+	}
+	return string(size), nil
+}
+
+func (fs RelocatableSysFs) GetNetworkDevices() ([]os.FileInfo, error) {
+	files, err := ioutil.ReadDir(filepath.Join(fs.root, netDir))
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out non-directory & non-symlink files
+	var dirs []os.FileInfo
+	for _, f := range files {
+		if f.Mode()|os.ModeSymlink != 0 {
+			f, err = os.Stat(filepath.Join(fs.root, netDir, f.Name()))
+			if err != nil {
+				continue
+			}
+		}
+		if f.IsDir() {
+			dirs = append(dirs, f)
+		}
+	}
+	return dirs, nil
+}
+
+func (fs RelocatableSysFs) GetNetworkAddress(name string) (string, error) {
+	address, err := ioutil.ReadFile(filepath.Join(fs.root, netDir, name, "/address"))
+	if err != nil {
+		return "", err
+	}
+	return string(address), nil
+}
+
+func (fs RelocatableSysFs) GetNetworkMtu(name string) (string, error) {
+	mtu, err := ioutil.ReadFile(filepath.Join(fs.root, netDir, name, "/mtu"))
+	if err != nil {
+		return "", err
+	}
+	return string(mtu), nil
+}
+
+func (fs RelocatableSysFs) GetNetworkSpeed(name string) (string, error) {
+	speed, err := ioutil.ReadFile(filepath.Join(fs.root, netDir, name, "/speed"))
+	if err != nil {
+		return "", err
+	}
+	return string(speed), nil
+}
+
+func (fs RelocatableSysFs) GetNetworkStatValue(dev string, stat string) (uint64, error) {
+	statPath := filepath.Join(fs.root, netDir, dev, "/statistics", stat)
+	out, err := ioutil.ReadFile(statPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read stat from %q for device %q", statPath, dev)
+	}
+	var s uint64
+	n, err := fmt.Sscanf(string(out), "%d", &s)
+	if err != nil || n != 1 {
+		return 0, fmt.Errorf("could not parse value from %q for file %s", string(out), statPath)
+	}
+	return s, nil
+}
+
+func (fs RelocatableSysFs) GetCaches(id int) ([]os.FileInfo, error) {
+	cpuPath := filepath.Join(fs.root, fmt.Sprintf("%s%d/cache", cacheDir, id))
+	return ioutil.ReadDir(cpuPath)
+}
+
+func bitCount(i uint64) (count int) {
+	for i != 0 {
+		if i&1 == 1 {
+			count++
+		}
+		i >>= 1
+	}
+	return
+}
+
+func getCPUCount(cache string) (count int, err error) {
+	out, err := ioutil.ReadFile(filepath.Join(cache, "/shared_cpu_map"))
+	if err != nil {
+		return 0, err
+	}
+	masks := strings.Split(string(out), ",")
+	for _, mask := range masks {
+		// convert hex string to uint64
+		m, err := strconv.ParseUint(strings.TrimSpace(mask), 16, 64)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse cpu map %q: %v", string(out), err)
+		}
+		count += bitCount(m)
+	}
+	return
+}
+
+func (fs RelocatableSysFs) GetCacheInfo(id int, name string) (sysfs.CacheInfo, error) {
+	cachePath := filepath.Join(fs.root, fmt.Sprintf("%s%d/cache/%s", cacheDir, id, name))
+	out, err := ioutil.ReadFile(filepath.Join(cachePath, "/size"))
+	if err != nil {
+		return sysfs.CacheInfo{}, err
+	}
+	var size uint64
+	n, err := fmt.Sscanf(string(out), "%dK", &size)
+	if err != nil || n != 1 {
+		return sysfs.CacheInfo{}, err
+	}
+	// convert to bytes
+	size = size * 1024
+	out, err = ioutil.ReadFile(filepath.Join(cachePath, "/level"))
+	if err != nil {
+		return sysfs.CacheInfo{}, err
+	}
+	var level int
+	n, err = fmt.Sscanf(string(out), "%d", &level)
+	if err != nil || n != 1 {
+		return sysfs.CacheInfo{}, err
+	}
+
+	out, err = ioutil.ReadFile(filepath.Join(cachePath, "/type"))
+	if err != nil {
+		return sysfs.CacheInfo{}, err
+	}
+	cacheType := strings.TrimSpace(string(out))
+	cpuCount, err := getCPUCount(cachePath)
+	if err != nil {
+		return sysfs.CacheInfo{}, err
+	}
+	return sysfs.CacheInfo{
+		Size:  size,
+		Level: level,
+		Type:  cacheType,
+		Cpus:  cpuCount,
+	}, nil
+}
+
+func (fs RelocatableSysFs) GetSystemUUID() (string, error) {
+	if id, err := ioutil.ReadFile(filepath.Join(fs.root, dmiDir, "id", "product_uuid")); err == nil {
+		return strings.TrimSpace(string(id)), nil
+	} else if id, err = ioutil.ReadFile(filepath.Join(fs.root, ppcDevTree, "system-id")); err == nil {
+		return strings.TrimSpace(strings.TrimRight(string(id), "\000")), nil
+	} else if id, err = ioutil.ReadFile(filepath.Join(fs.root, ppcDevTree, "vm,uuid")); err == nil {
+		return strings.TrimSpace(strings.TrimRight(string(id), "\000")), nil
+	} else if id, err = ioutil.ReadFile(filepath.Join(fs.root, s390xDevTree, "machine-id")); err == nil {
+		return strings.TrimSpace(string(id)), nil
+	} else {
+		return "", err
+	}
+}
+
+func (fs RelocatableSysFs) IsCPUOnline(cpuPath string) bool {
+	onlinePath, err := filepath.Abs(filepath.Join(fs.root, cpuPath+"/../online"))
+	if err != nil {
+		klog.V(1).Infof("Unable to get absolute path for %s", cpuPath)
+		return false
+	}
+
+	// Quick check to determine if file exists: if it does not then kernel CPU hotplug is disabled and all CPUs are online.
+	_, err = os.Stat(onlinePath)
+	if err != nil && os.IsNotExist(err) {
+		return true
+	}
+	if err != nil {
+		klog.V(1).Infof("Unable to stat %s: %s", onlinePath, err)
+	}
+
+	cpuID, err := getCPUID(cpuPath)
+	if err != nil {
+		klog.V(1).Infof("Unable to get CPU ID from path %s: %s", cpuPath, err)
+		return false
+	}
+
+	isOnline, err := isCPUOnline(onlinePath, cpuID)
+	if err != nil {
+		klog.V(1).Infof("Unable to get online CPUs list: %s", err)
+		return false
+	}
+	return isOnline
+}
+
+func getCPUID(dir string) (uint16, error) {
+	regex := regexp.MustCompile("cpu([0-9]+)")
+	matches := regex.FindStringSubmatch(dir)
+	if len(matches) == 2 {
+		id, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return 0, err
+		}
+		return uint16(id), nil
+	}
+	return 0, fmt.Errorf("can't get CPU ID from %s", dir)
+}
+
+func isCPUOnline(path string, cpuID uint16) (bool, error) {
+	fileContent, err := ioutil.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	if len(fileContent) == 0 {
+		return false, fmt.Errorf("%s found to be empty", path)
+	}
+
+	cpus, err := cpuset.Parse(strings.TrimSpace(string(fileContent)))
+	if err != nil {
+		return false, err
+	}
+
+	for _, cpu := range cpus.ToSlice() {
+		if uint16(cpu) == cpuID {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/procs/info.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/procs/info.go
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package procs
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	cpuset "github.com/openshift-kni/debug-tools/pkg/k8s_imported"
+
+	"github.com/openshift-kni/debug-tools/pkg/fswrap"
+)
+
+type TIDInfo struct {
+	Tid      int    `json:"tid"`
+	Name     string `json:"name"`
+	Affinity []int  `json:"affinity"`
+}
+
+type PIDInfo struct {
+	Pid  int             `json:"pid"`
+	Name string          `json:"name"`
+	TIDs map[int]TIDInfo `json:"threads"`
+}
+
+type Handler struct {
+	log        *log.Logger
+	procfsRoot string
+	fs         fswrap.FSWrapper
+}
+
+func New(logger *log.Logger, procfsRoot string) *Handler {
+	return &Handler{
+		log:        logger,
+		procfsRoot: procfsRoot,
+		fs:         fswrap.FSWrapper{Log: logger},
+	}
+}
+
+func (handler *Handler) ListAll() (map[int]PIDInfo, error) {
+	infos := make(map[int]PIDInfo)
+	pidEntries, err := handler.fs.ReadDir(handler.procfsRoot)
+	if err != nil {
+		return infos, err
+	}
+
+	for _, pidEntry := range pidEntries {
+		if !pidEntry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(pidEntry.Name())
+		if err != nil {
+			// doesn't look like a pid
+			continue
+		}
+
+		pidInfo, err := handler.FromPID(pid)
+		if err != nil {
+			handler.log.Printf("Error extracting PID info from %d: %v", pid, err)
+			continue
+		}
+
+		infos[pid] = pidInfo
+	}
+	return infos, nil
+}
+
+func (handler *Handler) FromPID(pid int) (PIDInfo, error) {
+	pidInfo := PIDInfo{
+		Pid:  pid,
+		TIDs: make(map[int]TIDInfo),
+	}
+
+	procName, err := handler.readProcessName(pid)
+	if err == nil {
+		pidInfo.Name = fixFilename(procName)
+	} else {
+		// failures are not critical
+		handler.log.Printf("Error reading process name for pid %d: %v", pid, err)
+	}
+
+	tasksDir := filepath.Join(handler.procfsRoot, procEntry(pid), "task")
+	tidEntries, err := handler.fs.ReadDir(tasksDir)
+	if err != nil {
+		handler.log.Printf("Error reading the tasks %q for %d: %v", tasksDir, pid, err)
+		return pidInfo, err
+	}
+
+	for _, tidEntry := range tidEntries {
+		// TODO: use x/sys/unix schedGetAffinity?
+		info, err := handler.parseProcStatus(filepath.Join(tasksDir, tidEntry.Name(), "status"))
+		if err != nil {
+			// failures are not critical
+			handler.log.Printf("Error parsing status for pid %d tid %s: %v", pid, tidEntry.Name(), err)
+			continue
+		}
+		pidInfo.TIDs[info.Tid] = info
+	}
+
+	return pidInfo, nil
+}
+
+func (handler *Handler) parseProcStatus(path string) (TIDInfo, error) {
+	info := TIDInfo{}
+	file, err := handler.fs.Open(path)
+	if err != nil {
+		return info, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		// see /proc/self/status to check the file content
+		line := scanner.Text()
+		if strings.HasPrefix(line, "Name:") {
+			items := strings.SplitN(line, ":", 2)
+			info.Name = strings.TrimSpace(items[1])
+		}
+		if strings.HasPrefix(line, "Pid:") {
+			items := strings.SplitN(line, ":", 2)
+			pid, err := strconv.Atoi(strings.TrimSpace(items[1]))
+			if err != nil {
+				return info, err
+			}
+			// yep, the field is called "pid" even if we are scaning /proc/XXX/task/YYY/status
+			info.Tid = pid
+		}
+		if strings.HasPrefix(line, "Cpus_allowed_list:") {
+			items := strings.SplitN(line, ":", 2)
+			cpuIDs, err := cpuset.Parse(strings.TrimSpace(items[1]))
+			if err != nil {
+				return info, err
+			}
+			info.Affinity = cpuIDs.ToSlice()
+		}
+	}
+
+	return info, scanner.Err()
+}
+
+func (handler *Handler) readProcessName(pid int) (string, error) {
+	data, err := handler.fs.ReadFile(filepath.Join(handler.procfsRoot, procEntry(pid), "cmdline"))
+	if err != nil {
+		return "", err
+	}
+	cmdline := string(data)
+	// workaround for running on developer laptops, on which the slack process seems to
+	// unexpectedly use " " as non standard separator.
+	if off := strings.Index(cmdline, " "); off > 0 {
+		cmdline = cmdline[:off]
+	}
+	if off := strings.Index(cmdline, "\x00"); off > 0 {
+		return cmdline[:off], nil
+	}
+	return cmdline, nil
+}
+
+func fixFilename(filename string) string {
+	name := filepath.Base(filename)
+	if name == "." {
+		return ""
+	}
+	return strings.Trim(name, "\x00")
+}
+
+func procEntry(pid int) string {
+	if pid == 0 {
+		return "self"
+	}
+	return fmt.Sprintf("%d", pid)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -462,6 +462,16 @@ github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
+# github.com/openshift-kni/debug-tools v0.1.11
+## explicit; go 1.18
+github.com/openshift-kni/debug-tools/pkg/fswrap
+github.com/openshift-kni/debug-tools/pkg/irqs
+github.com/openshift-kni/debug-tools/pkg/irqs/soft
+github.com/openshift-kni/debug-tools/pkg/k8s_imported
+github.com/openshift-kni/debug-tools/pkg/knit/cmd
+github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s
+github.com/openshift-kni/debug-tools/pkg/machineinformer
+github.com/openshift-kni/debug-tools/pkg/procs
 # github.com/openshift/api v0.0.0-20230223193310-d964c7a58d75
 ## explicit; go 1.19
 github.com/openshift/api/config/v1


### PR DESCRIPTION
The gather-sysinfo binary is used by must-gather to collect
structured hardware information data about an OCP node.

This data is then also used by the Performance Profile Creator
also present in this repository.

Must-gather also needs the lspci binary from the pciutils package.