### PR TITLE
OCPBUGS-16348: OSLAT latency spikes due to tsc karg setting

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -138,7 +138,7 @@ cmdline_isolation=+isolcpus=managed_irq,${isolated_cores}
 {{end}}
 
 {{if .RealTimeHint}}
-cmdline_realtime=+nohz_full=${isolated_cores} tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11
+cmdline_realtime=+nohz_full=${isolated_cores} tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11
 {{end}}
 
 {{if .HighPowerConsumption}}

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -26,7 +26,7 @@ var (
 	cmdlineCPUsPartitioning           = "+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded} intel_iommu=on iommu=pt"
 	cmdlineWithStaticIsolation        = "+isolcpus=domain,managed_irq,${isolated_cores}"
 	cmdlineWithoutStaticIsolation     = "+isolcpus=managed_irq,${isolated_cores}"
-	cmdlineRealtime                   = "+nohz_full=${isolated_cores} tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11"
+	cmdlineRealtime                   = "+nohz_full=${isolated_cores} tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11"
 	cmdlineHighPowerConsumption       = "+processor.max_cstate=1 intel_idle.max_cstate=0"
 	cmdlineIdlePoll                   = "+idle=poll"
 	cmdlineHugepages                  = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4"

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -105,7 +105,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{noHzParam, "tsc=nowatchdog", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1"}
+				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1"}
 
 				wg := sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
@@ -163,7 +163,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{noHzParam, "tsc=nowatchdog", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1"}
+				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1"}
 
 				wg := sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
@@ -281,7 +281,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{noHzParam, "tsc=nowatchdog", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
+				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
 					"processor.max_cstate=1", "intel_idle.max_cstate=0", "intel_pstate=disable", "idle=poll"}
 
 				wg := sync.WaitGroup{}
@@ -398,7 +398,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{noHzParam, "tsc=nowatchdog", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
+				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
 					"processor.max_cstate=1", "intel_idle.max_cstate=0", "intel_pstate=disable", "idle=poll"}
 
 				wg := sync.WaitGroup{}
@@ -463,7 +463,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters = []string{noHzParam, "tsc=nowatchdog", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1", "intel_pstate=passive"}
+				kernelParameters = []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1", "intel_pstate=passive"}
 
 				wg = sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
@@ -534,7 +534,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{noHzParam, "tsc=nowatchdog", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1", "intel_pstate=passive"}
+				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1", "intel_pstate=passive"}
 
 				wg := sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
@@ -598,7 +598,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters = []string{noHzParam, "tsc=nowatchdog", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
+				kernelParameters = []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
 					"processor.max_cstate=1", "intel_idle.max_cstate=0", "intel_pstate=disable", "idle=poll"}
 
 				wg = sync.WaitGroup{}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -52,7 +52,7 @@ spec:
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=nowatchdog nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n"
     name: openshift-node-performance-manual
   recommend:


### PR DESCRIPTION
Signed-off-by: Brent Rowsell <browsell@redhat.com>

A RHEL 9.x change added a timer to make sure TSC_adjust is always which introduces latency spikes. Update tsc karg to tsc=reliable. This aligns with the realtime tuned profile.