### PR TITLE
Makefile: hack: add helpers to compile testsuites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ IMAGE=$(REGISTRY)/$(ORG)/origin-cluster-node-tuning-operator:$(TAG)
 CLUSTER ?= "ci"
 PAO_CRD_APIS :=$(addprefix ./$(API_TYPES_DIR)/performanceprofile/,v2 v1 v1alpha1)
 
+PAO_E2E_SUITES := $(shell hack/list-test-bin.sh)
+
 all: build
 
 # Do not put any includes above the "all" target.  We want the default target to build
@@ -258,3 +260,16 @@ gather-sysinfo-tests: build-gather-sysinfo
 .PHONY: render-sync
 render-sync: build
 	hack/render-sync.sh
+
+pao-build-e2e-%:
+	@hack/build-test-bin.sh $(shell echo $@ | sed -e 's/^pao-build-e2e-//' )
+
+.PHONY: pao-build-e2e
+pao-build-e2e:
+	@for suite in $(PAO_E2E_SUITES); do \
+		hack/build-test-bin.sh $$suite; \
+	done
+
+.PHONY: pao-clean-e2e
+pao-clean-e2e:
+	@rm -f _output/e2e-pao*.test

--- a/hack/build-test-bin.sh
+++ b/hack/build-test-bin.sh
@@ -2,17 +2,29 @@
 
 set -e
 
-if ! which go; then
-  echo "No go command available"
-  exit 1
+PREFIX="pao-build-e2e-"
+SUITEPATH="./test/e2e/performanceprofile/functests"
+TARGET=$1
+
+if [ -z "$TARGET" ]; then
+	echo "usage: $0 suite"
+	echo "example: $0 1_performance"
+	exit 1
 fi
 
-GOPATH="${GOPATH:-~/go}"
-export PATH=$PATH:$GOPATH/bin
+OUTDIR="${2:-_output}"
 
-if ! which gingko; then
-	echo "Downloading ginkgo tool"
-	go install github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+if [ ! -d "$SUITEPATH/$TARGET" ]; then
+	echo "unknown suite: $TARGET"
+	echo -e "must be one of:\n$( ls $SUITEPATH | grep -E '[0-9]+_.*' )"
+	exit 2
 fi
 
-ginkgo build ./functests/*
+SUITE="${SUITEPATH}/${TARGET}"
+SUFFIX=$( echo $TARGET | cut -d_ -f2- )
+BASENAME="e2e-pao"
+EXTENSION="test"
+OUTPUT="${BASENAME}-${SUFFIX}.${EXTENSION}"
+
+echo "${SUITE} -> ${OUTDIR}/${OUTPUT}"
+go test -c -v -o ${OUTDIR}/${OUTPUT} ${SUITE}

--- a/hack/list-test-bin.sh
+++ b/hack/list-test-bin.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+SUITEPATH="./test/e2e/performanceprofile/functests"
+
+if [ -z "$1" ]; then
+	ls $SUITEPATH | grep -E '[0-9]+_.*'
+	exit 0
+fi
+
+if [ ! -d "$SUITEPATH/$1" ]; then
+	echo "unknown suite: $1"
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
In order to enable developers to spot issues when
developing e2e tests and/or updating deps before to hit CI and save time and CI runs, add helpers and targets to compile testsuites without running them. This alone helps us spotting a fair share of code issues.