### PR TITLE
Backporting Tuned rendering and MCP detection improvements

### DIFF
--- a/pkg/performanceprofile/cmd/render/render.go
+++ b/pkg/performanceprofile/cmd/render/render.go
@@ -160,6 +160,9 @@ func render(inputDir, outputDir string) error {
 		}
 	}
 
+	// Append any missing default manifests (i.e. `master`/`worker`)
+	mcPools = util.AppendMissingDefaultMCPManifests(mcPools)
+
 	for _, pp := range perfProfiles {
 		mcp, err := selectMachineConfigPool(mcPools, pp.Spec.NodeSelector)
 		if err != nil {

--- a/pkg/tuned/cmd/render/cmd.go
+++ b/pkg/tuned/cmd/render/cmd.go
@@ -1,0 +1,90 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/klog"
+)
+
+type renderOpts struct {
+	assetsInDir  []string
+	assetsOutDir string
+	mcpName      string
+}
+
+func NewRenderBootCmdMCCommand() *cobra.Command {
+	renderOpts := renderOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "render-bootcmd-mc",
+		Short: "Render MC with kernel args",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := renderOpts.Validate(); err != nil {
+				klog.Fatal(err)
+			}
+
+			if err := renderOpts.Run(); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+
+	addKlogFlags(cmd)
+	renderOpts.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func (r *renderOpts) AddFlags(fs *pflag.FlagSet) {
+	fs.StringArrayVar(&r.assetsInDir, "asset-input-dir", []string{components.AssetsDir}, "Input path for the assets directory. (Can use it more than one to define multiple directories)")
+	fs.StringVar(&r.assetsOutDir, "asset-output-dir", r.assetsOutDir, "Output path for the rendered manifests.")
+	fs.StringVar(&r.mcpName, "mcp-name", r.mcpName, "MachineConfigPool name for the current node.")
+}
+
+func (r *renderOpts) Validate() error {
+	var err string
+	if len(r.assetsInDir) == 0 {
+		err += "asset-input-dir must be specified. "
+	}
+	if len(r.assetsOutDir) == 0 {
+		err += "asset-output-dir must be specified. "
+	}
+	if len(r.mcpName) == 0 {
+		err += "mcp-name must be specified. "
+	}
+
+	if len(err) == 0 {
+		return nil
+	}
+	return fmt.Errorf(err)
+}
+
+func (r *renderOpts) Run() error {
+	return render(r.assetsInDir, r.assetsOutDir, r.mcpName)
+}
+
+func addKlogFlags(cmd *cobra.Command) {
+	fs := flag.NewFlagSet("", flag.PanicOnError)
+	klog.InitFlags(fs)
+	cmd.Flags().AddGoFlagSet(fs)
+}

--- a/pkg/tuned/cmd/render/render.go
+++ b/pkg/tuned/cmd/render/render.go
@@ -1,0 +1,318 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package render
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/manifests"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/operator"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/tuned"
+	"sigs.k8s.io/yaml"
+
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	tunedpkg "github.com/openshift/cluster-node-tuning-operator/pkg/tuned"
+
+	"github.com/openshift/cluster-node-tuning-operator/pkg/util"
+	"github.com/openshift/cluster-node-tuning-operator/version"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog"
+)
+
+var (
+	manifestScheme = runtime.NewScheme()
+	codecFactory   serializer.CodecFactory
+	runtimeDecoder runtime.Decoder
+)
+
+func init() {
+	utilruntime.Must(performancev2.AddToScheme(manifestScheme))
+	utilruntime.Must(mcfgv1.Install(manifestScheme))
+	utilruntime.Must(tunedv1.AddToScheme(manifestScheme))
+	codecFactory = serializer.NewCodecFactory(manifestScheme)
+	runtimeDecoder = codecFactory.UniversalDecoder(
+		performancev2.GroupVersion,
+		mcfgv1.GroupVersion,
+		tunedv1.SchemeGroupVersion,
+	)
+}
+
+func render(inputDir []string, outputDir string, mcpName string) error {
+	klog.Info("Rendering files from: ", inputDir)
+	klog.Info("Rendering files into: ", outputDir)
+	klog.Info("Using MachineConfigPool: ", mcpName)
+
+	bootstrapSafeEnv := os.Getenv("CLUSTER_NODE_TUNED_BOOTSTRAP_SAFE_ENV")
+	if len(bootstrapSafeEnv) == 0 {
+		return fmt.Errorf("Should only be run on bootstrap safe environment. Please define env var 'CLUSTER_NODE_TUNED_BOOTSTRAP_SAFE_ENV' ")
+	}
+
+	// Get pools, mConfigs and profile from inputDir
+	// Read asset directory fileInfo
+	filePaths, err := util.ListFilesFromMultiplePaths(inputDir)
+	if err != nil {
+		return fmt.Errorf("error while listing files: %w", err)
+	}
+	klog.Infof("listed files: %v", filePaths)
+	// Make output dir if not present
+	err = os.MkdirAll(outputDir, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("Error while creating outputdir %s : %w", outputDir, err)
+	}
+
+	var (
+		perfProfiles []*performancev2.PerformanceProfile
+		mcPools      []*mcfgv1.MachineConfigPool
+		mcConfigs    []*mcfgv1.MachineConfig
+		tuneD        []*tunedv1.Tuned
+	)
+
+	// Iterate through the file paths and read in desired files
+	klog.Info("Iterating over listed files ... ")
+	for _, path := range filePaths {
+		file, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("error opening %s: %w", file.Name(), err)
+		}
+		defer file.Close()
+
+		manifests, err := util.ParseManifests(file.Name(), file)
+		if err != nil {
+			return fmt.Errorf("error parsing manifests from %s: %w", file.Name(), err)
+		}
+
+		// Decode manifest files
+		klog.V(4).Infof("decoding manifests for file %s...", path)
+		for idx, m := range manifests {
+			obji, err := runtime.Decode(runtimeDecoder, m.Raw)
+			if err != nil {
+				if runtime.IsNotRegisteredError(err) {
+					klog.V(4).Infof("skipping path %q [%d] manifest because it is not part of expected api group: %v", file.Name(), idx+1, err)
+					continue
+				}
+				return fmt.Errorf("error parsing %q [%d] manifest: %w", file.Name(), idx+1, err)
+			}
+
+			switch obj := obji.(type) {
+			case *performancev2.PerformanceProfile:
+				perfProfiles = append(perfProfiles, obj)
+			case *mcfgv1.MachineConfigPool:
+				mcPools = append(mcPools, obj)
+			case *mcfgv1.MachineConfig:
+				mcConfigs = append(mcConfigs, obj)
+			case *tunedv1.Tuned:
+				tuneD = append(tuneD, obj)
+			default:
+				klog.Infof("skipping %q [%d] manifest because of unhandled %T", file.Name(), idx+1, obji)
+			}
+		}
+	}
+
+	// Append any missing default manifests (i.e. `master`/`worker`)
+	mcPools = util.AppendMissingDefaultMCPManifests(mcPools)
+
+	mcp := findMachineConfigPoolByName(mcPools, mcpName)
+	if mcp == nil {
+		klog.Errorf("Unable to find MachineConfigPool:%q in input folders", mcpName)
+		return fmt.Errorf("Unable to find MachineConfigPool:%q in input folders", mcpName)
+	}
+
+	filteredPerformanceProfiles, err := filterPerformanceProfilesByMachineConfigPool(perfProfiles, mcp)
+	if err != nil {
+		klog.Errorf("Unable to find a PerformanceProfile that matches the MachineConfigPool %s. error : %v", mcpName, err)
+		return fmt.Errorf("Unable to get PerformanceProfile to apply using MachineConfigPool %s. error : %w", mcpName, err)
+	}
+
+	if len(filteredPerformanceProfiles) > 1 {
+		klog.Warningf("Found %d PerformanceProfiles for MachineConfigPool %s, only ONE is allowed.", len(filteredPerformanceProfiles), mcpName)
+		return fmt.Errorf("Found %d PerformanceProfiles for MachineConfigPool %s, only ONE is allowed.", len(filteredPerformanceProfiles), mcpName)
+	}
+
+	if len(filteredPerformanceProfiles) > 0 {
+		perfProfile := filteredPerformanceProfiles[0]
+		tunedFromPP, err := tuned.NewNodePerformance(perfProfile)
+		if err != nil {
+			klog.Errorf("Unable to get tuned from PerformanceProfile %s. error : %v", perfProfile.Name, err)
+			return fmt.Errorf("unable to get tuned from PerformanceProfile:%s. error: %w", perfProfile.Name, err)
+		}
+		// add tuned from PP to the list
+		tuneD = append(tuneD, tunedFromPP)
+	}
+
+	tuneDrecommended := operator.TunedRecommend(tuneD)
+	if len(tuneDrecommended) == 0 {
+		klog.Error("Unable to get tuned recommended profile.")
+		return fmt.Errorf("Unable to get tuned recommended profile.")
+	}
+
+	recommendedProfile := *tuneDrecommended[0].Profile
+	err = tunedpkg.TunedRecommendFileWrite(recommendedProfile)
+	if err != nil {
+		klog.Errorf("error writing recommended profile %q : %v", recommendedProfile, err)
+		return fmt.Errorf("error writing recommended profile %q : %w", recommendedProfile, err)
+	}
+
+	t := manifests.TunedRenderedResource(tuneD)
+	//extract all the profiles.
+	_, _, _, err = tunedpkg.ProfilesExtract(t.Spec.Profile, recommendedProfile)
+	if err != nil {
+		klog.Errorf("error extracting tuned profiles : %v", err)
+		return fmt.Errorf("error extracting tuned profiles: %w", err)
+	}
+
+	//Should run tuned
+	tunedCmd := tunedpkg.TunedCreateCmd(false)
+	err = tunedpkg.TunedRunNoDaemon(tunedCmd)
+	if err != nil {
+		klog.Errorf("Unable to run tuned error : %v", err)
+		return err
+	}
+
+	bootcmdline, err := tunedpkg.GetBootcmdline()
+	if err != nil {
+		klog.Errorf("Unable to get bootcmdline. error : %v", err)
+		return err
+	}
+
+	mc, err := renderMachineConfig(mcp, bootcmdline, mcConfigs, tuneDrecommended[0].MachineConfigLabels)
+	if err != nil {
+		klog.Errorf("error while rendering machine config  %v", err)
+		return fmt.Errorf("error while rendering machine config: %w", err)
+	}
+
+	if mc != nil {
+		//Render mc in output dir
+		byteOutput, err := yaml.Marshal(mc)
+		if err != nil {
+			klog.Errorf("Unable to render output machineconfig. error : %v", err)
+			return err
+		}
+
+		fileName := fmt.Sprintf("%s_%s_kargs.yaml", recommendedProfile, strings.ToLower(mc.Kind))
+		fullFilePath := filepath.Join(outputDir, fileName)
+		klog.Info("Writing file: ", fullFilePath)
+		err = os.WriteFile(fullFilePath, byteOutput, 0644)
+		if err != nil {
+			klog.Errorf("Unable to write output file %s. error : %v", fullFilePath, err)
+			return err
+		}
+
+		klog.Infof("MachineConfig written at : %s", fullFilePath)
+	}
+
+	return nil
+}
+
+func renderMachineConfig(pool *mcfgv1.MachineConfigPool, bootcmdline string, mConfigs []*mcfgv1.MachineConfig, mcLabels map[string]string) (*mcfgv1.MachineConfig, error) {
+	if len(bootcmdline) == 0 {
+		klog.Info("Empty cmdbootline. Avoid creating MachineConfig")
+		return nil, nil
+	}
+
+	pools := []*mcfgv1.MachineConfigPool{pool}
+	mcName := operator.GetMachineConfigNameForPools(pools)
+	kernelArgs := util.SplitKernelArguments(bootcmdline)
+	annotations := map[string]string{operator.GeneratedByControllerVersionAnnotationKey: version.Version}
+
+	mc := getMachineConfigByName(mConfigs, mcName)
+	if mc == nil { //not found
+		// Expect only one PerformanceProfile => one TuneD
+		mc = operator.NewMachineConfig(mcName, annotations, mcLabels, kernelArgs)
+		klog.Infof("rendered MachineConfig %s with%s", mc.ObjectMeta.Name, operator.MachineConfigGenerationLogLine(len(bootcmdline) != 0, bootcmdline))
+		return mc, nil
+	}
+
+	// found a MC need to modify it
+	mcNew := operator.NewMachineConfig(mcName, annotations, mcLabels, kernelArgs)
+
+	kernelArgsEq := util.StringSlicesEqual(mc.Spec.KernelArguments, kernelArgs)
+	if kernelArgsEq {
+		// No update needed
+		klog.Infof("renderMachineConfig: MachineConfig %s doesn't need updating", mc.ObjectMeta.Name)
+		return nil, nil
+	}
+
+	mc = mc.DeepCopy() // never update the objects from cache
+	mc.ObjectMeta.Annotations = mcNew.ObjectMeta.Annotations
+	mc.Spec.KernelArguments = removeDuplicates(append(mc.Spec.KernelArguments, kernelArgs...))
+	mc.Spec.Config = mcNew.Spec.Config
+	l := operator.MachineConfigGenerationLogLine(!kernelArgsEq, bootcmdline)
+	klog.Infof("renderMachineConfig: updating MachineConfig %s with%s", mc.ObjectMeta.Name, l)
+
+	return mc, nil
+}
+
+func getMachineConfigByName(mConfigs []*mcfgv1.MachineConfig, name string) *mcfgv1.MachineConfig {
+	for _, mc := range mConfigs {
+		if mc.Name == name {
+			return mc
+		}
+	}
+	return nil
+}
+
+func removeDuplicates[T string | int](sliceList []T) []T {
+	allKeys := make(map[T]bool)
+	list := []T{}
+	for _, item := range sliceList {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}
+
+func findMachineConfigPoolByName(mcPools []*mcfgv1.MachineConfigPool, mcpName string) *mcfgv1.MachineConfigPool {
+	for _, mcp := range mcPools {
+		if mcp.Name == mcpName {
+			return mcp
+		}
+	}
+	return nil
+}
+
+func filterPerformanceProfilesByMachineConfigPool(performanceProfiles []*performancev2.PerformanceProfile, mcp *mcfgv1.MachineConfigPool) ([]*performancev2.PerformanceProfile, error) {
+	mcpSelector, err := metav1.LabelSelectorAsSelector(mcp.Spec.NodeSelector)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get NodeSelector from MachineConfigPool: %s. error: %w", mcp.Name, err)
+	}
+
+	result := make([]*performancev2.PerformanceProfile, 0, len(performanceProfiles))
+
+	for _, perfProfile := range performanceProfiles {
+		if perfProfile.Spec.NodeSelector == nil {
+			//NOTE - this is not a valid PerformanceProfile as NodeSelect should not be empty
+			continue
+		}
+
+		perfProfileNodeSelector := labels.Set(perfProfile.Spec.NodeSelector)
+
+		if mcpSelector.Matches(perfProfileNodeSelector) {
+			result = append(result, perfProfile)
+		}
+	}
+
+	return result, nil
+}

--- a/test/e2e/performanceprofile/cluster-setup/bootstrap-cluster/extra-mcp/machine_config_pool.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/bootstrap-cluster/extra-mcp/machine_config_pool.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-cnf
+  namespace: openshift-machine-config-operator
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+spec:
+  paused: true
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [worker,worker-cnf]
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-cnf: ""

--- a/test/e2e/performanceprofile/cluster-setup/bootstrap-cluster/performance/pao_master.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/bootstrap-cluster/performance/pao_master.yaml
@@ -1,0 +1,12 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: openshift-bootstrap-master
+spec:
+  cpu:
+    isolated: 0-1
+    reserved: 2-7
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/master: ""
+  nodeSelector:
+    node-role.kubernetes.io/master: ""

