### PR TITLE
NO-JIRA: e2e: set performance profile cpus using env vars

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -1153,7 +1153,7 @@ func verifyV2Conversion(v2Profile *performancev2.PerformanceProfile, v1Profile *
 		}
 
 		if (specCPU.Offlined == nil) != (v1Profile.Spec.CPU.Offlined == nil) {
-			return fmt.Errorf("spec CPUs Isolated field is different")
+			return fmt.Errorf("spec CPUs Offlined field is different")
 		}
 		if specCPU.Offlined != nil {
 			if string(*specCPU.Offlined) != string(*v1Profile.Spec.CPU.Offlined) {

--- a/test/e2e/performanceprofile/functests/README.md
+++ b/test/e2e/performanceprofile/functests/README.md
@@ -17,6 +17,9 @@ This deployment takes some time and requires reboot
 Tests are executed in order of file-names
 So be careful with renaming existing or adding new suites
 
-DISCOVERY_MODE env variable to get an already deployed performanceProfile
+Environment variables:
+DISCOVERY_MODE: to get an already deployed performanceProfile.
 If DISCOVERY_MODE set to true the suites will search for a PerformanceProfile on the cluster and use it.
-If no PerformanceProfile is found, that suites will be skipped
+If no PerformanceProfile is found, that suites will be skipped.
+
+RESERVED_CPU_SET, ISOLATED_CPU_SET, OFFLINED_CPU_SET: strings that present the CPU sets distributed between reserved, isolated, and offlined CPU profile specifications. The runner is responsible for validating that these values are compatible with the testing environment. 


### PR DESCRIPTION
We've been observing lately that some tests that involve disabling load balancing are failing (like 32646) because the expected result does not have specific anticipated CPUs. After investigation, it turns out that one factor is the profile configuration of the CPU distribution.

PAO functional tests configure fixed CPU values under the PP. This is considered misconfiguration, especially when the system has more than 4 CPUs, and there is no guarantee that the functionality of the performance profile controller will work adequately with not all cpus reflected in the CPU section in the PP.

To resolve this complication, we are introducing new environment variables RESERVED_CPU_SET, ISOLATED_CPU_SET, OFFLINED_CPU_SET, should be set the profile would use them instead of the defaults.