### PR TITLE
NO-JIRA: Remove RELEASE_VERSION from test-upstream-tuned.sh

### DIFF
--- a/hack/test-upstream-tuned.sh
+++ b/hack/test-upstream-tuned.sh
@@ -31,7 +31,7 @@ cvo_scale() {
 
 nto_deploy_custom() {
   oc project openshift-cluster-node-tuning-operator
-  oc patch deploy cluster-node-tuning-operator -p '{"spec":{"template":{"spec":{"containers":[{"env":[{"name":"RELEASE_VERSION","value":"'$TAG'"},{"name":"CLUSTER_NODE_TUNED_IMAGE","value":"'$IMAGE'"}],"name":"cluster-node-tuning-operator"}]}}}}'
+  oc patch deploy cluster-node-tuning-operator -p '{"spec":{"template":{"spec":{"containers":[{"env":[{"name":"CLUSTER_NODE_TUNED_IMAGE","value":"'$IMAGE'"}],"name":"cluster-node-tuning-operator"}]}}}}'
 }
 
 wait_for_updated_tuned_pods() {


### PR DESCRIPTION
Starting with PR858, we can no longer use a random `RELEASE_VERSION` to trigger daemonset/operand updates.  In the context of testing upstream TuneD this is causes an issue.  Not changing `RELEASE_VERSION` at all is a simple fix, because we are also adjusting `CLUSTER_NODE_TUNED_IMAGE` and that will cause a daemonset/operand update.