### PR TITLE
NO-JIRA: Skip PerformanceProfile update test

### DIFF
--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
@@ -200,6 +200,7 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, func() {
 				initialProfile = profile.DeepCopy()
 			})
 			It("[test_id:64100] matches with ovs process affinity", func() {
+				testutils.KnownIssueJira("OCPBUGS-27834")
 				ovnPod, err := getOvnPod(context.TODO(), workerRTNode)
 				Expect(err).ToNot(HaveOccurred(), "Unable to get ovnPod")
 
@@ -221,6 +222,7 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, func() {
 			})
 
 			It("[test_id:64101] Creating gu pods modifies affinity of ovs", func() {
+				testutils.KnownIssueJira("OCPBUGS-27834")
 				var testpod *corev1.Pod
 				var err error
 				testpod = pods.GetTestPod()


### PR DESCRIPTION
This tests is failing because of a known issue that is already being handled.
In the meantime skip it to avoid PRs to pile.