### PR TITLE
OCPBUGS-29183: e2e: when crun is enabled by default skip checking runc config

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -1163,9 +1163,25 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 	})
 
-	Context("ContainerRuntimeConfig", func() {
+	Context("ContainerRuntimeConfig", Ordered, func() {
+		var ctrcfg *machineconfigv1.ContainerRuntimeConfig
+		const ContainerRuntimeConfigName = "ctrcfg-test"
+		mcp := &machineconfigv1.MachineConfigPool{}
+		BeforeAll(func() {
+			key := types.NamespacedName{
+				Name: performanceMCP,
+			}
+			Expect(testclient.Client.Get(context.TODO(), key, mcp)).ToNot(HaveOccurred(), "cannot get MCP %q", performanceMCP)
+			By("checking if ContainerRuntimeConfig object already exists")
+			ctrcfg, err = getContainerRuntimeConfigFrom(context.TODO(), profile, mcp)
+			Expect(err).ToNot(HaveOccurred(), "failed to get ContainerRuntimeConfig from profile %q mcp %q", profile.Name, mcp.Name)
+		})
+
 		When("is not given", func() {
 			It("should run high-performance runtimes class with runc as container-runtime", func() {
+				if ctrcfg != nil {
+					Skip("runc is not the default runtime configuration")
+				}
 				cmd := []string{"cat", "/rootfs/etc/crio/crio.conf.d/99-runtimes.conf"}
 				for i := 0; i < len(workerRTNodes); i++ {
 					out, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &workerRTNodes[i])
@@ -1176,20 +1192,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 			})
 		})
-
-		When("updates the default runtime to crun", Ordered, func() {
-			BeforeAll(func() {
-				const ContainerRuntimeConfigName = "ctrcfg-test"
-
-				key := types.NamespacedName{
-					Name: performanceMCP,
-				}
-				mcp := &machineconfigv1.MachineConfigPool{}
-				Expect(testclient.Client.Get(context.TODO(), key, mcp)).ToNot(HaveOccurred(), "cannot get MCP %q", performanceMCP)
-
-				By("checking if ContainerRuntimeConfig object already exists")
-				ctrcfg, err := getContainerRuntimeConfigFrom(context.TODO(), profile, mcp)
-				Expect(err).ToNot(HaveOccurred(), "failed to get ContainerRuntimeConfig from profile %q mcp %q", profile.Name, mcp.Name)
+		When("updates the default runtime to crun", func() {
+			It("should run high-performance runtimes class with crun as container-runtime", func() {
 				if ctrcfg == nil {
 					testlog.Infof("ContainerRuntimeConfig not exist")
 					ctrcfg = newContainerRuntimeConfig(ContainerRuntimeConfigName, profile, mcp)
@@ -1210,8 +1214,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 					mcps.WaitForConditionFunc(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue, getMCPConditionStatus)
 				}
 				Expect(ctrcfg.Spec.ContainerRuntimeConfig.DefaultRuntime == machineconfigv1.ContainerRuntimeDefaultRuntimeCrun).To(BeTrue())
-			})
-			It("should run high-performance runtimes class with crun as container-runtime", func() {
 				cmd := []string{"cat", "/rootfs/etc/crio/crio.conf.d/99-runtimes.conf"}
 				for i := 0; i < len(workerRTNodes); i++ {
 					out, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &workerRTNodes[i])


### PR DESCRIPTION
This patch fixes runc configuration test which
was failing when crun is configured prior to running the test

In this patch we move BeforeAll at the context level to check if any container runtime is pre configured

if crun is preconfigured: skip runc config test
if crun is not preconfigured: check runc configuration and in the subsequent test, we enable crun and test crun and delete crun configuration