### PR TITLE
OCPBUGS-19459: check for object being nil

### DIFF
--- a/pkg/util/objectinfo.go
+++ b/pkg/util/objectinfo.go
@@ -7,6 +7,10 @@ import (
 )
 
 func ObjectInfo(o interface{}) string {
+	if o == nil {
+		return "nil"
+	}
+
 	object := o.(metav1.Object)
 	s := fmt.Sprintf("%T, ", o)
 	if namespace := object.GetNamespace(); namespace != "" {


### PR DESCRIPTION
This change fixes a crash during error reporting when a returned object is nil.

Resolves: OCPBUGS-19459