### PR TITLE
CNF-6517: Export ValidateBasicFields for Hypershift

### DIFF
--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -65,7 +65,7 @@ func (r *PerformanceProfile) validateCreateOrUpdate() (admission.Warnings, error
 	allErrs = append(allErrs, r.validateNodeSelectorDuplication(ppList)...)
 
 	// validate basic fields
-	allErrs = append(allErrs, r.validateFields()...)
+	allErrs = append(allErrs, r.ValidateBasicFields()...)
 
 	if len(allErrs) == 0 {
 		return admission.Warnings{}, nil
@@ -102,7 +102,7 @@ func (r *PerformanceProfile) validateNodeSelectorDuplication(ppList *Performance
 	return allErrs
 }
 
-func (r *PerformanceProfile) validateFields() field.ErrorList {
+func (r *PerformanceProfile) ValidateBasicFields() field.ErrorList {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, r.validateCPUs()...)

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -433,7 +433,7 @@ var _ = Describe("PerformanceProfile", func() {
 			profile.Spec.Net.Devices[0].VendorID = pointer.StringPtr(invalidVendor)
 			profile.Spec.Net.Devices[0].DeviceID = pointer.StringPtr(invalidDevice)
 
-			errors := profile.validateFields()
+			errors := profile.ValidateBasicFields()
 
 			type void struct{}
 			var member void


### PR DESCRIPTION
In Hypershift we need to validate PerformanceProfile from NodePool controller.
As a one-to-one relationship between NodePool and Performance Profile is already enforced there is no need ( and no easy way ) to check for PerformanceProfiles with duplicated selectors, so we just need to check the fields.