### PR TITLE
OCPBUGS-17219: Render mode should not segfault w/ no matching MCP

### DIFF
--- a/pkg/performanceprofile/cmd/render/render.go
+++ b/pkg/performanceprofile/cmd/render/render.go
@@ -270,6 +270,10 @@ func selectMachineConfigPool(pools []*mcfgv1.MachineConfigPool, selectors map[st
 		}
 	}
 
+	if count == 0 {
+		return nil, fmt.Errorf("no MCP found that matches performance profile node selector %q", profileNodeSelector.String())
+	}
+
 	if count > 1 {
 		return nil, fmt.Errorf("more than one MCP found that matches performance profile node selector %q", profileNodeSelector.String())
 	}


### PR DESCRIPTION
There was a possibility of a segfault when the input directory for the render mode had some MCPs, but none of them matched the expected node selector.