### PR TITLE
NO-JIRA: e2e: log: set ctrl-runtime logger

### DIFF
--- a/test/e2e/performanceprofile/functests/0_config/test_suite_performance_config_test.go
+++ b/test/e2e/performanceprofile/functests/0_config/test_suite_performance_config_test.go
@@ -5,12 +5,17 @@ package __performance_config_test
 
 import (
 	"flag"
+	"log"
+	"os"
 	"path"
 	"testing"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kniK8sReporter "github.com/openshift-kni/k8sreporter"
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
@@ -30,6 +35,7 @@ func init() {
 }
 
 func TestPerformanceConfig(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
 	// We want to collect logs before any resource is deleted in AfterEach, so we register the global fail handler
 	// in a way such that the reporter's Dump is always called before the default Fail.
 	RegisterFailHandler(func(message string, callerSkip ...int) {

--- a/test/e2e/performanceprofile/functests/1_performance/test_suite_performance_test.go
+++ b/test/e2e/performanceprofile/functests/1_performance/test_suite_performance_test.go
@@ -6,13 +6,18 @@ package __performance_test
 import (
 	"context"
 	"flag"
+	"log"
+	"os"
 	"path"
 	"testing"
 	"time"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kniK8sReporter "github.com/openshift-kni/k8sreporter"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -52,6 +57,7 @@ var _ = AfterSuite(func() {
 })
 
 func TestPerformance(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
 	// We want to collect logs before any resource is deleted in AfterEach, so we register the global fail handler
 	// in a way such that the reporter's Dump is always called before the default Fail.
 	RegisterFailHandler(func(message string, callerSkip ...int) {

--- a/test/e2e/performanceprofile/functests/2_performance_update/test_suite_performance_update_test.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/test_suite_performance_update_test.go
@@ -5,14 +5,19 @@ package __performance_update_test
 
 import (
 	"context"
+	"log"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
@@ -39,6 +44,8 @@ var _ = AfterSuite(func() {
 })
 
 func TestPerformanceUpdate(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Performance Addon Operator configuration")

--- a/test/e2e/performanceprofile/functests/3_performance_status/test_suite_performance_status_test.go
+++ b/test/e2e/performanceprofile/functests/3_performance_status/test_suite_performance_status_test.go
@@ -5,14 +5,19 @@ package __performance_status_test
 
 import (
 	"context"
+	"log"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
@@ -39,6 +44,8 @@ var _ = AfterSuite(func() {
 })
 
 func TestPerformanceUpdate(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Performance Addon Operator configuration")

--- a/test/e2e/performanceprofile/functests/4_latency/test_suite_latency_test.go
+++ b/test/e2e/performanceprofile/functests/4_latency/test_suite_latency_test.go
@@ -6,13 +6,18 @@ package __latency_test
 import (
 	"context"
 	"flag"
+	"log"
+	"os"
 	"path"
 	"testing"
 	"time"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kniK8sReporter "github.com/openshift-kni/k8sreporter"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -52,6 +57,7 @@ var _ = AfterSuite(func() {
 })
 
 func TestLatency(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
 	// We want to collect logs before any resource is deleted in AfterEach, so we register the global fail handler
 	// in a way such that the reporter's Dump is always called before the default Fail.
 	RegisterFailHandler(func(message string, callerSkip ...int) {

--- a/test/e2e/performanceprofile/functests/6_mustgather_testing/test_suite_mustgather_test.go
+++ b/test/e2e/performanceprofile/functests/6_mustgather_testing/test_suite_mustgather_test.go
@@ -2,13 +2,17 @@ package pao_mustgather
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"testing"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
@@ -43,6 +47,8 @@ var _ = AfterSuite(func() {
 })
 
 func TestPaoMustgatherTests(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Performance Profile must gather tests")

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/test_suite_performance_kubelet_node_test.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/test_suite_performance_kubelet_node_test.go
@@ -5,14 +5,19 @@ package __performance_kubelet_node_test
 
 import (
 	"context"
+	"log"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
@@ -40,6 +45,8 @@ var _ = AfterSuite(func() {
 })
 
 func TestPerformanceKubelet(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Performance Addon Operator Kubelet")

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/test_suite_performance_workloadhints_test.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/test_suite_performance_workloadhints_test.go
@@ -5,14 +5,19 @@ package __performance_workloadhints_test
 
 import (
 	"context"
+	"log"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	qe_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
@@ -39,6 +44,8 @@ var _ = AfterSuite(func() {
 })
 
 func TestPerformanceUpdate(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Performance Addon Operator WorkloadHints")

--- a/test/e2e/performanceprofile/functests/9_reboot/test_suite_reboot_test.go
+++ b/test/e2e/performanceprofile/functests/9_reboot/test_suite_reboot_test.go
@@ -5,12 +5,17 @@ package __reboot_test
 
 import (
 	"context"
+	"log"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
+
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -40,6 +45,8 @@ var _ = AfterSuite(func() {
 })
 
 func TestReboot(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
+
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Performance Addon Operator Reboot")


### PR DESCRIPTION
avoid nasty stacktrace when trying to log, because we didn't manage to set the logger explicitly.
Thus, avoid things like
```
 [rfe_id:27368][performance] Verify API Conversions  when the GloballyDisableIrqLoadBalancing field set to false should preserve the value during the v1 <-> v2 conversion
/go/src/github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/performance.go:727
[controller-runtime] log.SetLogger(...) was never called, logs will not be displayed:
goroutine 7762 [running]:
runtime/debug.Stack()
	/usr/lib/golang/src/runtime/debug/stack.go:24 +0x5e
sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go:59 +0xcd
sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0xc000328b00, 0x800000000000000?)
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/sigs.k8s.io/controller-runtime/pkg/log/deleg.go:111 +0x32
github.com/go-logr/logr.Logger.Enabled(...)
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/github.com/go-logr/logr/logr.go:261
github.com/go-logr/logr.Logger.Info({{0x1e4a498?, 0xc000328b00?}, 0xc00030cd00?}, {0xc00030cd00, 0x8f}, {0x0, 0x0, 0x0})
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/github.com/go-logr/logr/logr.go:274 +0x72
sigs.k8s.io/controller-runtime/pkg/log.(*KubeAPIWarningLogger).HandleWarningHeader(0xc00011c3f0?, 0x1?, {0x1b53b78?, 0x7?}, {0xc00030cd00?, 0x8f?})
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/sigs.k8s.io/controller-runtime/pkg/log/warning_handler.go:65 +0x167
k8s.io/client-go/rest.handleWarnings(0xc00047f530?, {0x1e2d360?, 0xc00011c3f0?})
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/k8s.io/client-go/rest/warnings.go:144 +0xef
k8s.io/client-go/rest.(*Request).transformResponse(0xc000a3a6c0, 0xc000a625a0, 0xc0004fc800)
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/k8s.io/client-go/rest/request.go:1155 +0x5c8
k8s.io/client-go/rest.(*Request).Do.func1(0xc000804500?, 0x0?)
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/k8s.io/client-go/rest/request.go:1040 +0x31
k8s.io/client-go/rest.(*Request).request.func3.1(...)
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/k8s.io/client-go/rest/request.go:1015
k8s.io/client-go/rest.(*Request).request.func3(0xc000a625a0, 0xc0005fdca8, {0x1e47698?, 0xc000804500?}, 0x0?, 0x0?, 0xc00084cfc0?, {0x0?, 0x0?}, 0x1c98a00)
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/k8s.io/client-go/rest/request.go:1022 +0xd7
k8s.io/client-go/rest.(*Request).request(0xc000a3a6c0, {0x1e472c8, 0x2cf75a0}, 0x2?)
	/go/src/github.com/openshift/cluster-node-tuning-operator/vendor/k8s.io/client-go/rest/request.go:1024 +0x4ed
k8s.io/client-go/rest.(*Request).Do(0xc000a3a6c0, {0x1e472c8, 0x2cf75a0})
```

xref: #881 