### PR TITLE
CNF-9173: e2e: mixedcpus test

### DIFF
--- a/test/e2e/performanceprofile/functests/11_mixedcpus/11_mixedcpus_suite_test.go
+++ b/test/e2e/performanceprofile/functests/11_mixedcpus/11_mixedcpus_suite_test.go
@@ -5,17 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
 )
 
 func TestMixedCPUs(t *testing.T) {
-	BeforeSuite(func() {
-		if discovery.Enabled() && testutils.ProfileNotFound {
-			Skip("discovery mode enabled, performance profile not found")
-		}
-	})
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Performance Profile Mixed Cpus")
 }

--- a/test/e2e/performanceprofile/functests/utils/cgroup/v1/v1.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/v1/v1.go
@@ -30,8 +30,8 @@ func (cm *ControllersManager) CpuSet(ctx context.Context, pod *corev1.Pod, conta
 	dirPath := path.Join(controller.CgroupMountPoint, "cpuset", childName)
 	store := map[string]*string{
 		"cpuset.cpus":               &cfg.Cpus,
-		"cpuset.cpus.exclusive":     &cfg.Exclusive,
-		"cpuset.cpus.effective":     &cfg.Effective,
+		"cpuset.cpu_exclusive":      &cfg.Exclusive,
+		"cpuset.effective_cpus":     &cfg.Effective,
 		"cpuset.sched_load_balance": &cfg.SchedLoadBalance,
 		"cpuset.mems":               &cfg.Mems,
 	}

--- a/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
+++ b/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
@@ -30,6 +30,9 @@ func init() {
 var TestingNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: testutils.NamespaceTesting,
+		Annotations: map[string]string{
+			"workload.mixedcpus.openshift.io/allowed": "",
+		},
 		Labels: map[string]string{
 			"security.openshift.io/scc.podSecurityLabelSync": "false",
 			"pod-security.kubernetes.io/audit":               "privileged",


### PR DESCRIPTION
This is a first PR (more to come) that tests the mixed-cpus e2e.
It contains the following tests:
1. Basic test to verify that pod which asks for shared cpus, has the shared cpus under
its cgroup cpuset.

2. Check that `cpu-quota.crio.io: disable` annotation works along with mixedcpus. 
3. Check that `OPENSHIFT_ISOLATED_CPUS` and `OPENSHIFT_SHARED_CPUS` env variables are under the container and configured properly.
4. Verify that updates to shared CPUs under the profile are reflect under the containers correctly.