### PR TITLE
CNF-10170: Avoid command to fail if there is no PP on input folders

### DIFF
--- a/assets/tuned/assets.go
+++ b/assets/tuned/assets.go
@@ -1,0 +1,11 @@
+package assets
+
+import "embed"
+
+var (
+	//go:embed manifests/default-cr-tuned.yaml
+	DefaultCrTuned []byte
+
+	//go:embed manifests
+	Manifests embed.FS
+)

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -375,12 +375,15 @@ func ProfilesExtract(profiles []tunedv1.TunedProfile, recommendedProfile string)
 	var (
 		change bool
 	)
-	klog.Info("profilesExtract(): extracting TuneD profiles")
+	klog.Infof("profilesExtract(): extracting %d TuneD profiles", len(profiles))
 
-	// Get a list of TuneD profiles names the recommended profile depends on.
-	recommendedProfileDeps := profileDepends(recommendedProfile)
-	// Add the recommended profile itself.
-	recommendedProfileDeps[recommendedProfile] = true
+	recommendedProfileDeps := map[string]bool{}
+	if len(recommendedProfile) > 0 {
+		// Get a list of TuneD profiles names the recommended profile depends on.
+		recommendedProfileDeps = profileDepends(recommendedProfile)
+		// Add the recommended profile itself.
+		recommendedProfileDeps[recommendedProfile] = true
+	}
 	extracted := map[string]bool{} // TuneD profile names present in TuneD CR and successfully extracted to /etc/tuned/<profile>/
 
 	for index, profile := range profiles {


### PR DESCRIPTION
When there is no enough information to choose a recommended TuneD profile from the input folder manifests we load the `default-cr-tuned` manifests.

modifies: #844 
see: https://github.com/openshift/installer/pull/8007