### PR TITLE
OCPBUGS-18783: e2e: perfprof: enhance the scheduling domain tests

### DIFF
--- a/pkg/performanceprofile/utils/schedstat/schedstat.go
+++ b/pkg/performanceprofile/utils/schedstat/schedstat.go
@@ -1,0 +1,98 @@
+package schedstat
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	DefaultPath = "/proc/schedstat"
+)
+
+func MakeCPUIDListFromCPUList(cpus []string) ([]int, error) {
+	cpuIDs := make([]int, 0, len(cpus))
+	for _, cpu := range cpus {
+		if !strings.HasPrefix(cpu, "cpu") {
+			continue
+		}
+		// len("cpu") == 3
+		cpuID, err := strconv.Atoi(cpu[3:])
+		if err != nil {
+			return cpuIDs, err
+		}
+		cpuIDs = append(cpuIDs, cpuID)
+	}
+	return cpuIDs, nil
+}
+
+type Info struct {
+	cpuDomains map[string][]string
+}
+
+// GetCPUs returns all the known CPUs, sorted.
+func (inf Info) GetCPUs() []string {
+	ret := []string{}
+	for cpu := range inf.cpuDomains {
+		ret = append(ret, cpu)
+	}
+	sort.Strings(ret)
+	return ret
+}
+
+func (inf Info) GetDomainsByID(cpuID int) ([]string, bool) {
+	return inf.GetDomains(fmt.Sprintf("cpu%d", cpuID))
+}
+
+// GetDomains will return all the domains the given cpu belongs.
+// The domains are returned sorted.
+func (inf Info) GetDomains(cpu string) ([]string, bool) {
+	doms, ok := inf.cpuDomains[cpu]
+	if !ok {
+		// skip unnecessary work
+		return doms, ok
+	}
+	ret := make([]string, len(doms))
+	copy(ret, doms)
+	sort.Strings(ret)
+	return ret, ok
+}
+
+func ParseData(r io.Reader) (Info, error) {
+	ret := Info{
+		cpuDomains: make(map[string][]string),
+	}
+	curCpu := ""
+	domains := []string{}
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if err := scanner.Err(); err != nil {
+			return ret, err
+		}
+		tokens := strings.Fields(line)
+		if len(tokens) == 0 {
+			return ret, fmt.Errorf("malformed line: %q", line)
+		}
+		if strings.HasPrefix(tokens[0], "cpu") {
+			if curCpu != "" {
+				ret.cpuDomains[curCpu] = domains
+			}
+			curCpu = tokens[0]
+			domains = []string{}
+			continue
+		}
+		if strings.HasPrefix(tokens[0], "domain") {
+			domains = append(domains, tokens[1])
+			continue
+		}
+		// else just ignore
+	}
+	if curCpu != "" {
+		ret.cpuDomains[curCpu] = domains
+	}
+	return ret, nil
+}

