### PR TITLE
OCPBUGS-21932: Disable HTTP/2 for webhook and metrics servers

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"os"
 	"path/filepath"
@@ -137,6 +138,7 @@ func operatorRun() {
 			CertDir:  webhookCertDir,
 			CertName: webhookCertName,
 			KeyName:  webhookKeyName,
+			TLSOpts:  []func(config *tls.Config){func(c *tls.Config) { c.NextProtos = []string{"http/1.1"} }}, // CVE-2023-44487
 		}),
 	})
 

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -86,6 +86,7 @@ func buildServer(port int) *http.Server {
 				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			}
+			tlsConfig.NextProtos = []string{"http/1.1"} // CVE-2023-44487
 		} else {
 			klog.Error("failed to parse %q", authCAFile)
 		}


### PR DESCRIPTION
Remove HTTP/2 support for webhook and metrics servers -- mitigation for CVE-2023-44487.

Resolves: OCPBUGS-21932