### PR TITLE
OCPBUGS-18392: Change the OVN trigger file name to adapt to OVN IC

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -64,7 +64,7 @@ const (
 
 	ovsSliceName                     = "ovs.slice"
 	ovsDynamicPinningTriggerFile     = "ovs-enable-dynamic-cpu-affinity"
-	ovsDynamicPinningTriggerHostFile = "/etc/openvswitch/enable_dynamic_cpu_affinity"
+	ovsDynamicPinningTriggerHostFile = "/var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity"
 
 	cpusetConfigure = "cpuset-configure"
 )

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
@@ -114,7 +114,7 @@ spec:
           verification: {}
         group: {}
         mode: 420
-        path: /etc/openvswitch/enable_dynamic_cpu_affinity
+        path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
     systemd:
       units:


### PR DESCRIPTION
OVN Interconnect feature was merged to CNO [1] and the manifests mounting /etc/openvswitch to the ovnkube-node containers changed.

This caused the trigger file to become invisible and so the dynamic OVS pinning was disabled.

This change moves the trigger file to the new directory used by OVN+CNO to re-enable the feature.

[1] https://github.com/openshift/cluster-network-operator/pull/1874