### PR TITLE
OCPBUGS-19795: Add kubeconfig path for IBM Managed OpenShift 

### DIFF
--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -44,6 +44,10 @@ spec:
         - mountPath: /etc/sysconfig
           name: etc-sysconfig
           mountPropagation: HostToContainer
+        - mountPath: /etc/kubernetes
+          name: etc-kubernetes
+          mountPropagation: HostToContainer
+          readOnly: true
         - mountPath: /etc/sysctl.d
           name: etc-sysctl-d
           mountPropagation: HostToContainer
@@ -96,6 +100,10 @@ spec:
           path: /etc/sysconfig
           type: Directory
         name: etc-sysconfig
+      - hostPath:
+          path: /etc/kubernetes
+          type: Directory
+        name: etc-kubernetes
       - hostPath:
           path: /etc/sysctl.d
           type: Directory


### PR DESCRIPTION
IBM Managed OpenShift seems to use `/etc/kubernetes/kubelet-kubeconfig` instead of the traditional `/var/lib/kubelet/kubeconfig` kubelet config path.

Other changes:
  - fix a crash when kubelet's kubeconfig is not found and in-cluster config is used instead

Resolves: OCPBUGS-19795