### PR TITLE
OCPBUGS-13429: Split pao lanes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,15 @@ pao-functests-only:
 	hack/show-cluster-version.sh
 	hack/run-functests.sh
 
+.PHONY: pao-functests-updating-profile
+pao-functests-updating-profile: cluster-label-worker-cnf pao-functests-update-only
+
+.PHONY: pao-functests-update-only
+pao-functests-update-only:
+	@echo "Cluster Version"
+	hack/show-cluster-version.sh
+	hack/run-update-testing.sh
+
 .PHONY: pao-functests-latency-testing
 pao-functests-latency-testing: dist-latency-tests
 	@echo "Cluster Version"

--- a/hack/run-update-testing.sh
+++ b/hack/run-update-testing.sh
@@ -1,27 +1,26 @@
 #!/bin/bash
 
-GINKGO_SUITS=${GINKGO_SUITS:-"test/e2e/performanceprofile/functests"}
+GINKGO_SUITS=${GINKGO_SUITS:-"test/e2e/performanceprofile/functests/0_config test/e2e/performanceprofile/functests/2_performance_update"}
 LATENCY_TEST_RUN=${LATENCY_TEST_RUN:-"false"}
 
 which ginkgo
 if [ $? -ne 0 ]; then
-	echo "Downloading ginkgo tool"
-	# drop -mod=vendor flags, otherwise the installation will fail
-	# because of the package can not be installed under the vendor directory
+    echo "Downloading ginkgo tool"
+    # drop -mod=vendor flags, otherwise the installation will fail
+    # because of the package can not be installed under the vendor directory
     GOFLAGS='' go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 fi
 
 NO_COLOR=""
-if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
-  echo "Terminal does not seem to support colored output, disabling it"
-  NO_COLOR="-noColor"
+if ! which tput &>/dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
+    echo "Terminal does not seem to support colored output, disabling it"
+    NO_COLOR="-noColor"
 fi
 
 # run the latency tests under the OpenShift CI, just to verify that the image works
 if [ -n "${IMAGE_FORMAT}" ]; then
-  LATENCY_TEST_RUN="true"
+    LATENCY_TEST_RUN="true"
 fi
-
 
 echo "Running Functional Tests: ${GINKGO_SUITS}"
 # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
@@ -29,4 +28,4 @@ echo "Running Functional Tests: ${GINKGO_SUITS}"
 # --failFast: ginkgo will stop the suite right after the first spec failure
 # --flakeAttempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
-GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast -skipPackage="5_latency_testing,2_performance_update" --flakeAttempts=2 -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts
+GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast --flakeAttempts=2 -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts


### PR DESCRIPTION
`e2e-gcp-pao` consistently  falling on timeouts because the lane split to 4.12 (updating-profile lane) wasn't backport.
Split the lane to improve situation.