### PR TITLE
NO-JIRA: Report duplicate profiles as ERRORs

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -133,7 +133,7 @@ func tunedRenderedProfiles(tuned *tunedv1.Tuned, m map[string]tunedv1.TunedProfi
 					if *v.Data == *existingProfile.Data {
 						klog.Infof("duplicate profiles names %s but they have the same contents", *v.Name)
 					} else {
-						klog.Warningf("WARNING: duplicate profiles named %s with different contents", *v.Name)
+						klog.Errorf("ERROR: duplicate profiles named %s with different contents found in Tuned CR %q", *v.Name, tuned.Name)
 					}
 				}
 				m[*v.Name] = v


### PR DESCRIPTION
In the past, duplicate profiles were being report as WARNINGs only. Increase seriousness of this fact, so that it helps the users to fix their configuration issues.