### PR TITLE
OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
@@ -9,6 +9,7 @@ import (
 	profilecomponent "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/runtimeclass"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/tuned"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/node"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	nodev1 "k8s.io/api/node/v1"
@@ -71,19 +72,7 @@ func GetNewComponents(profile *performancev2.PerformanceProfile, profileMCP *mco
 		return nil, err
 	}
 
-	nodeConfig := &apiconfigv1.Node{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: apiconfigv1.SchemeGroupVersion.String(),
-			Kind:       "Node",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster",
-		},
-		Spec: apiconfigv1.NodeSpec{
-			CgroupMode: apiconfigv1.CgroupModeV1,
-		},
-	}
-
+	nodeConfig := node.NewNodeConfig(apiconfigv1.CgroupModeV1)
 	runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
 
 	manifestResultSet := ManifestResultSet{

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -485,32 +485,6 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-
-		klog.Info("waiting for cgroupv1 rollout")
-
-		// wait for Cgroupv1 roll out
-		err = wait.PollUntilContextCancel(context.Background(), 7*time.Second, true, func(ctx context.Context) (done bool, err error) {
-			profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)
-			if err != nil {
-				return true, err
-			}
-			// check to see if all machines are updated
-			if profileMCP.Status.MachineCount == profileMCP.Status.ReadyMachineCount {
-				klog.Infof("MachineConfigPool %v and Node config has rolled out", profileMCP.Name)
-				return true, nil
-			}
-			// check to see if all machines are updated
-			if profileMCP.Status.DegradedMachineCount > 0 {
-				return true, fmt.Errorf("machines have become degraded")
-			}
-			klog.Infof("MachineConfigPool %v and Node config is still rolling out (%v/%v)", profileMCP.Name, profileMCP.Status.ReadyMachineCount, profileMCP.Status.MachineCount)
-			return false, nil
-		})
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		klog.Infof("Cluster is using cgroupv1")
 	}
 
 	profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 
@@ -449,16 +450,61 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 	})
 	err = r.Client.Get(context.Background(), key, nodeCfg)
 	if err != nil {
-		klog.Errorf("failed to get config node object; name=%q err=%v", nodeCfg.GetName(), err)
-		nodeCfg.Name = nodeCfgName
-		nodeCfg.Spec.CgroupMode = apiconfigv1.CgroupModeV1
-		//nolint:errcheck
-		r.Client.Update(ctx, nodeCfg)
+		return reconcile.Result{}, err
 	}
+
 	if nodeCfg.Spec.CgroupMode != apiconfigv1.CgroupModeV1 {
+		// gather the MCP generation
+		profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		startGeneration := profileMCP.Generation
+
 		nodeCfg.Spec.CgroupMode = apiconfigv1.CgroupModeV1
-		//nolint:errcheck
-		r.Client.Update(ctx, nodeCfg)
+		if err := r.Client.Update(ctx, nodeCfg); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// wait for MCP generation to change
+		err = wait.PollUntilContextCancel(context.Background(), time.Duration(7*time.Second), true, func(ctx context.Context) (done bool, err error) {
+			profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)
+			if err != nil {
+				return true, err
+			}
+			// check to see if machine rollout has happened
+			if startGeneration != profileMCP.Generation {
+				return true, nil
+			}
+			// check to see if all machines are updating
+			if profileMCP.Status.DegradedMachineCount > 0 {
+				return true, fmt.Errorf("machines have become degraded")
+			}
+			return false, nil
+		})
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// wait for Cgroupv1 roll out
+		err = wait.PollUntilContextCancel(context.Background(), time.Duration(7*time.Second), true, func(ctx context.Context) (done bool, err error) {
+			profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)
+			if err != nil {
+				return true, err
+			}
+			// check to see if all machines are updated
+			if profileMCP.Status.MachineCount == profileMCP.Status.ReadyMachineCount {
+				return true, nil
+			}
+			// check to see if all machines are updated
+			if profileMCP.Status.DegradedMachineCount > 0 {
+				return true, fmt.Errorf("machines have become degraded")
+			}
+			return false, nil
+		})
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -468,7 +468,7 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return reconcile.Result{}, err
 		}
 
