### PR TITLE
change min_granularity_ns value to 3000000

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -417,7 +417,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				"vm.swappiness":             "10",
 			}
 			schedulerKnobs := map[string]string{
-				"min_granularity_ns": "10000000",
+				"min_granularity_ns": "3000000",
 				"migration_cost_ns":  "5000000",
 			}
 			key := types.NamespacedName{


### PR DESCRIPTION
With recent changes to kernel the value of
min_granularity_ns is changed from 10000000 to 3000000