### PR TITLE
WIP: performance: e2e: configure adaptive cpu in profile

### DIFF
--- a/pkg/performanceprofile/profilecreator/profilecreator.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator.go
@@ -331,13 +331,13 @@ type extendedCPUInfo struct {
 	LogicalProcessorsUsed    map[int]struct{}
 }
 
-type systemInfo struct {
+type SystemInfo struct {
 	CpuInfo      *extendedCPUInfo
 	TopologyInfo *topology.Info
 	HtEnabled    bool
 }
 
-func (ghwHandler GHWHandler) GatherSystemInfo() (*systemInfo, error) {
+func (ghwHandler GHWHandler) GatherSystemInfo() (*SystemInfo, error) {
 	cpuInfo, err := ghwHandler.SortedCPU()
 	if err != nil {
 		return nil, err
@@ -353,7 +353,7 @@ func (ghwHandler GHWHandler) GatherSystemInfo() (*systemInfo, error) {
 		return nil, err
 	}
 
-	return &systemInfo{
+	return &SystemInfo{
 		CpuInfo: &extendedCPUInfo{
 			CpuInfo:                  cpuInfo,
 			NumLogicalProcessorsUsed: make(map[int]int, len(cpuInfo.Processors)),
@@ -365,7 +365,7 @@ func (ghwHandler GHWHandler) GatherSystemInfo() (*systemInfo, error) {
 }
 
 // Calculates the resevered, isolated and offlined cpuSets.
-func CalculateCPUSets(systemInfo *systemInfo, reservedCPUCount int, offlinedCPUCount int, splitReservedCPUsAcrossNUMA bool, disableHTFlag bool, highPowerConsumptionMode bool) (cpuset.CPUSet, cpuset.CPUSet, cpuset.CPUSet, error) {
+func CalculateCPUSets(systemInfo *SystemInfo, reservedCPUCount int, offlinedCPUCount int, splitReservedCPUsAcrossNUMA bool, disableHTFlag bool, highPowerConsumptionMode bool) (cpuset.CPUSet, cpuset.CPUSet, cpuset.CPUSet, error) {
 	topologyInfo := systemInfo.TopologyInfo
 	htEnabled := systemInfo.HtEnabled
 

--- a/pkg/performanceprofile/profilecreator/profilecreator.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator.go
@@ -324,7 +324,7 @@ func topologyHTDisabled(info *topology.Info) *topology.Info {
 	return disabledHTTopology
 }
 
-type extendedCPUInfo struct {
+type ExtendedCPUInfo struct {
 	CpuInfo *cpu.Info
 	// Number of logicalprocessors already reserved for each Processor (aka Socket)
 	NumLogicalProcessorsUsed map[int]int
@@ -332,7 +332,7 @@ type extendedCPUInfo struct {
 }
 
 type SystemInfo struct {
-	CpuInfo      *extendedCPUInfo
+	CpuInfo      *ExtendedCPUInfo
 	TopologyInfo *topology.Info
 	HtEnabled    bool
 }
@@ -354,7 +354,7 @@ func (ghwHandler GHWHandler) GatherSystemInfo() (*SystemInfo, error) {
 	}
 
 	return &SystemInfo{
-		CpuInfo: &extendedCPUInfo{
+		CpuInfo: &ExtendedCPUInfo{
 			CpuInfo:                  cpuInfo,
 			NumLogicalProcessorsUsed: make(map[int]int, len(cpuInfo.Processors)),
 			LogicalProcessorsUsed:    make(map[int]struct{}),
@@ -433,7 +433,7 @@ func getIsolatedCPUs(topologyInfoNodes []*topology.Node, reserved, offlined cpus
 	return total.Difference(reserved.Union(offlined)), nil
 }
 
-func AreAllLogicalProcessorsFromSocketUnused(extCpuInfo *extendedCPUInfo, socketId int) bool {
+func AreAllLogicalProcessorsFromSocketUnused(extCpuInfo *ExtendedCPUInfo, socketId int) bool {
 	if val, ok := extCpuInfo.NumLogicalProcessorsUsed[socketId]; ok {
 		return val == 0
 	} else {
@@ -441,7 +441,7 @@ func AreAllLogicalProcessorsFromSocketUnused(extCpuInfo *extendedCPUInfo, socket
 	}
 }
 
-func getOfflinedCPUs(extCpuInfo *extendedCPUInfo, offlinedCPUCount int, disableHTFlag bool, htEnabled bool, highPowerConsumption bool) (cpuset.CPUSet, error) {
+func getOfflinedCPUs(extCpuInfo *ExtendedCPUInfo, offlinedCPUCount int, disableHTFlag bool, htEnabled bool, highPowerConsumption bool) (cpuset.CPUSet, error) {
 	offlined := newCPUAccumulator()
 	lpOfflined := 0
 
@@ -748,13 +748,13 @@ func GetAdditionalKernelArgs(disableHT bool) []string {
 	return kernelArgs
 }
 
-func updateExtendedCPUInfo(extCpuInfo *extendedCPUInfo, used cpuset.CPUSet, disableHT, htEnabled bool) (*extendedCPUInfo, error) {
+func updateExtendedCPUInfo(extCpuInfo *ExtendedCPUInfo, used cpuset.CPUSet, disableHT, htEnabled bool) (*ExtendedCPUInfo, error) {
 	retCpuInfo := &cpu.Info{
 		TotalCores:   0,
 		TotalThreads: 0,
 	}
 
-	ret := &extendedCPUInfo{
+	ret := &ExtendedCPUInfo{
 		CpuInfo:                  retCpuInfo,
 		NumLogicalProcessorsUsed: make(map[int]int, len(extCpuInfo.NumLogicalProcessorsUsed)),
 		LogicalProcessorsUsed:    make(map[int]struct{}),
@@ -821,7 +821,7 @@ func updateExtendedCPUInfo(extCpuInfo *extendedCPUInfo, used cpuset.CPUSet, disa
 	return ret, nil
 }
 
-func IsLogicalProcessorUsed(extCPUInfo *extendedCPUInfo, logicalProcessor int) bool {
+func IsLogicalProcessorUsed(extCPUInfo *ExtendedCPUInfo, logicalProcessor int) bool {
 	_, ok := extCPUInfo.LogicalProcessorsUsed[logicalProcessor]
 	return ok
 }

--- a/pkg/performanceprofile/profilecreator/profilecreator_test.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator_test.go
@@ -249,7 +249,7 @@ var _ = Describe("PerformanceProfileCreator: Consuming GHW Snapshot from Must Ga
 var _ = Describe("Performance profile creator: test with a simple cpu architecture to see algorithm easely", func() {
 	Context("With 16 cores, 32 Threads, 2 sockets 2 NUMA zones", func() {
 
-		var sysInfo systemInfo
+		var sysInfo SystemInfo
 
 		BeforeEach(func() {
 			core0 := cpu.ProcessorCore{
@@ -443,7 +443,7 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 				LogicalProcessorsUsed:    make(map[int]struct{}),
 			}
 
-			sysInfo = systemInfo{
+			sysInfo = SystemInfo{
 				CpuInfo:      &extCpuInfo,
 				TopologyInfo: &topologyInfo,
 				HtEnabled:    true,

--- a/pkg/performanceprofile/profilecreator/profilecreator_test.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator_test.go
@@ -437,7 +437,7 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 				Processors:   processors,
 			}
 
-			extCpuInfo := extendedCPUInfo{
+			extCpuInfo := ExtendedCPUInfo{
 				CpuInfo:                  &cpuInfo,
 				NumLogicalProcessorsUsed: make(map[int]int),
 				LogicalProcessorsUsed:    make(map[int]struct{}),

--- a/test/e2e/performanceprofile/functests/0_config/config.go
+++ b/test/e2e/performanceprofile/functests/0_config/config.go
@@ -3,6 +3,7 @@ package __performance_config
 import (
 	"context"
 	"fmt"
+	"github.com/jaypipes/ghw/pkg/cpu"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/profilecreator"
 	"os"
 	"time"
@@ -253,5 +254,30 @@ func testProfile() (*performancev2.PerformanceProfile, error) {
 }
 
 func getSysInfoForPPC() profilecreator.SystemInfo {
-	return nil
+	cpuInfo := cpu.Info{
+		TotalCores:   getTotalcores(),
+		TotalThreads: getTotalThreads(),
+		Processors:   processors,
+	}
+
+	extCpuInfo := profilecreator.ExtendedCPUInfo{
+		CpuInfo:                  &cpuInfo,
+		NumLogicalProcessorsUsed: make(map[int]int),
+		LogicalProcessorsUsed:    make(map[int]struct{}),
+	}
+
+	sysInfo := profilecreator.SystemInfo{
+		CpuInfo:      &extCpuInfo,
+		TopologyInfo: &topologyInfo,
+		HtEnabled:    true,
+	}
+	return sysInfo
+}
+
+func getTotalcores() uint32 {
+
+}
+
+func getTotalThreads() uint32 {
+
 }


### PR DESCRIPTION
We've been observing lately that some tests that involve disabling load balancing are failing (like 32646) because the expected result does not have specific anticipated CPUs. After investigation, it turns out that one factor is the profile configuration of the CPU distribution.

PAO functional tests configure fixed CPU values under the PP. This is considered misconfiguration, especially when the system has more than 4 CPUs, and there is no guarantee that the functionality of the performance profile controller will work adequately with not all cpus reflected in the CPU section in the PP.

To fix this, we check the actual CPU capacity on a worker node and divide that between reserved and isolated (required cpu fields in PP).