### PR TITLE
Add the k8s reporter to the configuration suite

### DIFF
--- a/test/e2e/performanceprofile/functests/0_config/test_suite_performance_config_test.go
+++ b/test/e2e/performanceprofile/functests/0_config/test_suite_performance_config_test.go
@@ -4,19 +4,49 @@
 package __performance_config_test
 
 import (
+	"flag"
+	"path"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 
-	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
-
+	kniK8sReporter "github.com/openshift-kni/k8sreporter"
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
+
+	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
+	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/k8sreporter"
 )
 
+var (
+	reportPath *string
+	reporter   *kniK8sReporter.KubernetesReporter
+)
+
+func init() {
+	reportPath = flag.String("report", "", "the path of the report file containing details for failed tests")
+}
+
 func TestPerformanceConfig(t *testing.T) {
-	RegisterFailHandler(Fail)
+	// We want to collect logs before any resource is deleted in AfterEach, so we register the global fail handler
+	// in a way such that the reporter's Dump is always called before the default Fail.
+	RegisterFailHandler(func(message string, callerSkip ...int) {
+		if reporter != nil {
+			reporter.Dump(testutils.LogsFetchDuration, CurrentSpecReport().FullText())
+		}
+
+		// Ensure failing line location is not affected by this wrapper
+		for i := range callerSkip {
+			callerSkip[i]++
+		}
+		Fail(message, callerSkip...)
+	})
+	if *reportPath != "" {
+		reportPath := path.Join(*reportPath, "nto_failure_report.log")
+		reporter = k8sreporter.New(reportPath)
+	}
 
 	RunSpecs(t, "Performance Addon Operator configuration")
 }


### PR DESCRIPTION
This commit adds the k8s reporter to the config suite that is also used by the cnf-tests.