### PR TITLE
OCPBUGS-7980:e2e:ht-aware: exec on the correct worker node

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -665,7 +665,7 @@ func checkPodHTSiblings(testpod *corev1.Pod) bool {
 		fmt.Sprintf("/bin/crictl inspect %s | /bin/jq -r '.info.runtimeSpec.linux.resources.cpu.cpus'", containerID),
 	}
 	output, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
-	Expect(err).ToNot(HaveOccurred(), "Unable to crictl inspect containerID %s", "containerID")
+	Expect(err).ToNot(HaveOccurred(), "Unable to crictl inspect containerID %q", containerID)
 
 	podcpus, err := cpuset.Parse(strings.Trim(fmt.Sprint(output), "\n"))
 	Expect(err).ToNot(

--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -670,7 +670,7 @@ func checkPodHTSiblings(testpod *corev1.Pod) bool {
 	podcpus, err := cpuset.Parse(strings.Trim(fmt.Sprint(output), "\n"))
 	Expect(err).ToNot(
 		HaveOccurred(), "Unable to cpuset.Parse pod allocated cpu set from output %s", fmt.Sprint(output))
-	By(fmt.Sprintf("Test pod CPU list: %s", podcpus.String()))
+	testlog.Infof("Test pod CPU list: %s", podcpus.String())
 
 	// aggregate cpu sibling paris from the host based on the cpus allocated to the pod
 	By("Get host cpu siblings for pod cpuset")

--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -718,6 +718,7 @@ func startHTtestPod(cpuCount int) *corev1.Pod {
 	testpod.Namespace = testutils.NamespaceTesting
 
 	By(fmt.Sprintf("Creating test pod with %d cpus", cpuCount))
+	testlog.Info(pods.DumpResourceRequirements(testpod))
 	err := testclient.Client.Create(context.TODO(), testpod)
 	Expect(err).ToNot(HaveOccurred())
 	testpod, err = pods.WaitForCondition(client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)

--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -664,12 +664,15 @@ func checkPodHTSiblings(testpod *corev1.Pod) bool {
 		"-c",
 		fmt.Sprintf("/bin/crictl inspect %s | /bin/jq -r '.info.runtimeSpec.linux.resources.cpu.cpus'", containerID),
 	}
-	output, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
+	node, err := nodes.GetByName(testpod.Spec.NodeName)
+	Expect(err).ToNot(HaveOccurred(), "failed to get node %q", testpod.Spec.NodeName)
+	Expect(testpod.Spec.NodeName).ToNot(BeEmpty(), "testpod %s/%s still pending - no nodeName set", testpod.Namespace, testpod.Name)
+	output, err := nodes.ExecCommandOnNode(cmd, node)
 	Expect(err).ToNot(HaveOccurred(), "Unable to crictl inspect containerID %q", containerID)
 
-	podcpus, err := cpuset.Parse(strings.Trim(fmt.Sprint(output), "\n"))
+	podcpus, err := cpuset.Parse(strings.Trim(output, "\n"))
 	Expect(err).ToNot(
-		HaveOccurred(), "Unable to cpuset.Parse pod allocated cpu set from output %s", fmt.Sprint(output))
+		HaveOccurred(), "Unable to cpuset.Parse pod allocated cpu set from output %s", output)
 	testlog.Infof("Test pod CPU list: %s", podcpus.String())
 
 	// aggregate cpu sibling paris from the host based on the cpus allocated to the pod


### PR DESCRIPTION
We  retrieve the worker node where the pod
located, before executing command against it.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>