### PR TITLE
OCPBUGS-24638: Do not set default RPS sysctl twice

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -109,9 +109,11 @@ vm.dirty_background_ratio=3
 vm.swappiness=10
 
 # also configured via a sysctl.d file
-# placed here for better reflection of the change
+# placed here for documentation purposes and commented out due
+# to a tuned logging bug complaining about duplicate sysctl:
+#   https://issues.redhat.com/browse/RHEL-18972
 #> rps configuration
-net.core.rps_default_mask=${not_isolated_cpumask}
+# net.core.rps_default_mask=${not_isolated_cpumask}
 
 
 [selinux]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -45,8 +45,9 @@ spec:
       swapping processes out of physical memory\n# for as long as possible\n# 100
       tells the kernel to aggressively swap processes out of physical memory\n# and
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
-      configured via a sysctl.d file\n# placed here for better reflection of the change\n#>
-      rps configuration\nnet.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
+      configured via a sysctl.d file\n# placed here for documentation purposes and
+      commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}


### PR DESCRIPTION
tuned complains that the sysctl value was already set via a sysctl.d file:

```
2023-12-05T22:23:07.343622915Z 2023-12-05 22:23:07,343 INFO     tuned.plugins.plugin_sysctl: Overriding sysctl parameter 'net.core.rps_default_mask' from '${not_isolated_cpumask}' to '30000003'
```

The comparison in tuned is broken as ${not_isolated_cpumask} should actually expand to the same value. But this INFO causes NTO to mark the profile as Degraded and we do not want that.

Commenting out the sysctl in the tuned profile is not going to break anything, because the sysctl.d version of it is applied anyway.
