### PR TITLE
OCPBUGS-19351: Keep Profile status.bootcmdline around

### DIFF
--- a/manifests/20-profile.crd.yaml
+++ b/manifests/20-profile.crd.yaml
@@ -80,6 +80,9 @@ spec:
               required:
                 - tunedProfile
               properties:
+                bootcmdline:
+                  description: kernel parameters calculated by tuned for the active Tuned profile; this field is OBSOLETE and will be removed, see OCPBUGS-19351
+                  type: string
                 conditions:
                   description: conditions represents the state of the per-node Profile application
                   type: array

--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -169,6 +169,10 @@ type ProfileConfig struct {
 // ProfileStatus is the status for a Profile resource; the status is for internal use only
 // and its fields may be changed/removed in the future.
 type ProfileStatus struct {
+	// kernel parameters calculated by tuned for the active Tuned profile; this field is OBSOLETE and will be removed, see OCPBUGS-19351
+	// +optional
+	Bootcmdline string `json:"bootcmdline"`
+
 	// the current profile in use by the Tuned daemon
 	TunedProfile string `json:"tunedProfile"`
 


### PR DESCRIPTION
https://github.com/openshift/cluster-node-tuning-operator/pull/766 introduced a fix for OCPBUGS-17941 by tightening the rules for modifying Tuned Profiles.  Unfortunately, the fix introduced an upgrade issue (race), where the old operator still relies on removed Profile status.bootcmdline.

Reintroduce the field for the old operator, so that it does not cause additional reboots by seeing the bootcmdline as empty.  The status.bootcmdline field is not used in any way by the new operator, it is marked as obsolete and will be removed in the future.

Resolves: OCPBUGS-19351