### PR TITLE
e2e: wait for objects deletion

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/profiles/profiles.go
+++ b/test/e2e/performanceprofile/functests/utils/profiles/profiles.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
@@ -142,6 +144,8 @@ func Delete(name string) error {
 	if err := testclient.Client.Delete(context.TODO(), profile); err != nil {
 		return err
 	}
-
-	return nil
+	key := client.ObjectKey{
+		Name: name,
+	}
+	return WaitForDeletion(key, 2*time.Minute)
 }


### PR DESCRIPTION
There are times when the deletion is not completed and the next test begins, trying to create the object which not completly deleted.

That cause the test to failed with `Object already exist error`.

In order to fix that, we should wait for the objects to be removed completely from the cluster.