### PR TITLE
NO-JIRA: perfprof: fix condition reason

### DIFF
--- a/pkg/performanceprofile/controller/status.go
+++ b/pkg/performanceprofile/controller/status.go
@@ -25,7 +25,7 @@ const (
 	conditionReasonComponentsCreationFailed  = "ComponentCreationFailed"
 	conditionReasonMCPDegraded               = "MCPDegraded"
 	conditionFailedGettingMCPStatus          = "GettingMCPStatusFailed"
-	conditionKubeletFailed                   = "KubeletConfig failure"
+	conditionKubeletFailed                   = "KubeletConfigFailure"
 	conditionFailedGettingKubeletStatus      = "GettingKubeletStatusFailed"
 	conditionReasonTunedDegraded             = "TunedProfileDegraded"
 	conditionFailedGettingTunedProfileStatus = "GettingTunedStatusFailed"


### PR DESCRIPTION
Per Condition type description,
`Reason: one-word CamelCase reason for the condition's last transition`

So let's fix existing conditions to make sure they are all indeed CamelCase one-words.

It must be noted that even though the code was wrong, this is a breaking change.