### PR TITLE
e2e:cpuloadbalance: deflake the test

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -232,8 +232,8 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		var smtLevel int
 		var testpod *corev1.Pod
 
-		// getCPUswithLoadBalanceDisabled Return cpus which are not in any scheduling domain
-		getCPUswithLoadBalanceDisabled := func() (map[int]string, error) {
+		// getCPUsWithLoadBalanceDisabled Return cpus which are not in any scheduling domain
+		getCPUsWithLoadBalanceDisabled := func() (map[int]string, error) {
 			cmd := []string{"/bin/bash", "-c", "cat /proc/schedstat"}
 			schedstat, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
 			if err != nil {
@@ -269,7 +269,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			var err error
 			// It's possible that when this test runs the value of
 			// defaultCpuNotInSchedulingDomains is empty if no gu pods are running
-			defaultCpuNotInSchedulingDomains, err := getCPUswithLoadBalanceDisabled()
+			defaultCpuNotInSchedulingDomains, err := getCPUsWithLoadBalanceDisabled()
 			Expect(err).ToNot(HaveOccurred(), "Unable to fetch scheduling domains")
 			testlog.Infof("Default scheduling Domains are: %v", defaultCpuNotInSchedulingDomains)
 			annotations := map[string]string{
@@ -322,7 +322,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			// After the testpod is started get the schedstat and check for cpus
 			// not participating in scheduling domains
 			Eventually(func() bool {
-				cpusNotInSchedulingDomains, err := getCPUswithLoadBalanceDisabled()
+				cpusNotInSchedulingDomains, err := getCPUsWithLoadBalanceDisabled()
 				testlog.Infof("cpus with load balancing disabled are: %v", cpusNotInSchedulingDomains)
 				Expect(err).ToNot(HaveOccurred(), "unable to fetch cpus with load balancing disabled from /proc/schedstat")
 
@@ -343,7 +343,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			// to be under scheduling domains
 			Eventually(func() bool {
 				By("Getting the CPU scheduling flags")
-				cpusNotinSchedulingDomains, err := getCPUswithLoadBalanceDisabled()
+				cpusNotinSchedulingDomains, err := getCPUsWithLoadBalanceDisabled()
 				Expect(err).ToNot(HaveOccurred())
 				testlog.Infof("cpus with load balancing disabled are: %v", cpusNotinSchedulingDomains)
 				if len(cpusNotinSchedulingDomains) == 0 {

--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -350,20 +350,8 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 				cpusNotinSchedulingDomains, err := getCPUsWithLoadBalanceDisabled()
 				Expect(err).ToNot(HaveOccurred())
 				testlog.Infof("cpus with load balancing disabled are: %v", cpusNotinSchedulingDomains)
-				if len(cpusNotinSchedulingDomains) == 0 {
-					return true
-				} else {
-					for _, podcpu := range podCpus.ToSlice() {
-						// all pod's cpus should NOT be present in this map
-						// IOW they should be back into the scheduling domain
-						if _, ok := cpusNotinSchedulingDomains[podcpu]; ok {
-							return false
-						}
-					}
-				}
-				return true
+				return len(cpusNotinSchedulingDomains) == 0
 			}, 15*time.Minute, 10*time.Second).Should(BeTrue())
-
 		})
 	})
 

--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -290,10 +290,6 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			testpod = getTestPodWithAnnotations(annotations, smtLevel)
 		})
 
-		AfterEach(func() {
-			deleteTestPod(testpod)
-		})
-
 		It("[test_id:32646] should disable CPU load balancing for CPU's used by the pod", func() {
 			var err error
 			By("Starting the pod")


### PR DESCRIPTION
This PR contains bunch of improvement in order to deflake the test.
Most of the commits are cosmetics, but the verification of the sched
domains before the test begins commit.