### PR TITLE
OCPBUGS-20567: Remove obsolete protocols and weak ciphers

### DIFF
--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -75,6 +75,17 @@ func buildServer(port int) *http.Server {
 		if caCertPool.AppendCertsFromPEM(caCert) {
 			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			tlsConfig.ClientCAs = caCertPool
+			// Default minimum version is TLS 1.2, previous versions are insecure and deprecated.
+			tlsConfig.MinVersion = tls.VersionTLS12
+			tlsConfig.CipherSuites = []uint16{
+				// Drop
+				// - 64-bit block cipher 3DES as it is vulnerable to SWEET32 attack.
+				// - CBC encryption method.
+				// - RSA key exchange.
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			}
 		} else {
 			klog.Error("failed to parse %q", authCAFile)
 		}


### PR DESCRIPTION
NTO metrics server was using the default tls.Config.  However, the default tls.Config supports obsolete/insecure protocols, such as TLS 1.0 and 1.1 and weak ciphers (3DES).  Drop support for TLS 1.0, 1.1 and 3DES. Also, drop CBC encryption method and RSA key exchanges.

Resolves: OCPBUGS-20567