### PR TITLE
OCPBUGS-19840: Add kubeconfig path for IBM Managed OpenShift

### DIFF
--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -43,6 +43,11 @@ spec:
           mountPropagation: HostToContainer
         - mountPath: /etc/sysconfig
           name: etc-sysconfig
+          mountPropagation: HostToContainer
+        - mountPath: /etc/kubernetes
+          name: etc-kubernetes
+          mountPropagation: HostToContainer
+          readOnly: true
         - mountPath: /etc/sysctl.d
           name: etc-sysctl-d
           mountPropagation: HostToContainer
@@ -100,6 +105,10 @@ spec:
           path: /etc/sysconfig
           type: Directory
         name: etc-sysconfig
+      - hostPath:
+          path: /etc/kubernetes
+          type: Directory
+        name: etc-kubernetes
       - hostPath:
           path: /etc/sysctl.d
           type: Directory


### PR DESCRIPTION
IBM Managed OpenShift seems to use "/etc/kubernetes/kubelet-kubeconfig" instead of the traditional "/var/lib/kubelet/kubeconfig" kubelet config path.

Other changes:
  - fix a crash when kubelet's kubeconfig is not found and in-cluster config is used instead
  - fix an omitted mountPropagation for /etc/sysconfig
  
  Resolves: [OCPBUGS-19840](https://issues.redhat.com/browse/OCPBUGS-19840)
  