### PR TITLE
refactor:components: pass all arguments under `Options`

### DIFF
--- a/pkg/performanceprofile/cmd/render/render.go
+++ b/pkg/performanceprofile/cmd/render/render.go
@@ -29,6 +29,7 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	performanceprofilecomponents "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/manifestset"
 
@@ -175,7 +176,13 @@ func render(inputDir, outputDir string) error {
 			return fmt.Errorf("render: could not determine high-performance runtime class container-runtime for profile %q; %w", pp.Name, err)
 		}
 
-		components, err := manifestset.GetNewComponents(pp, mcp, partitioningMode, defaultRuntime)
+		components, err := manifestset.GetNewComponents(pp,
+			&performanceprofilecomponents.Options{
+				ProfileMCP: mcp,
+				MachineConfig: performanceprofilecomponents.MachineConfigOptions{
+					PinningMode:    partitioningMode,
+					DefaultRuntime: defaultRuntime},
+			})
 		if err != nil {
 			return err
 		}

--- a/pkg/performanceprofile/controller/performanceprofile/components/components.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/components.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package components
+
+import (
+	apiconfigv1 "github.com/openshift/api/config/v1"
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+)
+
+type Options struct {
+	ProfileMCP    *mcov1.MachineConfigPool
+	MachineConfig MachineConfigOptions
+}
+
+type MachineConfigOptions struct {
+	PinningMode    *apiconfigv1.CPUPartitioningMode
+	DefaultRuntime mcov1.ContainerRuntimeDefaultRuntime
+}

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -110,7 +110,7 @@ const (
 )
 
 // New returns new machine configuration object for performance sensitive workloads