-		err = wait.PollUntilContextCancel(context.Background(), 7*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextCancel(context.Background(), 7*time.Second, true, func(ctx context.Context) (done bool, err error) {
 			profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)
 			if err != nil {
 				return true, err
@@ -489,7 +489,7 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		klog.Info("waiting for cgroupv1 rollout")
 
 		// wait for Cgroupv1 roll out
-		err = wait.PollUntilContextCancel(context.Background(), 7*time.Second, false, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextCancel(context.Background(), 7*time.Second, true, func(ctx context.Context) (done bool, err error) {
 			profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)
 			if err != nil {
 				return true, err

--- a/pkg/performanceprofile/node/helper.go
+++ b/pkg/performanceprofile/node/helper.go
@@ -1,0 +1,21 @@
+package node
+
+import (
+	apiconfigv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewNodeConfig(mode apiconfigv1.CgroupMode) *apiconfigv1.Node {
+	return &apiconfigv1.Node{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiconfigv1.SchemeGroupVersion.String(),
+			Kind:       "Node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: apiconfigv1.NodeSpec{
+			CgroupMode: mode,
+		},
+	}
+}

--- a/pkg/performanceprofile/utils/testing/testing.go
+++ b/pkg/performanceprofile/utils/testing/testing.go
@@ -24,13 +24,13 @@ const (
 	OfflinedCPUs     = performancev2.CPUSet("6-7") // SingleNUMAPolicy defines the topologyManager policy used for tests
 	SingleNUMAPolicy = "single-numa-node"
 
-	//MachineConfigLabelKey defines the MachineConfig label key of the test profile
+	// MachineConfigLabelKey defines the MachineConfig label key of the test profile
 	MachineConfigLabelKey = "mcKey"
-	//MachineConfigLabelValue defines the MachineConfig label vlue of the test profile
+	// MachineConfigLabelValue defines the MachineConfig label vlue of the test profile
 	MachineConfigLabelValue = "mcValue"
-	//MachineConfigPoolLabelKey defines the MachineConfigPool label key of the test profile
+	// MachineConfigPoolLabelKey defines the MachineConfigPool label key of the test profile
 	MachineConfigPoolLabelKey = "mcpKey"
-	//MachineConfigPoolLabelValue defines the MachineConfigPool label value of the test profile
+	// MachineConfigPoolLabelValue defines the MachineConfigPool label value of the test profile
 	MachineConfigPoolLabelValue = "mcpValue"
 )
 
@@ -115,7 +115,7 @@ func NewProfileMCP() *mcov1.MachineConfigPool {
 }
 
 func NewInfraResource(pin bool) *apiconfigv1.Infrastructure {
-	var pinningMode = apiconfigv1.CPUPartitioningNone
+	pinningMode := apiconfigv1.CPUPartitioningNone
 	if pin {
 		pinningMode = apiconfigv1.CPUPartitioningAllNodes
 	}
@@ -141,6 +141,17 @@ func NewClusterOperator() *apiconfigv1.ClusterOperator {
 					Version: "",
 				},
 			},
+		},
+	}
+}
+
+func NewNodeConfig(mode apiconfigv1.CgroupMode) *apiconfigv1.Node {
+	return &apiconfigv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: apiconfigv1.NodeSpec{
+			CgroupMode: mode,
 		},
 	}
 }

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_node.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_node.yaml
@@ -1,0 +1,5 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_node.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_node.yaml
@@ -1,5 +1,13 @@
 apiVersion: config.openshift.io/v1
 kind: Node
 metadata:
+  creationTimestamp: null
   name: cluster
-spec: {}
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+spec:
+  cgroupMode: v1
+status: {}


### PR DESCRIPTION
This PR fixes a bug where two machine configs can race and sometimes we see incorrect kernel arguments on a Node.

Specifically, there is a problem with the controller updating the Node object to use Cgroupv1 and the controller writing the performance profile machine config. The patch addresses Day-0 and Day-2 operations.

## Day 0

Day 0 did not apply the Node object at bootstrap, so MCO configures the machine with Cgroupv1 at boot. The fix is to lay down the Node object to force cgroupv1 at bootstrap. MCO will pick up the Node object and configure the nodes with Cgroupv1 from the post-pivot boot.

## Day 2

The controller would originally update 2 MachineConfigs at the same time: 1) update the Node object (to switch to cgroupv1), and 2) create the perf profile machine config. These two configs are racing in certain scenarios; sometimes providing the node with duplicate (or wrong) kernel arguments.

The fix is to update the Node config to switch a cluster to Cgroupv1 and then watch for the Machine Config Pool generation to increment. The generation change signals that a new rendered-config has been created, and the NTO can then write the perfprofile machine config.

## Summary
Day 0 is the best approach and minimizes the amount of reboots necessary for PerformanceProfiles, since it does not require any extra reboots.
