### PR TITLE
Improve error handling in tuned render cmd

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	coreerrors "errors"
 	"flag"
 	"fmt"
 	"os"
@@ -381,7 +382,13 @@ func main() {
 	switch runAs {
 	case version.OperatorFilename:
 		prepareCommands()
-		_ = rootCmd.Execute()
+		if err := rootCmd.Execute(); err != nil {
+			klog.Error("error found con command", err)
+			if coreerrors.Is(err, tunedrender.ErrorNoPerformanceProfileFound) {
+				os.Exit(69)
+			}
+			os.Exit(255)
+		}
 	case version.OperandFilename:
 		tunedOperandRun()
 	default:

--- a/pkg/tuned/cmd/render/cmd.go
+++ b/pkg/tuned/cmd/render/cmd.go
@@ -37,16 +37,20 @@ func NewRenderBootCmdMCCommand() *cobra.Command {
 	renderOpts := renderOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "render-bootcmd-mc",
-		Short: "Render MC with kernel args",
-		Run: func(cmd *cobra.Command, args []string) {
+		Use:          "render-bootcmd-mc",
+		Short:        "Render MC with kernel args",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := renderOpts.Validate(); err != nil {
-				klog.Fatal(err)
+				klog.Error(err)
+				return err
 			}
 
 			if err := renderOpts.Run(); err != nil {
-				klog.Fatal(err)
+				klog.Error(err)
+				return err
 			}
+			return nil
 		},
 	}
 

--- a/pkg/tuned/cmd/render/render.go
+++ b/pkg/tuned/cmd/render/render.go
@@ -14,6 +14,7 @@ limitations under the License.
 package render
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,9 +42,10 @@ import (
 )
 
 var (
-	manifestScheme = runtime.NewScheme()
-	codecFactory   serializer.CodecFactory
-	runtimeDecoder runtime.Decoder
+	manifestScheme                 = runtime.NewScheme()
+	codecFactory                   serializer.CodecFactory
+	runtimeDecoder                 runtime.Decoder
+	ErrorNoPerformanceProfileFound = errors.New("PerformanceProfile Not Found")
 )
 
 func init() {
@@ -146,7 +148,7 @@ func render(inputDir []string, outputDir string, mcpName string) error {
 
 	if len(filteredPerformanceProfiles) == 0 {
 		klog.Warningf("Cannot find any PerformanceProfile applicable to MachineConfigPool %s.", mcpName)
-		return fmt.Errorf("Cannot find any PerformanceProfile complying with MachineConfigPool %s.", mcpName)
+		return fmt.Errorf("%w: Cannot find any PerformanceProfile applicable to MachineConfigPool %s.", ErrorNoPerformanceProfileFound, mcpName)
 	}
 
 	if len(filteredPerformanceProfiles) > 1 {


### PR DESCRIPTION
As per [this conversation](https://github.com/openshift/cluster-node-tuning-operator/pull/833#issuecomment-1891793520) we need to be able to differentiate when the command is returning an error because there is no PerformanceProfile from the rest of errors [in the installer](https://github.com/openshift/installer/pull/7692).

To do that change command to pop errors up and return a different error code so scripts could handle this error differently 