### PR TITLE
OCPBUGS-29596: e2e: Enhance tests related to crio annotations

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/cgroup/controller/controller.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/controller/controller.go
@@ -14,7 +14,7 @@ type CpuSet struct {
 }
 
 type Cpu struct {
-	Quota   string
-	Period  string
-	cpuStat map[string]string
+	Quota  string
+	Period string
+	Stat   map[string]string
 }

--- a/test/e2e/performanceprofile/functests/utils/cgroup/v1/v1.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/v1/v1.go
@@ -57,7 +57,32 @@ func (cm *ControllersManager) Cpu(ctx context.Context, pod *corev1.Pod, containe
 	output := strings.Split(string(b), "\r\n")
 	cfg.Quota = output[0]
 	cfg.Period = output[1]
+	cfg.Stat, err = stat(cm.k8sClient, pod, containerName, childName)
+	if err != nil {
+		return nil, err
+	}
 	return cfg, nil
+}
+
+// stat fetch cpu.stat values
+func stat(k8sclient *kubernetes.Clientset, pod *corev1.Pod, containerName, childName string) (map[string]string, error) {
+	cpuStat := make(map[string]string)
+	dirPath := path.Join(controller.CgroupMountPoint, childName)
+	cmd := []string{
+		"/bin/cat",
+		dirPath + "/cpu/cpu.stat",
+	}
+	statBytes, err := pods.ExecCommandOnPod(k8sclient, pod, containerName, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve cgroup config for pod. pod=%q, container=%q; %w", client.ObjectKeyFromObject(pod).String(), containerName, err)
+	}
+	output := strings.TrimSpace(string(statBytes))
+	interfacevalues := strings.Split(output, "\r\n")
+	for _, v := range interfacevalues {
+		values := strings.Split(v, " ")
+		cpuStat[values[0]] = values[1]
+	}
+	return cpuStat, nil
 }
 
 func (cm *ControllersManager) Pod(ctx context.Context, pod *corev1.Pod, controllerConfig interface{}) error {


### PR DESCRIPTION
1. Add new test case  for testing cpu-quota.crio.io annotation
2. Move the existing cpu load balancing test under single container where all the tests related to crio annotation exist
3. Modify tests to be executed under different runtimes and cgroup versions