### PR TITLE
OCPBUGS-18662:rps: trigger udev even per queue

### DIFF
--- a/assets/performanceprofile/configs/99-netdev-physical-rps.rules
+++ b/assets/performanceprofile/configs/99-netdev-physical-rps.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="net", ACTION=="add", ENV{DEVPATH}!="/devices/virtual/net/*", TAG+="systemd", ENV{SYSTEMD_WANTS}="update-rps@%k.service"
+SUBSYSTEM=="queues", ACTION=="add", ENV{DEVPATH}=="/devices/pci*/queues/rx*", TAG+="systemd", ENV{SYSTEMD_WANTS}="update-rps@%p.service"

--- a/assets/performanceprofile/scripts/set-rps-mask.sh
+++ b/assets/performanceprofile/scripts/set-rps-mask.sh
@@ -1,38 +1,18 @@
 #!/usr/bin/env bash
 
-dev=$1
-[ -n "${dev}" ] || { echo "The device argument is missing" >&2 ; exit 1; }
+full_path=${1}
+[ -n "${full_path}" ] || { echo "The full device path argument is missing" >&2 ; exit 1; }
 
-mask=$2
+mask=${2}
 [ -n "${mask}" ] || { echo "The mask argument is missing" >&2 ; exit 1; }
 
-dev_dir="/sys/class/net/${dev}"
+# replace '-' with '/'
+de_escape_path="/sys${full_path//-//}"
 
-function find_dev_dir {
-  systemd_devs=$(systemctl list-units -t device | grep sys-subsystem-net-devices | cut -d' ' -f1)
+# get the path for the queues
+queues_path=${de_escape_path%/rx*}
 
-  for systemd_dev in ${systemd_devs}; do
-    dev_sysfs=$(systemctl show "${systemd_dev}" -p SysFSPath --value)
-
-    dev_orig_name="${dev_sysfs##*/}"
-    if [ "${dev_orig_name}" = "${dev}" ]; then
-      dev_name="${systemd_dev##*-}"
-      dev_name="${dev_name%%.device}"
-      if [ "${dev_name}" = "${dev}" ]; then # disregard the original device unit
-              continue
-      fi
-
-      echo "${dev} device was renamed to $dev_name"
-      dev_dir="/sys/class/net/${dev_name}"
-      break
-    fi
-  done
-}
-
-[ -d "${dev_dir}" ] || find_dev_dir                # the net device was renamed, find the new name
-[ -d "${dev_dir}" ] || { sleep 5; find_dev_dir; }  # search failed, wait a little and try again
-[ -d "${dev_dir}" ] || { echo "${dev_dir}" directory not found >&2 ; exit 0; } # the interface disappeared, not an error
-
-for i in "${dev_dir}"/queues/rx-*/rps_cpus; do
+# set rps affinity for all queues
+for i in "${queues_path}"/rx-*/rps_cpus; do
   echo "${mask}" > "${i}"
 done

--- a/assets/performanceprofile/scripts/set-rps-mask.sh
+++ b/assets/performanceprofile/scripts/set-rps-mask.sh
@@ -1,18 +1,16 @@
 #!/usr/bin/env bash
 
-full_path=${1}
-[ -n "${full_path}" ] || { echo "The full device path argument is missing" >&2 ; exit 1; }
+path=${1}
+[ -n "${path}" ] || { echo "The device path argument is missing" >&2 ; exit 1; }
 
 mask=${2}
 [ -n "${mask}" ] || { echo "The mask argument is missing" >&2 ; exit 1; }
 
-# replace '-' with '/'
-de_escape_path="/sys${full_path//-//}"
+queue_path=${path%rx*}
 
