### PR TITLE
OCPBUGS-25860: Disable managed interrupts for smartpqi

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -170,6 +170,12 @@ cmdline_pstate=+intel_pstate=active
 cmdline_pstate=+intel_pstate=${automatic_pstate}
 {{end}}
 
+# In case a smartpqi device is present, make sure the interrupt affinity
+# can be managed by userspace services. This driver does not obey
+# the isolcpus=managed_irq hint and is causing interference.
+# See: https://issues.redhat.com/browse/OCPBUGS-25860
+cmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\bsmartpqi\b:smartpqi.disable_managed_interrupts=1:}
+
 [rtentsk]
 
 {{ if .HardwareTuning }}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -51,7 +51,10 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n# In case a
+      smartpqi device is present, make sure the interrupt affinity\n# can be managed
+      by userspace services. This driver does not obey\n# the isolcpus=managed_irq
+      hint and is causing interference.\n# See: https://issues.redhat.com/browse/OCPBUGS-25860\ncmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\\bsmartpqi\\b:smartpqi.disable_managed_interrupts=1:}\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -51,7 +51,10 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n# In case a
+      smartpqi device is present, make sure the interrupt affinity\n# can be managed
+      by userspace services. This driver does not obey\n# the isolcpus=managed_irq
+      hint and is causing interference.\n# See: https://issues.redhat.com/browse/OCPBUGS-25860\ncmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\\bsmartpqi\\b:smartpqi.disable_managed_interrupts=1:}\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -51,7 +51,10 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n# In case a
+      smartpqi device is present, make sure the interrupt affinity\n# can be managed
+      by userspace services. This driver does not obey\n# the isolcpus=managed_irq
+      hint and is causing interference.\n# See: https://issues.redhat.com/browse/OCPBUGS-25860\ncmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\\bsmartpqi\\b:smartpqi.disable_managed_interrupts=1:}\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -51,7 +51,10 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n# In case a
+      smartpqi device is present, make sure the interrupt affinity\n# can be managed
+      by userspace services. This driver does not obey\n# the isolcpus=managed_irq
+      hint and is causing interference.\n# See: https://issues.redhat.com/browse/OCPBUGS-25860\ncmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\\bsmartpqi\\b:smartpqi.disable_managed_interrupts=1:}\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -51,7 +51,10 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n# In case a
+      smartpqi device is present, make sure the interrupt affinity\n# can be managed
+      by userspace services. This driver does not obey\n# the isolcpus=managed_irq
+      hint and is causing interference.\n# See: https://issues.redhat.com/browse/OCPBUGS-25860\ncmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\\bsmartpqi\\b:smartpqi.disable_managed_interrupts=1:}\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -51,7 +51,10 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n# In case a
+      smartpqi device is present, make sure the interrupt affinity\n# can be managed
+      by userspace services. This driver does not obey\n# the isolcpus=managed_irq
+      hint and is causing interference.\n# See: https://issues.redhat.com/browse/OCPBUGS-25860\ncmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\\bsmartpqi\\b:smartpqi.disable_managed_interrupts=1:}\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -49,7 +49,10 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=active\n\n\n[rtentsk]\n\n\n[sysfs]\n#
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=active\n\n\n#
+      In case a smartpqi device is present, make sure the interrupt affinity\n# can
+      be managed by userspace services. This driver does not obey\n# the isolcpus=managed_irq
+      hint and is causing interference.\n# See: https://issues.redhat.com/browse/OCPBUGS-25860\ncmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\\bsmartpqi\\b:smartpqi.disable_managed_interrupts=1:}\n\n[rtentsk]\n\n\n[sysfs]\n#
       sets provided frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -51,7 +51,10 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n#
+      In case a smartpqi device is present, make sure the interrupt affinity\n# can
+      be managed by userspace services. This driver does not obey\n# the isolcpus=managed_irq
+      hint and is causing interference.\n# See: https://issues.redhat.com/browse/OCPBUGS-25860\ncmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\\bsmartpqi\\b:smartpqi.disable_managed_interrupts=1:}\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -49,7 +49,10 @@ spec:
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
       intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n#
+      In case a smartpqi device is present, make sure the interrupt affinity\n# can
+      be managed by userspace services. This driver does not obey\n# the isolcpus=managed_irq
+      hint and is causing interference.\n# See: https://issues.redhat.com/browse/OCPBUGS-25860\ncmdline_smartpqi=+${f:regex_search_ternary:${f:exec:/usr/sbin/lsmod}:\\bsmartpqi\\b:smartpqi.disable_managed_interrupts=1:}\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance


### PR DESCRIPTION
This driver does not obey the isolcpus=managed_irq hint and is causing interference.

This kernel argument makes sure the interrupt affinity can be managed by userspace services.

The alternative approach using /etc/modprobe.d/smartpqi.conf with option smartpqi ... does not work, because the driver is loaded early at the initrd stage and we would have to rebuild the RHCOS initrd. That is much heavier than a simple kernel arg.