--- a/test/e2e/performanceprofile/cluster-setup/bootstrap-cluster/performance/pao_worker.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/bootstrap-cluster/performance/pao_worker.yaml
@@ -1,0 +1,12 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: openshift-bootstrap-worker
+spec:
+  cpu:
+    isolated: 0-1
+    reserved: 2-3
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/worker: ""
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/01_01-master-cpu-partitioning_workload_pinning_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/01_01-master-cpu-partitioning_workload_pinning_machineconfig.yaml
@@ -1,0 +1,42 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 01-master-cpu-partitioning
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CnsKICAibWFuYWdlbWVudCI6IHsKICAgICJjcHVzZXQiOiAiIgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWUud29ya2xvYWRzLm1hbmFnZW1lbnRdCmFjdGl2YXRpb25fYW5ub3RhdGlvbiA9ICJ0YXJnZXQud29ya2xvYWQub3BlbnNoaWZ0LmlvL21hbmFnZW1lbnQiCmFubm90YXRpb25fcHJlZml4ID0gInJlc291cmNlcy53b3JrbG9hZC5vcGVuc2hpZnQuaW8iCnJlc291cmNlcyA9IHsgImNwdXNoYXJlcyIgPSAwLCAiY3B1c2V0IiA9ICIiIH0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/01-workload-pinning-default.conf
+        user: {}
+    systemd: {}
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: ""
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/01_01-worker-cnf-cpu-partitioning_workload_pinning_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/01_01-worker-cnf-cpu-partitioning_workload_pinning_machineconfig.yaml
@@ -1,0 +1,42 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+  name: 01-worker-cnf-cpu-partitioning
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CnsKICAibWFuYWdlbWVudCI6IHsKICAgICJjcHVzZXQiOiAiIgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWUud29ya2xvYWRzLm1hbmFnZW1lbnRdCmFjdGl2YXRpb25fYW5ub3RhdGlvbiA9ICJ0YXJnZXQud29ya2xvYWQub3BlbnNoaWZ0LmlvL21hbmFnZW1lbnQiCmFubm90YXRpb25fcHJlZml4ID0gInJlc291cmNlcy53b3JrbG9hZC5vcGVuc2hpZnQuaW8iCnJlc291cmNlcyA9IHsgImNwdXNoYXJlcyIgPSAwLCAiY3B1c2V0IiA9ICIiIH0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/01-workload-pinning-default.conf
+        user: {}
+    systemd: {}
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: ""
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/01_01-worker-cpu-partitioning_workload_pinning_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/01_01-worker-cpu-partitioning_workload_pinning_machineconfig.yaml
@@ -1,0 +1,42 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 01-worker-cpu-partitioning
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CnsKICAibWFuYWdlbWVudCI6IHsKICAgICJjcHVzZXQiOiAiIgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWUud29ya2xvYWRzLm1hbmFnZW1lbnRdCmFjdGl2YXRpb25fYW5ub3RhdGlvbiA9ICJ0YXJnZXQud29ya2xvYWQub3BlbnNoaWZ0LmlvL21hbmFnZW1lbnQiCmFubm90YXRpb25fcHJlZml4ID0gInJlc291cmNlcy53b3JrbG9hZC5vcGVuc2hpZnQuaW8iCnJlc291cmNlcyA9IHsgImNwdXNoYXJlcyIgPSAwLCAiY3B1c2V0IiA9ICIiIH0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/01-workload-pinning-default.conf
+        user: {}
+    systemd: {}
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: ""
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_kubeletconfig.yaml
@@ -1,0 +1,61 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  creationTimestamp: null
+  name: performance-openshift-bootstrap-master
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+spec:
+  kubeletConfig:
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous: {}
+      webhook:
+        cacheTTL: 0s
+      x509: {}
+    authorization:
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    containerRuntimeEndpoint: ""
+    cpuManagerPolicy: static
+    cpuManagerReconcilePeriod: 5s
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 0s
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      memory: 500Mi
+    logging:
+      flushFrequency: 0
+      options:
+        json:
+          infoBufferSize: "0"
+      verbosity: 0
+    memorySwap: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    reservedSystemCPUs: 2-7
+    runtimeRequestTimeout: 0s
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      memory: 500Mi
+    topologyManagerPolicy: best-effort
+    volumeStatsAggPeriod: 0s
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+status:
+  conditions: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -1,0 +1,175 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 50-performance-openshift-bootstrap-master
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCm5vZGVzX3BhdGg9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vbm9kZSIKaHVnZXBhZ2VzX2ZpbGU9IiR7bm9kZXNfcGF0aH0vbm9kZSR7TlVNQV9OT0RFfS9odWdlcGFnZXMvaHVnZXBhZ2VzLSR7SFVHRVBBR0VTX1NJWkV9a0IvbnJfaHVnZXBhZ2VzIgoKaWYgWyAhIC1mICIke2h1Z2VwYWdlc19maWxlfSIgXTsgdGhlbgogIGVjaG8gIkVSUk9SOiAke2h1Z2VwYWdlc19maWxlfSBkb2VzIG5vdCBleGlzdCIKICBleGl0IDEKZmkKCnRpbWVvdXQ9NjAKc2FtcGxlPTEKY3VycmVudF90aW1lPTAKd2hpbGUgWyAiJChjYXQgIiR7aHVnZXBhZ2VzX2ZpbGV9IikiIC1uZSAiJHtIVUdFUEFHRVNfQ09VTlR9IiBdOyBkbwogIGVjaG8gIiR7SFVHRVBBR0VTX0NPVU5UfSIgPiIke2h1Z2VwYWdlc19maWxlfSIKCiAgY3VycmVudF90aW1lPSQoKGN1cnJlbnRfdGltZSArIHNhbXBsZSkpCiAgaWYgWyAkY3VycmVudF90aW1lIC1ndCAkdGltZW91dCBdOyB0aGVuCiAgICBlY2hvICJFUlJPUjogJHtodWdlcGFnZXNfZmlsZX0gZG9lcyBub3QgaGF2ZSB0aGUgZXhwZWN0ZWQgbnVtYmVyIG9mIGh1Z2VwYWdlcyAke0hVR0VQQUdFU19DT1VOVH0iCiAgICBleGl0IDEKICBmaQoKICBzbGVlcCAkc2FtcGxlCmRvbmUK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/hugepages-allocation.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZnVuY3Rpb24gc2V0X3F1ZXVlX3Jwc19tYXNrKCkgewojIHJlcGxhY2UgeDJkIHdpdGggaHlwaGVuICgtKSB3aGljaCBpcyBhbiBlc2NhcGVkIGNoYXJhY3RlcgojIHRoYXQgd2FzIGFkZGVkIGJ5IHN5c3RlbWQtZXNjYXBlIGluIG9yZGVyIHRvIGVzY2FwZSB0aGUgc3lzdGVtZCB1bml0IG5hbWUgdGhhdCBpbnZva2VzIHRoaXMgc2NyaXB0CnBhdGg9JHtwYXRoL3gyZC8tfQojIHNldCBycHMgYWZmaW5pdHkgZm9yIHRoZSBxdWV1ZQplY2hvICIke21hc2t9IiAgMj4gL2Rldi9udWxsID4gIi9zeXMvJHtwYXRofS9ycHNfY3B1cyIKIyB3ZSByZXR1cm4gMCBiZWNhdXNlIHRoZSAnZWNobycgY29tbWFuZCBtaWdodCBmYWlsIGlmIHRoZSBkZXZpY2UgcGF0aCB0byB3aGljaCB0aGUgcXVldWUgYmVsb25ncyBoYXMgY2hhbmdlZC4KIyB0aGlzIGNhbiBoYXBwZW4gaW4gY2FzZSBvZiBTUkktT1YgZGV2aWNlcyByZW5hbWluZy4KcmV0dXJuIDAKfQoKZnVuY3Rpb24gc2V0X25ldF9kZXZfcnBzX21hc2soKSB7CiAgIyBpbiBjYXNlIG9mIGRldmljZSB3ZSB3YW50IHRvIGl0ZXJhdGUgdGhyb3VnaCBhbGwgcXVldWVzCmZvciBpIGluIC9zeXMvIiR7cGF0aH0iL3F1ZXVlcy9yeC0qOyBkbwogIGVjaG8gIiR7bWFza30iIDI+IC9kZXYvbnVsbCA+ICIke2l9L3Jwc19jcHVzIgpkb25lCiMgd2UgcmV0dXJuIDAgYmVjYXVzZSB0aGUgJ2VjaG8nIGNvbW1hbmQgbWlnaHQgZmFpbCBpZiB0aGUgZGV2aWNlIHBhdGggdG8gd2hpY2ggdGhlIHF1ZXVlIGJlbG9uZ3MgaGFzIGNoYW5nZWQuCiMgdGhpcyBjYW4gaGFwcGVuIGluIGNhc2Ugb2YgU1JJLU9WIGRldmljZXMgcmVuYW1pbmcuCnJldHVybiAwCiB9CgpwYXRoPSR7MX0KWyAtbiAiJHtwYXRofSIgXSB8fCB7IGVjaG8gIlRoZSBkZXZpY2UgcGF0aCBhcmd1bWVudCBpcyBtaXNzaW5nIiA+JjIgOyBleGl0IDE7IH0KCm1hc2s9JHsyfQpbIC1uICIke21hc2t9IiBdIHx8IHsgZWNobyAiVGhlIG1hc2sgYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgppZiBbWyAiJHtwYXRofSIgPX4gInF1ZXVlcyIgXV07IHRoZW4KIHNldF9xdWV1ZV9ycHNfbWFzawplbHNlCiBzZXRfbmV0X2Rldl9ycHNfbWFzawpmaQo=
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-rps-mask.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9iYXNoCgpzZXQgLWV1byBwaXBlZmFpbAoKZm9yIGNwdSBpbiAke09GRkxJTkVfQ1BVUy8vLC8gfTsKICBkbwogICAgb25saW5lX2NwdV9maWxlPSIvc3lzL2RldmljZXMvc3lzdGVtL2NwdS9jcHUkY3B1L29ubGluZSIKICAgIGlmIFsgISAtZiAiJHtvbmxpbmVfY3B1X2ZpbGV9IiBdOyB0aGVuCiAgICAgIGVjaG8gIkVSUk9SOiAke29ubGluZV9jcHVfZmlsZX0gZG9lcyBub3QgZXhpc3QsIGFib3J0IHNjcmlwdCBleGVjdXRpb24iCiAgICAgIGV4aXQgMQogICAgZmkKICBkb25lCgplY2hvICJBbGwgY3B1cyBvZmZsaW5lZCBleGlzdHMsIHNldCB0aGVtIG9mZmxpbmUiCgpmb3IgY3B1IGluICR7T0ZGTElORV9DUFVTLy8sLyB9OwogIGRvCiAgICBvbmxpbmVfY3B1X2ZpbGU9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vY3B1L2NwdSRjcHUvb25saW5lIgogICAgZWNobyAwID4gIiR7b25saW5lX2NwdV9maWxlfSIKICAgIGVjaG8gIm9mZmxpbmUgY3B1IG51bSAkY3B1IgogIGRvbmUKCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-cpus-offline.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLWV1byBwaXBlZmFpbApzZXQgLXgKCiMgY29uc3QKU0VEPSIvdXNyL2Jpbi9zZWQiCiMgdHVuYWJsZSAtIG92ZXJyaWRhYmxlIGZvciB0ZXN0aW5nIHB1cnBvc2VzCklSUUJBTEFOQ0VfQ09ORj0iJHsxOi0vZXRjL3N5c2NvbmZpZy9pcnFiYWxhbmNlfSIKQ1JJT19PUklHX0JBTk5FRF9DUFVTPSIkezI6LS9ldGMvc3lzY29uZmlnL29yaWdfaXJxX2Jhbm5lZF9jcHVzfSIKClsgISAtZiAke0lSUUJBTEFOQ0VfQ09ORn0gXSAmJiBleGl0IDAKCiR7U0VEfSAtaSAnL15ccypJUlFCQUxBTkNFX0JBTk5FRF9DUFVTXGIvZCcgJHtJUlFCQUxBTkNFX0NPTkZ9IHx8IGV4aXQgMAplY2hvICJJUlFCQUxBTkNFX0JBTk5FRF9DUFVTPSIgPj4gJHtJUlFCQUxBTkNFX0NPTkZ9CgojIHdlIG5vdyBvd24gdGhpcyBjb25maWd1cmF0aW9uLiBCdXQgQ1JJLU8gaGFzIGNvZGUgdG8gcmVzdG9yZSB0aGUgY29uZmlndXJhdGlvbiwKIyBhbmQgdW50aWwgaXQgZ2FpbnMgdGhlIG9wdGlvbiB0byBkaXNhYmxlIHRoaXMgcmVzdG9yZSBmbG93LCB3ZSBuZWVkIHRvIG1ha2UKIyB0aGUgY29uZmlndXJhdGlvbiBjb25zaXN0ZW50IHN1Y2ggYXMgdGhlIENSSS1PIHJlc3RvcmUgd2lsbCBkbyBub3RoaW5nLgppZiBbIC1uICR7Q1JJT19PUklHX0JBTk5FRF9DUFVTfSBdICYmIFsgLWYgJHtDUklPX09SSUdfQkFOTkVEX0NQVVN9IF07IHRoZW4KCXRydWUgPiAke0NSSU9fT1JJR19CQU5ORURfQ1BVU30KZmkK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/clear-irqbalance-banned-cpus.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMi03IgoKCgojIFdlIHNob3VsZCBjb3B5IHBhc3RlIHRoZSBkZWZhdWx0IHJ1bnRpbWUgYmVjYXVzZSB0aGlzIHNuaXBwZXQgd2lsbCBvdmVycmlkZSB0aGUgd2hvbGUgcnVudGltZXMgc2VjdGlvbgpbY3Jpby5ydW50aW1lLnJ1bnRpbWVzLnJ1bmNdCnJ1bnRpbWVfcGF0aCA9ICIiCnJ1bnRpbWVfdHlwZSA9ICJvY2kiCnJ1bnRpbWVfcm9vdCA9ICIvcnVuL3J1bmMiCgojIFRoZSBDUkktTyB3aWxsIGNoZWNrIHRoZSBhbGxvd2VkX2Fubm90YXRpb25zIHVuZGVyIHRoZSBydW50aW1lIGhhbmRsZXIgYW5kIGFwcGx5IGhpZ2gtcGVyZm9ybWFuY2UgaG9va3Mgd2hlbiBvbmUgb2YKIyBoaWdoLXBlcmZvcm1hbmNlIGFubm90YXRpb25zIHByZXNlbnRzIHVuZGVyIGl0LgojIFdlIHNob3VsZCBwcm92aWRlIHRoZSBydW50aW1lX3BhdGggYmVjYXVzZSB3ZSBuZWVkIHRvIGluZm9ybSB0aGF0IHdlIHdhbnQgdG8gcmUtdXNlIHJ1bmMgYmluYXJ5IGFuZCB3ZQojIGRvIG5vdCBoYXZlIGhpZ2gtcGVyZm9ybWFuY2UgYmluYXJ5IHVuZGVyIHRoZSAkUEFUSCB0aGF0IHdpbGwgcG9pbnQgdG8gaXQuCltjcmlvLnJ1bnRpbWUucnVudGltZXMuaGlnaC1wZXJmb3JtYW5jZV0KcnVudGltZV9wYXRoID0gIi9iaW4vcnVuYyIKcnVudGltZV90eXBlID0gIm9jaSIKcnVudGltZV9yb290ID0gIi9ydW4vcnVuYyIKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LWMtc3RhdGVzLmNyaW8uaW8iLCAiY3B1LWZyZXEtZ292ZXJub3IuY3Jpby5pbyJdCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-runtimes.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBBcHBseSB0aGUgUlBTIG1hc2sgb24gdGhlIHZpcnR1YWwgaW50ZXJmYWNlcyBvZiB0aGUgaG9zdCBieSBkZWZhdWx0LCBiZWNhc3VlCiMgZnJvbSB0aGUgY29udGFpbmVyIHBlcnNwZWN0aXZlIHRoZSBSUFMgbWFzayB0aGUgd2lsbCBiZSBjb25zdWx0ZWQsIGlzIHRoZSBvbmUgb24gdGhlIFJYIHNpZGUgb2YgdGhlIHZldGggaW4gdGhlIGhvc3QuCiMgQ29uc2lkZXIgdGhlIGZvbGxvd2luZyBkaWFncmFtOgojIFBvZCBBIDx2ZXRoMSAtIHZldGgyPiBob3N0IDx2ZXRoMyAtIHZldGg0PiBQb2QgQgojICB2ZXRoMidzIFJQUyBhZmZpbml0eSBpcyB0aGUgb25lIGRldGVybWluaW5nIHRoZSBDUFVzIHRoYXQgYXJlIGhhbmRsaW5nIHRoZSBwYWNrZXQgcHJvY2Vzc2luZyB3aGVuIHNlbmRpbmcgZGF0YSBmcm9tIFBvZCBBIHRvIHBvZCBCLgojIEFkZGl0aW9uYWwgY29tbW9uIHNjZW5hcmlvczoKIyAxLiBQb2QgQSA9IHNlbmRlciwgaG9zdCA9IHJlY2VpdmVyCiMgIFRoZSBSUFMgYWZmaW5pdHkgb2YgdGhlIGhvc3Qgc2lkZSBzaG91bGQgYmUgY29uc3VsdGVkIChiZWNhdXNlIGl04oCZcyB0aGUgcmVjZWl2ZXIpIGFuZCBpdCBzaG91bGQgYmUgc2V0IHRvIGNwdXMgbm90IHNlbnNpdGl2ZSB0byBwcmVlbXB0aW9uIChyZXNlcnZlZCBwb29sKS4KIyAyLiBQb2QgQSA9IHJlY2VpdmVyLCBob3N0ID0gc2VuZGVyCiMgIEluIGNhc2Ugb2Ygbm8gUlBTIG1hc2sgb24gdGhlIHJlY2VpdmVyIHNpZGUsIHRoZSBzZW5kZXIgbmVlZHMgdG8gcGF5IHRoZSBwcmljZSBhbmQgZG8gYWxsIHRoZSBwcm9jZXNzaW5nIG9uIGl0cyBjb3Jlcy4KbmV0LmNvcmUucnBzX2RlZmF1bHRfbWFzayA9IDAwMDAwMGZjCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysctl.d/99-default-rps-mask.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0icXVldWVzIiwgQUNUSU9OPT0iYWRkIiwgRU5We0RFVlBBVEh9PT0iL2RldmljZXMvcGNpKi9xdWV1ZXMvcngqIiwgVEFHKz0ic3lzdGVtZCIsIFBST0dSQU09Ii9iaW4vc3lzdGVtZC1lc2NhcGUgLS1wYXRoIC0tdGVtcGxhdGU9dXBkYXRlLXJwc0Auc2VydmljZSAkZW52e0RFVlBBVEh9IiwgRU5We1NZU1RFTURfV0FOVFN9PSIlYyIKCiMgU1ItSU9WIGRldmljZXMgYXJlIG1vdmVkIChyZW5hbWVkKSwgaGVuY2Ugd2Ugd2FudCB0byBjYXRjaCB0aGlzIGV2ZW50IGFzIHdlbGwKU1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0ibW92ZSIsIEVOVntERVZQQVRIfSE9Ii9kZXZpY2VzL3ZpcnR1YWwvbmV0LyoiLCBUQUcrPSJzeXN0ZW1kIiwgUFJPR1JBTT0iL2Jpbi9zeXN0ZW1kLWVzY2FwZSAtLXBhdGggLS10ZW1wbGF0ZT11cGRhdGUtcnBzQC5zZXJ2aWNlICRlbnZ7REVWUEFUSH0iLCBFTlZ7U1lTVEVNRF9XQU5UU309IiVjIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/99-netdev-physical-rps.rules
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWUud29ya2xvYWRzLm1hbmFnZW1lbnRdCmFjdGl2YXRpb25fYW5ub3RhdGlvbiA9ICJ0YXJnZXQud29ya2xvYWQub3BlbnNoaWZ0LmlvL21hbmFnZW1lbnQiCmFubm90YXRpb25fcHJlZml4ID0gInJlc291cmNlcy53b3JrbG9hZC5vcGVuc2hpZnQuaW8iCnJlc291cmNlcyA9IHsgImNwdXNoYXJlcyIgPSAwLCAiY3B1c2V0IiA9ICIyLTciIH0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-workload-pinning.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CnsKICAibWFuYWdlbWVudCI6IHsKICAgICJjcHVzZXQiOiAiMi03IgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCiMgY3B1c2V0LWNvbmZpZ3VyZS5zaCBjb25maWd1cmVzIHRocmVlIGNwdXNldHMgaW4gcHJlcGFyYXRpb24gZm9yIGFsbG93aW5nIGNvbnRhaW5lcnMgdG8gaGF2ZSBjcHUgbG9hZCBiYWxhbmNpbmcgZGlzYWJsZWQuCiMgVG8gY29uZmlndXJlIGEgY3B1c2V0IHRvIGhhdmUgbG9hZCBiYWxhbmNlIGRpc2FibGVkIChvbiBjZ3JvdXAgdjEpLCBhIGNwdXNldCBjZ3JvdXAgbXVzdCBoYXZlIGBjcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlYAojIHNldCB0byAwIChkaXNhYmxlKSwgYW5kIGFueSBjcHVzZXQgdGhhdCBjb250YWlucyB0aGUgc2FtZSBzZXQgYXMgYGNwdXNldC5jcHVzYCBtdXN0IGFsc28gaGF2ZSBgY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZWAgc2V0IHRvIGRpc2FibGVkLgoKc2V0IC1ldW8gcGlwZWZhaWwKCmlmIHRlc3QgIiQoc3RhdCAtZiAtYyVUIC9zeXMvZnMvY2dyb3VwKSIgPSAiY2dyb3VwMmZzIjsgdGhlbgoJZWNobyAiTm9kZSBpcyB1c2luZyBjZ3JvdXAgdjIsIG5vIGNvbmZpZ3VyYXRpb24gbmVlZGVkIgoJZXhpdCAwCmZpCgpyb290PS9zeXMvZnMvY2dyb3VwL2NwdXNldApzeXN0ZW09IiRyb290Ii9zeXN0ZW0uc2xpY2UKbWFjaGluZT0iJHJvb3QiL21hY2hpbmUuc2xpY2UKCm92c3NsaWNlPSIke3Jvb3R9L292cy5zbGljZSIKb3Zzc2xpY2Vfc3lzdGVtZD0iL3N5cy9mcy9jZ3JvdXAvcGlkcy9vdnMuc2xpY2UiCgojIEFzIHN1Y2gsIHRoZSByb290IGNncm91cCBuZWVkcyB0byBoYXZlIGNwdXNldC5zY2hlZF9sb2FkX2JhbGFuY2U9MC4gCmVjaG8gMCA+ICIkcm9vdCIvY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZQoKIyBIb3dldmVyLCB0aGlzIHdvdWxkIHByZXNlbnQgYSBwcm9ibGVtIGZvciBzeXN0ZW0gZGFlbW9ucywgd2hpY2ggc2hvdWxkIGhhdmUgbG9hZCBiYWxhbmNpbmcgZW5hYmxlZC4KIyBBcyBzdWNoLCBhIHNlY29uZCBjcHVzZXQgbXVzdCBiZSBjcmVhdGVkLCBoZXJlIGR1YmJlZCBgc3lzdGVtYCwgd2hpY2ggd2lsbCB0YWtlIGFsbCBzeXN0ZW0gZGFlbW9ucy4KIyBTaW5jZSBzeXN0ZW1kIHN0YXJ0cyBpdHMgY2hpbGRyZW4gd2l0aCB0aGUgY3B1c2V0IGl0IGlzIGluLCBtb3Zpbmcgc3lzdGVtZCB3aWxsIGVuc3VyZSBhbGwgcHJvY2Vzc2VzIHN5c3RlbWQgYmVnaW5zIHdpbGwgYmUgaW4gdGhlIGNvcnJlY3QgY2dyb3VwLgpta2RpciAtcCAiJHN5c3RlbSIKIyBjcHVzZXQubWVtcyBtdXN0IGJlIGluaXRpYWxpemVkIG9yIHByb2Nlc3NlcyB3aWxsIGZhaWwgdG8gYmUgbW92ZWQgaW50byBpdC4KY2F0ICIkcm9vdC9jcHVzZXQubWVtcyIgPiAiJHN5c3RlbSIvY3B1c2V0Lm1lbXMKIyBSZXRyaWV2ZSB0aGUgY3B1c2V0IG9mIHN5c3RlbWQsIGFuZCB3cml0ZSBpdCB0byBjcHVzZXQuY3B1cyBvZiB0aGUgc3lzdGVtIGNncm91cC4KcmVzZXJ2ZWRfc2V0PSQodGFza3NldCAtY3AgIDEgIHwgYXdrICdORnsgcHJpbnQgJE5GIH0nKQplY2hvICIkcmVzZXJ2ZWRfc2V0IiA+ICIkc3lzdGVtIi9jcHVzZXQuY3B1cwoKIyBBbmQgbW92ZSB0aGUgc3lzdGVtIHByb2Nlc3NlcyBpbnRvIGl0LgojIE5vdGUsIHNvbWUga2VybmVsIHRocmVhZHMgd2lsbCBmYWlsIHRvIGJlIG1vdmVkIHdpdGggIkludmFsaWQgQXJndW1lbnQiLiBUaGlzIHNob3VsZCBiZSBpZ25vcmVkLgpmb3IgcHJvY2VzcyBpbiAkKGNhdCAiJHJvb3QiL2Nncm91cC5wcm9jcyB8IHNvcnQgLXIpOyBkbwoJZWNobyAkcHJvY2VzcyA+ICIkc3lzdGVtIi9jZ3JvdXAucHJvY3MgMj4mMSB8IGdyZXAgLXYgIkludmFsaWQgQXJndW1lbnQiIHx8IHRydWU7CmRvbmUKCiMgRmluYWxseSwgYSB0aGUgYG1hY2hpbmUuc2xpY2VgIGNncm91cCBtdXN0IGJlIHByZWNvbmZpZ3VyZWQuIFBvZG1hbiB3aWxsIGNyZWF0ZSBjb250YWluZXJzIGFuZCBtb3ZlIHRoZW0gaW50byB0aGUgYG1hY2hpbmUuc2xpY2VgLCBidXQgdGhlcmUncwojIG5vIHdheSB0byB0ZWxsIHBvZG1hbiB0byB1cGRhdGUgbWFjaGluZS5zbGljZSB0byBub3QgaGF2ZSB0aGUgZnVsbCBzZXQgb2YgY3B1cy4gSW5zdGVhZCBvZiBkaXNhYmxpbmcgbG9hZCBiYWxhbmNpbmcgaW4gaXQsIHdlIGNhbiBwcmUtY3JlYXRlIGl0LgojIHdpdGggdGhlIHJlc2VydmVkIENQVXMgc2V0IGFoZWFkIG9mIHRpbWUsIHNvIHdoZW4gaXNvbGF0ZWQgcHJvY2Vzc2VzIGJlZ2luLCB0aGUgY2dyb3VwIGRvZXMgbm90IGhhdmUgYW4gb3ZlcmxhcHBpbmcgY3B1c2V0IGJldHdlZW4gbWFjaGluZS5zbGljZSBhbmQgaXNvbGF0ZWQgY29udGFpbmVycy4KbWtkaXIgLXAgIiRtYWNoaW5lIgoKIyBJdCdzIHVubGlrZWx5LCBidXQgcG9zc2libGUsIHRoYXQgdGhpcyBjcHVzZXQgYWxyZWFkeSBleGlzdGVkLiBJdGVyYXRlIGp1c3QgaW4gY2FzZS4KZm9yIGZpbGUgaW4gJChmaW5kICIkbWFjaGluZSIgLW5hbWUgY3B1c2V0LmNwdXMgfCBzb3J0IC1yKTsgZG8gZWNobyAiJHJlc2VydmVkX3NldCIgPiAiJGZpbGUiOyBkb25lCgojIE9WUyBpcyBydW5uaW5nIGluIGl0cyBvd24gc2xpY2UgdGhhdCBzcGFucyBhbGwgY3B1cy4gVGhlIHJlYWwgYWZmaW5pdHkgaXMgbWFuYWdlZCBieSBPVk4tSyBvdm5rdWJlLW5vZGUgZGFlbW9uc2V0CiMgTWFrZSBzdXJlIHRoaXMgc2xpY2Ugd2lsbCBub3QgZW5hYmxlIGNwdSBiYWxhbmNpbmcgZm9yIG90aGVyIHNsaWNlIGNvbmZpZ3VyZWQgYnkgdGhpcyBzY3JpcHQuCiMgVGhpcyBtaWdodCBzZWVtIGNvdW50ZXItaW50dWl0aXZlLCBidXQgdGhpcyB3aWxsIGFjdHVhbGx5IE5PVCBkaXNhYmxlIGNwdSBiYWxhbmNpbmcgZm9yIE9WUyBpdHNlbGYuCiMgLSBPVlMgaGFzIGFjY2VzcyB0byByZXNlcnZlZCBjcHVzLCBidXQgdGhvc2UgaGF2ZSBiYWxhbmNpbmcgZW5hYmxlZCB2aWEgdGhlIGBzeXN0ZW1gIGNncm91cCBjcmVhdGVkIGFib3ZlCiMgLSBPVlMgaGFzIGFjY2VzcyB0byBpc29sYXRlZCBjcHVzIHRoYXQgYXJlIGN1cnJlbnRseSBub3QgYXNzaWduZWQgdG8gcGlubmVkIHBvZHMuIFRob3NlIGhhdmUgYmFsYW5jaW5nIGVuYWJsZWQgYnkgdGhlCiMgICBwb2RzIHJ1bm5pbmcgdGhlcmUgKGJ1cnN0YWJsZSBhbmQgYmVzdC1lZmZvcnQgcG9kcyBoYXZlIGJhbGFuY2luZyBlbmFibGVkIGluIHRoZSBjb250YWluZXIgY2dyb3VwIGFuZCBhY2Nlc3MgdG8gYWxsCiMgICB1bnBpbm5lZCBjcHVzKS4KCiMgc3lzdGVtZCBkb2VzIG5vdCBtYW5hZ2UgdGhlIGNwdXNldCBjZ3JvdXAgY29udHJvbGxlciwgc28gbW92ZSBldmVyeXRoaW5nIGZyb20gdGhlIG1hbmFnZWQgcGlkcyBjb250cm9sbGVyJ3Mgb3ZzLnNsaWNlCiMgdG8gdGhlIGNwdXNldCBjb250cm9sbGVyLgoKIyBDcmVhdGUgdGhlIG92cy5zbGljZQpta2RpciAtcCAiJG92c3NsaWNlIgplY2hvIDAgPiAiJG92c3NsaWNlIi9jcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlCmNhdCAiJHJvb3QiL2NwdXNldC5jcHVzID4gIiRvdnNzbGljZSIvY3B1c2V0LmNwdXMKY2F0ICIkcm9vdCIvY3B1c2V0Lm1lbXMgPiAiJG92c3NsaWNlIi9jcHVzZXQubWVtcwoKIyBNb3ZlIE9WUyBvdmVyCmZvciBwcm9jZXNzIGluICQoY2F0ICIkb3Zzc2xpY2Vfc3lzdGVtZCIvKi9jZ3JvdXAucHJvY3MgfCBzb3J0IC1yKTsgZG8KICAgICAgICBlY2hvICRwcm9jZXNzID4gIiRvdnNzbGljZSIvY2dyb3VwLnByb2NzIDI+JjEgfCBncmVwIC12ICJJbnZhbGlkIEFyZ3VtZW50IiB8fCB0cnVlOwpkb25lCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/cpuset-configure.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs.slice
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/openvswitch.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs-vswitchd.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovsdb-server.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBUaGlzIGZpbGUgZW5hYmxlcyB0aGUgZHluYW1pYyBjcHUgYWZmaW5pdHkgbWFuYWdlbWVudCBvZiB0aGUgT1ZTIHNlcnZpY2VzCiMKIyBJdCBpcyByZWFkIGJ5IHRoZSBPVk4ncyBvdm5rdWJlLW5vZGUgRGFlbW9uU2V0IGNvbnRhaW5lciBhbmQgdGhlIGZlYXR1cmUKIyBpcyBlbmFibGVkIHdoZW4gdGhpcyBmaWxlIGV4aXN0cyBhbmQgaXMgbm90IGVtcHR5ICh0aGlzIGNvbW1lbnRhcnkgdGV4dAojIGVuc3VyZXMgdGhhdCkKIwojIEZvciBkaXNhYmxpbmcgdGhpcyBmZWF0dXJlIGluIGVtZXJnZW5jaWVzLCBlaXRoZXI6CiMgMSkgZGVsZXRlIHRoaXMgZmlsZSBhbmQgc2V0IHRoZSBjcHUgYWZmaW5pdHkgb2YgT1ZTIHNlcnZpY2VzIG1hbnVhbGx5CiMgMikgb3IgcmVwbGFjZSB0aGUgY29udGVudHMgb2YgdGhpcyBmaWxlIHdpdGggYW4gZW1wdHkgc3RyaW5nCiMgICAgdmlhIGEgTWFjaGluZUNvbmZpZwo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
+        user: {}
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Sets network devices RPS mask
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/set-rps-mask.sh %I 0
+        name: update-rps@.service
+      - contents: |
+          [Unit]
+          Description=Move services to reserved cpuset
+          Before=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/cpuset-configure.sh
+
+          [Install]
+          WantedBy=multi-user.target crio.service
+        enabled: true
+        name: cpuset-configure.service
+      - contents: |
+          [Unit]
+          Description=Clear the IRQBalance Banned CPU mask early in the boot
+          Before=kubelet.service
+          Before=irqbalance.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/clear-irqbalance-banned-cpus.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: clear-irqbalance-banned-cpus.service
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: default
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_node.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_node.yaml
@@ -1,0 +1,13 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  creationTimestamp: null
+  name: cluster
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+spec:
+  cgroupMode: v1
+status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_runtimeclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: node.k8s.io/v1
+handler: high-performance
+kind: RuntimeClass
+metadata:
+  creationTimestamp: null
+  name: performance-openshift-bootstrap-master
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/master: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -1,0 +1,67 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  creationTimestamp: null
+  name: openshift-node-performance-openshift-bootstrap-master
+  namespace: openshift-cluster-node-tuning-operator
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+spec:
+  profile:
+  - data: "[main]\nsummary=Openshift node optimized for deterministic performance
+      at the cost of increased power consumption, focused on low latency network performance.
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
+      -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
+      All values are mapped with a comment where a parent profile contains them.\n#
+      Different values will override the original values in parent profiles.\n\n[variables]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
+      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
+      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
+      plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      = ignore\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
+      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
+      RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
+      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
+      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
+      working set is buffered for I/O, and any more write buffering would require\n#
+      swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
+      that mostly use file mappings may be able to use even higher values.\n#\n# The
+      generator of dirty data starts writeback at this percentage (system default\n#
+      is 20%)\n#> latency-performance\nvm.dirty_ratio=10\n\n# Start background writeback
+      (via writeback threads) at this percentage (system\n# default is 10%)\n#> latency-performance\nvm.dirty_background_ratio=3\n\n#
+      The swappiness parameter controls the tendency of the kernel to move\n# processes
+      out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
+      swapping processes out of physical memory\n# for as long as possible\n# 100
+      tells the kernel to aggressively swap processes out of physical memory\n# and
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
+      configured via a sysctl.d file\n# placed here for documentation purposes and
+      commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
+    name: openshift-node-performance-openshift-bootstrap-master
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: master
+    operand:
+      tunedConfig:
+        reapply_sysctl: null
+    priority: 20
+    profile: openshift-node-performance-openshift-bootstrap-master
+status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_kubeletconfig.yaml
@@ -1,0 +1,61 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  creationTimestamp: null
+  name: performance-openshift-bootstrap-worker
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+spec:
+  kubeletConfig:
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous: {}
+      webhook:
+        cacheTTL: 0s
+      x509: {}
+    authorization:
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    containerRuntimeEndpoint: ""
+    cpuManagerPolicy: static
+    cpuManagerReconcilePeriod: 5s
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 0s
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      memory: 500Mi
+    logging:
+      flushFrequency: 0
+      options:
+        json:
+          infoBufferSize: "0"
+      verbosity: 0
+    memorySwap: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    reservedSystemCPUs: 2-3
+    runtimeRequestTimeout: 0s
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      memory: 500Mi
+    topologyManagerPolicy: best-effort
+    volumeStatsAggPeriod: 0s
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+status:
+  conditions: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -1,0 +1,175 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-performance-openshift-bootstrap-worker
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCm5vZGVzX3BhdGg9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vbm9kZSIKaHVnZXBhZ2VzX2ZpbGU9IiR7bm9kZXNfcGF0aH0vbm9kZSR7TlVNQV9OT0RFfS9odWdlcGFnZXMvaHVnZXBhZ2VzLSR7SFVHRVBBR0VTX1NJWkV9a0IvbnJfaHVnZXBhZ2VzIgoKaWYgWyAhIC1mICIke2h1Z2VwYWdlc19maWxlfSIgXTsgdGhlbgogIGVjaG8gIkVSUk9SOiAke2h1Z2VwYWdlc19maWxlfSBkb2VzIG5vdCBleGlzdCIKICBleGl0IDEKZmkKCnRpbWVvdXQ9NjAKc2FtcGxlPTEKY3VycmVudF90aW1lPTAKd2hpbGUgWyAiJChjYXQgIiR7aHVnZXBhZ2VzX2ZpbGV9IikiIC1uZSAiJHtIVUdFUEFHRVNfQ09VTlR9IiBdOyBkbwogIGVjaG8gIiR7SFVHRVBBR0VTX0NPVU5UfSIgPiIke2h1Z2VwYWdlc19maWxlfSIKCiAgY3VycmVudF90aW1lPSQoKGN1cnJlbnRfdGltZSArIHNhbXBsZSkpCiAgaWYgWyAkY3VycmVudF90aW1lIC1ndCAkdGltZW91dCBdOyB0aGVuCiAgICBlY2hvICJFUlJPUjogJHtodWdlcGFnZXNfZmlsZX0gZG9lcyBub3QgaGF2ZSB0aGUgZXhwZWN0ZWQgbnVtYmVyIG9mIGh1Z2VwYWdlcyAke0hVR0VQQUdFU19DT1VOVH0iCiAgICBleGl0IDEKICBmaQoKICBzbGVlcCAkc2FtcGxlCmRvbmUK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/hugepages-allocation.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZnVuY3Rpb24gc2V0X3F1ZXVlX3Jwc19tYXNrKCkgewojIHJlcGxhY2UgeDJkIHdpdGggaHlwaGVuICgtKSB3aGljaCBpcyBhbiBlc2NhcGVkIGNoYXJhY3RlcgojIHRoYXQgd2FzIGFkZGVkIGJ5IHN5c3RlbWQtZXNjYXBlIGluIG9yZGVyIHRvIGVzY2FwZSB0aGUgc3lzdGVtZCB1bml0IG5hbWUgdGhhdCBpbnZva2VzIHRoaXMgc2NyaXB0CnBhdGg9JHtwYXRoL3gyZC8tfQojIHNldCBycHMgYWZmaW5pdHkgZm9yIHRoZSBxdWV1ZQplY2hvICIke21hc2t9IiAgMj4gL2Rldi9udWxsID4gIi9zeXMvJHtwYXRofS9ycHNfY3B1cyIKIyB3ZSByZXR1cm4gMCBiZWNhdXNlIHRoZSAnZWNobycgY29tbWFuZCBtaWdodCBmYWlsIGlmIHRoZSBkZXZpY2UgcGF0aCB0byB3aGljaCB0aGUgcXVldWUgYmVsb25ncyBoYXMgY2hhbmdlZC4KIyB0aGlzIGNhbiBoYXBwZW4gaW4gY2FzZSBvZiBTUkktT1YgZGV2aWNlcyByZW5hbWluZy4KcmV0dXJuIDAKfQoKZnVuY3Rpb24gc2V0X25ldF9kZXZfcnBzX21hc2soKSB7CiAgIyBpbiBjYXNlIG9mIGRldmljZSB3ZSB3YW50IHRvIGl0ZXJhdGUgdGhyb3VnaCBhbGwgcXVldWVzCmZvciBpIGluIC9zeXMvIiR7cGF0aH0iL3F1ZXVlcy9yeC0qOyBkbwogIGVjaG8gIiR7bWFza30iIDI+IC9kZXYvbnVsbCA+ICIke2l9L3Jwc19jcHVzIgpkb25lCiMgd2UgcmV0dXJuIDAgYmVjYXVzZSB0aGUgJ2VjaG8nIGNvbW1hbmQgbWlnaHQgZmFpbCBpZiB0aGUgZGV2aWNlIHBhdGggdG8gd2hpY2ggdGhlIHF1ZXVlIGJlbG9uZ3MgaGFzIGNoYW5nZWQuCiMgdGhpcyBjYW4gaGFwcGVuIGluIGNhc2Ugb2YgU1JJLU9WIGRldmljZXMgcmVuYW1pbmcuCnJldHVybiAwCiB9CgpwYXRoPSR7MX0KWyAtbiAiJHtwYXRofSIgXSB8fCB7IGVjaG8gIlRoZSBkZXZpY2UgcGF0aCBhcmd1bWVudCBpcyBtaXNzaW5nIiA+JjIgOyBleGl0IDE7IH0KCm1hc2s9JHsyfQpbIC1uICIke21hc2t9IiBdIHx8IHsgZWNobyAiVGhlIG1hc2sgYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgppZiBbWyAiJHtwYXRofSIgPX4gInF1ZXVlcyIgXV07IHRoZW4KIHNldF9xdWV1ZV9ycHNfbWFzawplbHNlCiBzZXRfbmV0X2Rldl9ycHNfbWFzawpmaQo=
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-rps-mask.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9iYXNoCgpzZXQgLWV1byBwaXBlZmFpbAoKZm9yIGNwdSBpbiAke09GRkxJTkVfQ1BVUy8vLC8gfTsKICBkbwogICAgb25saW5lX2NwdV9maWxlPSIvc3lzL2RldmljZXMvc3lzdGVtL2NwdS9jcHUkY3B1L29ubGluZSIKICAgIGlmIFsgISAtZiAiJHtvbmxpbmVfY3B1X2ZpbGV9IiBdOyB0aGVuCiAgICAgIGVjaG8gIkVSUk9SOiAke29ubGluZV9jcHVfZmlsZX0gZG9lcyBub3QgZXhpc3QsIGFib3J0IHNjcmlwdCBleGVjdXRpb24iCiAgICAgIGV4aXQgMQogICAgZmkKICBkb25lCgplY2hvICJBbGwgY3B1cyBvZmZsaW5lZCBleGlzdHMsIHNldCB0aGVtIG9mZmxpbmUiCgpmb3IgY3B1IGluICR7T0ZGTElORV9DUFVTLy8sLyB9OwogIGRvCiAgICBvbmxpbmVfY3B1X2ZpbGU9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vY3B1L2NwdSRjcHUvb25saW5lIgogICAgZWNobyAwID4gIiR7b25saW5lX2NwdV9maWxlfSIKICAgIGVjaG8gIm9mZmxpbmUgY3B1IG51bSAkY3B1IgogIGRvbmUKCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-cpus-offline.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLWV1byBwaXBlZmFpbApzZXQgLXgKCiMgY29uc3QKU0VEPSIvdXNyL2Jpbi9zZWQiCiMgdHVuYWJsZSAtIG92ZXJyaWRhYmxlIGZvciB0ZXN0aW5nIHB1cnBvc2VzCklSUUJBTEFOQ0VfQ09ORj0iJHsxOi0vZXRjL3N5c2NvbmZpZy9pcnFiYWxhbmNlfSIKQ1JJT19PUklHX0JBTk5FRF9DUFVTPSIkezI6LS9ldGMvc3lzY29uZmlnL29yaWdfaXJxX2Jhbm5lZF9jcHVzfSIKClsgISAtZiAke0lSUUJBTEFOQ0VfQ09ORn0gXSAmJiBleGl0IDAKCiR7U0VEfSAtaSAnL15ccypJUlFCQUxBTkNFX0JBTk5FRF9DUFVTXGIvZCcgJHtJUlFCQUxBTkNFX0NPTkZ9IHx8IGV4aXQgMAplY2hvICJJUlFCQUxBTkNFX0JBTk5FRF9DUFVTPSIgPj4gJHtJUlFCQUxBTkNFX0NPTkZ9CgojIHdlIG5vdyBvd24gdGhpcyBjb25maWd1cmF0aW9uLiBCdXQgQ1JJLU8gaGFzIGNvZGUgdG8gcmVzdG9yZSB0aGUgY29uZmlndXJhdGlvbiwKIyBhbmQgdW50aWwgaXQgZ2FpbnMgdGhlIG9wdGlvbiB0byBkaXNhYmxlIHRoaXMgcmVzdG9yZSBmbG93LCB3ZSBuZWVkIHRvIG1ha2UKIyB0aGUgY29uZmlndXJhdGlvbiBjb25zaXN0ZW50IHN1Y2ggYXMgdGhlIENSSS1PIHJlc3RvcmUgd2lsbCBkbyBub3RoaW5nLgppZiBbIC1uICR7Q1JJT19PUklHX0JBTk5FRF9DUFVTfSBdICYmIFsgLWYgJHtDUklPX09SSUdfQkFOTkVEX0NQVVN9IF07IHRoZW4KCXRydWUgPiAke0NSSU9fT1JJR19CQU5ORURfQ1BVU30KZmkK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/clear-irqbalance-banned-cpus.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMi0zIgoKCgojIFdlIHNob3VsZCBjb3B5IHBhc3RlIHRoZSBkZWZhdWx0IHJ1bnRpbWUgYmVjYXVzZSB0aGlzIHNuaXBwZXQgd2lsbCBvdmVycmlkZSB0aGUgd2hvbGUgcnVudGltZXMgc2VjdGlvbgpbY3Jpby5ydW50aW1lLnJ1bnRpbWVzLnJ1bmNdCnJ1bnRpbWVfcGF0aCA9ICIiCnJ1bnRpbWVfdHlwZSA9ICJvY2kiCnJ1bnRpbWVfcm9vdCA9ICIvcnVuL3J1bmMiCgojIFRoZSBDUkktTyB3aWxsIGNoZWNrIHRoZSBhbGxvd2VkX2Fubm90YXRpb25zIHVuZGVyIHRoZSBydW50aW1lIGhhbmRsZXIgYW5kIGFwcGx5IGhpZ2gtcGVyZm9ybWFuY2UgaG9va3Mgd2hlbiBvbmUgb2YKIyBoaWdoLXBlcmZvcm1hbmNlIGFubm90YXRpb25zIHByZXNlbnRzIHVuZGVyIGl0LgojIFdlIHNob3VsZCBwcm92aWRlIHRoZSBydW50aW1lX3BhdGggYmVjYXVzZSB3ZSBuZWVkIHRvIGluZm9ybSB0aGF0IHdlIHdhbnQgdG8gcmUtdXNlIHJ1bmMgYmluYXJ5IGFuZCB3ZQojIGRvIG5vdCBoYXZlIGhpZ2gtcGVyZm9ybWFuY2UgYmluYXJ5IHVuZGVyIHRoZSAkUEFUSCB0aGF0IHdpbGwgcG9pbnQgdG8gaXQuCltjcmlvLnJ1bnRpbWUucnVudGltZXMuaGlnaC1wZXJmb3JtYW5jZV0KcnVudGltZV9wYXRoID0gIi9iaW4vcnVuYyIKcnVudGltZV90eXBlID0gIm9jaSIKcnVudGltZV9yb290ID0gIi9ydW4vcnVuYyIKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LWMtc3RhdGVzLmNyaW8uaW8iLCAiY3B1LWZyZXEtZ292ZXJub3IuY3Jpby5pbyJdCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-runtimes.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBBcHBseSB0aGUgUlBTIG1hc2sgb24gdGhlIHZpcnR1YWwgaW50ZXJmYWNlcyBvZiB0aGUgaG9zdCBieSBkZWZhdWx0LCBiZWNhc3VlCiMgZnJvbSB0aGUgY29udGFpbmVyIHBlcnNwZWN0aXZlIHRoZSBSUFMgbWFzayB0aGUgd2lsbCBiZSBjb25zdWx0ZWQsIGlzIHRoZSBvbmUgb24gdGhlIFJYIHNpZGUgb2YgdGhlIHZldGggaW4gdGhlIGhvc3QuCiMgQ29uc2lkZXIgdGhlIGZvbGxvd2luZyBkaWFncmFtOgojIFBvZCBBIDx2ZXRoMSAtIHZldGgyPiBob3N0IDx2ZXRoMyAtIHZldGg0PiBQb2QgQgojICB2ZXRoMidzIFJQUyBhZmZpbml0eSBpcyB0aGUgb25lIGRldGVybWluaW5nIHRoZSBDUFVzIHRoYXQgYXJlIGhhbmRsaW5nIHRoZSBwYWNrZXQgcHJvY2Vzc2luZyB3aGVuIHNlbmRpbmcgZGF0YSBmcm9tIFBvZCBBIHRvIHBvZCBCLgojIEFkZGl0aW9uYWwgY29tbW9uIHNjZW5hcmlvczoKIyAxLiBQb2QgQSA9IHNlbmRlciwgaG9zdCA9IHJlY2VpdmVyCiMgIFRoZSBSUFMgYWZmaW5pdHkgb2YgdGhlIGhvc3Qgc2lkZSBzaG91bGQgYmUgY29uc3VsdGVkIChiZWNhdXNlIGl04oCZcyB0aGUgcmVjZWl2ZXIpIGFuZCBpdCBzaG91bGQgYmUgc2V0IHRvIGNwdXMgbm90IHNlbnNpdGl2ZSB0byBwcmVlbXB0aW9uIChyZXNlcnZlZCBwb29sKS4KIyAyLiBQb2QgQSA9IHJlY2VpdmVyLCBob3N0ID0gc2VuZGVyCiMgIEluIGNhc2Ugb2Ygbm8gUlBTIG1hc2sgb24gdGhlIHJlY2VpdmVyIHNpZGUsIHRoZSBzZW5kZXIgbmVlZHMgdG8gcGF5IHRoZSBwcmljZSBhbmQgZG8gYWxsIHRoZSBwcm9jZXNzaW5nIG9uIGl0cyBjb3Jlcy4KbmV0LmNvcmUucnBzX2RlZmF1bHRfbWFzayA9IDAwMDAwMDBjCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysctl.d/99-default-rps-mask.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0icXVldWVzIiwgQUNUSU9OPT0iYWRkIiwgRU5We0RFVlBBVEh9PT0iL2RldmljZXMvcGNpKi9xdWV1ZXMvcngqIiwgVEFHKz0ic3lzdGVtZCIsIFBST0dSQU09Ii9iaW4vc3lzdGVtZC1lc2NhcGUgLS1wYXRoIC0tdGVtcGxhdGU9dXBkYXRlLXJwc0Auc2VydmljZSAkZW52e0RFVlBBVEh9IiwgRU5We1NZU1RFTURfV0FOVFN9PSIlYyIKCiMgU1ItSU9WIGRldmljZXMgYXJlIG1vdmVkIChyZW5hbWVkKSwgaGVuY2Ugd2Ugd2FudCB0byBjYXRjaCB0aGlzIGV2ZW50IGFzIHdlbGwKU1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0ibW92ZSIsIEVOVntERVZQQVRIfSE9Ii9kZXZpY2VzL3ZpcnR1YWwvbmV0LyoiLCBUQUcrPSJzeXN0ZW1kIiwgUFJPR1JBTT0iL2Jpbi9zeXN0ZW1kLWVzY2FwZSAtLXBhdGggLS10ZW1wbGF0ZT11cGRhdGUtcnBzQC5zZXJ2aWNlICRlbnZ7REVWUEFUSH0iLCBFTlZ7U1lTVEVNRF9XQU5UU309IiVjIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/99-netdev-physical-rps.rules
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWUud29ya2xvYWRzLm1hbmFnZW1lbnRdCmFjdGl2YXRpb25fYW5ub3RhdGlvbiA9ICJ0YXJnZXQud29ya2xvYWQub3BlbnNoaWZ0LmlvL21hbmFnZW1lbnQiCmFubm90YXRpb25fcHJlZml4ID0gInJlc291cmNlcy53b3JrbG9hZC5vcGVuc2hpZnQuaW8iCnJlc291cmNlcyA9IHsgImNwdXNoYXJlcyIgPSAwLCAiY3B1c2V0IiA9ICIyLTMiIH0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-workload-pinning.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CnsKICAibWFuYWdlbWVudCI6IHsKICAgICJjcHVzZXQiOiAiMi0zIgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCiMgY3B1c2V0LWNvbmZpZ3VyZS5zaCBjb25maWd1cmVzIHRocmVlIGNwdXNldHMgaW4gcHJlcGFyYXRpb24gZm9yIGFsbG93aW5nIGNvbnRhaW5lcnMgdG8gaGF2ZSBjcHUgbG9hZCBiYWxhbmNpbmcgZGlzYWJsZWQuCiMgVG8gY29uZmlndXJlIGEgY3B1c2V0IHRvIGhhdmUgbG9hZCBiYWxhbmNlIGRpc2FibGVkIChvbiBjZ3JvdXAgdjEpLCBhIGNwdXNldCBjZ3JvdXAgbXVzdCBoYXZlIGBjcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlYAojIHNldCB0byAwIChkaXNhYmxlKSwgYW5kIGFueSBjcHVzZXQgdGhhdCBjb250YWlucyB0aGUgc2FtZSBzZXQgYXMgYGNwdXNldC5jcHVzYCBtdXN0IGFsc28gaGF2ZSBgY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZWAgc2V0IHRvIGRpc2FibGVkLgoKc2V0IC1ldW8gcGlwZWZhaWwKCmlmIHRlc3QgIiQoc3RhdCAtZiAtYyVUIC9zeXMvZnMvY2dyb3VwKSIgPSAiY2dyb3VwMmZzIjsgdGhlbgoJZWNobyAiTm9kZSBpcyB1c2luZyBjZ3JvdXAgdjIsIG5vIGNvbmZpZ3VyYXRpb24gbmVlZGVkIgoJZXhpdCAwCmZpCgpyb290PS9zeXMvZnMvY2dyb3VwL2NwdXNldApzeXN0ZW09IiRyb290Ii9zeXN0ZW0uc2xpY2UKbWFjaGluZT0iJHJvb3QiL21hY2hpbmUuc2xpY2UKCm92c3NsaWNlPSIke3Jvb3R9L292cy5zbGljZSIKb3Zzc2xpY2Vfc3lzdGVtZD0iL3N5cy9mcy9jZ3JvdXAvcGlkcy9vdnMuc2xpY2UiCgojIEFzIHN1Y2gsIHRoZSByb290IGNncm91cCBuZWVkcyB0byBoYXZlIGNwdXNldC5zY2hlZF9sb2FkX2JhbGFuY2U9MC4gCmVjaG8gMCA+ICIkcm9vdCIvY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZQoKIyBIb3dldmVyLCB0aGlzIHdvdWxkIHByZXNlbnQgYSBwcm9ibGVtIGZvciBzeXN0ZW0gZGFlbW9ucywgd2hpY2ggc2hvdWxkIGhhdmUgbG9hZCBiYWxhbmNpbmcgZW5hYmxlZC4KIyBBcyBzdWNoLCBhIHNlY29uZCBjcHVzZXQgbXVzdCBiZSBjcmVhdGVkLCBoZXJlIGR1YmJlZCBgc3lzdGVtYCwgd2hpY2ggd2lsbCB0YWtlIGFsbCBzeXN0ZW0gZGFlbW9ucy4KIyBTaW5jZSBzeXN0ZW1kIHN0YXJ0cyBpdHMgY2hpbGRyZW4gd2l0aCB0aGUgY3B1c2V0IGl0IGlzIGluLCBtb3Zpbmcgc3lzdGVtZCB3aWxsIGVuc3VyZSBhbGwgcHJvY2Vzc2VzIHN5c3RlbWQgYmVnaW5zIHdpbGwgYmUgaW4gdGhlIGNvcnJlY3QgY2dyb3VwLgpta2RpciAtcCAiJHN5c3RlbSIKIyBjcHVzZXQubWVtcyBtdXN0IGJlIGluaXRpYWxpemVkIG9yIHByb2Nlc3NlcyB3aWxsIGZhaWwgdG8gYmUgbW92ZWQgaW50byBpdC4KY2F0ICIkcm9vdC9jcHVzZXQubWVtcyIgPiAiJHN5c3RlbSIvY3B1c2V0Lm1lbXMKIyBSZXRyaWV2ZSB0aGUgY3B1c2V0IG9mIHN5c3RlbWQsIGFuZCB3cml0ZSBpdCB0byBjcHVzZXQuY3B1cyBvZiB0aGUgc3lzdGVtIGNncm91cC4KcmVzZXJ2ZWRfc2V0PSQodGFza3NldCAtY3AgIDEgIHwgYXdrICdORnsgcHJpbnQgJE5GIH0nKQplY2hvICIkcmVzZXJ2ZWRfc2V0IiA+ICIkc3lzdGVtIi9jcHVzZXQuY3B1cwoKIyBBbmQgbW92ZSB0aGUgc3lzdGVtIHByb2Nlc3NlcyBpbnRvIGl0LgojIE5vdGUsIHNvbWUga2VybmVsIHRocmVhZHMgd2lsbCBmYWlsIHRvIGJlIG1vdmVkIHdpdGggIkludmFsaWQgQXJndW1lbnQiLiBUaGlzIHNob3VsZCBiZSBpZ25vcmVkLgpmb3IgcHJvY2VzcyBpbiAkKGNhdCAiJHJvb3QiL2Nncm91cC5wcm9jcyB8IHNvcnQgLXIpOyBkbwoJZWNobyAkcHJvY2VzcyA+ICIkc3lzdGVtIi9jZ3JvdXAucHJvY3MgMj4mMSB8IGdyZXAgLXYgIkludmFsaWQgQXJndW1lbnQiIHx8IHRydWU7CmRvbmUKCiMgRmluYWxseSwgYSB0aGUgYG1hY2hpbmUuc2xpY2VgIGNncm91cCBtdXN0IGJlIHByZWNvbmZpZ3VyZWQuIFBvZG1hbiB3aWxsIGNyZWF0ZSBjb250YWluZXJzIGFuZCBtb3ZlIHRoZW0gaW50byB0aGUgYG1hY2hpbmUuc2xpY2VgLCBidXQgdGhlcmUncwojIG5vIHdheSB0byB0ZWxsIHBvZG1hbiB0byB1cGRhdGUgbWFjaGluZS5zbGljZSB0byBub3QgaGF2ZSB0aGUgZnVsbCBzZXQgb2YgY3B1cy4gSW5zdGVhZCBvZiBkaXNhYmxpbmcgbG9hZCBiYWxhbmNpbmcgaW4gaXQsIHdlIGNhbiBwcmUtY3JlYXRlIGl0LgojIHdpdGggdGhlIHJlc2VydmVkIENQVXMgc2V0IGFoZWFkIG9mIHRpbWUsIHNvIHdoZW4gaXNvbGF0ZWQgcHJvY2Vzc2VzIGJlZ2luLCB0aGUgY2dyb3VwIGRvZXMgbm90IGhhdmUgYW4gb3ZlcmxhcHBpbmcgY3B1c2V0IGJldHdlZW4gbWFjaGluZS5zbGljZSBhbmQgaXNvbGF0ZWQgY29udGFpbmVycy4KbWtkaXIgLXAgIiRtYWNoaW5lIgoKIyBJdCdzIHVubGlrZWx5LCBidXQgcG9zc2libGUsIHRoYXQgdGhpcyBjcHVzZXQgYWxyZWFkeSBleGlzdGVkLiBJdGVyYXRlIGp1c3QgaW4gY2FzZS4KZm9yIGZpbGUgaW4gJChmaW5kICIkbWFjaGluZSIgLW5hbWUgY3B1c2V0LmNwdXMgfCBzb3J0IC1yKTsgZG8gZWNobyAiJHJlc2VydmVkX3NldCIgPiAiJGZpbGUiOyBkb25lCgojIE9WUyBpcyBydW5uaW5nIGluIGl0cyBvd24gc2xpY2UgdGhhdCBzcGFucyBhbGwgY3B1cy4gVGhlIHJlYWwgYWZmaW5pdHkgaXMgbWFuYWdlZCBieSBPVk4tSyBvdm5rdWJlLW5vZGUgZGFlbW9uc2V0CiMgTWFrZSBzdXJlIHRoaXMgc2xpY2Ugd2lsbCBub3QgZW5hYmxlIGNwdSBiYWxhbmNpbmcgZm9yIG90aGVyIHNsaWNlIGNvbmZpZ3VyZWQgYnkgdGhpcyBzY3JpcHQuCiMgVGhpcyBtaWdodCBzZWVtIGNvdW50ZXItaW50dWl0aXZlLCBidXQgdGhpcyB3aWxsIGFjdHVhbGx5IE5PVCBkaXNhYmxlIGNwdSBiYWxhbmNpbmcgZm9yIE9WUyBpdHNlbGYuCiMgLSBPVlMgaGFzIGFjY2VzcyB0byByZXNlcnZlZCBjcHVzLCBidXQgdGhvc2UgaGF2ZSBiYWxhbmNpbmcgZW5hYmxlZCB2aWEgdGhlIGBzeXN0ZW1gIGNncm91cCBjcmVhdGVkIGFib3ZlCiMgLSBPVlMgaGFzIGFjY2VzcyB0byBpc29sYXRlZCBjcHVzIHRoYXQgYXJlIGN1cnJlbnRseSBub3QgYXNzaWduZWQgdG8gcGlubmVkIHBvZHMuIFRob3NlIGhhdmUgYmFsYW5jaW5nIGVuYWJsZWQgYnkgdGhlCiMgICBwb2RzIHJ1bm5pbmcgdGhlcmUgKGJ1cnN0YWJsZSBhbmQgYmVzdC1lZmZvcnQgcG9kcyBoYXZlIGJhbGFuY2luZyBlbmFibGVkIGluIHRoZSBjb250YWluZXIgY2dyb3VwIGFuZCBhY2Nlc3MgdG8gYWxsCiMgICB1bnBpbm5lZCBjcHVzKS4KCiMgc3lzdGVtZCBkb2VzIG5vdCBtYW5hZ2UgdGhlIGNwdXNldCBjZ3JvdXAgY29udHJvbGxlciwgc28gbW92ZSBldmVyeXRoaW5nIGZyb20gdGhlIG1hbmFnZWQgcGlkcyBjb250cm9sbGVyJ3Mgb3ZzLnNsaWNlCiMgdG8gdGhlIGNwdXNldCBjb250cm9sbGVyLgoKIyBDcmVhdGUgdGhlIG92cy5zbGljZQpta2RpciAtcCAiJG92c3NsaWNlIgplY2hvIDAgPiAiJG92c3NsaWNlIi9jcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlCmNhdCAiJHJvb3QiL2NwdXNldC5jcHVzID4gIiRvdnNzbGljZSIvY3B1c2V0LmNwdXMKY2F0ICIkcm9vdCIvY3B1c2V0Lm1lbXMgPiAiJG92c3NsaWNlIi9jcHVzZXQubWVtcwoKIyBNb3ZlIE9WUyBvdmVyCmZvciBwcm9jZXNzIGluICQoY2F0ICIkb3Zzc2xpY2Vfc3lzdGVtZCIvKi9jZ3JvdXAucHJvY3MgfCBzb3J0IC1yKTsgZG8KICAgICAgICBlY2hvICRwcm9jZXNzID4gIiRvdnNzbGljZSIvY2dyb3VwLnByb2NzIDI+JjEgfCBncmVwIC12ICJJbnZhbGlkIEFyZ3VtZW50IiB8fCB0cnVlOwpkb25lCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/cpuset-configure.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs.slice
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/openvswitch.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs-vswitchd.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovsdb-server.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBUaGlzIGZpbGUgZW5hYmxlcyB0aGUgZHluYW1pYyBjcHUgYWZmaW5pdHkgbWFuYWdlbWVudCBvZiB0aGUgT1ZTIHNlcnZpY2VzCiMKIyBJdCBpcyByZWFkIGJ5IHRoZSBPVk4ncyBvdm5rdWJlLW5vZGUgRGFlbW9uU2V0IGNvbnRhaW5lciBhbmQgdGhlIGZlYXR1cmUKIyBpcyBlbmFibGVkIHdoZW4gdGhpcyBmaWxlIGV4aXN0cyBhbmQgaXMgbm90IGVtcHR5ICh0aGlzIGNvbW1lbnRhcnkgdGV4dAojIGVuc3VyZXMgdGhhdCkKIwojIEZvciBkaXNhYmxpbmcgdGhpcyBmZWF0dXJlIGluIGVtZXJnZW5jaWVzLCBlaXRoZXI6CiMgMSkgZGVsZXRlIHRoaXMgZmlsZSBhbmQgc2V0IHRoZSBjcHUgYWZmaW5pdHkgb2YgT1ZTIHNlcnZpY2VzIG1hbnVhbGx5CiMgMikgb3IgcmVwbGFjZSB0aGUgY29udGVudHMgb2YgdGhpcyBmaWxlIHdpdGggYW4gZW1wdHkgc3RyaW5nCiMgICAgdmlhIGEgTWFjaGluZUNvbmZpZwo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
+        user: {}
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Sets network devices RPS mask
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/set-rps-mask.sh %I 0
+        name: update-rps@.service
+      - contents: |
+          [Unit]
+          Description=Move services to reserved cpuset
+          Before=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/cpuset-configure.sh
+
+          [Install]
+          WantedBy=multi-user.target crio.service
+        enabled: true
+        name: cpuset-configure.service
+      - contents: |
+          [Unit]
+          Description=Clear the IRQBalance Banned CPU mask early in the boot
+          Before=kubelet.service
+          Before=irqbalance.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/clear-irqbalance-banned-cpus.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: clear-irqbalance-banned-cpus.service
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: default
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_node.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_node.yaml
@@ -1,0 +1,13 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  creationTimestamp: null
+  name: cluster
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+spec:
+  cgroupMode: v1
+status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_runtimeclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: node.k8s.io/v1
+handler: high-performance
+kind: RuntimeClass
+metadata:
+  creationTimestamp: null
+  name: performance-openshift-bootstrap-worker
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -1,0 +1,67 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  creationTimestamp: null
+  name: openshift-node-performance-openshift-bootstrap-worker
+  namespace: openshift-cluster-node-tuning-operator
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+spec:
+  profile:
+  - data: "[main]\nsummary=Openshift node optimized for deterministic performance
+      at the cost of increased power consumption, focused on low latency network performance.
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
+      -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
+      All values are mapped with a comment where a parent profile contains them.\n#
+      Different values will override the original values in parent profiles.\n\n[variables]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
+      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
+      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
+      plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      = ignore\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
+      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
+      RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
+      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
+      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
+      working set is buffered for I/O, and any more write buffering would require\n#
+      swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
+      that mostly use file mappings may be able to use even higher values.\n#\n# The
+      generator of dirty data starts writeback at this percentage (system default\n#
+      is 20%)\n#> latency-performance\nvm.dirty_ratio=10\n\n# Start background writeback
+      (via writeback threads) at this percentage (system\n# default is 10%)\n#> latency-performance\nvm.dirty_background_ratio=3\n\n#
+      The swappiness parameter controls the tendency of the kernel to move\n# processes
+      out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
+      swapping processes out of physical memory\n# for as long as possible\n# 100
+      tells the kernel to aggressively swap processes out of physical memory\n# and
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
+      configured via a sysctl.d file\n# placed here for documentation purposes and
+      commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
+    name: openshift-node-performance-openshift-bootstrap-worker
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: worker
+    operand:
+      tunedConfig:
+        reapply_sysctl: null
+    priority: 20
+    profile: openshift-node-performance-openshift-bootstrap-worker
+status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/01_01-master-cpu-partitioning_workload_pinning_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/01_01-master-cpu-partitioning_workload_pinning_machineconfig.yaml
@@ -1,0 +1,42 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 01-master-cpu-partitioning
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CnsKICAibWFuYWdlbWVudCI6IHsKICAgICJjcHVzZXQiOiAiIgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWUud29ya2xvYWRzLm1hbmFnZW1lbnRdCmFjdGl2YXRpb25fYW5ub3RhdGlvbiA9ICJ0YXJnZXQud29ya2xvYWQub3BlbnNoaWZ0LmlvL21hbmFnZW1lbnQiCmFubm90YXRpb25fcHJlZml4ID0gInJlc291cmNlcy53b3JrbG9hZC5vcGVuc2hpZnQuaW8iCnJlc291cmNlcyA9IHsgImNwdXNoYXJlcyIgPSAwLCAiY3B1c2V0IiA9ICIiIH0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/01-workload-pinning-default.conf
+        user: {}
+    systemd: {}
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: ""
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/01_01-worker-cpu-partitioning_workload_pinning_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/01_01-worker-cpu-partitioning_workload_pinning_machineconfig.yaml
@@ -1,0 +1,42 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 01-worker-cpu-partitioning
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CnsKICAibWFuYWdlbWVudCI6IHsKICAgICJjcHVzZXQiOiAiIgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWUud29ya2xvYWRzLm1hbmFnZW1lbnRdCmFjdGl2YXRpb25fYW5ub3RhdGlvbiA9ICJ0YXJnZXQud29ya2xvYWQub3BlbnNoaWZ0LmlvL21hbmFnZW1lbnQiCmFubm90YXRpb25fcHJlZml4ID0gInJlc291cmNlcy53b3JrbG9hZC5vcGVuc2hpZnQuaW8iCnJlc291cmNlcyA9IHsgImNwdXNoYXJlcyIgPSAwLCAiY3B1c2V0IiA9ICIiIH0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/01-workload-pinning-default.conf
+        user: {}
+    systemd: {}
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: ""
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_kubeletconfig.yaml
@@ -1,0 +1,61 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  creationTimestamp: null
+  name: performance-openshift-bootstrap-master
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+spec:
+  kubeletConfig:
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous: {}
+      webhook:
+        cacheTTL: 0s
+      x509: {}
+    authorization:
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    containerRuntimeEndpoint: ""
+    cpuManagerPolicy: static
+    cpuManagerReconcilePeriod: 5s
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 0s
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      memory: 500Mi
+    logging:
+      flushFrequency: 0
+      options:
+        json:
+          infoBufferSize: "0"
+      verbosity: 0
+    memorySwap: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    reservedSystemCPUs: 2-7
+    runtimeRequestTimeout: 0s
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      memory: 500Mi
+    topologyManagerPolicy: best-effort
+    volumeStatsAggPeriod: 0s
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+status:
+  conditions: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -1,0 +1,175 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 50-performance-openshift-bootstrap-master
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCm5vZGVzX3BhdGg9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vbm9kZSIKaHVnZXBhZ2VzX2ZpbGU9IiR7bm9kZXNfcGF0aH0vbm9kZSR7TlVNQV9OT0RFfS9odWdlcGFnZXMvaHVnZXBhZ2VzLSR7SFVHRVBBR0VTX1NJWkV9a0IvbnJfaHVnZXBhZ2VzIgoKaWYgWyAhIC1mICIke2h1Z2VwYWdlc19maWxlfSIgXTsgdGhlbgogIGVjaG8gIkVSUk9SOiAke2h1Z2VwYWdlc19maWxlfSBkb2VzIG5vdCBleGlzdCIKICBleGl0IDEKZmkKCnRpbWVvdXQ9NjAKc2FtcGxlPTEKY3VycmVudF90aW1lPTAKd2hpbGUgWyAiJChjYXQgIiR7aHVnZXBhZ2VzX2ZpbGV9IikiIC1uZSAiJHtIVUdFUEFHRVNfQ09VTlR9IiBdOyBkbwogIGVjaG8gIiR7SFVHRVBBR0VTX0NPVU5UfSIgPiIke2h1Z2VwYWdlc19maWxlfSIKCiAgY3VycmVudF90aW1lPSQoKGN1cnJlbnRfdGltZSArIHNhbXBsZSkpCiAgaWYgWyAkY3VycmVudF90aW1lIC1ndCAkdGltZW91dCBdOyB0aGVuCiAgICBlY2hvICJFUlJPUjogJHtodWdlcGFnZXNfZmlsZX0gZG9lcyBub3QgaGF2ZSB0aGUgZXhwZWN0ZWQgbnVtYmVyIG9mIGh1Z2VwYWdlcyAke0hVR0VQQUdFU19DT1VOVH0iCiAgICBleGl0IDEKICBmaQoKICBzbGVlcCAkc2FtcGxlCmRvbmUK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/hugepages-allocation.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZnVuY3Rpb24gc2V0X3F1ZXVlX3Jwc19tYXNrKCkgewojIHJlcGxhY2UgeDJkIHdpdGggaHlwaGVuICgtKSB3aGljaCBpcyBhbiBlc2NhcGVkIGNoYXJhY3RlcgojIHRoYXQgd2FzIGFkZGVkIGJ5IHN5c3RlbWQtZXNjYXBlIGluIG9yZGVyIHRvIGVzY2FwZSB0aGUgc3lzdGVtZCB1bml0IG5hbWUgdGhhdCBpbnZva2VzIHRoaXMgc2NyaXB0CnBhdGg9JHtwYXRoL3gyZC8tfQojIHNldCBycHMgYWZmaW5pdHkgZm9yIHRoZSBxdWV1ZQplY2hvICIke21hc2t9IiAgMj4gL2Rldi9udWxsID4gIi9zeXMvJHtwYXRofS9ycHNfY3B1cyIKIyB3ZSByZXR1cm4gMCBiZWNhdXNlIHRoZSAnZWNobycgY29tbWFuZCBtaWdodCBmYWlsIGlmIHRoZSBkZXZpY2UgcGF0aCB0byB3aGljaCB0aGUgcXVldWUgYmVsb25ncyBoYXMgY2hhbmdlZC4KIyB0aGlzIGNhbiBoYXBwZW4gaW4gY2FzZSBvZiBTUkktT1YgZGV2aWNlcyByZW5hbWluZy4KcmV0dXJuIDAKfQoKZnVuY3Rpb24gc2V0X25ldF9kZXZfcnBzX21hc2soKSB7CiAgIyBpbiBjYXNlIG9mIGRldmljZSB3ZSB3YW50IHRvIGl0ZXJhdGUgdGhyb3VnaCBhbGwgcXVldWVzCmZvciBpIGluIC9zeXMvIiR7cGF0aH0iL3F1ZXVlcy9yeC0qOyBkbwogIGVjaG8gIiR7bWFza30iIDI+IC9kZXYvbnVsbCA+ICIke2l9L3Jwc19jcHVzIgpkb25lCiMgd2UgcmV0dXJuIDAgYmVjYXVzZSB0aGUgJ2VjaG8nIGNvbW1hbmQgbWlnaHQgZmFpbCBpZiB0aGUgZGV2aWNlIHBhdGggdG8gd2hpY2ggdGhlIHF1ZXVlIGJlbG9uZ3MgaGFzIGNoYW5nZWQuCiMgdGhpcyBjYW4gaGFwcGVuIGluIGNhc2Ugb2YgU1JJLU9WIGRldmljZXMgcmVuYW1pbmcuCnJldHVybiAwCiB9CgpwYXRoPSR7MX0KWyAtbiAiJHtwYXRofSIgXSB8fCB7IGVjaG8gIlRoZSBkZXZpY2UgcGF0aCBhcmd1bWVudCBpcyBtaXNzaW5nIiA+JjIgOyBleGl0IDE7IH0KCm1hc2s9JHsyfQpbIC1uICIke21hc2t9IiBdIHx8IHsgZWNobyAiVGhlIG1hc2sgYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgppZiBbWyAiJHtwYXRofSIgPX4gInF1ZXVlcyIgXV07IHRoZW4KIHNldF9xdWV1ZV9ycHNfbWFzawplbHNlCiBzZXRfbmV0X2Rldl9ycHNfbWFzawpmaQo=
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-rps-mask.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9iYXNoCgpzZXQgLWV1byBwaXBlZmFpbAoKZm9yIGNwdSBpbiAke09GRkxJTkVfQ1BVUy8vLC8gfTsKICBkbwogICAgb25saW5lX2NwdV9maWxlPSIvc3lzL2RldmljZXMvc3lzdGVtL2NwdS9jcHUkY3B1L29ubGluZSIKICAgIGlmIFsgISAtZiAiJHtvbmxpbmVfY3B1X2ZpbGV9IiBdOyB0aGVuCiAgICAgIGVjaG8gIkVSUk9SOiAke29ubGluZV9jcHVfZmlsZX0gZG9lcyBub3QgZXhpc3QsIGFib3J0IHNjcmlwdCBleGVjdXRpb24iCiAgICAgIGV4aXQgMQogICAgZmkKICBkb25lCgplY2hvICJBbGwgY3B1cyBvZmZsaW5lZCBleGlzdHMsIHNldCB0aGVtIG9mZmxpbmUiCgpmb3IgY3B1IGluICR7T0ZGTElORV9DUFVTLy8sLyB9OwogIGRvCiAgICBvbmxpbmVfY3B1X2ZpbGU9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vY3B1L2NwdSRjcHUvb25saW5lIgogICAgZWNobyAwID4gIiR7b25saW5lX2NwdV9maWxlfSIKICAgIGVjaG8gIm9mZmxpbmUgY3B1IG51bSAkY3B1IgogIGRvbmUKCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-cpus-offline.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLWV1byBwaXBlZmFpbApzZXQgLXgKCiMgY29uc3QKU0VEPSIvdXNyL2Jpbi9zZWQiCiMgdHVuYWJsZSAtIG92ZXJyaWRhYmxlIGZvciB0ZXN0aW5nIHB1cnBvc2VzCklSUUJBTEFOQ0VfQ09ORj0iJHsxOi0vZXRjL3N5c2NvbmZpZy9pcnFiYWxhbmNlfSIKQ1JJT19PUklHX0JBTk5FRF9DUFVTPSIkezI6LS9ldGMvc3lzY29uZmlnL29yaWdfaXJxX2Jhbm5lZF9jcHVzfSIKClsgISAtZiAke0lSUUJBTEFOQ0VfQ09ORn0gXSAmJiBleGl0IDAKCiR7U0VEfSAtaSAnL15ccypJUlFCQUxBTkNFX0JBTk5FRF9DUFVTXGIvZCcgJHtJUlFCQUxBTkNFX0NPTkZ9IHx8IGV4aXQgMAplY2hvICJJUlFCQUxBTkNFX0JBTk5FRF9DUFVTPSIgPj4gJHtJUlFCQUxBTkNFX0NPTkZ9CgojIHdlIG5vdyBvd24gdGhpcyBjb25maWd1cmF0aW9uLiBCdXQgQ1JJLU8gaGFzIGNvZGUgdG8gcmVzdG9yZSB0aGUgY29uZmlndXJhdGlvbiwKIyBhbmQgdW50aWwgaXQgZ2FpbnMgdGhlIG9wdGlvbiB0byBkaXNhYmxlIHRoaXMgcmVzdG9yZSBmbG93LCB3ZSBuZWVkIHRvIG1ha2UKIyB0aGUgY29uZmlndXJhdGlvbiBjb25zaXN0ZW50IHN1Y2ggYXMgdGhlIENSSS1PIHJlc3RvcmUgd2lsbCBkbyBub3RoaW5nLgppZiBbIC1uICR7Q1JJT19PUklHX0JBTk5FRF9DUFVTfSBdICYmIFsgLWYgJHtDUklPX09SSUdfQkFOTkVEX0NQVVN9IF07IHRoZW4KCXRydWUgPiAke0NSSU9fT1JJR19CQU5ORURfQ1BVU30KZmkK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/clear-irqbalance-banned-cpus.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMi03IgoKCgojIFdlIHNob3VsZCBjb3B5IHBhc3RlIHRoZSBkZWZhdWx0IHJ1bnRpbWUgYmVjYXVzZSB0aGlzIHNuaXBwZXQgd2lsbCBvdmVycmlkZSB0aGUgd2hvbGUgcnVudGltZXMgc2VjdGlvbgpbY3Jpby5ydW50aW1lLnJ1bnRpbWVzLnJ1bmNdCnJ1bnRpbWVfcGF0aCA9ICIiCnJ1bnRpbWVfdHlwZSA9ICJvY2kiCnJ1bnRpbWVfcm9vdCA9ICIvcnVuL3J1bmMiCgojIFRoZSBDUkktTyB3aWxsIGNoZWNrIHRoZSBhbGxvd2VkX2Fubm90YXRpb25zIHVuZGVyIHRoZSBydW50aW1lIGhhbmRsZXIgYW5kIGFwcGx5IGhpZ2gtcGVyZm9ybWFuY2UgaG9va3Mgd2hlbiBvbmUgb2YKIyBoaWdoLXBlcmZvcm1hbmNlIGFubm90YXRpb25zIHByZXNlbnRzIHVuZGVyIGl0LgojIFdlIHNob3VsZCBwcm92aWRlIHRoZSBydW50aW1lX3BhdGggYmVjYXVzZSB3ZSBuZWVkIHRvIGluZm9ybSB0aGF0IHdlIHdhbnQgdG8gcmUtdXNlIHJ1bmMgYmluYXJ5IGFuZCB3ZQojIGRvIG5vdCBoYXZlIGhpZ2gtcGVyZm9ybWFuY2UgYmluYXJ5IHVuZGVyIHRoZSAkUEFUSCB0aGF0IHdpbGwgcG9pbnQgdG8gaXQuCltjcmlvLnJ1bnRpbWUucnVudGltZXMuaGlnaC1wZXJmb3JtYW5jZV0KcnVudGltZV9wYXRoID0gIi9iaW4vcnVuYyIKcnVudGltZV90eXBlID0gIm9jaSIKcnVudGltZV9yb290ID0gIi9ydW4vcnVuYyIKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LWMtc3RhdGVzLmNyaW8uaW8iLCAiY3B1LWZyZXEtZ292ZXJub3IuY3Jpby5pbyJdCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-runtimes.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBBcHBseSB0aGUgUlBTIG1hc2sgb24gdGhlIHZpcnR1YWwgaW50ZXJmYWNlcyBvZiB0aGUgaG9zdCBieSBkZWZhdWx0LCBiZWNhc3VlCiMgZnJvbSB0aGUgY29udGFpbmVyIHBlcnNwZWN0aXZlIHRoZSBSUFMgbWFzayB0aGUgd2lsbCBiZSBjb25zdWx0ZWQsIGlzIHRoZSBvbmUgb24gdGhlIFJYIHNpZGUgb2YgdGhlIHZldGggaW4gdGhlIGhvc3QuCiMgQ29uc2lkZXIgdGhlIGZvbGxvd2luZyBkaWFncmFtOgojIFBvZCBBIDx2ZXRoMSAtIHZldGgyPiBob3N0IDx2ZXRoMyAtIHZldGg0PiBQb2QgQgojICB2ZXRoMidzIFJQUyBhZmZpbml0eSBpcyB0aGUgb25lIGRldGVybWluaW5nIHRoZSBDUFVzIHRoYXQgYXJlIGhhbmRsaW5nIHRoZSBwYWNrZXQgcHJvY2Vzc2luZyB3aGVuIHNlbmRpbmcgZGF0YSBmcm9tIFBvZCBBIHRvIHBvZCBCLgojIEFkZGl0aW9uYWwgY29tbW9uIHNjZW5hcmlvczoKIyAxLiBQb2QgQSA9IHNlbmRlciwgaG9zdCA9IHJlY2VpdmVyCiMgIFRoZSBSUFMgYWZmaW5pdHkgb2YgdGhlIGhvc3Qgc2lkZSBzaG91bGQgYmUgY29uc3VsdGVkIChiZWNhdXNlIGl04oCZcyB0aGUgcmVjZWl2ZXIpIGFuZCBpdCBzaG91bGQgYmUgc2V0IHRvIGNwdXMgbm90IHNlbnNpdGl2ZSB0byBwcmVlbXB0aW9uIChyZXNlcnZlZCBwb29sKS4KIyAyLiBQb2QgQSA9IHJlY2VpdmVyLCBob3N0ID0gc2VuZGVyCiMgIEluIGNhc2Ugb2Ygbm8gUlBTIG1hc2sgb24gdGhlIHJlY2VpdmVyIHNpZGUsIHRoZSBzZW5kZXIgbmVlZHMgdG8gcGF5IHRoZSBwcmljZSBhbmQgZG8gYWxsIHRoZSBwcm9jZXNzaW5nIG9uIGl0cyBjb3Jlcy4KbmV0LmNvcmUucnBzX2RlZmF1bHRfbWFzayA9IDAwMDAwMGZjCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysctl.d/99-default-rps-mask.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0icXVldWVzIiwgQUNUSU9OPT0iYWRkIiwgRU5We0RFVlBBVEh9PT0iL2RldmljZXMvcGNpKi9xdWV1ZXMvcngqIiwgVEFHKz0ic3lzdGVtZCIsIFBST0dSQU09Ii9iaW4vc3lzdGVtZC1lc2NhcGUgLS1wYXRoIC0tdGVtcGxhdGU9dXBkYXRlLXJwc0Auc2VydmljZSAkZW52e0RFVlBBVEh9IiwgRU5We1NZU1RFTURfV0FOVFN9PSIlYyIKCiMgU1ItSU9WIGRldmljZXMgYXJlIG1vdmVkIChyZW5hbWVkKSwgaGVuY2Ugd2Ugd2FudCB0byBjYXRjaCB0aGlzIGV2ZW50IGFzIHdlbGwKU1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0ibW92ZSIsIEVOVntERVZQQVRIfSE9Ii9kZXZpY2VzL3ZpcnR1YWwvbmV0LyoiLCBUQUcrPSJzeXN0ZW1kIiwgUFJPR1JBTT0iL2Jpbi9zeXN0ZW1kLWVzY2FwZSAtLXBhdGggLS10ZW1wbGF0ZT11cGRhdGUtcnBzQC5zZXJ2aWNlICRlbnZ7REVWUEFUSH0iLCBFTlZ7U1lTVEVNRF9XQU5UU309IiVjIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/99-netdev-physical-rps.rules
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWUud29ya2xvYWRzLm1hbmFnZW1lbnRdCmFjdGl2YXRpb25fYW5ub3RhdGlvbiA9ICJ0YXJnZXQud29ya2xvYWQub3BlbnNoaWZ0LmlvL21hbmFnZW1lbnQiCmFubm90YXRpb25fcHJlZml4ID0gInJlc291cmNlcy53b3JrbG9hZC5vcGVuc2hpZnQuaW8iCnJlc291cmNlcyA9IHsgImNwdXNoYXJlcyIgPSAwLCAiY3B1c2V0IiA9ICIyLTciIH0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-workload-pinning.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CnsKICAibWFuYWdlbWVudCI6IHsKICAgICJjcHVzZXQiOiAiMi03IgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCiMgY3B1c2V0LWNvbmZpZ3VyZS5zaCBjb25maWd1cmVzIHRocmVlIGNwdXNldHMgaW4gcHJlcGFyYXRpb24gZm9yIGFsbG93aW5nIGNvbnRhaW5lcnMgdG8gaGF2ZSBjcHUgbG9hZCBiYWxhbmNpbmcgZGlzYWJsZWQuCiMgVG8gY29uZmlndXJlIGEgY3B1c2V0IHRvIGhhdmUgbG9hZCBiYWxhbmNlIGRpc2FibGVkIChvbiBjZ3JvdXAgdjEpLCBhIGNwdXNldCBjZ3JvdXAgbXVzdCBoYXZlIGBjcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlYAojIHNldCB0byAwIChkaXNhYmxlKSwgYW5kIGFueSBjcHVzZXQgdGhhdCBjb250YWlucyB0aGUgc2FtZSBzZXQgYXMgYGNwdXNldC5jcHVzYCBtdXN0IGFsc28gaGF2ZSBgY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZWAgc2V0IHRvIGRpc2FibGVkLgoKc2V0IC1ldW8gcGlwZWZhaWwKCmlmIHRlc3QgIiQoc3RhdCAtZiAtYyVUIC9zeXMvZnMvY2dyb3VwKSIgPSAiY2dyb3VwMmZzIjsgdGhlbgoJZWNobyAiTm9kZSBpcyB1c2luZyBjZ3JvdXAgdjIsIG5vIGNvbmZpZ3VyYXRpb24gbmVlZGVkIgoJZXhpdCAwCmZpCgpyb290PS9zeXMvZnMvY2dyb3VwL2NwdXNldApzeXN0ZW09IiRyb290Ii9zeXN0ZW0uc2xpY2UKbWFjaGluZT0iJHJvb3QiL21hY2hpbmUuc2xpY2UKCm92c3NsaWNlPSIke3Jvb3R9L292cy5zbGljZSIKb3Zzc2xpY2Vfc3lzdGVtZD0iL3N5cy9mcy9jZ3JvdXAvcGlkcy9vdnMuc2xpY2UiCgojIEFzIHN1Y2gsIHRoZSByb290IGNncm91cCBuZWVkcyB0byBoYXZlIGNwdXNldC5zY2hlZF9sb2FkX2JhbGFuY2U9MC4gCmVjaG8gMCA+ICIkcm9vdCIvY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZQoKIyBIb3dldmVyLCB0aGlzIHdvdWxkIHByZXNlbnQgYSBwcm9ibGVtIGZvciBzeXN0ZW0gZGFlbW9ucywgd2hpY2ggc2hvdWxkIGhhdmUgbG9hZCBiYWxhbmNpbmcgZW5hYmxlZC4KIyBBcyBzdWNoLCBhIHNlY29uZCBjcHVzZXQgbXVzdCBiZSBjcmVhdGVkLCBoZXJlIGR1YmJlZCBgc3lzdGVtYCwgd2hpY2ggd2lsbCB0YWtlIGFsbCBzeXN0ZW0gZGFlbW9ucy4KIyBTaW5jZSBzeXN0ZW1kIHN0YXJ0cyBpdHMgY2hpbGRyZW4gd2l0aCB0aGUgY3B1c2V0IGl0IGlzIGluLCBtb3Zpbmcgc3lzdGVtZCB3aWxsIGVuc3VyZSBhbGwgcHJvY2Vzc2VzIHN5c3RlbWQgYmVnaW5zIHdpbGwgYmUgaW4gdGhlIGNvcnJlY3QgY2dyb3VwLgpta2RpciAtcCAiJHN5c3RlbSIKIyBjcHVzZXQubWVtcyBtdXN0IGJlIGluaXRpYWxpemVkIG9yIHByb2Nlc3NlcyB3aWxsIGZhaWwgdG8gYmUgbW92ZWQgaW50byBpdC4KY2F0ICIkcm9vdC9jcHVzZXQubWVtcyIgPiAiJHN5c3RlbSIvY3B1c2V0Lm1lbXMKIyBSZXRyaWV2ZSB0aGUgY3B1c2V0IG9mIHN5c3RlbWQsIGFuZCB3cml0ZSBpdCB0byBjcHVzZXQuY3B1cyBvZiB0aGUgc3lzdGVtIGNncm91cC4KcmVzZXJ2ZWRfc2V0PSQodGFza3NldCAtY3AgIDEgIHwgYXdrICdORnsgcHJpbnQgJE5GIH0nKQplY2hvICIkcmVzZXJ2ZWRfc2V0IiA+ICIkc3lzdGVtIi9jcHVzZXQuY3B1cwoKIyBBbmQgbW92ZSB0aGUgc3lzdGVtIHByb2Nlc3NlcyBpbnRvIGl0LgojIE5vdGUsIHNvbWUga2VybmVsIHRocmVhZHMgd2lsbCBmYWlsIHRvIGJlIG1vdmVkIHdpdGggIkludmFsaWQgQXJndW1lbnQiLiBUaGlzIHNob3VsZCBiZSBpZ25vcmVkLgpmb3IgcHJvY2VzcyBpbiAkKGNhdCAiJHJvb3QiL2Nncm91cC5wcm9jcyB8IHNvcnQgLXIpOyBkbwoJZWNobyAkcHJvY2VzcyA+ICIkc3lzdGVtIi9jZ3JvdXAucHJvY3MgMj4mMSB8IGdyZXAgLXYgIkludmFsaWQgQXJndW1lbnQiIHx8IHRydWU7CmRvbmUKCiMgRmluYWxseSwgYSB0aGUgYG1hY2hpbmUuc2xpY2VgIGNncm91cCBtdXN0IGJlIHByZWNvbmZpZ3VyZWQuIFBvZG1hbiB3aWxsIGNyZWF0ZSBjb250YWluZXJzIGFuZCBtb3ZlIHRoZW0gaW50byB0aGUgYG1hY2hpbmUuc2xpY2VgLCBidXQgdGhlcmUncwojIG5vIHdheSB0byB0ZWxsIHBvZG1hbiB0byB1cGRhdGUgbWFjaGluZS5zbGljZSB0byBub3QgaGF2ZSB0aGUgZnVsbCBzZXQgb2YgY3B1cy4gSW5zdGVhZCBvZiBkaXNhYmxpbmcgbG9hZCBiYWxhbmNpbmcgaW4gaXQsIHdlIGNhbiBwcmUtY3JlYXRlIGl0LgojIHdpdGggdGhlIHJlc2VydmVkIENQVXMgc2V0IGFoZWFkIG9mIHRpbWUsIHNvIHdoZW4gaXNvbGF0ZWQgcHJvY2Vzc2VzIGJlZ2luLCB0aGUgY2dyb3VwIGRvZXMgbm90IGhhdmUgYW4gb3ZlcmxhcHBpbmcgY3B1c2V0IGJldHdlZW4gbWFjaGluZS5zbGljZSBhbmQgaXNvbGF0ZWQgY29udGFpbmVycy4KbWtkaXIgLXAgIiRtYWNoaW5lIgoKIyBJdCdzIHVubGlrZWx5LCBidXQgcG9zc2libGUsIHRoYXQgdGhpcyBjcHVzZXQgYWxyZWFkeSBleGlzdGVkLiBJdGVyYXRlIGp1c3QgaW4gY2FzZS4KZm9yIGZpbGUgaW4gJChmaW5kICIkbWFjaGluZSIgLW5hbWUgY3B1c2V0LmNwdXMgfCBzb3J0IC1yKTsgZG8gZWNobyAiJHJlc2VydmVkX3NldCIgPiAiJGZpbGUiOyBkb25lCgojIE9WUyBpcyBydW5uaW5nIGluIGl0cyBvd24gc2xpY2UgdGhhdCBzcGFucyBhbGwgY3B1cy4gVGhlIHJlYWwgYWZmaW5pdHkgaXMgbWFuYWdlZCBieSBPVk4tSyBvdm5rdWJlLW5vZGUgZGFlbW9uc2V0CiMgTWFrZSBzdXJlIHRoaXMgc2xpY2Ugd2lsbCBub3QgZW5hYmxlIGNwdSBiYWxhbmNpbmcgZm9yIG90aGVyIHNsaWNlIGNvbmZpZ3VyZWQgYnkgdGhpcyBzY3JpcHQuCiMgVGhpcyBtaWdodCBzZWVtIGNvdW50ZXItaW50dWl0aXZlLCBidXQgdGhpcyB3aWxsIGFjdHVhbGx5IE5PVCBkaXNhYmxlIGNwdSBiYWxhbmNpbmcgZm9yIE9WUyBpdHNlbGYuCiMgLSBPVlMgaGFzIGFjY2VzcyB0byByZXNlcnZlZCBjcHVzLCBidXQgdGhvc2UgaGF2ZSBiYWxhbmNpbmcgZW5hYmxlZCB2aWEgdGhlIGBzeXN0ZW1gIGNncm91cCBjcmVhdGVkIGFib3ZlCiMgLSBPVlMgaGFzIGFjY2VzcyB0byBpc29sYXRlZCBjcHVzIHRoYXQgYXJlIGN1cnJlbnRseSBub3QgYXNzaWduZWQgdG8gcGlubmVkIHBvZHMuIFRob3NlIGhhdmUgYmFsYW5jaW5nIGVuYWJsZWQgYnkgdGhlCiMgICBwb2RzIHJ1bm5pbmcgdGhlcmUgKGJ1cnN0YWJsZSBhbmQgYmVzdC1lZmZvcnQgcG9kcyBoYXZlIGJhbGFuY2luZyBlbmFibGVkIGluIHRoZSBjb250YWluZXIgY2dyb3VwIGFuZCBhY2Nlc3MgdG8gYWxsCiMgICB1bnBpbm5lZCBjcHVzKS4KCiMgc3lzdGVtZCBkb2VzIG5vdCBtYW5hZ2UgdGhlIGNwdXNldCBjZ3JvdXAgY29udHJvbGxlciwgc28gbW92ZSBldmVyeXRoaW5nIGZyb20gdGhlIG1hbmFnZWQgcGlkcyBjb250cm9sbGVyJ3Mgb3ZzLnNsaWNlCiMgdG8gdGhlIGNwdXNldCBjb250cm9sbGVyLgoKIyBDcmVhdGUgdGhlIG92cy5zbGljZQpta2RpciAtcCAiJG92c3NsaWNlIgplY2hvIDAgPiAiJG92c3NsaWNlIi9jcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlCmNhdCAiJHJvb3QiL2NwdXNldC5jcHVzID4gIiRvdnNzbGljZSIvY3B1c2V0LmNwdXMKY2F0ICIkcm9vdCIvY3B1c2V0Lm1lbXMgPiAiJG92c3NsaWNlIi9jcHVzZXQubWVtcwoKIyBNb3ZlIE9WUyBvdmVyCmZvciBwcm9jZXNzIGluICQoY2F0ICIkb3Zzc2xpY2Vfc3lzdGVtZCIvKi9jZ3JvdXAucHJvY3MgfCBzb3J0IC1yKTsgZG8KICAgICAgICBlY2hvICRwcm9jZXNzID4gIiRvdnNzbGljZSIvY2dyb3VwLnByb2NzIDI+JjEgfCBncmVwIC12ICJJbnZhbGlkIEFyZ3VtZW50IiB8fCB0cnVlOwpkb25lCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/cpuset-configure.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs.slice
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/openvswitch.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs-vswitchd.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovsdb-server.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBUaGlzIGZpbGUgZW5hYmxlcyB0aGUgZHluYW1pYyBjcHUgYWZmaW5pdHkgbWFuYWdlbWVudCBvZiB0aGUgT1ZTIHNlcnZpY2VzCiMKIyBJdCBpcyByZWFkIGJ5IHRoZSBPVk4ncyBvdm5rdWJlLW5vZGUgRGFlbW9uU2V0IGNvbnRhaW5lciBhbmQgdGhlIGZlYXR1cmUKIyBpcyBlbmFibGVkIHdoZW4gdGhpcyBmaWxlIGV4aXN0cyBhbmQgaXMgbm90IGVtcHR5ICh0aGlzIGNvbW1lbnRhcnkgdGV4dAojIGVuc3VyZXMgdGhhdCkKIwojIEZvciBkaXNhYmxpbmcgdGhpcyBmZWF0dXJlIGluIGVtZXJnZW5jaWVzLCBlaXRoZXI6CiMgMSkgZGVsZXRlIHRoaXMgZmlsZSBhbmQgc2V0IHRoZSBjcHUgYWZmaW5pdHkgb2YgT1ZTIHNlcnZpY2VzIG1hbnVhbGx5CiMgMikgb3IgcmVwbGFjZSB0aGUgY29udGVudHMgb2YgdGhpcyBmaWxlIHdpdGggYW4gZW1wdHkgc3RyaW5nCiMgICAgdmlhIGEgTWFjaGluZUNvbmZpZwo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
+        user: {}
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Sets network devices RPS mask
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/set-rps-mask.sh %I 0
+        name: update-rps@.service
+      - contents: |
+          [Unit]
+          Description=Move services to reserved cpuset
+          Before=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/cpuset-configure.sh
+
+          [Install]
+          WantedBy=multi-user.target crio.service
+        enabled: true
+        name: cpuset-configure.service
+      - contents: |
+          [Unit]
+          Description=Clear the IRQBalance Banned CPU mask early in the boot
+          Before=kubelet.service
+          Before=irqbalance.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/clear-irqbalance-banned-cpus.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: clear-irqbalance-banned-cpus.service
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: default
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_node.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_node.yaml
@@ -1,0 +1,13 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  creationTimestamp: null
+  name: cluster
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+spec:
+  cgroupMode: v1
+status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_runtimeclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: node.k8s.io/v1
+handler: high-performance
+kind: RuntimeClass
+metadata:
+  creationTimestamp: null
+  name: performance-openshift-bootstrap-master
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/master: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -1,0 +1,67 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  creationTimestamp: null
+  name: openshift-node-performance-openshift-bootstrap-master
+  namespace: openshift-cluster-node-tuning-operator
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-master
+    uid: ""
+spec:
+  profile:
+  - data: "[main]\nsummary=Openshift node optimized for deterministic performance
+      at the cost of increased power consumption, focused on low latency network performance.
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
+      -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
+      All values are mapped with a comment where a parent profile contains them.\n#
+      Different values will override the original values in parent profiles.\n\n[variables]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
+      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
+      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
+      plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      = ignore\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
+      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
+      RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
+      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
+      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
+      working set is buffered for I/O, and any more write buffering would require\n#
+      swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
+      that mostly use file mappings may be able to use even higher values.\n#\n# The
+      generator of dirty data starts writeback at this percentage (system default\n#
+      is 20%)\n#> latency-performance\nvm.dirty_ratio=10\n\n# Start background writeback
+      (via writeback threads) at this percentage (system\n# default is 10%)\n#> latency-performance\nvm.dirty_background_ratio=3\n\n#
+      The swappiness parameter controls the tendency of the kernel to move\n# processes
+      out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
+      swapping processes out of physical memory\n# for as long as possible\n# 100
+      tells the kernel to aggressively swap processes out of physical memory\n# and
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
+      configured via a sysctl.d file\n# placed here for documentation purposes and
+      commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
+    name: openshift-node-performance-openshift-bootstrap-master
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: master
+    operand:
+      tunedConfig:
+        reapply_sysctl: null
+    priority: 20
+    profile: openshift-node-performance-openshift-bootstrap-master
+status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_kubeletconfig.yaml
@@ -1,0 +1,61 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  creationTimestamp: null
+  name: performance-openshift-bootstrap-worker
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+spec:
+  kubeletConfig:
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous: {}
+      webhook:
+        cacheTTL: 0s
+      x509: {}
+    authorization:
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    containerRuntimeEndpoint: ""
+    cpuManagerPolicy: static
+    cpuManagerReconcilePeriod: 5s
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 0s
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      memory: 500Mi
+    logging:
+      flushFrequency: 0
+      options:
+        json:
+          infoBufferSize: "0"
+      verbosity: 0
+    memorySwap: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    reservedSystemCPUs: 2-3
+    runtimeRequestTimeout: 0s
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      memory: 500Mi
+    topologyManagerPolicy: best-effort
+    volumeStatsAggPeriod: 0s
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+status:
+  conditions: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -1,0 +1,175 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-performance-openshift-bootstrap-worker
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCm5vZGVzX3BhdGg9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vbm9kZSIKaHVnZXBhZ2VzX2ZpbGU9IiR7bm9kZXNfcGF0aH0vbm9kZSR7TlVNQV9OT0RFfS9odWdlcGFnZXMvaHVnZXBhZ2VzLSR7SFVHRVBBR0VTX1NJWkV9a0IvbnJfaHVnZXBhZ2VzIgoKaWYgWyAhIC1mICIke2h1Z2VwYWdlc19maWxlfSIgXTsgdGhlbgogIGVjaG8gIkVSUk9SOiAke2h1Z2VwYWdlc19maWxlfSBkb2VzIG5vdCBleGlzdCIKICBleGl0IDEKZmkKCnRpbWVvdXQ9NjAKc2FtcGxlPTEKY3VycmVudF90aW1lPTAKd2hpbGUgWyAiJChjYXQgIiR7aHVnZXBhZ2VzX2ZpbGV9IikiIC1uZSAiJHtIVUdFUEFHRVNfQ09VTlR9IiBdOyBkbwogIGVjaG8gIiR7SFVHRVBBR0VTX0NPVU5UfSIgPiIke2h1Z2VwYWdlc19maWxlfSIKCiAgY3VycmVudF90aW1lPSQoKGN1cnJlbnRfdGltZSArIHNhbXBsZSkpCiAgaWYgWyAkY3VycmVudF90aW1lIC1ndCAkdGltZW91dCBdOyB0aGVuCiAgICBlY2hvICJFUlJPUjogJHtodWdlcGFnZXNfZmlsZX0gZG9lcyBub3QgaGF2ZSB0aGUgZXhwZWN0ZWQgbnVtYmVyIG9mIGh1Z2VwYWdlcyAke0hVR0VQQUdFU19DT1VOVH0iCiAgICBleGl0IDEKICBmaQoKICBzbGVlcCAkc2FtcGxlCmRvbmUK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/hugepages-allocation.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZnVuY3Rpb24gc2V0X3F1ZXVlX3Jwc19tYXNrKCkgewojIHJlcGxhY2UgeDJkIHdpdGggaHlwaGVuICgtKSB3aGljaCBpcyBhbiBlc2NhcGVkIGNoYXJhY3RlcgojIHRoYXQgd2FzIGFkZGVkIGJ5IHN5c3RlbWQtZXNjYXBlIGluIG9yZGVyIHRvIGVzY2FwZSB0aGUgc3lzdGVtZCB1bml0IG5hbWUgdGhhdCBpbnZva2VzIHRoaXMgc2NyaXB0CnBhdGg9JHtwYXRoL3gyZC8tfQojIHNldCBycHMgYWZmaW5pdHkgZm9yIHRoZSBxdWV1ZQplY2hvICIke21hc2t9IiAgMj4gL2Rldi9udWxsID4gIi9zeXMvJHtwYXRofS9ycHNfY3B1cyIKIyB3ZSByZXR1cm4gMCBiZWNhdXNlIHRoZSAnZWNobycgY29tbWFuZCBtaWdodCBmYWlsIGlmIHRoZSBkZXZpY2UgcGF0aCB0byB3aGljaCB0aGUgcXVldWUgYmVsb25ncyBoYXMgY2hhbmdlZC4KIyB0aGlzIGNhbiBoYXBwZW4gaW4gY2FzZSBvZiBTUkktT1YgZGV2aWNlcyByZW5hbWluZy4KcmV0dXJuIDAKfQoKZnVuY3Rpb24gc2V0X25ldF9kZXZfcnBzX21hc2soKSB7CiAgIyBpbiBjYXNlIG9mIGRldmljZSB3ZSB3YW50IHRvIGl0ZXJhdGUgdGhyb3VnaCBhbGwgcXVldWVzCmZvciBpIGluIC9zeXMvIiR7cGF0aH0iL3F1ZXVlcy9yeC0qOyBkbwogIGVjaG8gIiR7bWFza30iIDI+IC9kZXYvbnVsbCA+ICIke2l9L3Jwc19jcHVzIgpkb25lCiMgd2UgcmV0dXJuIDAgYmVjYXVzZSB0aGUgJ2VjaG8nIGNvbW1hbmQgbWlnaHQgZmFpbCBpZiB0aGUgZGV2aWNlIHBhdGggdG8gd2hpY2ggdGhlIHF1ZXVlIGJlbG9uZ3MgaGFzIGNoYW5nZWQuCiMgdGhpcyBjYW4gaGFwcGVuIGluIGNhc2Ugb2YgU1JJLU9WIGRldmljZXMgcmVuYW1pbmcuCnJldHVybiAwCiB9CgpwYXRoPSR7MX0KWyAtbiAiJHtwYXRofSIgXSB8fCB7IGVjaG8gIlRoZSBkZXZpY2UgcGF0aCBhcmd1bWVudCBpcyBtaXNzaW5nIiA+JjIgOyBleGl0IDE7IH0KCm1hc2s9JHsyfQpbIC1uICIke21hc2t9IiBdIHx8IHsgZWNobyAiVGhlIG1hc2sgYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgppZiBbWyAiJHtwYXRofSIgPX4gInF1ZXVlcyIgXV07IHRoZW4KIHNldF9xdWV1ZV9ycHNfbWFzawplbHNlCiBzZXRfbmV0X2Rldl9ycHNfbWFzawpmaQo=
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-rps-mask.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9iYXNoCgpzZXQgLWV1byBwaXBlZmFpbAoKZm9yIGNwdSBpbiAke09GRkxJTkVfQ1BVUy8vLC8gfTsKICBkbwogICAgb25saW5lX2NwdV9maWxlPSIvc3lzL2RldmljZXMvc3lzdGVtL2NwdS9jcHUkY3B1L29ubGluZSIKICAgIGlmIFsgISAtZiAiJHtvbmxpbmVfY3B1X2ZpbGV9IiBdOyB0aGVuCiAgICAgIGVjaG8gIkVSUk9SOiAke29ubGluZV9jcHVfZmlsZX0gZG9lcyBub3QgZXhpc3QsIGFib3J0IHNjcmlwdCBleGVjdXRpb24iCiAgICAgIGV4aXQgMQogICAgZmkKICBkb25lCgplY2hvICJBbGwgY3B1cyBvZmZsaW5lZCBleGlzdHMsIHNldCB0aGVtIG9mZmxpbmUiCgpmb3IgY3B1IGluICR7T0ZGTElORV9DUFVTLy8sLyB9OwogIGRvCiAgICBvbmxpbmVfY3B1X2ZpbGU9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vY3B1L2NwdSRjcHUvb25saW5lIgogICAgZWNobyAwID4gIiR7b25saW5lX2NwdV9maWxlfSIKICAgIGVjaG8gIm9mZmxpbmUgY3B1IG51bSAkY3B1IgogIGRvbmUKCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-cpus-offline.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLWV1byBwaXBlZmFpbApzZXQgLXgKCiMgY29uc3QKU0VEPSIvdXNyL2Jpbi9zZWQiCiMgdHVuYWJsZSAtIG92ZXJyaWRhYmxlIGZvciB0ZXN0aW5nIHB1cnBvc2VzCklSUUJBTEFOQ0VfQ09ORj0iJHsxOi0vZXRjL3N5c2NvbmZpZy9pcnFiYWxhbmNlfSIKQ1JJT19PUklHX0JBTk5FRF9DUFVTPSIkezI6LS9ldGMvc3lzY29uZmlnL29yaWdfaXJxX2Jhbm5lZF9jcHVzfSIKClsgISAtZiAke0lSUUJBTEFOQ0VfQ09ORn0gXSAmJiBleGl0IDAKCiR7U0VEfSAtaSAnL15ccypJUlFCQUxBTkNFX0JBTk5FRF9DUFVTXGIvZCcgJHtJUlFCQUxBTkNFX0NPTkZ9IHx8IGV4aXQgMAplY2hvICJJUlFCQUxBTkNFX0JBTk5FRF9DUFVTPSIgPj4gJHtJUlFCQUxBTkNFX0NPTkZ9CgojIHdlIG5vdyBvd24gdGhpcyBjb25maWd1cmF0aW9uLiBCdXQgQ1JJLU8gaGFzIGNvZGUgdG8gcmVzdG9yZSB0aGUgY29uZmlndXJhdGlvbiwKIyBhbmQgdW50aWwgaXQgZ2FpbnMgdGhlIG9wdGlvbiB0byBkaXNhYmxlIHRoaXMgcmVzdG9yZSBmbG93LCB3ZSBuZWVkIHRvIG1ha2UKIyB0aGUgY29uZmlndXJhdGlvbiBjb25zaXN0ZW50IHN1Y2ggYXMgdGhlIENSSS1PIHJlc3RvcmUgd2lsbCBkbyBub3RoaW5nLgppZiBbIC1uICR7Q1JJT19PUklHX0JBTk5FRF9DUFVTfSBdICYmIFsgLWYgJHtDUklPX09SSUdfQkFOTkVEX0NQVVN9IF07IHRoZW4KCXRydWUgPiAke0NSSU9fT1JJR19CQU5ORURfQ1BVU30KZmkK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/clear-irqbalance-banned-cpus.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMi0zIgoKCgojIFdlIHNob3VsZCBjb3B5IHBhc3RlIHRoZSBkZWZhdWx0IHJ1bnRpbWUgYmVjYXVzZSB0aGlzIHNuaXBwZXQgd2lsbCBvdmVycmlkZSB0aGUgd2hvbGUgcnVudGltZXMgc2VjdGlvbgpbY3Jpby5ydW50aW1lLnJ1bnRpbWVzLnJ1bmNdCnJ1bnRpbWVfcGF0aCA9ICIiCnJ1bnRpbWVfdHlwZSA9ICJvY2kiCnJ1bnRpbWVfcm9vdCA9ICIvcnVuL3J1bmMiCgojIFRoZSBDUkktTyB3aWxsIGNoZWNrIHRoZSBhbGxvd2VkX2Fubm90YXRpb25zIHVuZGVyIHRoZSBydW50aW1lIGhhbmRsZXIgYW5kIGFwcGx5IGhpZ2gtcGVyZm9ybWFuY2UgaG9va3Mgd2hlbiBvbmUgb2YKIyBoaWdoLXBlcmZvcm1hbmNlIGFubm90YXRpb25zIHByZXNlbnRzIHVuZGVyIGl0LgojIFdlIHNob3VsZCBwcm92aWRlIHRoZSBydW50aW1lX3BhdGggYmVjYXVzZSB3ZSBuZWVkIHRvIGluZm9ybSB0aGF0IHdlIHdhbnQgdG8gcmUtdXNlIHJ1bmMgYmluYXJ5IGFuZCB3ZQojIGRvIG5vdCBoYXZlIGhpZ2gtcGVyZm9ybWFuY2UgYmluYXJ5IHVuZGVyIHRoZSAkUEFUSCB0aGF0IHdpbGwgcG9pbnQgdG8gaXQuCltjcmlvLnJ1bnRpbWUucnVudGltZXMuaGlnaC1wZXJmb3JtYW5jZV0KcnVudGltZV9wYXRoID0gIi9iaW4vcnVuYyIKcnVudGltZV90eXBlID0gIm9jaSIKcnVudGltZV9yb290ID0gIi9ydW4vcnVuYyIKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LWMtc3RhdGVzLmNyaW8uaW8iLCAiY3B1LWZyZXEtZ292ZXJub3IuY3Jpby5pbyJdCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-runtimes.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBBcHBseSB0aGUgUlBTIG1hc2sgb24gdGhlIHZpcnR1YWwgaW50ZXJmYWNlcyBvZiB0aGUgaG9zdCBieSBkZWZhdWx0LCBiZWNhc3VlCiMgZnJvbSB0aGUgY29udGFpbmVyIHBlcnNwZWN0aXZlIHRoZSBSUFMgbWFzayB0aGUgd2lsbCBiZSBjb25zdWx0ZWQsIGlzIHRoZSBvbmUgb24gdGhlIFJYIHNpZGUgb2YgdGhlIHZldGggaW4gdGhlIGhvc3QuCiMgQ29uc2lkZXIgdGhlIGZvbGxvd2luZyBkaWFncmFtOgojIFBvZCBBIDx2ZXRoMSAtIHZldGgyPiBob3N0IDx2ZXRoMyAtIHZldGg0PiBQb2QgQgojICB2ZXRoMidzIFJQUyBhZmZpbml0eSBpcyB0aGUgb25lIGRldGVybWluaW5nIHRoZSBDUFVzIHRoYXQgYXJlIGhhbmRsaW5nIHRoZSBwYWNrZXQgcHJvY2Vzc2luZyB3aGVuIHNlbmRpbmcgZGF0YSBmcm9tIFBvZCBBIHRvIHBvZCBCLgojIEFkZGl0aW9uYWwgY29tbW9uIHNjZW5hcmlvczoKIyAxLiBQb2QgQSA9IHNlbmRlciwgaG9zdCA9IHJlY2VpdmVyCiMgIFRoZSBSUFMgYWZmaW5pdHkgb2YgdGhlIGhvc3Qgc2lkZSBzaG91bGQgYmUgY29uc3VsdGVkIChiZWNhdXNlIGl04oCZcyB0aGUgcmVjZWl2ZXIpIGFuZCBpdCBzaG91bGQgYmUgc2V0IHRvIGNwdXMgbm90IHNlbnNpdGl2ZSB0byBwcmVlbXB0aW9uIChyZXNlcnZlZCBwb29sKS4KIyAyLiBQb2QgQSA9IHJlY2VpdmVyLCBob3N0ID0gc2VuZGVyCiMgIEluIGNhc2Ugb2Ygbm8gUlBTIG1hc2sgb24gdGhlIHJlY2VpdmVyIHNpZGUsIHRoZSBzZW5kZXIgbmVlZHMgdG8gcGF5IHRoZSBwcmljZSBhbmQgZG8gYWxsIHRoZSBwcm9jZXNzaW5nIG9uIGl0cyBjb3Jlcy4KbmV0LmNvcmUucnBzX2RlZmF1bHRfbWFzayA9IDAwMDAwMDBjCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysctl.d/99-default-rps-mask.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0icXVldWVzIiwgQUNUSU9OPT0iYWRkIiwgRU5We0RFVlBBVEh9PT0iL2RldmljZXMvcGNpKi9xdWV1ZXMvcngqIiwgVEFHKz0ic3lzdGVtZCIsIFBST0dSQU09Ii9iaW4vc3lzdGVtZC1lc2NhcGUgLS1wYXRoIC0tdGVtcGxhdGU9dXBkYXRlLXJwc0Auc2VydmljZSAkZW52e0RFVlBBVEh9IiwgRU5We1NZU1RFTURfV0FOVFN9PSIlYyIKCiMgU1ItSU9WIGRldmljZXMgYXJlIG1vdmVkIChyZW5hbWVkKSwgaGVuY2Ugd2Ugd2FudCB0byBjYXRjaCB0aGlzIGV2ZW50IGFzIHdlbGwKU1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0ibW92ZSIsIEVOVntERVZQQVRIfSE9Ii9kZXZpY2VzL3ZpcnR1YWwvbmV0LyoiLCBUQUcrPSJzeXN0ZW1kIiwgUFJPR1JBTT0iL2Jpbi9zeXN0ZW1kLWVzY2FwZSAtLXBhdGggLS10ZW1wbGF0ZT11cGRhdGUtcnBzQC5zZXJ2aWNlICRlbnZ7REVWUEFUSH0iLCBFTlZ7U1lTVEVNRF9XQU5UU309IiVjIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/99-netdev-physical-rps.rules
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWUud29ya2xvYWRzLm1hbmFnZW1lbnRdCmFjdGl2YXRpb25fYW5ub3RhdGlvbiA9ICJ0YXJnZXQud29ya2xvYWQub3BlbnNoaWZ0LmlvL21hbmFnZW1lbnQiCmFubm90YXRpb25fcHJlZml4ID0gInJlc291cmNlcy53b3JrbG9hZC5vcGVuc2hpZnQuaW8iCnJlc291cmNlcyA9IHsgImNwdXNoYXJlcyIgPSAwLCAiY3B1c2V0IiA9ICIyLTMiIH0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-workload-pinning.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CnsKICAibWFuYWdlbWVudCI6IHsKICAgICJjcHVzZXQiOiAiMi0zIgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCiMgY3B1c2V0LWNvbmZpZ3VyZS5zaCBjb25maWd1cmVzIHRocmVlIGNwdXNldHMgaW4gcHJlcGFyYXRpb24gZm9yIGFsbG93aW5nIGNvbnRhaW5lcnMgdG8gaGF2ZSBjcHUgbG9hZCBiYWxhbmNpbmcgZGlzYWJsZWQuCiMgVG8gY29uZmlndXJlIGEgY3B1c2V0IHRvIGhhdmUgbG9hZCBiYWxhbmNlIGRpc2FibGVkIChvbiBjZ3JvdXAgdjEpLCBhIGNwdXNldCBjZ3JvdXAgbXVzdCBoYXZlIGBjcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlYAojIHNldCB0byAwIChkaXNhYmxlKSwgYW5kIGFueSBjcHVzZXQgdGhhdCBjb250YWlucyB0aGUgc2FtZSBzZXQgYXMgYGNwdXNldC5jcHVzYCBtdXN0IGFsc28gaGF2ZSBgY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZWAgc2V0IHRvIGRpc2FibGVkLgoKc2V0IC1ldW8gcGlwZWZhaWwKCmlmIHRlc3QgIiQoc3RhdCAtZiAtYyVUIC9zeXMvZnMvY2dyb3VwKSIgPSAiY2dyb3VwMmZzIjsgdGhlbgoJZWNobyAiTm9kZSBpcyB1c2luZyBjZ3JvdXAgdjIsIG5vIGNvbmZpZ3VyYXRpb24gbmVlZGVkIgoJZXhpdCAwCmZpCgpyb290PS9zeXMvZnMvY2dyb3VwL2NwdXNldApzeXN0ZW09IiRyb290Ii9zeXN0ZW0uc2xpY2UKbWFjaGluZT0iJHJvb3QiL21hY2hpbmUuc2xpY2UKCm92c3NsaWNlPSIke3Jvb3R9L292cy5zbGljZSIKb3Zzc2xpY2Vfc3lzdGVtZD0iL3N5cy9mcy9jZ3JvdXAvcGlkcy9vdnMuc2xpY2UiCgojIEFzIHN1Y2gsIHRoZSByb290IGNncm91cCBuZWVkcyB0byBoYXZlIGNwdXNldC5zY2hlZF9sb2FkX2JhbGFuY2U9MC4gCmVjaG8gMCA+ICIkcm9vdCIvY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZQoKIyBIb3dldmVyLCB0aGlzIHdvdWxkIHByZXNlbnQgYSBwcm9ibGVtIGZvciBzeXN0ZW0gZGFlbW9ucywgd2hpY2ggc2hvdWxkIGhhdmUgbG9hZCBiYWxhbmNpbmcgZW5hYmxlZC4KIyBBcyBzdWNoLCBhIHNlY29uZCBjcHVzZXQgbXVzdCBiZSBjcmVhdGVkLCBoZXJlIGR1YmJlZCBgc3lzdGVtYCwgd2hpY2ggd2lsbCB0YWtlIGFsbCBzeXN0ZW0gZGFlbW9ucy4KIyBTaW5jZSBzeXN0ZW1kIHN0YXJ0cyBpdHMgY2hpbGRyZW4gd2l0aCB0aGUgY3B1c2V0IGl0IGlzIGluLCBtb3Zpbmcgc3lzdGVtZCB3aWxsIGVuc3VyZSBhbGwgcHJvY2Vzc2VzIHN5c3RlbWQgYmVnaW5zIHdpbGwgYmUgaW4gdGhlIGNvcnJlY3QgY2dyb3VwLgpta2RpciAtcCAiJHN5c3RlbSIKIyBjcHVzZXQubWVtcyBtdXN0IGJlIGluaXRpYWxpemVkIG9yIHByb2Nlc3NlcyB3aWxsIGZhaWwgdG8gYmUgbW92ZWQgaW50byBpdC4KY2F0ICIkcm9vdC9jcHVzZXQubWVtcyIgPiAiJHN5c3RlbSIvY3B1c2V0Lm1lbXMKIyBSZXRyaWV2ZSB0aGUgY3B1c2V0IG9mIHN5c3RlbWQsIGFuZCB3cml0ZSBpdCB0byBjcHVzZXQuY3B1cyBvZiB0aGUgc3lzdGVtIGNncm91cC4KcmVzZXJ2ZWRfc2V0PSQodGFza3NldCAtY3AgIDEgIHwgYXdrICdORnsgcHJpbnQgJE5GIH0nKQplY2hvICIkcmVzZXJ2ZWRfc2V0IiA+ICIkc3lzdGVtIi9jcHVzZXQuY3B1cwoKIyBBbmQgbW92ZSB0aGUgc3lzdGVtIHByb2Nlc3NlcyBpbnRvIGl0LgojIE5vdGUsIHNvbWUga2VybmVsIHRocmVhZHMgd2lsbCBmYWlsIHRvIGJlIG1vdmVkIHdpdGggIkludmFsaWQgQXJndW1lbnQiLiBUaGlzIHNob3VsZCBiZSBpZ25vcmVkLgpmb3IgcHJvY2VzcyBpbiAkKGNhdCAiJHJvb3QiL2Nncm91cC5wcm9jcyB8IHNvcnQgLXIpOyBkbwoJZWNobyAkcHJvY2VzcyA+ICIkc3lzdGVtIi9jZ3JvdXAucHJvY3MgMj4mMSB8IGdyZXAgLXYgIkludmFsaWQgQXJndW1lbnQiIHx8IHRydWU7CmRvbmUKCiMgRmluYWxseSwgYSB0aGUgYG1hY2hpbmUuc2xpY2VgIGNncm91cCBtdXN0IGJlIHByZWNvbmZpZ3VyZWQuIFBvZG1hbiB3aWxsIGNyZWF0ZSBjb250YWluZXJzIGFuZCBtb3ZlIHRoZW0gaW50byB0aGUgYG1hY2hpbmUuc2xpY2VgLCBidXQgdGhlcmUncwojIG5vIHdheSB0byB0ZWxsIHBvZG1hbiB0byB1cGRhdGUgbWFjaGluZS5zbGljZSB0byBub3QgaGF2ZSB0aGUgZnVsbCBzZXQgb2YgY3B1cy4gSW5zdGVhZCBvZiBkaXNhYmxpbmcgbG9hZCBiYWxhbmNpbmcgaW4gaXQsIHdlIGNhbiBwcmUtY3JlYXRlIGl0LgojIHdpdGggdGhlIHJlc2VydmVkIENQVXMgc2V0IGFoZWFkIG9mIHRpbWUsIHNvIHdoZW4gaXNvbGF0ZWQgcHJvY2Vzc2VzIGJlZ2luLCB0aGUgY2dyb3VwIGRvZXMgbm90IGhhdmUgYW4gb3ZlcmxhcHBpbmcgY3B1c2V0IGJldHdlZW4gbWFjaGluZS5zbGljZSBhbmQgaXNvbGF0ZWQgY29udGFpbmVycy4KbWtkaXIgLXAgIiRtYWNoaW5lIgoKIyBJdCdzIHVubGlrZWx5LCBidXQgcG9zc2libGUsIHRoYXQgdGhpcyBjcHVzZXQgYWxyZWFkeSBleGlzdGVkLiBJdGVyYXRlIGp1c3QgaW4gY2FzZS4KZm9yIGZpbGUgaW4gJChmaW5kICIkbWFjaGluZSIgLW5hbWUgY3B1c2V0LmNwdXMgfCBzb3J0IC1yKTsgZG8gZWNobyAiJHJlc2VydmVkX3NldCIgPiAiJGZpbGUiOyBkb25lCgojIE9WUyBpcyBydW5uaW5nIGluIGl0cyBvd24gc2xpY2UgdGhhdCBzcGFucyBhbGwgY3B1cy4gVGhlIHJlYWwgYWZmaW5pdHkgaXMgbWFuYWdlZCBieSBPVk4tSyBvdm5rdWJlLW5vZGUgZGFlbW9uc2V0CiMgTWFrZSBzdXJlIHRoaXMgc2xpY2Ugd2lsbCBub3QgZW5hYmxlIGNwdSBiYWxhbmNpbmcgZm9yIG90aGVyIHNsaWNlIGNvbmZpZ3VyZWQgYnkgdGhpcyBzY3JpcHQuCiMgVGhpcyBtaWdodCBzZWVtIGNvdW50ZXItaW50dWl0aXZlLCBidXQgdGhpcyB3aWxsIGFjdHVhbGx5IE5PVCBkaXNhYmxlIGNwdSBiYWxhbmNpbmcgZm9yIE9WUyBpdHNlbGYuCiMgLSBPVlMgaGFzIGFjY2VzcyB0byByZXNlcnZlZCBjcHVzLCBidXQgdGhvc2UgaGF2ZSBiYWxhbmNpbmcgZW5hYmxlZCB2aWEgdGhlIGBzeXN0ZW1gIGNncm91cCBjcmVhdGVkIGFib3ZlCiMgLSBPVlMgaGFzIGFjY2VzcyB0byBpc29sYXRlZCBjcHVzIHRoYXQgYXJlIGN1cnJlbnRseSBub3QgYXNzaWduZWQgdG8gcGlubmVkIHBvZHMuIFRob3NlIGhhdmUgYmFsYW5jaW5nIGVuYWJsZWQgYnkgdGhlCiMgICBwb2RzIHJ1bm5pbmcgdGhlcmUgKGJ1cnN0YWJsZSBhbmQgYmVzdC1lZmZvcnQgcG9kcyBoYXZlIGJhbGFuY2luZyBlbmFibGVkIGluIHRoZSBjb250YWluZXIgY2dyb3VwIGFuZCBhY2Nlc3MgdG8gYWxsCiMgICB1bnBpbm5lZCBjcHVzKS4KCiMgc3lzdGVtZCBkb2VzIG5vdCBtYW5hZ2UgdGhlIGNwdXNldCBjZ3JvdXAgY29udHJvbGxlciwgc28gbW92ZSBldmVyeXRoaW5nIGZyb20gdGhlIG1hbmFnZWQgcGlkcyBjb250cm9sbGVyJ3Mgb3ZzLnNsaWNlCiMgdG8gdGhlIGNwdXNldCBjb250cm9sbGVyLgoKIyBDcmVhdGUgdGhlIG92cy5zbGljZQpta2RpciAtcCAiJG92c3NsaWNlIgplY2hvIDAgPiAiJG92c3NsaWNlIi9jcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlCmNhdCAiJHJvb3QiL2NwdXNldC5jcHVzID4gIiRvdnNzbGljZSIvY3B1c2V0LmNwdXMKY2F0ICIkcm9vdCIvY3B1c2V0Lm1lbXMgPiAiJG92c3NsaWNlIi9jcHVzZXQubWVtcwoKIyBNb3ZlIE9WUyBvdmVyCmZvciBwcm9jZXNzIGluICQoY2F0ICIkb3Zzc2xpY2Vfc3lzdGVtZCIvKi9jZ3JvdXAucHJvY3MgfCBzb3J0IC1yKTsgZG8KICAgICAgICBlY2hvICRwcm9jZXNzID4gIiRvdnNzbGljZSIvY2dyb3VwLnByb2NzIDI+JjEgfCBncmVwIC12ICJJbnZhbGlkIEFyZ3VtZW50IiB8fCB0cnVlOwpkb25lCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/cpuset-configure.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs.slice
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/openvswitch.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs-vswitchd.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovsdb-server.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBUaGlzIGZpbGUgZW5hYmxlcyB0aGUgZHluYW1pYyBjcHUgYWZmaW5pdHkgbWFuYWdlbWVudCBvZiB0aGUgT1ZTIHNlcnZpY2VzCiMKIyBJdCBpcyByZWFkIGJ5IHRoZSBPVk4ncyBvdm5rdWJlLW5vZGUgRGFlbW9uU2V0IGNvbnRhaW5lciBhbmQgdGhlIGZlYXR1cmUKIyBpcyBlbmFibGVkIHdoZW4gdGhpcyBmaWxlIGV4aXN0cyBhbmQgaXMgbm90IGVtcHR5ICh0aGlzIGNvbW1lbnRhcnkgdGV4dAojIGVuc3VyZXMgdGhhdCkKIwojIEZvciBkaXNhYmxpbmcgdGhpcyBmZWF0dXJlIGluIGVtZXJnZW5jaWVzLCBlaXRoZXI6CiMgMSkgZGVsZXRlIHRoaXMgZmlsZSBhbmQgc2V0IHRoZSBjcHUgYWZmaW5pdHkgb2YgT1ZTIHNlcnZpY2VzIG1hbnVhbGx5CiMgMikgb3IgcmVwbGFjZSB0aGUgY29udGVudHMgb2YgdGhpcyBmaWxlIHdpdGggYW4gZW1wdHkgc3RyaW5nCiMgICAgdmlhIGEgTWFjaGluZUNvbmZpZwo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
+        user: {}
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Sets network devices RPS mask
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/set-rps-mask.sh %I 0
+        name: update-rps@.service
+      - contents: |
+          [Unit]
+          Description=Move services to reserved cpuset
+          Before=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/cpuset-configure.sh
+
+          [Install]
+          WantedBy=multi-user.target crio.service
+        enabled: true
+        name: cpuset-configure.service
+      - contents: |
+          [Unit]
+          Description=Clear the IRQBalance Banned CPU mask early in the boot
+          Before=kubelet.service
+          Before=irqbalance.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/clear-irqbalance-banned-cpus.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: clear-irqbalance-banned-cpus.service
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: default
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_node.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_node.yaml
@@ -1,0 +1,13 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  creationTimestamp: null
+  name: cluster
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+spec:
+  cgroupMode: v1
+status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_runtimeclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: node.k8s.io/v1
+handler: high-performance
+kind: RuntimeClass
+metadata:
+  creationTimestamp: null
+  name: performance-openshift-bootstrap-worker
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -1,0 +1,67 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  creationTimestamp: null
+  name: openshift-node-performance-openshift-bootstrap-worker
+  namespace: openshift-cluster-node-tuning-operator
+  ownerReferences:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    name: openshift-bootstrap-worker
+    uid: ""
+spec:
+  profile:
+  - data: "[main]\nsummary=Openshift node optimized for deterministic performance
+      at the cost of increased power consumption, focused on low latency network performance.
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
+      -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
+      All values are mapped with a comment where a parent profile contains them.\n#
+      Different values will override the original values in parent profiles.\n\n[variables]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
+      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
+      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
+      plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      = ignore\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
+      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
+      RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
+      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
+      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
+      working set is buffered for I/O, and any more write buffering would require\n#
+      swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
+      that mostly use file mappings may be able to use even higher values.\n#\n# The
+      generator of dirty data starts writeback at this percentage (system default\n#
+      is 20%)\n#> latency-performance\nvm.dirty_ratio=10\n\n# Start background writeback
+      (via writeback threads) at this percentage (system\n# default is 10%)\n#> latency-performance\nvm.dirty_background_ratio=3\n\n#
+      The swappiness parameter controls the tendency of the kernel to move\n# processes
+      out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
+      swapping processes out of physical memory\n# for as long as possible\n# 100
+      tells the kernel to aggressively swap processes out of physical memory\n# and
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
+      configured via a sysctl.d file\n# placed here for documentation purposes and
+      commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
+      \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
+    name: openshift-node-performance-openshift-bootstrap-worker
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: worker
+    operand:
+      tunedConfig:
+        reapply_sysctl: null
+    priority: 20
+    profile: openshift-node-performance-openshift-bootstrap-worker
+status: {}


### PR DESCRIPTION
* NTO: Add MCP name to filter PP (#878)

render-bootcmd-mc can only compute the kernel args for a MachineConfigPool that matches the node it is executed on, so we add the MachineConfigPool name as input parameter to filter the applicable PerformanceProfiles.



* OCPBUGS-22095: Add default MCP objects for rendering (#833)

* feat: update render command to create default MCPs

added default MCP creation to help correctly render out the resources for performance profile to use



upkeep: fix spelling



* feat: add default mcpools to tuned renderer



---------



* Enhance render sync to include bootstrap rendering tests

* Render MC without additional PP

This command should render a MC from the available sources. PerformanceProfile is a source, but it is not mandatory.

So, as there are scenarios where this command should work with no additional PP let's the command proceed even if there is no PP



* Render sync

---------