-# get the path for the queues
-queues_path=${de_escape_path%/rx*}
+queue_num=${path#*queues/}
+# replace '/' with '-'
+queue_num="${queue_num/\//-}"
 
-# set rps affinity for all queues
-for i in "${queues_path}"/rx-*/rps_cpus; do
-  echo "${mask}" > "${i}"
-done
+# set rps affinity for the queue
+echo "${mask}" > "/sys${queue_path}${queue_num}/rps_cpus"

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -514,7 +514,7 @@ func getOfflineCPUs(offlineCpus string) []*unit.UnitOption {
 }
 
 func getRPSUnitOptions(rpsMask string) []*unit.UnitOption {
-	cmd := fmt.Sprintf("%s %%i %s", getBashScriptPath(setRPSMask), rpsMask)
+	cmd := fmt.Sprintf("%s %%I %s", getBashScriptPath(setRPSMask), rpsMask)
 	return []*unit.UnitOption{
 		// [Unit]
 		// Description

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_kubeletconfig.yaml
@@ -1,0 +1,68 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  creationTimestamp: null
+  name: performance-manual
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+spec:
+  kubeletConfig:
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous: {}
+      webhook:
+        cacheTTL: 0s
+      x509: {}
+    authorization:
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    containerRuntimeEndpoint: ""
+    cpuManagerPolicy: static
+    cpuManagerPolicyOptions:
+      full-pcpus-only: "true"
+    cpuManagerReconcilePeriod: 5s
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 0s
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      memory: 500Mi
+    logging:
+      flushFrequency: 0
+      options:
+        json:
+          infoBufferSize: "0"
+      verbosity: 0
+    memoryManagerPolicy: Static
+    memorySwap: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    reservedMemory:
+    - limits:
+        memory: 1100Mi
+      numaNode: 0
+    reservedSystemCPUs: "0"
+    runtimeRequestTimeout: 0s
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      memory: 500Mi
+    topologyManagerPolicy: single-numa-node
+    volumeStatsAggPeriod: 0s
+  machineConfigPoolSelector:
+    matchLabels:
+      machineconfiguration.openshift.io/role: worker-cnf
+status:
+  conditions: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
@@ -33,7 +33,7 @@ spec:
         path: /usr/local/bin/hugepages-allocation.sh
         user: {}
       - contents:
-          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKcGF0aD0kezF9ClsgLW4gIiR7cGF0aH0iIF0gfHwgeyBlY2hvICJUaGUgZGV2aWNlIHBhdGggYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgptYXNrPSR7Mn0KWyAtbiAiJHttYXNrfSIgXSB8fCB7IGVjaG8gIlRoZSBtYXNrIGFyZ3VtZW50IGlzIG1pc3NpbmciID4mMiA7IGV4aXQgMTsgfQoKcXVldWVfcGF0aD0ke3BhdGglcngqfQoKcXVldWVfbnVtPSR7cGF0aCMqcXVldWVzL30KIyByZXBsYWNlICcvJyB3aXRoICctJwpxdWV1ZV9udW09IiR7cXVldWVfbnVtL1wvLy19IgoKIyBzZXQgcnBzIGFmZmluaXR5IGZvciB0aGUgcXVldWUKZWNobyAiJHttYXNrfSIgPiAiL3N5cyR7cXVldWVfcGF0aH0ke3F1ZXVlX251bX0vcnBzX2NwdXMi
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZnVsbF9wYXRoPSR7MX0KWyAtbiAiJHtmdWxsX3BhdGh9IiBdIHx8IHsgZWNobyAiVGhlIGZ1bGwgZGV2aWNlIHBhdGggYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgptYXNrPSR7Mn0KWyAtbiAiJHttYXNrfSIgXSB8fCB7IGVjaG8gIlRoZSBtYXNrIGFyZ3VtZW50IGlzIG1pc3NpbmciID4mMiA7IGV4aXQgMTsgfQoKIyByZXBsYWNlICctJyB3aXRoICcvJwpkZV9lc2NhcGVfcGF0aD0iL3N5cyR7ZnVsbF9wYXRoLy8tLy99IgoKIyBnZXQgdGhlIHBhdGggZm9yIHRoZSBxdWV1ZXMKcXVldWVzX3BhdGg9JHtkZV9lc2NhcGVfcGF0aCUvcngqfQoKIyBzZXQgcnBzIGFmZmluaXR5IGZvciBhbGwgcXVldWVzCmZvciBpIGluICIke3F1ZXVlc19wYXRofSIvcngtKi9ycHNfY3B1czsgZG8KICBlY2hvICIke21hc2t9IiA+ICIke2l9Igpkb25lCg==
           verification: {}
         group: {}
         mode: 448
@@ -124,7 +124,7 @@ spec:
 
           [Service]
           Type=oneshot
-          ExecStart=/usr/local/bin/set-rps-mask.sh %I 0
+          ExecStart=/usr/local/bin/set-rps-mask.sh %i 0
         name: update-rps@.service
       - contents: |
           [Unit]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_runtimeclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: node.k8s.io/v1
+handler: high-performance
+kind: RuntimeClass
+metadata:
+  creationTimestamp: null
+  name: performance-manual
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_tuned.yaml
@@ -1,0 +1,66 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  creationTimestamp: null
+  name: openshift-node-performance-manual
+  namespace: openshift-cluster-node-tuning-operator
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+spec:
+  profile:
+  - data: "[main]\nsummary=Openshift node optimized for deterministic performance
+      at the cost of increased power consumption, focused on low latency network performance.
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
+      -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
+      All values are mapped with a comment where a parent profile contains them.\n#
+      Different values will override the original values in parent profiles.\n\n[variables]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
+      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
+      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
+      plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      = ignore\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
+      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
+      RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
+      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
+      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
+      working set is buffered for I/O, and any more write buffering would require\n#
+      swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
+      that mostly use file mappings may be able to use even higher values.\n#\n# The
+      generator of dirty data starts writeback at this percentage (system default\n#
+      is 20%)\n#> latency-performance\nvm.dirty_ratio=10\n\n# Start background writeback
+      (via writeback threads) at this percentage (system\n# default is 10%)\n#> latency-performance\nvm.dirty_background_ratio=3\n\n#
+      The swappiness parameter controls the tendency of the kernel to move\n# processes
+      out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
+      swapping processes out of physical memory\n# for as long as possible\n# 100
+      tells the kernel to aggressively swap processes out of physical memory\n# and
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
+      configured via a sysctl.d file\n# placed here for better reflection of the change\n#>
+      rps configuration\nnet.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
+    name: openshift-node-performance-manual
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: worker-cnf
+    operand:
+      tunedConfig:
+        reapply_sysctl: null
+    priority: 20
+    profile: openshift-node-performance-manual
+status: {}


### PR DESCRIPTION
Instead of trigger udev event per physical device creation,
triggers it per queue creation so in case of queue resize
(i.e. more queues are added) it applies the correct rps mask on the
new created queues as well.