### PR TITLE
OCPBUGS-18000: Release leader election on manager exit

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -119,15 +119,16 @@ func operatorRun() {
 	restConfig := ctrl.GetConfigOrDie()
 	le := util.GetLeaderElectionConfig(restConfig, enableLeaderElection)
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		NewCache:                cache.MultiNamespacedCacheBuilder(namespaces),
-		Scheme:                  scheme,
-		LeaderElection:          true,
-		LeaderElectionID:        config.OperatorLockName,
-		LeaderElectionNamespace: ntoNamespace,
-		LeaseDuration:           &le.LeaseDuration.Duration,
-		RetryPeriod:             &le.RetryPeriod.Duration,
-		RenewDeadline:           &le.RenewDeadline.Duration,
-		Namespace:               ntoNamespace,
+		NewCache:                      cache.MultiNamespacedCacheBuilder(namespaces),
+		Scheme:                        scheme,
+		LeaderElection:                true,
+		LeaderElectionID:              config.OperatorLockName,
+		LeaderElectionNamespace:       ntoNamespace,
+		LeaderElectionReleaseOnCancel: true,
+		LeaseDuration:                 &le.LeaseDuration.Duration,
+		RetryPeriod:                   &le.RetryPeriod.Duration,
+		RenewDeadline:                 &le.RenewDeadline.Duration,
+		Namespace:                     ntoNamespace,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Step down voluntarily on manager exit and speed up voluntary leader transitions as the new leader doesn't have to wait LeaseDuration time first.

Resolves: OCPBUGS-18000

This is a backport of: https://github.com/openshift/cluster-node-tuning-operator/pull/745