### PR TITLE
Makefile: remote tmp folder on clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ test-unit: $(BINDATA)
 
 clean:
 	$(GO) clean $(PACKAGE_MAIN)
-	rm -rf $(BINDATA) $(OUT_DIR)
+	rm -rf $(BINDATA) $(OUT_DIR) tmp
 
 local-image:
 	$(IMAGE_BUILD_CMD) $(IMAGE_BUILD_EXTRA_OPTS) -t $(IMAGE) -f $(DOCKERFILE) .


### PR DESCRIPTION
Makefile target `pkg/generated` output some data on `tmp` folder. 
Lets delete it also on clean.