### PR TITLE
Revert "NO-JIRA: skip crun configuration test"

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -1179,7 +1179,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 
 		When("updates the default runtime to crun", func() {
 			It("should run high-performance runtimes class with crun as container-runtime", func() {
-				testutils.KnownIssueJira("OCPBUGS-26589")
 				const ContainerRuntimeConfigName = "ctrcfg-test"
 
 				key := types.NamespacedName{


### PR DESCRIPTION
Reverts openshift/cluster-node-tuning-operator#917
a crun version that contains https://github.com/containers/crun/pull/1384  fix is in, let's see if the test is passing now