### PR TITLE
NO-JIRA: e2e-test: Call SetLogger to avoid controller-runtime error.

### DIFF
--- a/test/e2e/basic/operator_test.go
+++ b/test/e2e/basic/operator_test.go
@@ -1,10 +1,15 @@
 package e2e
 
 import (
+	"log"
+	"os"
 	"testing"
 
+	"github.com/go-logr/stdr"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/openshift/cluster-node-tuning-operator/test/framework"
 )
@@ -14,6 +19,7 @@ var (
 )
 
 func TestNodeTuningOperator(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "Node Tuning Operator e2e tests: basic")
 }


### PR DESCRIPTION
You must set a logger for controller-runtime, otherwise it complains.