### PR TITLE
OCPBUGS-13330: Use RHEL9 as a base

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.13
+  tag: rhel-9-release-golang-1.19-openshift-4.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 RUN make build
 
-FROM quay.io/centos/centos:stream8 as tuned
+FROM quay.io/centos/centos:stream9 as tuned
 WORKDIR /root
 COPY assets /root/assets
 RUN INSTALL_PKGS=" \
@@ -16,7 +16,7 @@ RUN INSTALL_PKGS=" \
     make rpm PYTHON=/usr/bin/python3 && \
     rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*}
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -3,8 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 RUN make build
 
-# Switch to registry.ci.openshift.org/ocp/4.13:base once 4.13:base is UBI9-based
-FROM registry.access.redhat.com/ubi9:latest
+FROM registry.ci.openshift.org/ocp/4.13:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/


### PR DESCRIPTION
`x86_energy_perf_policy` from RHEL8 causes a kernel taint on RHEL9 kernels.  This is a problem for CNF certifications.  Switch the NTO base to RHEL9 so that we use an up-to-date `x86_energy_perf_policy` aligned with RHEL9 kernels.

Resolves: OCPBUGS-13330
