### PR TITLE
CNF-10750: Adding env var to enable feautregates ignore versions differentiation

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -338,9 +338,11 @@ func migratePinnedSingleNodeInfraStatus(cfg *rest.Config, scheme *apiruntime.Sch
 func setupFeatureGates(ctx context.Context, config *rest.Config, operatorNamespace string) (featuregates.FeatureGate, error) {
 	missingVersion := "0.0.1-snapshot"
 	desiredVersion := missingVersion
-	if v, ok := os.LookupEnv(version.ReleaseVersionEnvVarName); ok {
-		desiredVersion = v
-	}
+	if val, ok := os.LookupEnv(version.OverrideReleaseVersionVarName); !ok || (ok && val != "true") {
+		if v, ok := os.LookupEnv(version.ReleaseVersionEnvVarName); ok {
+			desiredVersion = v
+		}
+	}	
 	configClient, err := configclient.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -338,11 +338,12 @@ func migratePinnedSingleNodeInfraStatus(cfg *rest.Config, scheme *apiruntime.Sch
 func setupFeatureGates(ctx context.Context, config *rest.Config, operatorNamespace string) (featuregates.FeatureGate, error) {
 	missingVersion := "0.0.1-snapshot"
 	desiredVersion := missingVersion
-	if val, ok := os.LookupEnv(version.OverrideReleaseVersionVarName); !ok || (ok && val != "true") {
-		if v, ok := os.LookupEnv(version.ReleaseVersionEnvVarName); ok {
-			desiredVersion = v
-		}
-	}	
+	if v, ok := os.LookupEnv(version.ReleaseVersionEnvVarName); ok {
+		desiredVersion = v
+	}
+	if v, ok := os.LookupEnv(version.OverrideReleaseVersionVarName); ok && v == "true" {
+		desiredVersion = missingVersion
+	}
 	configClient, err := configclient.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/version/version.go
+++ b/version/version.go
@@ -4,6 +4,7 @@ const (
 	OperandFilename          = "openshift-tuned"
 	OperatorFilename         = "cluster-node-tuning-operator"
 	ReleaseVersionEnvVarName = "RELEASE_VERSION"
+	OverrideReleaseVersionVarName = "OVERRIDE_RELEASE_VERSION"
 )
 
 var (


### PR DESCRIPTION
This modification has been added to enable manually upgrading NTO for developers who want to upgrade and test a custom NTO image.
In the current design, upgrading NTO to a specific version by disabling CVO and manually adjusting RELEASE_VERSION in the operator manifest results in a mismatch of the RELEASE_VERSION with the cluster version.
Therefore, feature gates will force NTO to exit.
The proposed solution bypasses this and will enable feature-gate logic to ignore the differentiation of the versions by setting OVERRIDE_RELEASE_VERSION to "true" in the NTO deployment manifest.
