### PR TITLE
OCPBUGS-19351: Revert "Release leader election on manager exit

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -119,16 +119,15 @@ func operatorRun() {
 	restConfig := ctrl.GetConfigOrDie()
 	le := util.GetLeaderElectionConfig(restConfig, enableLeaderElection)
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		NewCache:                      cache.MultiNamespacedCacheBuilder(namespaces),
-		Scheme:                        scheme,
-		LeaderElection:                true,
-		LeaderElectionID:              config.OperatorLockName,
-		LeaderElectionNamespace:       ntoNamespace,
-		LeaderElectionReleaseOnCancel: true,
-		LeaseDuration:                 &le.LeaseDuration.Duration,
-		RetryPeriod:                   &le.RetryPeriod.Duration,
-		RenewDeadline:                 &le.RenewDeadline.Duration,
-		Namespace:                     ntoNamespace,
+		NewCache:                cache.MultiNamespacedCacheBuilder(namespaces),
+		Scheme:                  scheme,
+		LeaderElection:          true,
+		LeaderElectionID:        config.OperatorLockName,
+		LeaderElectionNamespace: ntoNamespace,
+		LeaseDuration:           &le.LeaseDuration.Duration,
+		RetryPeriod:             &le.RetryPeriod.Duration,
+		RenewDeadline:           &le.RenewDeadline.Duration,
+		Namespace:               ntoNamespace,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This reverts commit 8f21a273b3ff4ff21a15b9bdcc59ffa788be559b.