### PR TITLE
OCPBUGS-23167: Add performance real time tuned template

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -1,6 +1,12 @@
 [main]
 summary=Openshift node optimized for deterministic performance at the cost of increased power consumption, focused on low latency network performance. Based on Tuned 2.11 and Cluster node tuning (oc 4.5)
-include=openshift-node,cpu-partitioning
+
+# In case real time kernel is enabled the following include section will be evaluated as:
+# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
+# Otherwise:
+# include=openshift-node,cpu-partitioning
+include=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:}
+
 
 # Inheritance of base profiles legend:
 # cpu-partitioning -> network-latency -> latency-performance
@@ -78,10 +84,6 @@ vm.stat_interval=10
 #> scheduled timers when starting a guaranteed workload (= 1)
 kernel.timer_migration=1
 #> network-latency
-# TODO once rhbz#2120328 is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll do not exist on RT kernels
-kernel.numa_balancing=0
-net.core.busy_read=50
-net.core.busy_poll=50
 net.ipv4.tcp_fastopen=3
 
 # If a workload mostly uses anonymous memory and it hits this limit, the entire

--- a/assets/performanceprofile/tuned/openshift-node-performance-rt
+++ b/assets/performanceprofile/tuned/openshift-node-performance-rt
@@ -1,0 +1,8 @@
+[main]
+summary=Real time profile to override unsupported settings
+
+[sysctl]
+#Real time kernel doesn't support the following kernel parameters.
+#The openshift-node-performance profile inherits these kernel parameters from the network-latency profile. 
+#Therefore, if the real time kernel is detected they will be dropped, meaning won't be applied.
+drop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll

--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -41,3 +41,5 @@ function rendersync() {
 rendersync manual-cluster/performance base/performance default
 rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap/no-mcp
 rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap-cluster/extra-mcp bootstrap/extra-mcp
+rendersync --owner-ref none -- base/performance manual-cluster/performance no-ref 
+rendersync --owner-ref none -- base/performance manual-cluster/cpuFrequency default/cpuFrequency 

--- a/pkg/performanceprofile/controller/performanceprofile/components/consts.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/consts.go
@@ -21,6 +21,8 @@ const (
 	NamespaceNodeTuningOperator = "openshift-cluster-node-tuning-operator"
 	// ProfileNamePerformance defines the performance tuned profile name
 	ProfileNamePerformance = "openshift-node-performance"
+	// ProfileNamePerformanceRT defines the performance real time tuned profile name
+	ProfileNamePerformanceRT = "openshift-node-performance-rt"
 )
 
 const (

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
@@ -37,6 +37,7 @@ const (
 	templateReservedCpuMaxFreq              = "ReservedCpuMaxFreq"
 	templateIsolatedCpuList                 = "IsolatedCpuList"
 	templateReservedCpuList                 = "ReservedCpuList"
+	templatePerformanceProfileName          = "PerformanceProfileName"
 )
 
 func new(name string, profiles []tunedv1.TunedProfile, recommends []tunedv1.TunedRecommend) *tunedv1.Tuned {
@@ -59,6 +60,8 @@ func new(name string, profiles []tunedv1.TunedProfile, recommends []tunedv1.Tune
 // NewNodePerformance returns tuned profile for performance sensitive workflows
 func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tuned, error) {
 	templateArgs := make(map[string]interface{})
+
+	templateArgs[templatePerformanceProfileName] = profile.Name
 
 	if profile.Spec.CPU.Isolated != nil {
 		templateArgs[templateIsolatedCpus] = string(*profile.Spec.CPU.Isolated)
@@ -215,11 +218,20 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 		return nil, err
 	}
 
+	RealTimeKernelProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNamePerformanceRT), templateArgs)
+	if err != nil {
+		return nil, err
+	}
 	name := components.GetComponentName(profile.Name, components.ProfileNamePerformance)
+	RealTimeKernelProfileName := components.GetComponentName(profile.Name, components.ProfileNamePerformanceRT)
 	profiles := []tunedv1.TunedProfile{
 		{
 			Name: &name,
 			Data: &profileData,
+		},
+		{
+			Name: &RealTimeKernelProfileName,
+			Data: &RealTimeKernelProfileData,
 		},
 	}
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
       \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
       \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
       \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
       \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -8,7 +8,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -25,9 +27,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -52,6 +52,11 @@ spec:
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=active\n\n\n[rtentsk]\n\n\n[sysfs]\n#
       sets provided frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
     name: openshift-node-performance-manual
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -8,7 +8,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -25,9 +27,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -51,6 +51,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf


### PR DESCRIPTION
Kernel parameters that are not supported on RT kernel systems are being applied, causing errors to be logged to the tuned daemon, resulting in a degraded profile state.
Therefore, I added the openshift-node-performance-rt profile that would be included if an RT kernel is detected, thereby dropping the unsupported kernel parameters before they are applied.