### PR TITLE
NO-JIRA: Remove most //nolint:* overrides

### DIFF
--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -240,8 +240,9 @@ func parseNamespacedName(namespacedName string) string {
 
 func getMachineConfigFromConfigMap(config *corev1.ConfigMap) (*mcfgv1.MachineConfig, error) {
 	scheme := runtime.NewScheme()
-	//nolint:errcheck
-	mcfgv1.Install(scheme)
+	if err := mcfgv1.Install(scheme); err != nil {
+		return nil, err
+	}
 
 	YamlSerializer := serializer.NewSerializerWithOptions(
 		serializer.DefaultMetaFactory, scheme, scheme,
@@ -290,8 +291,9 @@ func newConfigMapForMachineConfig(configMapName string, nodePoolName string, mc 
 
 func serializeMachineConfig(mc *mcfgv1.MachineConfig) ([]byte, error) {
 	scheme := runtime.NewScheme()
-	//nolint:errcheck
-	mcfgv1.Install(scheme)
+	if err := mcfgv1.Install(scheme); err != nil {
+		return nil, err
+	}
 
 	YamlSerializer := serializer.NewSerializerWithOptions(
 		serializer.DefaultMetaFactory, scheme, scheme,

--- a/pkg/performanceprofile/profilecreator/helper.go
+++ b/pkg/performanceprofile/profilecreator/helper.go
@@ -4,6 +4,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+// This is a linter false positive, this function is used in unit tests.
+//
 //nolint:unused
 func newTestNode(nodeName string) *v1.Node {
 	n := v1.Node{}

--- a/pkg/tuned/tuned_parser.go
+++ b/pkg/tuned/tuned_parser.go
@@ -275,8 +275,9 @@ func execCmd(command []string) (string, error) {
 				return
 			}
 			// Ask nicely first.
-			//nolint:errcheck
-			cmd.Process.Signal(syscall.SIGTERM)
+			if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+				klog.Errorf("failed to signal process: %v", err)
+			}
 		}
 		// Wait for the process to stop.
 		select {
@@ -284,8 +285,9 @@ func execCmd(command []string) (string, error) {
 		case <-time.After(time.Second * waitSeconds):
 			// The process refused to terminate gracefully on SIGTERM.
 			klog.V(1).Infof("sending SIGKILL to PID %d", cmd.Process.Pid)
-			//nolint:errcheck
-			cmd.Process.Signal(syscall.SIGKILL)
+			if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+				klog.Errorf("failed to signal process: %v", err)
+			}
 			return
 		}
 	}(chSupervisor)


### PR DESCRIPTION
This change improves upon #793 by removing most linter overrides and replacing them with a proper fix to keep the linter happy.  Only overrides for one false positive (static analysis check), and two nolint:errcheck overrides due to failing unit tests (future work) in performanceprofile_controller.go are kept.
