### PR TITLE
OCPBUGS-19785: Set non-default UserAgent for easier debugging

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -47,12 +47,10 @@ import (
 )
 
 const (
-	operandFilename  = "openshift-tuned"
-	operatorFilename = "cluster-node-tuning-operator"
-	webhookPort      = 4343
-	webhookCertDir   = "/apiserver.local.config/certificates"
-	webhookCertName  = "apiserver.crt"
-	webhookKeyName   = "apiserver.key"
+	webhookPort     = 4343
+	webhookCertDir  = "/apiserver.local.config/certificates"
+	webhookCertName = "apiserver.crt"
+	webhookKeyName  = "apiserver.key"
 )
 
 var (
@@ -78,7 +76,7 @@ func printVersion() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   operatorFilename,
+	Use:   version.OperatorFilename,
 	Short: "NTO manages the containerized TuneD instances",
 	Run: func(cmd *cobra.Command, args []string) {
 		operatorRun()
@@ -122,7 +120,7 @@ func operatorRun() {
 
 	restConfig := ctrl.GetConfigOrDie()
 	le := util.GetLeaderElectionConfig(restConfig, enableLeaderElection)
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(rest.AddUserAgent(ctrl.GetConfigOrDie(), version.OperatorFilename), ctrl.Options{
 		NewCache:                      cache.MultiNamespacedCacheBuilder(namespaces),
 		Scheme:                        scheme,
 		LeaderElection:                enableLeaderElection,
@@ -336,12 +334,12 @@ func main() {
 	runAs := filepath.Base(os.Args[0])
 
 	switch runAs {
-	case operatorFilename:
+	case version.OperatorFilename:
 		prepareCommands()
 		_ = rootCmd.Execute()
-	case operandFilename:
+	case version.OperandFilename:
 		tunedOperandRun()
 	default:
-		klog.Fatalf("application should be run as \"%s\" or \"%s\"", operatorFilename, operandFilename)
+		klog.Fatalf("application should be run as \"%s\" or \"%s\"", version.OperatorFilename, version.OperandFilename)
 	}
 }

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -97,6 +97,7 @@ func NewController() (*Controller, error) {
 	if err != nil {
 		return nil, err
 	}
+	kubeconfig = restclient.AddUserAgent(kubeconfig, version.OperatorFilename)
 
 	listers := &ntoclient.Listers{}
 	clients := &ntoclient.Clients{}
@@ -159,7 +160,7 @@ func NewController() (*Controller, error) {
 		if err != nil {
 			return nil, err
 		}
-		controller.clients.ManagementKube, err = kubeset.NewForConfig(managementKubeconfig)
+		controller.clients.ManagementKube, err = kubeset.NewForConfig(restclient.AddUserAgent(managementKubeconfig, version.OperatorFilename))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -35,6 +35,7 @@ import (
 	tunedset "github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned"
 	tunedinformers "github.com/openshift/cluster-node-tuning-operator/pkg/generated/informers/externalversions"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/util"
+	"github.com/openshift/cluster-node-tuning-operator/version"
 )
 
 // Constants
@@ -52,7 +53,7 @@ const (
 // Constants
 const (
 	operandNamespace       = "openshift-cluster-node-tuning-operator"
-	programName            = "openshift-tuned"
+	programName            = version.OperandFilename
 	tunedProfilesDirCustom = "/etc/tuned"
 	tunedProfilesDirSystem = "/usr/lib/tuned"
 	tunedConfFile          = "tuned.conf"

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,10 @@
 package version
 
+const (
+	OperandFilename  = "openshift-tuned"
+	OperatorFilename = "cluster-node-tuning-operator"
+)
+
 var (
 	// Version is the operator version
 	Version = "0.0.1"


### PR DESCRIPTION
Add non-default UserAgent when communicating with the API server to ease debugging.  See OCPBUGS-19351 for more detail.