### PR TITLE
OCPBUGS-20661: Disable HTTP/2 for webhook and metrics servers

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"os"
 	"path/filepath"
@@ -168,6 +169,7 @@ func operatorRun() {
 		webHookServer.CertDir = webhookCertDir
 		webHookServer.CertName = webhookCertName
 		webHookServer.KeyName = webhookKeyName
+		webHookServer.TLSOpts = []func(config *tls.Config){func(c *tls.Config) { c.NextProtos = []string{"http/1.1"} }} // CVE-2023-44487
 
 		if err = (&performancev1.PerformanceProfile{}).SetupWebhookWithManager(mgr); err != nil {
 			klog.Exitf("unable to create PerformanceProfile v1 webhook: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ replace (
 	k8s.io/mount-utils => k8s.io/mount-utils v0.24.2
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.24.2
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.2
-	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.1
+	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.3-0.20230530190747-911faffb5965
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -938,6 +938,7 @@ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1393,7 +1394,6 @@ k8s.io/pod-security-admission v0.24.2/go.mod h1:znnuDHWWWvh/tpbYYPwTsd4y//qHi3cO
 k8s.io/sample-apiserver v0.24.2/go.mod h1:mf8qgDdu450wqpCJOkSAmoTgU4PIMAcfa5uTBwmJekE=
 k8s.io/system-validators v1.7.0/go.mod h1:gP1Ky+R9wtrSiFbrpEPwWMeYz9yqyy1S/KOh0Vci7WI=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 h1:HNSDgDCrr/6Ly3WEGKZftiE7IY19Vz2GdbOCyI4qqhc=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
@@ -1409,8 +1409,8 @@ rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/controller-runtime v0.11.1 h1:7YIHT2QnHJArj/dk9aUkYhfqfK5cIxPOX5gPECfdZLU=
-sigs.k8s.io/controller-runtime v0.11.1/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=
+sigs.k8s.io/controller-runtime v0.11.3-0.20230530190747-911faffb5965 h1:u0xF8LK22ZX3fJAPN2lt71mBUG0ZP2Li98+BdTpzvNA=
+sigs.k8s.io/controller-runtime v0.11.3-0.20230530190747-911faffb5965/go.mod h1:P6QCzrEjLaZGqHsfd+os7JQ+WFZhvB8MRFsn4dWF7O4=
 sigs.k8s.io/controller-tools v0.7.0 h1:iZIz1vEcavyEfxjcTLs1WH/MPf4vhPCtTKhoHqV8/G0=
 sigs.k8s.io/controller-tools v0.7.0/go.mod h1:bpBAo0VcSDDLuWt47evLhMLPxRPxMDInTEH/YbdeMK0=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
@@ -1421,7 +1421,6 @@ sigs.k8s.io/kustomize/cmd/config v0.10.6/go.mod h1:/S4A4nUANUa4bZJ/Edt7ZQTyKOY9W
 sigs.k8s.io/kustomize/kustomize/v4 v4.5.4/go.mod h1:Zo/Xc5FKD6sHl0lilbrieeGeZHVYCA4BzxeAaLI05Bg=
 sigs.k8s.io/kustomize/kyaml v0.13.6/go.mod h1:yHP031rn1QX1lr/Xd934Ri/xdVNG8BE2ECa78Ht/kEg=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
-sigs.k8s.io/structured-merge-diff/v4 v4.2.0/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.1 h1:bKCqE9GvQ5tiVHn5rfn1r+yao3aLQEaLzkkmAkf+A6Y=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.1/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -86,6 +86,7 @@ func buildServer(port int) *http.Server {
 				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			}
+			tlsConfig.NextProtos = []string{"http/1.1"} // CVE-2023-44487
 		} else {
 			klog.Error("failed to parse %q", authCAFile)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -979,7 +979,7 @@ k8s.io/utils/trace
 ## explicit
 kubevirt.io/qe-tools/pkg/ginkgo-reporters
 kubevirt.io/qe-tools/pkg/polarion-xml
-# sigs.k8s.io/controller-runtime v0.11.0 => sigs.k8s.io/controller-runtime v0.11.1
+# sigs.k8s.io/controller-runtime v0.11.0 => sigs.k8s.io/controller-runtime v0.11.3-0.20230530190747-911faffb5965
 ## explicit; go 1.17
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
@@ -1077,7 +1077,7 @@ sigs.k8s.io/yaml
 # k8s.io/mount-utils => k8s.io/mount-utils v0.24.2
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.24.2
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.2
-# sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.1
+# sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.11.3-0.20230530190747-911faffb5965
 # sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.7.0
 # github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
 # github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.40.0

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go
@@ -77,6 +77,9 @@ type Server struct {
 	// "", "1.0", "1.1", "1.2" and "1.3" only ("" is equivalent to "1.0" for backwards compatibility)
 	TLSMinVersion string
 
+	// TLSOpts is used to allow configuring the TLS config used for the server
+	TLSOpts []func(*tls.Config)
+
 	// WebhookMux is the multiplexer that handles different webhooks.
 	WebhookMux *http.ServeMux
 
@@ -253,6 +256,11 @@ func (s *Server) Start(ctx context.Context) error {
 
 		cfg.ClientCAs = certPool
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	// fallback TLS config ready, will now mutate if passer wants full control over it
+	for _, op := range s.TLSOpts {
+		op(cfg)
 	}
 
 	listener, err := tls.Listen("tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)), cfg)


### PR DESCRIPTION
Remove HTTP/2 support for webhook and metrics servers -- mitigation for CVE-2023-44487.  controller-runtime was upgraded to add support for TLSOpts.

Resolves: OCPBUGS-20661

This is a backport of https://github.com/openshift/cluster-node-tuning-operator/pull/846