### PR TITLE
OCPBUGS-25595: Make MC names deterministic

### DIFF
--- a/pkg/operator/mc.go
+++ b/pkg/operator/mc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -124,28 +125,54 @@ func ignEqual(mcOld, mcNew *mcfgv1.MachineConfig) (bool, error) {
 	return reflect.DeepEqual(ignOld.Storage.Files, ignNew.Storage.Files) && reflect.DeepEqual(ignOld.Systemd.Units, ignNew.Systemd.Units), nil
 }
 
-func getMachineConfigNameForPools(pools []*mcfgv1.MachineConfigPool) string {
+func printMachineConfigPoolsNames(pools []*mcfgv1.MachineConfigPool) string {
 	var (
 		sb        strings.Builder
-		sbPrimary strings.Builder
+		poolNames []string
 	)
 
-	sb.WriteString(MachineConfigPrefix)
 	for _, pool := range pools {
 		if pool == nil {
 			continue
 		}
-
-		sb.WriteString("-")
-		if pool.Name == "master" || pool.Name == "worker" {
-			sbPrimary.WriteString(pool.ObjectMeta.Name)
-		} else {
-			// This is a custom pool; a node can be a member of only one custom pool => return its name.
-			sb.WriteString(pool.ObjectMeta.Name)
-			return sb.String()
-		}
+		poolNames = append(poolNames, pool.ObjectMeta.Name)
 	}
-	sb.WriteString(sbPrimary.String())
+	sort.Strings(poolNames)
+
+	for i, poolName := range poolNames {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(poolName)
+	}
+
+	return sb.String()
+}
+
+// getMachineConfigNameForPools takes pools a slice of MachineConfigPools and returns
+// a MachineConfig name to be used for MachineConfigPool based matching.
+func getMachineConfigNameForPools(pools []*mcfgv1.MachineConfigPool) string {
+	var (
+		sb        strings.Builder
+		poolNames []string
+	)
+
+	for _, pool := range pools {
+		if pool == nil {
+			continue
+		}
+		poolNames = append(poolNames, pool.ObjectMeta.Name)
+	}
+	// See OCPBUGS-24792: the slice of MCP objects can be passed in random order.
+	sort.Strings(poolNames)
+
+	sb.WriteString(MachineConfigPrefix)
+	if len(poolNames) > 0 {
+		sb.WriteString("-")
+		// Use the first MCP's name out of all alphabetically sorted MCP names. This will either be a custom pool name
+		// or master/worker in that order.
+		sb.WriteString(poolNames[0])
+	}
 
 	return sb.String()
 }
@@ -186,6 +213,21 @@ func (pc *ProfileCalculator) getPoolsForMachineConfigLabels(mcLabels map[string]
 
 		pools = append(pools, p)
 	}
+
+	return pools, nil
+}
+
+// getPoolsForMachineConfigLabelsSorted is the same as getPoolsForMachineConfigLabels, but
+// returns the MCPs alphabetically sorted by their names.
+func (pc *ProfileCalculator) getPoolsForMachineConfigLabelsSorted(mcLabels map[string]string) ([]*mcfgv1.MachineConfigPool, error) {
+	pools, err := pc.getPoolsForMachineConfigLabels(mcLabels)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(pools, func(i, j int) bool {
+		return pools[i].Name < pools[j].Name
+	})
 
 	return pools, nil
 }
@@ -237,16 +279,18 @@ func (pc *ProfileCalculator) getPoolsForNode(node *corev1.Node) ([]*mcfgv1.Machi
 		klog.Errorf("node %s belongs to %d custom roles, cannot proceed with this Node", node.Name, len(custom))
 		return nil, nil
 	} else if len(custom) == 1 {
-		// We don't support making custom pools for masters
+		pls := []*mcfgv1.MachineConfigPool{}
 		if master != nil {
-			klog.Errorf("node %s has both master role and custom role %s", node.Name, custom[0].Name)
-			return nil, nil
+			// If we have a custom pool and master, defer to master and return.
+			pls = append(pls, master)
+		} else {
+			pls = append(pls, custom[0])
 		}
-		// One custom role, let's use its pool
-		pls := []*mcfgv1.MachineConfigPool{custom[0]}
 		if worker != nil {
 			pls = append(pls, worker)
 		}
+		// This allows us to have master, worker, infra but be in the master pool;
+		// or if !worker and !master then we just use the custom pool.
 		return pls, nil
 	} else if master != nil {
 		// In the case where a node is both master/worker, have it live under


### PR DESCRIPTION
OpenShift Nodes can be a part of only one custom MachineConfigPool. However, MCP configuration allows this not to be the case.  This is caught by the machine-config-controller and reported as an error (<node> belongs to <N> custom roles, cannot proceed with this Node).

In order to target an MCP with a configuration, NTO uses machineConfigLabels.  However, one or more MCPs can select a particular single MC.  This is due to the MCP's machineConfigSelector.  This is another challenge scenario.

In the above two scenarios, it was possible for NTO to generate a randomly-named MC based on the membership of one of the matching MCPs. Then, a pruning function would mistakenly remove the other MCs, seemingly unused.  This could result in a flip between the rendered MCs and cause a Node reboot.

This PR makes the process of establishing the names of the MC for the purposes of MachineConfigPool based matching deterministic.

Other changes/fixes:
 - Synced with MCO's latest getPoolsForNode() changes.
 - Logging in syncMachineConfigHyperShift().

Resolves: OCPBUGS-25595

This is a backport of https://github.com/openshift/cluster-node-tuning-operator/pull/888
