### PR TITLE
[release-4.15][manual] OCPBUGS-29396: Labels for e2e testing 

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/label/label.go
+++ b/test/e2e/performanceprofile/functests/utils/label/label.go
@@ -41,9 +41,9 @@ const (
 	PerformanceProfileCreator Feature = "performance-profile-creator"
 )
 
-// Tire is a label to classify tests under specific grade/level
+// Tier is a label to classify tests under specific grade/level
 // that should roughly describe the execution complexity, maintainer identity and processing criteria.
-type Tire string
+type Tier string
 
 const (
 	// Tier0 are automated unit tests
@@ -51,7 +51,7 @@ const (
 	// Process criteria:
 	// 100% automated, must-pass 100%
 	// Development maintains tests, and reviews result
-	Tier0 Tire = "tier-0"
+	Tier0 Tier = "tier-0"
 
 	// Tier1 are component level functional tests
 	// Minimal time needed to execute (minutes to hours)
@@ -59,7 +59,7 @@ const (
 	// Executed after tier 0 passing
 	// 100% automated and must pass 100%
 	// QE / Development maintains tests and reviews results
-	Tier1 Tire = "tier-1"
+	Tier1 Tier = "tier-1"
 
 	// Tier2 are integration level functional tests
 	// May include basic non-functional tests (security, performance regression, install, compose validation)
@@ -68,7 +68,7 @@ const (
 	// Executed after components pass tier 1 testing
 	// 100% automated and must pass 100%
 	// QE maintains tests and reviews result
-	Tier2 Tire = "tier-2"
+	Tier2 Tier = "tier-2"
 
 	// Tier3 are system, scenario and non-functional tests (which includes Fault Tolerance / Recovery / Fail over)
 	// Test that don't fit in tier 2 due to time, complexity, and other factors
@@ -77,5 +77,5 @@ const (
 	// System or scenario testing doesn't block Non-functional tests.They can be executed in parallel.
 	// 100% automated
 	// QE maintains tests and reviews result
-	Tier3 Tire = "tier-3"
+	Tier3 Tier = "tier-3"
 )

--- a/test/e2e/performanceprofile/functests/utils/label/label.go
+++ b/test/e2e/performanceprofile/functests/utils/label/label.go
@@ -1,0 +1,81 @@
+package label
+
+// The label package contains a list of labels that can be used in
+// the functests to indicate and point certain behavior or characteristics
+// of the various tests.
+// Those can be filtered/focused by ginkgo before the test runs.
+
+// Kind is a label indicates specific criteria that classify the test.
+// A Mixture of kinds can be used for the same test
+type Kind string
+
+const (
+	// Slow means test that usually requires reboot or takes a long time to finish.
+	Slow Kind = "slow"
+
+	// ReleaseCritical is for tests that are critical for a successful release of the component that is being tested.
+	ReleaseCritical Kind = "release-critical"
+
+	// SpecializedHardware is for tests that need special Hardware like SR-IOV devices, specific NICs, etc.
+	SpecializedHardware Kind = "specialized-hardware"
+)
+
+// Feature is a label indicates the feature that being tested.
+type Feature string
+
+const (
+	// WorkloadHints should be added in tests that are validating/verifying workload-hints behavior.
+	WorkloadHints Feature = "workload-hints"
+
+	// MustGather should be added in tests that are validating/verifying must-gather tool functionality.
+	MustGather Feature = "must-gather"
+
+	// MixedCPUs should be added in tests that are validating/verifying mixed-cpus feature functionality.
+	MixedCPUs Feature = "mixed-cpus"
+
+	// Latency should be added in tests that are meant to test latency sensitivity.
+	Latency Feature = "latency"
+
+	// PerformanceProfileCreator should be added in tests that are validating/verifying performance-profile-creator tool
+	// functionally.
+	PerformanceProfileCreator Feature = "performance-profile-creator"
+)
+
+// Tire is a label to classify tests under specific grade/level
+// that should roughly describe the execution complexity, maintainer identity and processing criteria.
+type Tire string
+
+const (
+	// Tier0 are automated unit tests
+	// Minimal time needed to execute (minutes to 1 hour)
+	// Process criteria:
+	// 100% automated, must-pass 100%
+	// Development maintains tests, and reviews result
+	Tier0 Tire = "tier-0"
+
+	// Tier1 are component level functional tests
+	// Minimal time needed to execute (minutes to hours)
+	// Process criteria:
+	// Executed after tier 0 passing
+	// 100% automated and must pass 100%
+	// QE / Development maintains tests and reviews results
+	Tier1 Tire = "tier-1"
+
+	// Tier2 are integration level functional tests
+	// May include basic non-functional tests (security, performance regression, install, compose validation)
+	// Runs during nightly time frame
+	// Process criteria:
+	// Executed after components pass tier 1 testing
+	// 100% automated and must pass 100%
+	// QE maintains tests and reviews result
+	Tier2 Tire = "tier-2"
+
+	// Tier3 are system, scenario and non-functional tests (which includes Fault Tolerance / Recovery / Fail over)
+	// Test that don't fit in tier 2 due to time, complexity, and other factors
+	// Process criteria:
+	// Executed after components pass tier 2 testing
+	// System or scenario testing doesn't block Non-functional tests.They can be executed in parallel.
+	// 100% automated
+	// QE maintains tests and reviews result
+	Tier3 Tire = "tier-3"
+)


### PR DESCRIPTION
backport of:
* https://github.com/openshift/cluster-node-tuning-operator/pull/947
* https://github.com/openshift/cluster-node-tuning-operator/pull/936 
