### PR TITLE
  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854)

### DIFF
--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -34,6 +34,10 @@ const PerformanceProfileEnablePhysicalRpsAnnotation = "performance.openshift.io/
 // that ignores the removal of all RPS settings when realtime workload hint is explicitly set to false.
 const PerformanceProfileEnableRpsAnnotation = "performance.openshift.io/enable-rps"
 
+// PerformanceProfileIgnoreCgroupsVersion allows an admin to suspend the operator's
+// automatic downgrade of Cgroups version to V1 for development purposes.
+const PerformanceProfileIgnoreCgroupsVersion = "performance.openshift.io/ignore-cgroups-version"
+
 // PerformanceProfileSpec defines the desired state of PerformanceProfile.
 type PerformanceProfileSpec struct {
 	// CPU defines a set of CPU related parameters.

--- a/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
@@ -9,6 +9,7 @@ import (
 	profilecomponent "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/runtimeclass"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/tuned"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/node"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	nodev1 "k8s.io/api/node/v1"
@@ -19,6 +20,7 @@ import (
 type ManifestResultSet struct {
 	MachineConfig *mcov1.MachineConfig
 	KubeletConfig *mcov1.KubeletConfig
+	NodeConfig    *apiconfigv1.Node
 	Tuned         *tunedv1.Tuned
 	RuntimeClass  *nodev1.RuntimeClass
 }
@@ -35,6 +37,7 @@ func (ms *ManifestResultSet) ToObjects() []metav1.Object {
 		ms.KubeletConfig.GetObjectMeta(),
 		ms.Tuned.GetObjectMeta(),
 		ms.RuntimeClass.GetObjectMeta(),
+		ms.NodeConfig.GetObjectMeta(),
 	)
 	return objs
 }
@@ -46,6 +49,7 @@ func (ms *ManifestResultSet) ToManifestTable() ManifestTable {
 	manifests[ms.KubeletConfig.Kind] = ms.KubeletConfig
 	manifests[ms.Tuned.Kind] = ms.Tuned
 	manifests[ms.RuntimeClass.Kind] = ms.RuntimeClass
+	manifests[ms.NodeConfig.Kind] = ms.NodeConfig
 	return manifests
 }
 
@@ -68,6 +72,7 @@ func GetNewComponents(profile *performancev2.PerformanceProfile, profileMCP *mco
 		return nil, err
 	}
 
+	nodeConfig := node.NewNodeConfig(apiconfigv1.CgroupModeV1)
 	runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
 
 	manifestResultSet := ManifestResultSet{
@@ -75,6 +80,7 @@ func GetNewComponents(profile *performancev2.PerformanceProfile, profileMCP *mco
 		KubeletConfig: kc,
 		Tuned:         performanceTuned,
 		RuntimeClass:  runtimeClass,
+		NodeConfig:    nodeConfig,
 	}
 	return &manifestResultSet, nil
 }

--- a/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
@@ -56,6 +56,21 @@ func IsPaused(profile *performancev2.PerformanceProfile) bool {
 	return false
 }
 
+// IsCgroupsVersionIgnored returns whether or not the performance profile's cgroup
+// downgrade logic should be executed
+func IsCgroupsVersionIgnored(profile *performancev2.PerformanceProfile) bool {
+	if profile.Annotations == nil {
+		return false
+	}
+
+	isIgnored, ok := profile.Annotations[performancev2.PerformanceProfileIgnoreCgroupsVersion]
+	if ok && isIgnored == "true" {
+		return true
+	}
+
+	return false
+}
+
 // IsPhysicalRpsEnabled checks if RPS mask should be set for all physical net devices
 func IsPhysicalRpsEnabled(profile *performancev2.PerformanceProfile) bool {
 	if profile.Annotations == nil {

--- a/pkg/performanceprofile/controller/performanceprofile/components/profile/profile_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/profile/profile_test.go
@@ -58,6 +58,28 @@ var _ = Describe("PerformanceProfile", func() {
 
 		})
 	})
+
+	DescribeTable("IsCgroupsVersionIgnored", func(anns map[string]string, exp bool) {
+		profile := testutils.NewPerformanceProfile("test")
+		profile.Annotations = anns
+		got := IsCgroupsVersionIgnored(profile)
+		Expect(got).To(Equal(exp), "got=%v exp=%v anns=%+v", got, exp, anns)
+	},
+		Entry("nil anns", nil, false),
+		Entry("empty anns", map[string]string{}, false),
+		Entry("unrelated anns", map[string]string{
+			performancev2.PerformanceProfilePauseAnnotation: "true",
+		}, false),
+		Entry("unexpected value - 1", map[string]string{
+			performancev2.PerformanceProfileIgnoreCgroupsVersion: "True",
+		}, false),
+		Entry("unexpected value - 2", map[string]string{
+			performancev2.PerformanceProfileIgnoreCgroupsVersion: "1",
+		}, false),
+		Entry("expected value - one and only", map[string]string{
+			performancev2.PerformanceProfileIgnoreCgroupsVersion: "true",
+		}, true),
+	)
 })
 
 func setValidNodeSelector(profile *performancev2.PerformanceProfile) {

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -422,25 +422,10 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return reconcile.Result{}, nil
 	}
 
