### PR TITLE
create webhook in init container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ FROM quay.io/centos/centos:stream9
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/cluster-node-tuning-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/performance-profile-creator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/gather-sysinfo /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/init-webhook /usr/bin/
 COPY manifests/*.yaml manifests/image-references /manifests/
 ENV APP_ROOT=/var/lib/tuned
 ENV PATH=${APP_ROOT}/bin:${PATH}

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ clone-tuned:
 	  cd $(TUNED_DIR) && git checkout $(TUNED_COMMIT) && cd .. && \
 	  rm -rf $(TUNED_DIR)/.git)
 
-build: $(BINDATA) pkg/generated build-performance-profile-creator build-gather-sysinfo
+build: $(BINDATA) pkg/generated build-performance-profile-creator build-gather-sysinfo build-init-container
 	$(GO_BUILD_RECIPE)
 	ln -sf $(PACKAGE_BIN) $(OUT_DIR)/openshift-tuned
 
@@ -271,6 +271,12 @@ build-performance-profile-creator:
 performance-profile-creator-tests: build-performance-profile-creator
 	@echo "Running Performance Profile Creator Tests"
 	hack/run-test.sh -t "test/e2e/performanceprofile/functests-performance-profile-creator" -p "--v -r --fail-fast --flake-attempts=2" -m "Running Functional Tests" -r "--junit-report=/tmp/artifacts"
+
+# Init container
+.PHONY: build-init-container
+build-init-container:
+	@echo "Building Init Container (PPC)"
+	$(GO) build  -v -o $(OUT_DIR)/init-webhook ./cmd/init-container
 
 # Gather sysinfo binary for use in must-gather
 .PHONY: build-gather-sysinfo

--- a/cmd/init-container/main.go
+++ b/cmd/init-container/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+
+	v1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	yaml "sigs.k8s.io/yaml"
+)
+
+const webhookManifest string = `
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    capability.openshift.io/name: NodeTuning
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: performance-addon-operator
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: performance-addon-operator-service
+        namespace: openshift-cluster-node-tuning-operator
+        path: /validate-performance-openshift-io-v2-performanceprofile
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: vwb.performance.openshift.io
+    rules:
+      - apiGroups:
+          - performance.openshift.io
+        apiVersions:
+          - v2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - performanceprofiles
+        scope: '*'
+    sideEffects: None
+    timeoutSeconds: 10
+`
+
+func main() {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		klog.Fatal(err.Error())
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Fatal(err.Error())
+	}
+	webhook := &v1.ValidatingWebhookConfiguration{}
+	if err := yaml.Unmarshal([]byte(webhookManifest), webhook); err != nil {
+		klog.Fatal(err.Error())
+	}
+	_, err = clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(
+		context.TODO(), webhook.Name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.Infof("validating webhook %s not found, creating...", webhook.Name)
+			_, err = clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(
+				context.TODO(), webhook, metav1.CreateOptions{})
+			if err != nil {
+				klog.Fatalf("failed to create validating webhook %s: %v", webhook.Name, err)
+			}
+		}
+	}
+}

--- a/manifests/40-rbac.yaml
+++ b/manifests/40-rbac.yaml
@@ -107,6 +107,10 @@ rules:
 - apiGroups: ["apps"]
   resources: ["replicasets"]
   verbs: ["get"]
+# Needed for init container
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["get","create"]
 ---
 
 # Bind the operator cluster role to its Service Account.

--- a/manifests/45-webhook-configuration.yaml
+++ b/manifests/45-webhook-configuration.yaml
@@ -22,40 +22,40 @@ spec:
     name: cluster-node-tuning-operator
   type: ClusterIP
 
----
+# ---
 
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  annotations:
-    capability.openshift.io/name: NodeTuning
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    service.beta.openshift.io/inject-cabundle: "true"
-  name: performance-addon-operator
-webhooks:
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: performance-addon-operator-service
-        namespace: openshift-cluster-node-tuning-operator
-        path: /validate-performance-openshift-io-v2-performanceprofile
-        port: 443
-    failurePolicy: Fail
-    matchPolicy: Equivalent
-    name: vwb.performance.openshift.io
-    rules:
-      - apiGroups:
-          - performance.openshift.io
-        apiVersions:
-          - v2
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - performanceprofiles
-        scope: '*'
-    sideEffects: None
-    timeoutSeconds: 10
+# apiVersion: admissionregistration.k8s.io/v1
+# kind: ValidatingWebhookConfiguration
+# metadata:
+#   annotations:
+#     capability.openshift.io/name: NodeTuning
+#     include.release.openshift.io/self-managed-high-availability: "true"
+#     include.release.openshift.io/single-node-developer: "true"
+#     include.release.openshift.io/ibm-cloud-managed: "true"
+#     service.beta.openshift.io/inject-cabundle: "true"
+#   name: performance-addon-operator
+# webhooks:
+#   - admissionReviewVersions:
+#       - v1
+#     clientConfig:
+#       service:
+#         name: performance-addon-operator-service
+#         namespace: openshift-cluster-node-tuning-operator
+#         path: /validate-performance-openshift-io-v2-performanceprofile
+#         port: 443
+#     failurePolicy: Fail
+#     matchPolicy: Equivalent
+#     name: vwb.performance.openshift.io
+#     rules:
+#       - apiGroups:
+#           - performance.openshift.io
+#         apiVersions:
+#           - v2
+#         operations:
+#           - CREATE
+#           - UPDATE
+#         resources:
+#           - performanceprofiles
+#         scope: '*'
+#     sideEffects: None
+#     timeoutSeconds: 10

--- a/manifests/50-operator.yaml
+++ b/manifests/50-operator.yaml
@@ -39,9 +39,18 @@ spec:
         operator: "Exists"
         effect: "NoExecute"
         tolerationSeconds: 120 # Evict pods within 2 mins.
+      initContainers:
+        - name: create-validating-webhook
+          image: quay.io/vgrinber/cluster-node-tuning-operator:init
+          imagePullPolicy: Always
+          command:
+          - bash
+          - -c
+          args:
+          - init-webhook
       containers:
         - name: cluster-node-tuning-operator
-          image: registry.ci.openshift.org/openshift/origin-v4.0:cluster-node-tuning-operator
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:37244fa8e239e3aac7b555bb6742703f88de247671d87f2efaf9619f7b01ed45
           command:
           - cluster-node-tuning-operator
           args:
@@ -60,7 +69,7 @@ spec:
           - name: RESYNC_PERIOD
             value: "600"
           - name: CLUSTER_NODE_TUNED_IMAGE
-            value: registry.ci.openshift.org/openshift/origin-v4.0:cluster-node-tuning-operator
+            value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:37244fa8e239e3aac7b555bb6742703f88de247671d87f2efaf9619f7b01ed45
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
PoC
Create performance profile validating webhook
in an init container. This allows removing the
webhook manifest from the operator manifests, so it would not be applied during bootstrap. This solution can be potentially extended to skip webhook creation in the hypershift environment