### PR TITLE
OCPBUGS-15044: e2e:irqbalance: wait for tuned profile to be ready

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/tuned/tuned.go
+++ b/test/e2e/performanceprofile/functests/utils/tuned/tuned.go
@@ -127,3 +127,16 @@ func CheckParameters(node *corev1.Node, sysctlMap map[string]string, kernelParam
 		ExpectWithOffset(1, err).To(HaveOccurred(), "node should have non-RT kernel")
 	}
 }
+
+func GetProfile(ctx context.Context, cli client.Client, ns, name string) (*tunedv1.Profile, error) {
+	key := client.ObjectKey{
+		Namespace: ns,
+		Name:      name,
+	}
+	p := &tunedv1.Profile{}
+	err := cli.Get(ctx, key, p)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}


### PR DESCRIPTION
We need to wait for tuned to apply the recent changes, before we check the irqbalance settings.

We poll the tuned profile and check the applied status. we failed the test if the status not consolidate to applied within the timeout value.