-	profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)
-	if err != nil {
-		conditions := r.getDegradedConditions(conditionFailedToFindMachineConfigPool, err.Error())
-		if err := r.updateStatus(instance, conditions); err != nil {
-			klog.Errorf("failed to update performance profile %q status: %v", instance.Name, err)
-			return reconcile.Result{}, err
+	if !profileutil.IsCgroupsVersionIgnored(instance) {
+		if res, err, done := r.reconcileCgroupsV1(ctx, instance); done {
+			return res, err
 		}
-
-		return reconcile.Result{}, nil
-	}
-
-	if err := validateProfileMachineConfigPool(instance, profileMCP); err != nil {
-		conditions := r.getDegradedConditions(conditionBadMachineConfigLabels, err.Error())
-		if err := r.updateStatus(instance, conditions); err != nil {
-			klog.Errorf("failed to update performance profile %q status: %v", instance.Name, err)
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{}, nil
 	}
 
 	// remove components with the old name after the upgrade
@@ -458,6 +443,17 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, fmt.Errorf("could not determine high-performance runtime class container-runtime for profile %q; %w", instance.Name, err)
 	}
 	klog.Infof("using %q as high-performance runtime class container-runtime for profile %q", ctrRuntime, instance.Name)
+
+	profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)
+	if err != nil {
+		conditions := r.getDegradedConditions(conditionFailedToFindMachineConfigPool, err.Error())
+		if err := r.updateStatus(instance, conditions); err != nil {
+			klog.Errorf("failed to update performance profile %q status: %v", instance.Name, err)
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
 
 	// apply components
 	result, err := r.applyComponents(instance, profileMCP, &pinningMode, ctrRuntime)
@@ -496,7 +492,8 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// if conditions were not added due to machine config pool status change then set as available
 	if conditions == nil {
-		conditions = r.getAvailableConditions()
+		message := "cgroup=" + string(apiconfigv1.CgroupModeV1) + ";"
+		conditions = r.getAvailableConditions(message)
 	}
 
 	if err := r.updateStatus(instance, conditions); err != nil {
@@ -514,6 +511,81 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *PerformanceProfileReconciler) reconcileCgroupsV1(ctx context.Context, instance *performancev2.PerformanceProfile) (ctrl.Result, error, bool) {
+	// Update the config.openshift.io/node object with the desired cgroupsv1 mode.
+	// (TODO) This code can be removed in the future when the cgroupsv2 is supported
+	key := types.NamespacedName{
+		Name: nodeCfgName,
+	}
+	nodeCfg := &apiconfigv1.Node{}
+	nodeCfg.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "Node",
+	})
+	err := r.Client.Get(ctx, key, nodeCfg)
+	if err != nil {
+		klog.Errorf("failed to get cluster nodeconfig %q: %v", nodeCfgName, err)
+		return reconcile.Result{}, err, true
+	}
+
+	if nodeCfg.Spec.CgroupMode != apiconfigv1.CgroupModeV1 {
+		klog.Infof("Switching cluster to cgroupv1")
+		nodeCfg.Spec.CgroupMode = apiconfigv1.CgroupModeV1
+		if err := r.Client.Update(ctx, nodeCfg); err != nil {
+			return reconcile.Result{}, err, true
+		}
+
+		klog.Infof("Switched cluster to cgroupv1")
+		// we exit the reconcile loop because we know it will take non-zero time to settle.
+		return reconcile.Result{RequeueAfter: 5 * time.Second}, nil, true
+	}
+
+	profileMCP, err := r.getMachineConfigPoolByProfile(ctx, instance)
+	if err != nil {
+		conditions := r.getDegradedConditions(conditionFailedToFindMachineConfigPool, err.Error())
+		if err := r.updateStatus(instance, conditions); err != nil {
+			klog.Errorf("failed to update performance profile %q status: %v", instance.Name, err)
+			return reconcile.Result{}, err, true
+		}
+
+		klog.Errorf("failed to get MCP: %v", err)
+		return reconcile.Result{}, nil, true
+	}
+
+	if err := validateProfileMachineConfigPool(instance, profileMCP); err != nil {
+		conditions := r.getDegradedConditions(conditionBadMachineConfigLabels, err.Error())
+		if err := r.updateStatus(instance, conditions); err != nil {
+			klog.Errorf("failed to update performance profile %q status: %v", instance.Name, err)
+			return reconcile.Result{}, err, true
+		}
+
+		klog.Errorf("failed to validate MCP %q: %v", profileMCP.Name, err)
+		return reconcile.Result{}, nil, true
+	}
+
+	// (TODO) This code can be removed in the future when the cgroupsv2 is supported
+	currentMC, err := r.getCurrentMachineConfigByMCP(ctx, profileMCP)
+	if err != nil {
+		return reconcile.Result{}, err, true
+	}
+
+	if err := validateCurrentMachineConfigCgroupV1(currentMC); err != nil {
+		conditions := r.getDegradedConditions(conditionReasonCgroupsV1NotEnabled, err.Error())
+		if err := r.updateStatus(instance, conditions); err != nil {
+			klog.Errorf("failed to update performance profile %q status: %v", instance.Name, err)
+			return reconcile.Result{}, err, true
+		}
+
+		klog.Errorf("failed to validate MC %q: %v", currentMC.Name, err)
+		return reconcile.Result{}, nil, true
+	}
+
+	klog.V(3).Infof("current MachineConfig %q configured for cgroups V1", currentMC.Name)
+
+	return reconcile.Result{}, nil, false
 }
 
 func (r *PerformanceProfileReconciler) deleteDeprecatedComponents(instance *performancev2.PerformanceProfile) error {
@@ -548,7 +620,7 @@ func (r *PerformanceProfileReconciler) applyComponents(profile *performancev2.Pe
 	}
 
 	// get mutated machine config
-	mcMutated, err := r.getMutatedMachineConfig(components.MachineConfig)
+	mcMutated, err := r.getMutatedMachineConfig(context.TODO(), components.MachineConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -650,7 +722,7 @@ func (r *PerformanceProfileReconciler) isComponentsExist(profile *performancev2.
 		return true
 	}
 
-	if _, err := r.getMachineConfig(machineconfig.GetMachineConfigName(profile)); !k8serros.IsNotFound(err) {
+	if _, err := r.getMachineConfig(context.TODO(), machineconfig.GetMachineConfigName(profile)); !k8serros.IsNotFound(err) {
 		klog.Infof("Machine Config %q exists under the cluster", name)
 		return true
 	}
@@ -763,4 +835,28 @@ func validateProfileMachineConfigPool(profile *performancev2.PerformanceProfile,
 	}
 
 	return nil
+}
+
+func validateCurrentMachineConfigCgroupV1(mc *mcov1.MachineConfig) error {
+	// taken from MCO pkg/controller/kubelet-config/helpers.go @ d469addcb
+	kernelArgsv1 := []string{
+		"systemd.unified_cgroup_hierarchy=0",
+		"systemd.legacy_systemd_cgroup_controller=1",
+	}
+
+	for _, karg := range kernelArgsv1 {
+		if !containString(mc.Spec.KernelArguments, karg) {
+			return fmt.Errorf("missing required cgroups V1 kernel argument: %q", karg)
+		}
+	}
+	return nil
+}
+
+func containString(strs []string, s string) bool {
+	for _, str := range strs {
+		if str == s {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,20 +36,34 @@ import (
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	kernelArgsv1 []string = []string{
+		"systemd.unified_cgroup_hierarchy=0",
+		"systemd.legacy_systemd_cgroup_controller=1",
+	}
 )
 
 var _ = Describe("Controller", func() {
 	var request reconcile.Request
 	var profile *performancev2.PerformanceProfile
+	var profileMC *mcov1.MachineConfig
 	var profileMCP *mcov1.MachineConfigPool
 	var infra *apiconfigv1.Infrastructure
 	var ctrcfg *mcov1.ContainerRuntimeConfig
+	var nodeConfig *apiconfigv1.Node
 
 	BeforeEach(func() {
+		profileMC = testutils.NewProfileMachineConfig("test", kernelArgsv1)
 		profileMCP = testutils.NewProfileMCP()
 		profile = testutils.NewPerformanceProfile("test")
 		infra = testutils.NewInfraResource(false)
+		clusterOperator = testutils.NewClusterOperator()
+		nodeConfig = testutils.NewNodeConfig(apiconfigv1.CgroupModeV1)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 		request = reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Namespace: metav1.NamespaceNone,
@@ -58,7 +73,8 @@ var _ = Describe("Controller", func() {
 	})
 
 	It("should add finalizer to the performance profile", func() {
-		r := newFakeReconciler(profile, profileMCP, infra)
+		r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 		Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -77,7 +93,8 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should create all resources on first reconcile loop", func() {
-			r := newFakeReconciler(profile, profileMCP, infra)
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -115,7 +132,8 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should create event on the second reconcile loop", func() {
-			r := newFakeReconciler(profile, profileMCP, infra)
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 			Expect(reconcileTimes(r, request, 2)).To(Equal(reconcile.Result{}))
 
@@ -127,7 +145,8 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should update the profile status", func() {
-			r := newFakeReconciler(profile, profileMCP, infra)
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -151,7 +170,8 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should promote kubelet config failure condition", func() {
-			r := newFakeReconciler(profile, profileMCP, infra)
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
 			name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
@@ -199,7 +219,8 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should not promote old failure condition", func() {
-			r := newFakeReconciler(profile, profileMCP, infra)
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
 			name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
@@ -257,7 +278,8 @@ var _ = Describe("Controller", func() {
 			tunedOutdatedB.OwnerReferences = []metav1.OwnerReference{
 				{Name: profile.Name},
 			}
-			r := newFakeReconciler(profile, tunedOutdatedA, tunedOutdatedB, profileMCP, infra)
+			r := newFakeReconciler(profile, tunedOutdatedA, tunedOutdatedB, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 			keyA := types.NamespacedName{
 				Name:      tunedOutdatedA.Name,
@@ -289,7 +311,8 @@ var _ = Describe("Controller", func() {
 
 		It("should create nothing when pause annotation is set", func() {
 			profile.Annotations = map[string]string{performancev2.PerformanceProfilePauseAnnotation: "true"}
-			r := newFakeReconciler(profile, profileMCP, infra)
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -350,7 +373,8 @@ var _ = Describe("Controller", func() {
 			})
 
 			It("should not record new create event", func() {
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, runtimeClass, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, runtimeClass, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -367,7 +391,8 @@ var _ = Describe("Controller", func() {
 
 			It("should update MC when RT kernel gets disabled", func() {
 				profile.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(false)
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -392,7 +417,8 @@ var _ = Describe("Controller", func() {
 					Isolated: &isolated,
 				}
 
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -427,7 +453,8 @@ var _ = Describe("Controller", func() {
 					BalanceIsolated: pointer.BoolPtr(true),
 				}
 
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -451,7 +478,8 @@ var _ = Describe("Controller", func() {
 					BalanceIsolated: pointer.BoolPtr(false),
 				}
 
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -478,7 +506,8 @@ var _ = Describe("Controller", func() {
 					},
 				}
 
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -507,7 +536,8 @@ var _ = Describe("Controller", func() {
 					},
 				}
 
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -543,11 +573,11 @@ var _ = Describe("Controller", func() {
 						ContainSubstring("Environment=NUMA_NODE=0"),
 					),
 				})))
-
 			})
 
 			It("should update status with generated tuned", func() {
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 				key := types.NamespacedName{
 					Name:      components.GetComponentName(profile.Name, components.ProfileNamePerformance),
@@ -568,7 +598,8 @@ var _ = Describe("Controller", func() {
 			})
 
 			It("should update status with generated runtime class", func() {
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, runtimeClass, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, runtimeClass, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
 				key := types.NamespacedName{
@@ -627,10 +658,16 @@ var _ = Describe("Controller", func() {
 								Message: mcpMessage,
 							},
 						},
+						Configuration: mcov1.MachineConfigPoolStatusConfiguration{
+							ObjectReference: corev1.ObjectReference{
+								Name: "test",
+							},
+						},
 					},
 				}
 
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, mcp, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, mcp, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -696,7 +733,8 @@ var _ = Describe("Controller", func() {
 					},
 				}
 
-				r := newFakeReconciler(profile, mc, kc, tunedPerformance, tuned, nodes, profileMCP, infra)
+				r := newFakeReconciler(profile, mc, kc, tunedPerformance, tuned, nodes, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -724,7 +762,8 @@ var _ = Describe("Controller", func() {
 				profileMCP.Spec.MachineConfigSelector = &metav1.LabelSelector{
 					MatchLabels: map[string]string{"wrongKey": "bad"},
 				}
-				r := newFakeReconciler(profile, profileMCP, infra)
+				r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
 				updatedProfile := &performancev2.PerformanceProfile{}
@@ -752,7 +791,8 @@ var _ = Describe("Controller", func() {
 					MatchLabels: map[string]string{"wrongKey": "bad"},
 				}
 				profile.Spec.MachineConfigLabel = nil
-				r := newFakeReconciler(profile, profileMCP, infra)
+				r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
 				updatedProfile := &performancev2.PerformanceProfile{}
@@ -772,6 +812,31 @@ var _ = Describe("Controller", func() {
 				Expect(degradedCondition.Reason).To(Equal(conditionBadMachineConfigLabels))
 				Expect(degradedCondition.Message).To(ContainSubstring("generated from the profile.spec.nodeSelector"))
 			})
+		})
+	})
+
+	Context("with the kubelet.experimental annotation set", func() {
+		It("should create all resources on first reconcile loop", func() {
+			prof := profile.DeepCopy()
+			prof.Annotations = map[string]string{
+				"kubeletconfig.experimental": `{"systemReserved": {"memory": "256Mi"}, "kubeReserved": {"memory": "256Mi"}}`,
+			}
+			r := newFakeReconciler(prof, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+
+			Expect(reconcileTimes(r, request, 2)).To(Equal(reconcile.Result{}))
+
+			key := types.NamespacedName{
+				Name:      components.GetComponentName(profile.Name, components.ComponentNamePrefix),
+				Namespace: metav1.NamespaceNone,
+			}
+
+			kc := &mcov1.KubeletConfig{}
+			err := r.Get(context.TODO(), key, kc)
+			Expect(err).ToNot(HaveOccurred())
+
+			kubeletConfigString := string(kc.Spec.KubeletConfig.Raw)
+			Expect(kubeletConfigString).To(ContainSubstring(`"kubeReserved":{"memory":"256Mi"}`))
+			Expect(kubeletConfigString).To(ContainSubstring(`"systemReserved":{"memory":"256Mi"}`))
 		})
 	})
 
@@ -796,7 +861,8 @@ var _ = Describe("Controller", func() {
 
 			runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
 
-			r := newFakeReconciler(profile, mc, kc, tunedPerformance, runtimeClass, profileMCP, infra)
+			r := newFakeReconciler(profile, mc, kc, tunedPerformance, runtimeClass, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 			result, err := r.Reconcile(context.TODO(), request)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -835,6 +901,97 @@ var _ = Describe("Controller", func() {
 		})
 	})
 
+	Context("with cgroups V1 enforcement", func() {
+		BeforeEach(func() {
+			infra = testutils.NewInfraResource(false)
+			clusterOperator = testutils.NewClusterOperator()
+			profileMCP = testutils.NewProfileMCP()
+			profile = testutils.NewPerformanceProfile("test")
+			request = reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: metav1.NamespaceNone,
+					Name:      profile.Name,
+				},
+			}
+		})
+
+		It("should progress cleanly if the nodeconfig is already set to cgroup v1", func() {
+			profileMC = testutils.NewProfileMachineConfig("test", kernelArgsv1)
+			nodeConfig = testutils.NewNodeConfig(apiconfigv1.CgroupModeV1)
+
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+			Expect(reconcileTimes(r, request, 2)).To(Equal(reconcile.Result{}))
+
+			updatedProfile := &performancev2.PerformanceProfile{}
+			key := types.NamespacedName{
+				Name:      profile.Name,
+				Namespace: metav1.NamespaceNone,
+			}
+			Expect(r.Get(context.TODO(), key, updatedProfile)).To(Succeed())
+
+			availableCondition := conditionsv1.FindStatusCondition(updatedProfile.Status.Conditions, conditionsv1.ConditionAvailable)
+			Expect(availableCondition).ToNot(BeNil())
+			Expect(availableCondition.Status).To(Equal(corev1.ConditionTrue))
+			message := strings.ToLower(availableCondition.Message)
+			Expect(message).To(ContainSubstring("cgroup=v1")) // quite ugly. Should we add an explicit condition?
+		})
+
+		It("should set performance profile as degraded until the machineconfig is set to cgroup v1", func() {
+			profileMC = testutils.NewProfileMachineConfig("test", []string{})
+			nodeConfig = testutils.NewNodeConfig(apiconfigv1.CgroupModeEmpty)
+
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+
+			reconcileTimes(r, request, 3)
+
+			updatedProfile := &performancev2.PerformanceProfile{}
+			key := types.NamespacedName{
+				Name:      profile.Name,
+				Namespace: metav1.NamespaceNone,
+			}
+			Expect(r.Get(context.TODO(), key, updatedProfile)).To(Succeed())
+
+			degradedCondition := conditionsv1.FindStatusCondition(updatedProfile.Status.Conditions, conditionsv1.ConditionDegraded)
+			Expect(degradedCondition.Status).To(Equal(corev1.ConditionTrue))
+			Expect(degradedCondition.Reason).To(Equal(conditionReasonCgroupsV1NotEnabled))
+		})
+
+		It("should set continue with the performance profile reconciliation once the machineconfig is set to cgroup v1", func() {
+			profileMC = testutils.NewProfileMachineConfig("test", []string{})
+			nodeConfig = testutils.NewNodeConfig(apiconfigv1.CgroupModeEmpty)
+
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator, nodeConfig, profileMC)
+
+			reconcileTimes(r, request, 3)
+
+			updatedProfile := &performancev2.PerformanceProfile{}
+			key := types.NamespacedName{
+				Name:      profile.Name,
+				Namespace: metav1.NamespaceNone,
+			}
+			Expect(r.Get(context.TODO(), key, updatedProfile)).To(Succeed())
+
+			degradedCondition := conditionsv1.FindStatusCondition(updatedProfile.Status.Conditions, conditionsv1.ConditionDegraded)
+			Expect(degradedCondition.Status).To(Equal(corev1.ConditionTrue))
+			Expect(degradedCondition.Reason).To(Equal(conditionReasonCgroupsV1NotEnabled))
+
+			updatedProfileMC := profileMC.DeepCopy()
+			updatedProfileMC.Spec.KernelArguments = kernelArgsv1
+
+			Expect(r.Update(context.TODO(), updatedProfileMC)).To(Succeed())
+
+			Expect(reconcileTimes(r, request, 2)).To(Equal(reconcile.Result{}))
+
+			Expect(r.Get(context.TODO(), key, updatedProfile)).To(Succeed())
+
+			availableCondition := conditionsv1.FindStatusCondition(updatedProfile.Status.Conditions, conditionsv1.ConditionAvailable)
+			Expect(availableCondition).ToNot(BeNil())
+			Expect(availableCondition.Status).To(Equal(corev1.ConditionTrue))
+			message := strings.ToLower(availableCondition.Message)
+			Expect(message).To(ContainSubstring("cgroup=v1")) // quite ugly. Should we add an explicit condition?
+		})
+	})
+
 	Context("with infrastructure cpuPartitioning", func() {
 		BeforeEach(func() {
 			infra = testutils.NewInfraResource(true)
@@ -843,7 +1000,8 @@ var _ = Describe("Controller", func() {
 		It("should contain cpu partitioning files in machine config", func() {
 			mc, err := machineconfig.New(profile, &infra.Status.CPUPartitioning, "")
 			Expect(err).ToNot(HaveOccurred())
-			r := newFakeReconciler(profile, profileMCP, mc, infra)
+			r := newFakeReconciler(profile, profileMCP, mc, infra, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 
 			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
@@ -860,8 +1018,8 @@ var _ = Describe("Controller", func() {
 			err = json.Unmarshal(mc.Spec.Config.Raw, config)
 			Expect(err).ToNot(HaveOccurred())
 
-			var mode = 420
-			var containFiles = []igntypes.File{
+			mode := 420
+			containFiles := []igntypes.File{
 				{
 					Node: igntypes.Node{
 						Path:  "/etc/kubernetes/openshift-workload-pinning",
@@ -920,8 +1078,10 @@ var _ = Describe("Controller", func() {
 				},
 			},
 		}
-		r := newFakeReconciler(profile, mcp)
-		requests := r.mcpToPerformanceProfile(mcp)
+
+		r := newFakeReconciler(profile, mcp, nodeConfig)
+		requests := r.mcpToPerformanceProfile(context.TODO(), mcp)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 		Expect(requests).NotTo(BeEmpty())
 		Expect(requests[0].Name).To(Equal(profile.Name))
 	})
@@ -935,7 +1095,9 @@ var _ = Describe("Controller", func() {
 			mc, err := machineconfig.New(profile, &infra.Status.CPUPartitioning, "")
 			Expect(err).ToNot(HaveOccurred())
 
-			r := newFakeReconciler(profile, profileMCP, mc, infra, ctrcfg)
+
+			r := newFakeReconciler(profile, profileMCP, mc, infra, ctrcfg, clusterOperator, nodeConfig, profileMC)
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 			Expect(reconcileTimes(r, request, 2)).To(Equal(reconcile.Result{}))
 
 			By("Verifying MC update")
@@ -951,8 +1113,8 @@ var _ = Describe("Controller", func() {
 			err = json.Unmarshal(mc.Spec.Config.Raw, config)
 			Expect(err).ToNot(HaveOccurred())
 
-			var mode = 420
-			var containFiles = []igntypes.File{
+			mode := 420
+			containFiles := []igntypes.File{
 				{
 					Node: igntypes.Node{
 						Path:  "/etc/crio/crio.conf.d/99-runtimes.conf",
@@ -970,9 +1132,7 @@ var _ = Describe("Controller", func() {
 			}
 			Expect(config.Storage.Files).To(ContainElements(containFiles))
 		})
-
 	})
-
 })
 
 func reconcileTimes(reconciler *PerformanceProfileReconciler, request reconcile.Request, times int) reconcile.Result {
@@ -980,14 +1140,53 @@ func reconcileTimes(reconciler *PerformanceProfileReconciler, request reconcile.
 	var err error
 	for i := 0; i < times; i++ {
 		result, err = reconciler.Reconcile(context.TODO(), request)
-		Expect(err).ToNot(HaveOccurred())
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	}
 	return result
 }
 
+func MCPInterceptor() interceptor.Funcs {
+	generationCounter := int64(0)
+
+	mutateMCP := func(mcp *mcov1.MachineConfigPool) {
+		mcp.SetGeneration(generationCounter)
+	}
+
+	return interceptor.Funcs{
+		Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, isNodeUpdate := obj.(*apiconfigv1.Node); isNodeUpdate {
+				generationCounter++
+			}
+			return client.Update(ctx, obj, opts...)
+		},
+		Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			mcp, isMcp := obj.(*mcov1.MachineConfigPool)
+			err := client.Get(ctx, key, obj)
+			if err == nil && isMcp {
+				mutateMCP(mcp)
+			}
+			return err
+		},
+		List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			mcpList, isMcpList := list.(*mcov1.MachineConfigPoolList)
+			err := client.List(ctx, list, opts...)
+			if err == nil && isMcpList {
+				for i := range mcpList.Items {
+					mutateMCP(&mcpList.Items[i])
+				}
+			}
+			return err
+		},
+	}
+}
+
 // newFakeReconciler returns a new reconcile.Reconciler with a fake client
-func newFakeReconciler(initObjects ...runtime.Object) *PerformanceProfileReconciler {
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(initObjects...).Build()
+func newFakeReconciler(profile client.Object, initObjects ...runtime.Object) *PerformanceProfileReconciler {
+	// we need to add the profile using the `WithStatusSubresource` function
+	// because we're updating its status during the reconciliation loop
+	initObjects = append(initObjects, profile)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithStatusSubresource(profile).WithRuntimeObjects(initObjects...).WithInterceptorFuncs(MCPInterceptor()).Build()
+>>>>>>> b70869c7 (  OCPBUGS-18640: Fix Racing Machine Configs and add Day 0 Support (#854))
 	fakeRecorder := record.NewFakeRecorder(10)
 	return &PerformanceProfileReconciler{
 		Client:   fakeClient,

--- a/pkg/performanceprofile/controller/status.go
+++ b/pkg/performanceprofile/controller/status.go
@@ -29,6 +29,7 @@ const (
 	conditionFailedGettingKubeletStatus      = "GettingKubeletStatusFailed"
 	conditionReasonTunedDegraded             = "TunedProfileDegraded"
 	conditionFailedGettingTunedProfileStatus = "GettingTunedStatusFailed"
+	conditionReasonCgroupsV1NotEnabled       = "CgroupsV1NotEnabled"
 )
 
 func (r *PerformanceProfileReconciler) updateStatus(profile *performancev2.PerformanceProfile, conditions []conditionsv1.Condition) error {
@@ -83,12 +84,13 @@ func (r *PerformanceProfileReconciler) updateStatus(profile *performancev2.Perfo
 	return r.Status().Update(context.TODO(), profileCopy)
 }
 
-func (r *PerformanceProfileReconciler) getAvailableConditions() []conditionsv1.Condition {
+func (r *PerformanceProfileReconciler) getAvailableConditions(message string) []conditionsv1.Condition {
 	now := time.Now()
 	return []conditionsv1.Condition{
 		{
 			Type:               conditionsv1.ConditionAvailable,
 			Status:             corev1.ConditionTrue,
+			Message:            message,
 			LastTransitionTime: metav1.Time{Time: now},
 			LastHeartbeatTime:  metav1.Time{Time: now},
 		},

--- a/pkg/performanceprofile/node/helper.go
+++ b/pkg/performanceprofile/node/helper.go
@@ -1,0 +1,21 @@
+package node
+
+import (
+	apiconfigv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewNodeConfig(mode apiconfigv1.CgroupMode) *apiconfigv1.Node {
+	return &apiconfigv1.Node{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiconfigv1.SchemeGroupVersion.String(),
+			Kind:       "Node",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: apiconfigv1.NodeSpec{
+			CgroupMode: mode,
+		},
+	}
+}

--- a/pkg/performanceprofile/utils/testing/testing.go
+++ b/pkg/performanceprofile/utils/testing/testing.go
@@ -23,13 +23,13 @@ const (
 	OfflinedCPUs     = performancev2.CPUSet("6-7") // SingleNUMAPolicy defines the topologyManager policy used for tests
 	SingleNUMAPolicy = "single-numa-node"
 
-	//MachineConfigLabelKey defines the MachineConfig label key of the test profile
+	// MachineConfigLabelKey defines the MachineConfig label key of the test profile
 	MachineConfigLabelKey = "mcKey"
-	//MachineConfigLabelValue defines the MachineConfig label vlue of the test profile
+	// MachineConfigLabelValue defines the MachineConfig label vlue of the test profile
 	MachineConfigLabelValue = "mcValue"
-	//MachineConfigPoolLabelKey defines the MachineConfigPool label key of the test profile
+	// MachineConfigPoolLabelKey defines the MachineConfigPool label key of the test profile
 	MachineConfigPoolLabelKey = "mcpKey"
-	//MachineConfigPoolLabelValue defines the MachineConfigPool label value of the test profile
+	// MachineConfigPoolLabelValue defines the MachineConfigPool label value of the test profile
 	MachineConfigPoolLabelValue = "mcpValue"
 )
 
@@ -94,7 +94,10 @@ func NewPerformanceProfile(name string) *performancev2.PerformanceProfile {
 // NewProfileMCP returns new MCP used for testing
 func NewProfileMCP() *mcov1.MachineConfigPool {
 	return &mcov1.MachineConfigPool{
-		TypeMeta: metav1.TypeMeta{Kind: "MachineConfigPool"},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfigPool",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 			UID:  "11111111-1111-1111-1111-1111111111111",
@@ -110,11 +113,34 @@ func NewProfileMCP() *mcov1.MachineConfigPool {
 				MatchLabels: map[string]string{MachineConfigLabelKey: MachineConfigLabelValue},
 			},
 		},
+		Status: mcov1.MachineConfigPoolStatus{
+			Configuration: mcov1.MachineConfigPoolStatusConfiguration{
+				ObjectReference: corev1.ObjectReference{
+					Name: "test",
+				},
+			},
+		},
+	}
+}
+
+func NewProfileMachineConfig(name string, kernelArgs []string) *mcov1.MachineConfig {
+	return &mcov1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  "11111111-1111-1111-1111-1111111111111",
+		},
+		Spec: mcov1.MachineConfigSpec{
+			KernelArguments: kernelArgs,
+		},
 	}
 }
 
 func NewInfraResource(pin bool) *apiconfigv1.Infrastructure {
-	var pinningMode = apiconfigv1.CPUPartitioningNone
+	pinningMode := apiconfigv1.CPUPartitioningNone
 	if pin {
 		pinningMode = apiconfigv1.CPUPartitioningAllNodes
 	}
@@ -124,6 +150,33 @@ func NewInfraResource(pin bool) *apiconfigv1.Infrastructure {
 		},
 		Status: apiconfigv1.InfrastructureStatus{
 			CPUPartitioning: pinningMode,
+		},
+	}
+}
+
+func NewClusterOperator() *apiconfigv1.ClusterOperator {
+	return &apiconfigv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-tuning",
+		},
+		Status: apiconfigv1.ClusterOperatorStatus{
+			Versions: []apiconfigv1.OperandVersion{
+				{
+					Name:    tunedv1.TunedOperandName,
+					Version: "",
+				},
+			},
+		},
+	}
+}
+
+func NewNodeConfig(mode apiconfigv1.CgroupMode) *apiconfigv1.Node {
+	return &apiconfigv1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: apiconfigv1.NodeSpec{
+			CgroupMode: mode,
 		},
 	}
 }

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -432,105 +432,6 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("KubeletConfig experimental annotation", func() {
-		var secondMCP *mcov1.MachineConfigPool
-		var secondProfile *performancev2.PerformanceProfile
-		var newRole = "test-annotation"
-
-		BeforeEach(func() {
-			newLabel := fmt.Sprintf("%s/%s", testutils.LabelRole, newRole)
-
-			reserved := performancev2.CPUSet("0")
-			isolated := performancev2.CPUSet("1-3")
-
-			secondProfile = &performancev2.PerformanceProfile{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "PerformanceProfile",
-					APIVersion: performancev2.GroupVersion.String(),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-annotation",
-					Annotations: map[string]string{
-						"kubeletconfig.experimental": `{"systemReserved": {"memory": "256Mi"}, "kubeReserved": {"memory": "256Mi"}}`,
-					},
-				},
-				Spec: performancev2.PerformanceProfileSpec{
-					CPU: &performancev2.CPU{
-						Reserved: &reserved,
-						Isolated: &isolated,
-					},
-					NodeSelector: map[string]string{newLabel: ""},
-					RealTimeKernel: &performancev2.RealTimeKernel{
-						Enabled: pointer.Bool(true),
-					},
-					NUMA: &performancev2.NUMA{
-						TopologyPolicy: pointer.String("restricted"),
-					},
-				},
-			}
-			Expect(testclient.Client.Create(context.TODO(), secondProfile)).ToNot(HaveOccurred())
-
-			machineConfigSelector := componentprofile.GetMachineConfigLabel(secondProfile)
-			secondMCP = &mcov1.MachineConfigPool{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-annotation",
-					Labels: map[string]string{
-						machineconfigv1.MachineConfigRoleLabelKey: newRole,
-					},
-				},
-				Spec: mcov1.MachineConfigPoolSpec{
-					MachineConfigSelector: &metav1.LabelSelector{
-						MatchLabels: machineConfigSelector,
-					},
-					NodeSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							newLabel: "",
-						},
-					},
-				},
-			}
-
-			Expect(testclient.Client.Create(context.TODO(), secondMCP)).ToNot(HaveOccurred())
-		})
-
-		It("should override system-reserved memory", func() {
-			var kubeletConfig *machineconfigv1.KubeletConfig
-
-			Eventually(func() error {
-				By("Getting that new KubeletConfig")
-				configKey := types.NamespacedName{
-					Name:      components.GetComponentName(secondProfile.Name, components.ComponentNamePrefix),
-					Namespace: metav1.NamespaceNone,
-				}
-				kubeletConfig = &machineconfigv1.KubeletConfig{}
-				if err := testclient.GetWithRetry(context.TODO(), configKey, kubeletConfig); err != nil {
-					klog.Warningf("Failed to get the KubeletConfig %q", configKey.Name)
-					return err
-				}
-
-				return nil
-			}, time.Minute, 5*time.Second).Should(BeNil())
-
-			kubeletConfigString := string(kubeletConfig.Spec.KubeletConfig.Raw)
-			Expect(kubeletConfigString).To(ContainSubstring(`"kubeReserved":{"memory":"256Mi"}`))
-			Expect(kubeletConfigString).To(ContainSubstring(`"systemReserved":{"memory":"256Mi"}`))
-		})
-
-		AfterEach(func() {
-			if secondProfile != nil {
-				if err := profiles.Delete(secondProfile.Name); err != nil {
-					klog.Warningf("failed to delete the performance profile %q: %v", secondProfile.Name, err)
-				}
-			}
-
-			if secondMCP != nil {
-				if err := mcps.Delete(secondMCP.Name); err != nil {
-					klog.Warningf("failed to delete the machine config pool %q: %v", secondMCP.Name, err)
-				}
-			}
-		})
-	})
-
 	Context("Create second performance profiles on a cluster", func() {
 		var secondMCP *mcov1.MachineConfigPool
 		var secondProfile *performancev2.PerformanceProfile
@@ -549,6 +450,9 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "second-profile",
+					Annotations: map[string]string{
+						performancev2.PerformanceProfileIgnoreCgroupsVersion: "true",
+					},
 				},
 				Spec: performancev2.PerformanceProfileSpec{
 					CPU: &performancev2.CPU{

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
@@ -6,16 +6,20 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
@@ -134,6 +138,26 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 
 			By("Waiting when mcp finishes updates")
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
+
+			var kubeletConfig machineconfigv1.KubeletConfig
+
+			Eventually(func() error {
+				By("Getting that new KubeletConfig")
+				configKey := types.NamespacedName{
+					Name:      components.GetComponentName(profile.Name, components.ComponentNamePrefix),
+					Namespace: metav1.NamespaceNone,
+				}
+				err := testclient.Client.Get(context.TODO(), configKey, &kubeletConfig)
+				if err != nil {
+					klog.Warningf("Failed to get the KubeletConfig %q", configKey.Name)
+				}
+				return err
+			}).WithPolling(5 * time.Second).WithTimeout(3 * time.Minute).Should(Succeed())
+
+			kubeletConfigString := string(kubeletConfig.Spec.KubeletConfig.Raw)
+			Expect(kubeletConfigString).To(ContainSubstring(`"kubeReserved":{"memory":"768Mi"}`))
+			Expect(kubeletConfigString).To(ContainSubstring(`"systemReserved":{"memory":"300Mi"}`))
+
 			for _, node := range workerRTNodes {
 				kubeletConfig, err := nodes.GetKubeletConfig(&node)
 				Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_node.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_node.yaml
@@ -1,0 +1,13 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  creationTimestamp: null
+  name: cluster
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+spec:
+  cgroupMode: v1
+status: {}


### PR DESCRIPTION
* render nodeconfig to cgroup v1

then, wait for cgroupv1 rollout; add logging and update tests and lint. add interceptor to increase generation counter.
do render sync.

* perfprof: controller: implicit wait for cgroups v1

rather than inject an explicit wait in the reconcile loop, we check that the MachineConfig includes the required cgroups V1 settings, exiting from the reconcile loop if not.

In addition, all the tuning features depend on cgroups v1. Hence, we set the perfprofile status to Degraded until the node(s) are configured to v1.

Last but not least, it must be noted that this approach depends on implementation details pertaining to MCO. We are thus adding an implicit dependency between the two components.



* perfprof: controller: e2e: dissolve the annotation test

Dissolve the early e2e annotation test in the new more modern 7_peformance_kubelet_node suite, which had already a better test running - more comprehensive, and add a controller test for extra safety.

Overall this change increases test coverage, not reduces it.



* Add annotation to disable cgroups v2 downgrade

This adds performance.openshift.io/ignore-cgroups-version that can be used during development of cgroups v2 related code.




* perfprof: e2e: test shortcut for second profile

We have (few) tests which want to add a second profile, but in CI we can hardly afford, if at all, a second MCP. So the tests takes shortcut and assume the manifests are created even without a matching MCP.

This assumption doesn't hold anymore when we apply the cgroups V1 revert, because in this flow we need to check the matching MCP picked up before we move on, intentionally.

To move forward, we disable the cgroup v1 switch in these tests which add a second profile. This admittedly creates a gap - we don't test how the two features interact, but it seem the only practical option without overhauling the CI flows.



---------