### PR TITLE
render: change directory path

### DIFF
--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -8,8 +8,8 @@ _output/cluster-node-tuning-operator render \
 --asset-input-dir "${WORKDIR}"/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance,"${WORKDIR}"/test/e2e/performanceprofile/cluster-setup/base/performance \
 --asset-output-dir "${ARTIFACT_DIR}"
 
-cp "${ARTIFACT_DIR}"/*  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output
-for f in  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output/*
+cp "${ARTIFACT_DIR}"/*  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output/default
+for f in  "${WORKDIR}"/test/e2e/performanceprofile/testdata/render-expected-output/default/*
 do
   sed -i "s/uid:.*/uid: \"\"/" "${f}"
 done


### PR DESCRIPTION
When https://github.com/openshift/cluster-node-tuning-operator/pull/778 got merged, the directory layout has changed and broke the `render-sync`  make target. This patch should fix it.