### PR TITLE
Improve render error handling

### DIFF
--- a/pkg/performanceprofile/cmd/render/render.go
+++ b/pkg/performanceprofile/cmd/render/render.go
@@ -156,6 +156,11 @@ func render(inputDir, outputDir string) error {
 			return err
 		}
 
+		if mcp == nil {
+			klog.Infof("render: No MachineConfigPool found for PerformanceProfile %s", pp.Name)
+			continue
+		}
+
 		defaultRuntime, err := getContainerRuntimeName(pp, mcp, ctrcfgs)
 		if err != nil {
 			return fmt.Errorf("render: could not determine high-performance runtime class container-runtime for profile %q; %w", pp.Name, err)


### PR DESCRIPTION
When looking for a MachineConfigPool match for each PerformanceProfile we can found no match at all.
We should check for this case before using the MCP.

This do not detect the root cause of the problem, an invalid PerformanceProfile. To tackle that problem we would need something more deep like a validator.