### PR TITLE
CNF-11091: Change webhook failure policy to ignore

### DIFF
--- a/manifests/45-webhook-configuration.yaml
+++ b/manifests/45-webhook-configuration.yaml
@@ -43,7 +43,7 @@ webhooks:
         namespace: openshift-cluster-node-tuning-operator
         path: /validate-performance-openshift-io-v2-performanceprofile
         port: 443
-    failurePolicy: Fail
+    failurePolicy: Ignore
     matchPolicy: Equivalent
     name: vwb.performance.openshift.io
     rules:


### PR DESCRIPTION
Change performance profile validating webhook failure policy to "Ignore". This is needed as a temporary workaround for bootstrap-in-place, where webhooks can not be served. This PR should be reverted after a permanent solution for BiP is implemented

/cc @MarSik @yanirq 