### PR TITLE
e2e: remove image parameter from must gather

### DIFF
--- a/test/e2e/performanceprofile/functests/6_mustgather_testing/test_suite_mustgather_test.go
+++ b/test/e2e/performanceprofile/functests/6_mustgather_testing/test_suite_mustgather_test.go
@@ -13,9 +13,6 @@ import (
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
-const must_gather_version = "4.12-snapshot"
-const must_gather_image = "quay.io/openshift-kni/performance-addon-operator-must-gather"
-
 var _ = BeforeSuite(func() {
 	By("Looking for oc tool")
 	ocExec, err := exec.LookPath("oc")
@@ -24,14 +21,12 @@ var _ = BeforeSuite(func() {
 		Skip(fmt.Sprintf("unable to find 'oc' executable %v\n", err))
 	}
 
-	mgImageParam := fmt.Sprintf("--image=%s:%s", must_gather_image, must_gather_version)
 	mgDestDirParam := fmt.Sprintf("--dest-dir=%s", destDir)
 
 	cmdline := []string{
 		ocExec,
 		"adm",
 		"must-gather",
-		mgImageParam,
 		mgDestDirParam,
 	}
 	By(fmt.Sprintf("running: %v\n", cmdline))


### PR DESCRIPTION
The PAO must gather is being merged with the NTO and hence in the updated versions the image parameter is not required to be given with the oc adm command.