### PR TITLE
e2e: images: bump default test image to 4.14

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/images/images.go
+++ b/test/e2e/performanceprofile/functests/utils/images/images.go
@@ -13,7 +13,7 @@ func init() {
 	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
 
 	if cnfTestsImage == "" {
-		cnfTestsImage = "cnf-tests:4.9"
+		cnfTestsImage = "cnf-tests:4.14"
 	}
 
 	if registry == "" {


### PR DESCRIPTION
no reason to keep referencing the ancient 4.9