--- a/pkg/performanceprofile/utils/schedstat/schedstat_test.go
+++ b/pkg/performanceprofile/utils/schedstat/schedstat_test.go
@@ -1,0 +1,198 @@
+package schedstat
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestParseDataGetCPUs(t *testing.T) {
+	testCases := []struct {
+		name          string
+		schedStatData string
+		expectedCPUs  []string
+	}{
+		{
+			name:          "empty",
+			schedStatData: "",
+			expectedCPUs:  []string{},
+		},
+		{
+			name:          "simple",
+			schedStatData: simpleSchedStat,
+			expectedCPUs: []string{
+				"cpu0",
+				"cpu1",
+				"cpu2",
+				"cpu3",
+				"cpu4",
+				"cpu5",
+				"cpu6",
+				"cpu7",
+			},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseData(strings.NewReader(tt.schedStatData))
+			if err != nil {
+				t.Errorf("failure: unexpected error %v", err)
+			}
+			gotCPUs := got.GetCPUs()
+
+			expCPUs := make([]string, len(tt.expectedCPUs))
+			copy(expCPUs, tt.expectedCPUs)
+			sort.Strings(expCPUs)
+
+			if !reflect.DeepEqual(gotCPUs, expCPUs) {
+				t.Errorf("mismatched cpus got %v expected %v", gotCPUs, expCPUs)
+			}
+		})
+	}
+}
+
+func TestParseDataHasDomains(t *testing.T) {
+	testCases := []struct {
+		name            string
+		schedStatData   string
+		expectedDomains map[string][]string
+		expectedError   bool
+	}{
+		{
+			name:            "empty",
+			schedStatData:   "",
+			expectedDomains: map[string][]string{},
+			expectedError:   false,
+		},
+		{
+			name:          "simple",
+			schedStatData: simpleSchedStat,
+			expectedDomains: map[string][]string{
+				"cpu0": {"11", "ff"},
+				"cpu1": {"22", "ff"},
+				"cpu2": {"44", "ff"},
+				"cpu3": {"88", "ff"},
+				"cpu4": {"11", "ff"},
+				"cpu5": {"22", "ff"},
+				"cpu6": {"44", "ff"},
+				"cpu7": {"88", "ff"},
+			},
+			expectedError: false,
+		},
+		{
+			name:          "simple disabled",
+			schedStatData: simpleSchedStatDisableBalanced,
+			expectedDomains: map[string][]string{
+				"cpu0": {"11", "ff"},
+				"cpu1": {"22", "ff"},
+				"cpu2": {},
+				"cpu3": {"88", "ff"},
+				"cpu4": {"11", "ff"},
+				"cpu5": {"22", "ff"},
+				"cpu6": {},
+				"cpu7": {"88", "ff"},
+			},
+			expectedError: false,
+		},
+		{
+			name:          "simple disabled all",
+			schedStatData: simpleSchedStatDisableBalancedAll,
+			expectedDomains: map[string][]string{
+				"cpu0": {},
+				"cpu1": {},
+				"cpu2": {},
+				"cpu3": {},
+				"cpu4": {},
+				"cpu5": {},
+				"cpu6": {},
+				"cpu7": {},
+			},
+			expectedError: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseData(strings.NewReader(tt.schedStatData))
+			gotErr := (err != nil)
+			if gotErr != tt.expectedError {
+				t.Errorf("failure: got error %v expected error %v", err, tt.expectedError)
+			}
+			for cpu, doms := range tt.expectedDomains {
+				gotDoms, ok := got.GetDomains(cpu)
+				if !ok {
+					t.Errorf("unknown cpu %v", cpu)
+				}
+
+				expDoms := make([]string, len(doms))
+				copy(expDoms, doms)
+				sort.Strings(expDoms)
+
+				if !reflect.DeepEqual(gotDoms, expDoms) {
+					t.Errorf("cpu %v expected to have domains %v got %v", cpu, expDoms, gotDoms)
+				}
+			}
+		})
+	}
+}
+
+var simpleSchedStat string = `version 15
+timestamp 4328437744
+cpu0 0 0 0 0 0 0 3363757224997 275119326171 32616635
+domain0 11 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu1 0 0 0 0 0 0 3257930259442 177915611662 28095631
+domain0 22 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu2 0 0 0 0 0 0 2890383859386 179902429182 29632607
+domain0 44 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu3 0 0 0 0 0 0 3124153191647 138052433751 22860854
+domain0 88 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu4 0 0 0 0 0 0 3019772575212 119367715509 17187184
+domain0 11 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu5 0 0 0 0 0 0 2814250511342 139574268225 19597185
+domain0 22 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu6 0 0 0 0 0 0 3231608205700 116734060741 16809898
+domain0 44 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu7 0 0 0 0 0 0 2874987700096 158494309403 18071885
+domain0 88 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0`
+
+var simpleSchedStatDisableBalanced string = `version 15
+timestamp 4328437744
+cpu0 0 0 0 0 0 0 3363757224997 275119326171 32616635
+domain0 11 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu1 0 0 0 0 0 0 3257930259442 177915611662 28095631
+domain0 22 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu2 0 0 0 0 0 0 2890383859386 179902429182 29632607
+cpu3 0 0 0 0 0 0 3124153191647 138052433751 22860854
+domain0 88 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu4 0 0 0 0 0 0 3019772575212 119367715509 17187184
+domain0 11 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu5 0 0 0 0 0 0 2814250511342 139574268225 19597185
+domain0 22 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+cpu6 0 0 0 0 0 0 3231608205700 116734060741 16809898
+cpu7 0 0 0 0 0 0 2874987700096 158494309403 18071885
+domain0 88 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+domain1 ff 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0`
+
+var simpleSchedStatDisableBalancedAll string = `version 15
+timestamp 4328437744
+cpu0 0 0 0 0 0 0 3363757224997 275119326171 32616635
+cpu1 0 0 0 0 0 0 3257930259442 177915611662 28095631
+cpu2 0 0 0 0 0 0 2890383859386 179902429182 29632607
+cpu3 0 0 0 0 0 0 3124153191647 138052433751 22860854
+cpu4 0 0 0 0 0 0 3019772575212 119367715509 17187184
+cpu5 0 0 0 0 0 0 2814250511342 139574268225 19597185
+cpu6 0 0 0 0 0 0 3231608205700 116734060741 16809898
+cpu7 0 0 0 0 0 0 2874987700096 158494309403 18071885`

--- a/test/e2e/performanceprofile/functests/utils/pods/pods.go
+++ b/test/e2e/performanceprofile/functests/utils/pods/pods.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -218,6 +219,15 @@ func DumpResourceRequirements(pod *corev1.Pod) string {
 	}
 	fmt.Fprintf(&sb, "---\n")
 	return sb.String()
+}
+
+func GetPodsOnNode(ctx context.Context, nodeName string) ([]corev1.Pod, error) {
+	pods := corev1.PodList{}
+	listOptions := &client.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}),
+	}
+	err := testclient.Client.List(ctx, &pods, listOptions)
+	return pods.Items, err
 }
 
 func resourceListToString(res corev1.ResourceList) string {


### PR DESCRIPTION
Add simple parser for `/proc/schedstat`, to have a good foundation for load balancing disabling tests.
Use it into the scheduling domains tests to make the test more precise and (hopefully) the failure conditions clearer.
Finally, builds on the aforementioned to tight up the tests.