### PR TITLE
OCPBUGS-29594: e2e: fix comparing incompatible types

### DIFF
--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -84,7 +84,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				By("Modifying profile")
 				profile.Spec.WorkloadHints = nil
 
-				if profile.Spec.RealTimeKernel.Enabled == pointer.Bool(false) {
+				if *profile.Spec.RealTimeKernel.Enabled != true {
 					testutils.KnownIssueJira("OCPBUGS-28828")
 				}
 				profile.Spec.RealTimeKernel = &performancev2.RealTimeKernel{
@@ -141,7 +141,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 			It("[test_id:50991][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", func() {
 				By("Modifying profile")
 
-				if profile.Spec.RealTimeKernel.Enabled == pointer.Bool(false) {
+				if *profile.Spec.RealTimeKernel.Enabled != true {
 					testutils.KnownIssueJira("OCPBUGS-28828")
 				}
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -84,7 +84,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				By("Modifying profile")
 				profile.Spec.WorkloadHints = nil
 
-				if *profile.Spec.RealTimeKernel.Enabled != true {
+				if *profile.Spec.RealTimeKernel.Enabled == false {
 					testutils.KnownIssueJira("OCPBUGS-28828")
 				}
 				profile.Spec.RealTimeKernel = &performancev2.RealTimeKernel{
@@ -141,14 +141,14 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 			It("[test_id:50991][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", func() {
 				By("Modifying profile")
 
-				if *profile.Spec.RealTimeKernel.Enabled != true {
+				if *profile.Spec.RealTimeKernel.Enabled == false {
 					testutils.KnownIssueJira("OCPBUGS-28828")
 				}
+
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
 					HighPowerConsumption: pointer.Bool(false),
 					RealTime:             pointer.Bool(true),
 				}
-
 				profile.Spec.RealTimeKernel = &performancev2.RealTimeKernel{
 					Enabled: pointer.Bool(false),
 				}


### PR DESCRIPTION
This patch fixes comparing incompatible types,
profile.Spec.RealTimeKernel.Enabled == pointer.Bool(false)

Instead of using pointer.Bool, directly compare the boolean value.