### PR TITLE
OCPBUGS-24792: Make MC names deterministic

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -42,7 +42,6 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/pkg/util"
 	"github.com/openshift/cluster-node-tuning-operator/version"
 
-	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	mcfgclientset "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned"
 	mcfginformers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
 )
@@ -620,7 +619,6 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	var (
 		tunedProfileName string
 		mcLabels         map[string]string
-		pools            []*mcfgv1.MachineConfigPool
 		operand          tunedv1.OperandConfig
 		nodePoolName     string
 	)
@@ -659,7 +657,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 			return err
 		}
 	} else {
-		tunedProfileName, mcLabels, pools, operand, err = c.pc.calculateProfile(nodeName)
+		tunedProfileName, mcLabels, operand, err = c.pc.calculateProfile(nodeName)
 		if err != nil {
 			return err
 		}
@@ -730,12 +728,12 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	} else {
 		if mcLabels != nil {
 			// The TuneD daemon profile 'tunedProfileName' for nodeName matched with MachineConfig
-			// labels set for additional machine configuration.  Sync the operator-created
-			// MachineConfig for MachineConfigPools 'pools'.
+			// labels 'mcLabels' set for additional machine configuration.  Sync the operator-created
+			// MachineConfig based on 'mcLabels'.
 			if profile.Status.TunedProfile == tunedProfileName && profileApplied(profile) {
 				// Synchronize MachineConfig only once the (calculated) TuneD profile 'tunedProfileName'
 				// has been successfully applied.
-				err := c.syncMachineConfig(pools, mcLabels, profile)
+				err := c.syncMachineConfig(mcLabels, profile)
 				if err != nil {
 					return fmt.Errorf("failed to update Profile %s: %v", profile.Name, err)
 				}
@@ -777,25 +775,36 @@ func (c *Controller) getProviderName(nodeName string) (string, error) {
 	return util.GetProviderName(node.Spec.ProviderID), nil
 }
 
-func (c *Controller) syncMachineConfig(pools []*mcfgv1.MachineConfigPool, labels map[string]string, profile *tunedv1.Profile) error {
+func (c *Controller) syncMachineConfig(labels map[string]string, profile *tunedv1.Profile) error {
 	var (
+		bootcmdline     string
 		kernelArguments []string
 	)
 
-	name := GetMachineConfigNameForPools(pools)
-	nodes, err := c.pc.getNodesForPool(pools[0])
+	pools, err := c.pc.getPoolsForMachineConfigLabels(labels)
 	if err != nil {
 		return err
 	}
 
-	bootcmdline, bootcmdlineSet := c.pc.state.bootcmdline[profile.Name]
-	if !bootcmdlineSet {
-		klog.V(2).Infof("syncMachineConfig(): bootcmdline for %s not cached, sync canceled", profile.Name)
-		return nil
-	}
+	name := GetMachineConfigNameForPools(pools)
+	klog.V(2).Infof("syncMachineConfig(): %v", name)
 
-	if ok := c.allNodesAgreeOnBootcmdline(nodes); !ok {
-		return fmt.Errorf("not all %d Nodes in MCP %v agree on bootcmdline: %s", len(nodes), pools[0].ObjectMeta.Name, bootcmdline)
+	for _, pool := range pools {
+		var bootcmdlineSet bool
+		nodes, err := c.pc.getNodesForPool(pool)
+		if err != nil {
+			return err
+		}
+
+		bootcmdline, bootcmdlineSet = c.pc.state.bootcmdline[profile.Name]
+		if !bootcmdlineSet {
+			klog.V(2).Infof("syncMachineConfig(): bootcmdline for %s not cached, sync canceled", profile.Name)
+			return nil
+		}
+
+		if ok := c.allNodesAgreeOnBootcmdline(nodes); !ok {
+			return fmt.Errorf("not all %d Nodes in MCP %v agree on bootcmdline: %s", len(nodes), pools[0].ObjectMeta.Name, bootcmdline)
+		}
 	}
 
 	kernelArguments = util.SplitKernelArguments(bootcmdline)
@@ -941,7 +950,7 @@ func (c *Controller) syncMachineConfigHyperShift(nodePoolName string, profile *t
 	// If mcfgs are equivalent don't update
 	if kernelArgsEq && cmLabelsAndAnnotationsCorrect {
 		// No update needed
-		klog.V(2).Infof("syncMachineConfig(): MachineConfig %s doesn't need updating", mc.ObjectMeta.Name)
+		klog.V(2).Infof("syncMachineConfigHyperShift(): MachineConfig %s doesn't need updating", mc.ObjectMeta.Name)
 		return nil
 	}
 
@@ -952,7 +961,7 @@ func (c *Controller) syncMachineConfigHyperShift(nodePoolName string, profile *t
 	mc.Spec.Config = mcNew.Spec.Config
 
 	l := MachineConfigGenerationLogLine(!kernelArgsEq, bootcmdline)
-	klog.V(2).Infof("syncMachineConfig(): updating MachineConfig %s with%s", mc.ObjectMeta.Name, l)
+	klog.V(2).Infof("syncMachineConfigHyperShift(): updating MachineConfig %s with%s", mc.ObjectMeta.Name, l)
 
 	newData, err := serializeMachineConfig(mc)
 	if err != nil {

--- a/pkg/operator/mc.go
+++ b/pkg/operator/mc.go
@@ -44,6 +44,30 @@ func NewMachineConfig(name string, annotations map[string]string, labels map[str
 	}
 }
 
+func printMachineConfigPoolsNames(pools []*mcfgv1.MachineConfigPool) string {
+	var (
+		sb        strings.Builder
+		poolNames []string
+	)
+
+	for _, pool := range pools {
+		if pool == nil {
+			continue
+		}
+		poolNames = append(poolNames, pool.ObjectMeta.Name)
+	}
+	sort.Strings(poolNames)
+
+	for i, poolName := range poolNames {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(poolName)
+	}
+
+	return sb.String()
+}
+
 // GetMachineConfigNameForPools takes pools a slice of MachineConfigPools and returns
 // a MachineConfig name to be used for MachineConfigPool based matching.
 func GetMachineConfigNameForPools(pools []*mcfgv1.MachineConfigPool) string {
@@ -99,6 +123,21 @@ func (pc *ProfileCalculator) getPoolsForMachineConfigLabels(mcLabels map[string]
 
 		pools = append(pools, p)
 	}
+
+	return pools, nil
+}
+
+// getPoolsForMachineConfigLabelsSorted is the same as getPoolsForMachineConfigLabels, but
+// returns the MCPs alphabetically sorted by their names.
+func (pc *ProfileCalculator) getPoolsForMachineConfigLabelsSorted(mcLabels map[string]string) ([]*mcfgv1.MachineConfigPool, error) {
+	pools, err := pc.getPoolsForMachineConfigLabels(mcLabels)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(pools, func(i, j int) bool {
+		return pools[i].Name < pools[j].Name
+	})
 
 	return pools, nil
 }

--- a/pkg/operator/profilecalculator.go
+++ b/pkg/operator/profilecalculator.go
@@ -155,17 +155,16 @@ func (pc *ProfileCalculator) nodeChangeHandler(nodeName string) (bool, error) {
 // Returns
 // * the tuned daemon profile name
 // * MachineConfig labels if the profile was selected by machineConfigLabels
-// * MachineConfigPools for 'nodeName' if the profile was selected by machineConfigLabels
 // * whether to run the Tuned daemon in debug mode on node nodeName
 // * an error if any
-func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[string]string, []*mcfgv1.MachineConfigPool, tunedv1.OperandConfig, error) {
+func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[string]string, tunedv1.OperandConfig, error) {
 	var operand tunedv1.OperandConfig
 
 	klog.V(3).Infof("calculateProfile(%s)", nodeName)
 	tunedList, err := pc.listers.TunedResources.List(labels.Everything())
 
 	if err != nil {
-		return "", nil, nil, operand, fmt.Errorf("failed to list Tuned: %v", err)
+		return "", nil, operand, fmt.Errorf("failed to list Tuned: %v", err)
 	}
 
 	for _, recommend := range TunedRecommend(tunedList) {
@@ -180,7 +179,7 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[stri
 		// we do not want to call profileMatches() in that case unless machineConfigLabels
 		// is undefined.
 		if (recommend.Match != nil || recommend.MachineConfigLabels == nil) && pc.profileMatches(recommend.Match, nodeName) {
-			return *recommend.Profile, nil, nil, recommend.Operand, nil
+			return *recommend.Profile, nil, recommend.Operand, nil
 		}
 
 		if recommend.MachineConfigLabels == nil {
@@ -194,19 +193,18 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[stri
 			// is often unneeded and would likely have a performance impact.
 			node, err = pc.listers.Nodes.Get(nodeName)
 			if err != nil {
-				return "", nil, nil, operand, err
+				return "", nil, operand, err
 			}
 
 			pools, err = pc.getPoolsForNode(node)
-
 			if err != nil {
-				return "", nil, nil, operand, err
+				return "", nil, operand, err
 			}
 		}
 
 		// MachineConfigLabels based matching
 		if pc.machineConfigLabelsMatch(recommend.MachineConfigLabels, pools) {
-			return *recommend.Profile, recommend.MachineConfigLabels, pools, recommend.Operand, nil
+			return *recommend.Profile, recommend.MachineConfigLabels, recommend.Operand, nil
 		}
 	}
 
@@ -214,10 +212,10 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[stri
 	// in the "recommend" section to select the default profile for the tuned daemon.
 	_, err = pc.listers.TunedResources.Get(tunedv1.TunedDefaultResourceName)
 	if err != nil {
-		return defaultProfile, nil, nil, operand, fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedDefaultResourceName, err)
+		return defaultProfile, nil, operand, fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedDefaultResourceName, err)
 	}
 
-	return defaultProfile, nil, nil, operand, fmt.Errorf("the default Tuned CR misses a catch-all profile selection")
+	return defaultProfile, nil, operand, fmt.Errorf("the default Tuned CR misses a catch-all profile selection")
 }
 
 // calculateProfileHyperShift calculates a tuned profile for Node nodeName.


### PR DESCRIPTION
OpenShift Nodes can be a part of only one custom MachineConfigPool. However, MCP configuration allows this not to be the case.  This is caught by the machine-config-controller and reported as an error (<node> belongs to <N> custom roles, cannot proceed with this Node).

In order to target an MCP with a configuration, NTO uses machineConfigLabels.  However, one or more MCPs can select a particular single MC.  This is due to the MCP's machineConfigSelector.  This is another challenge scenario.

In the above two scenarios, it was possible for NTO to generate a randomly-named MC based on the membership of one of the matching MCPs. Then, a pruning function would mistakenly remove the other MCs, seemingly unused.  This could result in a flip between the rendered MCs and cause a Node reboot.

This PR makes the process of establishing the names of the MC for the purposes of MachineConfigPool based matching deterministic.

Other changes/fixes:
 - Synced with MCO's latest getPoolsForNode() changes.
 - Logging in syncMachineConfigHyperShift().

Resolves: OCPBUGS-24792