### PR TITLE
NO-JIRA: Fix e2e tests on SNO

### DIFF
--- a/test/e2e/testing_manifests/sno/kernel_parameter_add_rm-child.yaml
+++ b/test/e2e/testing_manifests/sno/kernel_parameter_add_rm-child.yaml
@@ -1,0 +1,21 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-kernel-parameter-remove-child
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift child profile, test removal of kernel parameter defined in parent profile
+      include=openshift-kernel-parameter-remove-parent
+      [bootloader]
+      cmdline_openshift_kernel_parameter_remove_child_a=+nto.e2e.child.add1 nto.e2e.child.add2
+      cmdline_openshift_kernel_parameter_remove_child_r=-nto.e2e.parent.remove
+    name: openshift-kernel-parameter-remove-child
+
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: "master"
+    priority: 10
+    profile: openshift-kernel-parameter-remove-child

--- a/test/e2e/testing_manifests/sno/kernel_parameter_add_rm-parent.yaml
+++ b/test/e2e/testing_manifests/sno/kernel_parameter_add_rm-parent.yaml
@@ -1,0 +1,20 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-kernel-parameter-remove-parent
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift parent profile, test removal of kernel parameter defined in parent profile
+      include=openshift-node
+      [bootloader]
+      cmdline_openshift_kernel_parameter_remove_parent=nto.e2e.parent.keep nto.e2e.parent.remove
+    name: openshift-kernel-parameter-remove-parent
+
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: "master"
+    priority: 20
+    profile: openshift-kernel-parameter-remove-parent

--- a/test/e2e/testing_manifests/sno/stalld-disable.yaml
+++ b/test/e2e/testing_manifests/sno/stalld-disable.yaml
@@ -1,0 +1,27 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-realtime
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift realtime profile
+      include=openshift-node,realtime
+      [variables]
+      # isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7
+      isolated_cores=1
+      #isolate_managed_irq=Y
+      not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+      [bootloader]
+      cmdline_ocp_realtime=+systemd.cpu_affinity=${not_isolated_cores_expanded}
+      [service]
+      service.stalld=stop,disable
+    name: openshift-realtime
+
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: "master"
+    priority: 20
+    profile: openshift-realtime

--- a/test/e2e/testing_manifests/sno/stalld.yaml
+++ b/test/e2e/testing_manifests/sno/stalld.yaml
@@ -1,0 +1,27 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-realtime
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift realtime profile
+      include=openshift-node,realtime
+      [variables]
+      # isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7
+      isolated_cores=1
+      #isolate_managed_irq=Y
+      not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+      [bootloader]
+      cmdline_ocp_realtime=+systemd.cpu_affinity=${not_isolated_cores_expanded}
+      [service]
+      service.stalld=start,enable
+    name: openshift-realtime
+
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: "master"
+    priority: 20
+    profile: openshift-realtime


### PR DESCRIPTION
[PR459](https://github.com/openshift/cluster-node-tuning-operator/pull/459) made adjustments to fix NTO e2e tests on SNO.  Unfortunately, the PR did not include 4 SNO manifests to test with.  This change fixes this issue.