-func New(profile *performancev2.PerformanceProfile, pinningMode *apiconfigv1.CPUPartitioningMode, defaultRuntime machineconfigv1.ContainerRuntimeDefaultRuntime) (*machineconfigv1.MachineConfig, error) {
+func New(profile *performancev2.PerformanceProfile, opts *components.MachineConfigOptions) (*machineconfigv1.MachineConfig, error) {
 	name := GetMachineConfigName(profile)
 	mc := &machineconfigv1.MachineConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -124,7 +124,7 @@ func New(profile *performancev2.PerformanceProfile, pinningMode *apiconfigv1.CPU
 		Spec: machineconfigv1.MachineConfigSpec{},
 	}
 
-	ignitionConfig, err := getIgnitionConfig(profile, pinningMode, defaultRuntime)
+	ignitionConfig, err := getIgnitionConfig(profile, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func GetMachineConfigName(profile *performancev2.PerformanceProfile) string {
 	return fmt.Sprintf("50-%s", name)
 }
 
-func getIgnitionConfig(profile *performancev2.PerformanceProfile, pinningMode *apiconfigv1.CPUPartitioningMode, defaultRuntime machineconfigv1.ContainerRuntimeDefaultRuntime) (*igntypes.Config, error) {
+func getIgnitionConfig(profile *performancev2.PerformanceProfile, opts *components.MachineConfigOptions) (*igntypes.Config, error) {
 	var scripts []string
 	ignitionConfig := &igntypes.Config{
 		Ignition: igntypes.Ignition{
@@ -185,7 +185,7 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, pinningMode *a
 
 	// add crio config snippet under the node /etc/crio/crio.conf.d/ directory
 	crioConfdRuntimesMode := 0644
-	crioConfigSnippetContent, err := renderCrioConfigSnippet(profile, defaultRuntime, filepath.Join("configs", crioRuntimesConfig))
+	crioConfigSnippetContent, err := renderCrioConfigSnippet(profile, opts.DefaultRuntime, filepath.Join("configs", crioRuntimesConfig))
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +260,7 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, pinningMode *a
 
 	if profile.Spec.CPU != nil && profile.Spec.CPU.Reserved != nil {
 		// Workload partitioning specific configuration
-		clusterIsPinned := pinningMode != nil && *pinningMode == apiconfigv1.CPUPartitioningAllNodes
+		clusterIsPinned := opts.PinningMode != nil && *opts.PinningMode == apiconfigv1.CPUPartitioningAllNodes
 		if clusterIsPinned {
 			crioPartitionFileData, err := renderManagementCPUPinningConfig(profile.Spec.CPU, crioPartitioningConfig)
 			if err != nil {

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Machine Config", func() {
 			profile := testutils.NewPerformanceProfile("test")
 			profile.Spec.HugePages.Pages[0].Node = pointer.Int32Ptr(0)
 
-			_, err := New(profile, nil, "")
+			_, err := New(profile, &components.MachineConfigOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -102,7 +102,7 @@ var _ = Describe("Machine Config", func() {
 			profile.Spec.HugePages.Pages[0].Node = pointer.Int32Ptr(0)
 
 			labelKey, labelValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigLabel)
-			mc, err := New(profile, nil, "")
+			mc, err := New(profile, &components.MachineConfigOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mc.Spec.KernelType).To(Equal(MCKernelRT))
 

--- a/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
@@ -1,9 +1,9 @@
 package manifestset
 
 import (
-	apiconfigv1 "github.com/openshift/api/config/v1"
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/kubeletconfig"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
 	profilecomponent "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
@@ -50,10 +50,10 @@ func (ms *ManifestResultSet) ToManifestTable() ManifestTable {
 }
 
 // GetNewComponents return a list of all component's instances that should be created according to profile
-func GetNewComponents(profile *performancev2.PerformanceProfile, profileMCP *mcov1.MachineConfigPool, pinningMode *apiconfigv1.CPUPartitioningMode, defaultRuntime mcov1.ContainerRuntimeDefaultRuntime) (*ManifestResultSet, error) {
-	machineConfigPoolSelector := profilecomponent.GetMachineConfigPoolSelector(profile, profileMCP)
+func GetNewComponents(profile *performancev2.PerformanceProfile, opts *components.Options) (*ManifestResultSet, error) {
+	machineConfigPoolSelector := profilecomponent.GetMachineConfigPoolSelector(profile, opts.ProfileMCP)
 
-	mc, err := machineconfig.New(profile, pinningMode, defaultRuntime)
+	mc, err := machineconfig.New(profile, &opts.MachineConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -499,7 +499,7 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 	klog.Infof("using %q as high-performance runtime class container-runtime for profile %q", ctrRuntime, instance.Name)
 
 	// apply components
-	result, err := r.applyComponents(instance, profileMCP, &pinningMode, ctrRuntime)
+	result, err := r.applyComponents(instance, &components.Options{ProfileMCP: profileMCP, MachineConfig: components.MachineConfigOptions{PinningMode: &pinningMode, DefaultRuntime: ctrRuntime}})
 	if err != nil {
 		klog.Errorf("failed to deploy performance profile %q components: %v", instance.Name, err)
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "Creation failed", "Failed to create all components: %v", err)
@@ -570,13 +570,13 @@ func (r *PerformanceProfileReconciler) updateDegradedCondition(instance *perform
 	return reconcile.Result{}, conditionError
 }
 
-func (r *PerformanceProfileReconciler) applyComponents(profile *performancev2.PerformanceProfile, profileMCP *mcov1.MachineConfigPool, pinningMode *apiconfigv1.CPUPartitioningMode, defaultRuntime mcov1.ContainerRuntimeDefaultRuntime) (*reconcile.Result, error) {
+func (r *PerformanceProfileReconciler) applyComponents(profile *performancev2.PerformanceProfile, opts *components.Options) (*reconcile.Result, error) {
 	if profileutil.IsPaused(profile) {
 		klog.Infof("Ignoring reconcile loop for pause performance profile %s", profile.Name)
 		return nil, nil
 	}
 
-	components, err := manifestset.GetNewComponents(profile, profileMCP, pinningMode, defaultRuntime)
+	components, err := manifestset.GetNewComponents(profile, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -339,7 +339,7 @@ var _ = Describe("Controller", func() {
 			BeforeEach(func() {
 				var err error
 
-				mc, err = machineconfig.New(profile, &infra.Status.CPUPartitioning, "")
+				mc, err = machineconfig.New(profile, &components.MachineConfigOptions{PinningMode: &infra.Status.CPUPartitioning})
 				Expect(err).ToNot(HaveOccurred())
 
 				mcpSelectorKey, mcpSelectorValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigPoolSelector)
@@ -787,7 +787,7 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should remove all components and remove the finalizer on first reconcile loop", func() {
-			mc, err := machineconfig.New(profile, nil, "")
+			mc, err := machineconfig.New(profile, &components.MachineConfigOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			mcpSelectorKey, mcpSelectorValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigPoolSelector)
@@ -844,7 +844,7 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should contain cpu partitioning files in machine config", func() {
-			mc, err := machineconfig.New(profile, &infra.Status.CPUPartitioning, "")
+			mc, err := machineconfig.New(profile, &components.MachineConfigOptions{PinningMode: &infra.Status.CPUPartitioning})
 			Expect(err).ToNot(HaveOccurred())
 			r := newFakeReconciler(profile, profileMCP, mc, infra, clusterOperator)
 
@@ -935,7 +935,7 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should run high-performance runtimes class with crun as container-runtime", func() {
-			mc, err := machineconfig.New(profile, &infra.Status.CPUPartitioning, "")
+			mc, err := machineconfig.New(profile, &components.MachineConfigOptions{PinningMode: &infra.Status.CPUPartitioning})
 			Expect(err).ToNot(HaveOccurred())
 
 			r := newFakeReconciler(profile, profileMCP, mc, infra, ctrcfg, clusterOperator)


### PR DESCRIPTION
There are different variable that are needed,
in order to create the different components that
are handled by the controller.

The number of this variables keeps growing.
This require us to change the functions' signatures for every new variable that is being added.

It also make the code less readable as more and more variables are getting added.

In order to overcome the above,
we suggest to house all the different variables
under a single struct named `Options`

This changes should not  (and mustn't) affect the code functionality 