### PR TITLE
NO-JIRA: Add support to inject owner-ref argument to render command

### DIFF
--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -5,6 +5,14 @@ function join_by { local IFS="$1"; shift; echo "$*"; }
 
 function rendersync() {
   INPUT_DIRS=()
+  EXTRA_ARGS=()
+  if [[ "$1" =~ ^-.* ]]; then
+      while [[ "x$1" != "x--" ]]; do
+          EXTRA_ARGS+=("$1")
+          shift
+      done
+      shift
+  fi
   while (( $# > 1 )); do
     INPUT_DIRS+=("${WORKDIR}/test/e2e/performanceprofile/cluster-setup/$1")
     shift
@@ -18,7 +26,7 @@ function rendersync() {
   ARTIFACT_DIR=$(mktemp -d)
 
   cd "${WORKDIR}" || { echo "failed to change dir to ${WORKDIR}"; exit; }
-  _output/cluster-node-tuning-operator render \
+  _output/cluster-node-tuning-operator render ${EXTRA_ARGS[@]} \
   --asset-input-dir "${INPUT_DIRS}" \
   --asset-output-dir "${ARTIFACT_DIR}"
 


### PR DESCRIPTION
  We need this change because we also want to use also non default values for the owner-ref like the value none.
  The work on [this PR depends](https://github.com/openshift/cluster-node-tuning-operator/pull/954) on these modifications to be merged.
