### PR TITLE
Add annotation to disable cgroups v2 downgrade

### DIFF
--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -34,6 +34,10 @@ const PerformanceProfileEnablePhysicalRpsAnnotation = "performance.openshift.io/
 // that ignores the removal of all RPS settings when realtime workload hint is explicitly set to false.
 const PerformanceProfileEnableRpsAnnotation = "performance.openshift.io/enable-rps"
 
+// PerformanceProfileIgnoreCgroupsVersion allows an admin to suspend the operator's
+// automatic downgrade of Cgroups version to V1 for development purposes.
+const PerformanceProfileIgnoreCgroupsVersion = "performance.openshift.io/ignore-cgroups-version"
+
 // PerformanceProfileSpec defines the desired state of PerformanceProfile.
 type PerformanceProfileSpec struct {
 	// CPU defines a set of CPU related parameters.

--- a/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
@@ -56,6 +56,21 @@ func IsPaused(profile *performancev2.PerformanceProfile) bool {
 	return false
 }
 
+// IsCgroupsVersionIgnored returns whether or not the performance profile's cgroup
+// downgrade logic should be executed
+func IsCgroupsVersionIgnored(profile *performancev2.PerformanceProfile) bool {
+	if profile.Annotations == nil {
+		return false
+	}
+
+	isIgnored, ok := profile.Annotations[performancev2.PerformanceProfileIgnoreCgroupsVersion]
+	if ok && isIgnored == "true" {
+		return true
+	}
+
+	return false
+}
+
 // IsPhysicalRpsEnabled checks if RPS mask should be set for all physical net devices
 func IsPhysicalRpsEnabled(profile *performancev2.PerformanceProfile) bool {
 	if profile.Annotations == nil {

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -436,29 +436,31 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return reconcile.Result{}, nil
 	}
 
-	// Update the config.openshift.io/node object with the desired cgroupsv1 mode.
-	// (TODO) This code can be removed in the future when the cgroupsv2 is supported
-	key := types.NamespacedName{
-		Name: nodeCfgName,
-	}
-	nodeCfg := &apiconfigv1.Node{}
-	nodeCfg.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "config.openshift.io",
-		Version: "v1",
-		Kind:    "Node",
-	})
-	err = r.Client.Get(context.Background(), key, nodeCfg)
-	if err != nil {
-		klog.Errorf("failed to get config node object; name=%q err=%v", nodeCfg.GetName(), err)
-		nodeCfg.Name = nodeCfgName
-		nodeCfg.Spec.CgroupMode = apiconfigv1.CgroupModeV1
-		//nolint:errcheck
-		r.Client.Update(ctx, nodeCfg)
-	}
-	if nodeCfg.Spec.CgroupMode != apiconfigv1.CgroupModeV1 {
-		nodeCfg.Spec.CgroupMode = apiconfigv1.CgroupModeV1
-		//nolint:errcheck
-		r.Client.Update(ctx, nodeCfg)
+	if !profileutil.IsCgroupsVersionIgnored(instance) {
+		// Update the config.openshift.io/node object with the desired cgroupsv1 mode.
+		// (TODO) This code can be removed in the future when the cgroupsv2 is supported
+		key := types.NamespacedName{
+			Name: nodeCfgName,
+		}
+		nodeCfg := &apiconfigv1.Node{}
+		nodeCfg.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "config.openshift.io",
+			Version: "v1",
+			Kind:    "Node",
+		})
+		err = r.Client.Get(context.Background(), key, nodeCfg)
+		if err != nil {
+			klog.Errorf("failed to get config node object; name=%q err=%v", nodeCfg.GetName(), err)
+			nodeCfg.Name = nodeCfgName
+			nodeCfg.Spec.CgroupMode = apiconfigv1.CgroupModeV1
+			//nolint:errcheck
+			r.Client.Update(ctx, nodeCfg)
+		}
+		if nodeCfg.Spec.CgroupMode != apiconfigv1.CgroupModeV1 {
+			nodeCfg.Spec.CgroupMode = apiconfigv1.CgroupModeV1
+			//nolint:errcheck
+			r.Client.Update(ctx, nodeCfg)
+		}
 	}
 
 	profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)


### PR DESCRIPTION
This adds performance.openshift.io/ignore-cgroups-version that can be used during development of cgroups v2 related code.