### PR TITLE
NO-JIRA: PerformanceProfileController: Add relatedObjects status field

### DIFF
--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -760,6 +760,32 @@ spec:
                   - type
                   type: object
                 type: array
+              relatedObjects:
+                description: 'relatedObjects is a list of objects that are "interesting"
+                  or related to this operator.  Common uses are: 1. the detailed resource
+                  driving the operator 2. operator namespaces 3. operand namespaces'
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    group:
+                      description: group of the referent.
+                      type: string
+                    name:
+                      description: name of the referent.
+                      type: string
+                    namespace:
+                      description: namespace of the referent.
+                      type: string
+                    resource:
+                      description: resource of the referent.
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - resource
+                  type: object
+                type: array
               runtimeClass:
                 description: RuntimeClass contains the name of the RuntimeClass resource
                   created by the operator.

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v2
 
 import (
+	apiconfigv1 "github.com/openshift/api/config/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -226,6 +227,12 @@ type PerformanceProfileStatus struct {
 	Tuned *string `json:"tuned,omitempty"`
 	// RuntimeClass contains the name of the RuntimeClass resource created by the operator.
 	RuntimeClass *string `json:"runtimeClass,omitempty"`
+	// relatedObjects is a list of objects that are "interesting" or related to this operator.  Common uses are:
+	// 1. the detailed resource driving the operator
+	// 2. operator namespaces
+	// 3. operand namespaces
+	// +optional
+	RelatedObjects []apiconfigv1.ObjectReference `json:"relatedObjects,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
@@ -6,6 +6,7 @@
 package v2
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/custom-resource-status/conditions/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -368,6 +369,11 @@ func (in *PerformanceProfileStatus) DeepCopyInto(out *PerformanceProfileStatus) 
 		in, out := &in.RuntimeClass, &out.RuntimeClass
 		*out = new(string)
 		**out = **in
+	}
+	if in.RelatedObjects != nil {
+		in, out := &in.RelatedObjects, &out.RelatedObjects
+		*out = make([]configv1.ObjectReference, len(*in))
+		copy(*out, *in)
 	}
 	return
 }


### PR DESCRIPTION
Add relatedObjects support to better integrate with must-gather

relatedObjects is a list of objects that are "interesting" or related to this operator. 
must-gather uses this field to collect data from these object when data from the operator is collected.
