### PR TITLE
OCPBUGS-30111: Negative net interface name does not reduce queues

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
@@ -172,7 +172,8 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 			if device.InterfaceName != nil {
 				deviceNameAmendedRegex := strings.Replace(*device.InterfaceName, "*", ".*", -1)
 				if strings.HasPrefix(*device.InterfaceName, "!") {
-					devices = append(devices, "^INTERFACE="+"(?!"+deviceNameAmendedRegex+")")
+					// Strip the exclamation sign from the regex to avoid duplicating it
+					devices = append(devices, "^INTERFACE="+"(?!"+deviceNameAmendedRegex[1:]+")")
 				} else {
 					devices = append(devices, "^INTERFACE="+deviceNameAmendedRegex)
 				}

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -411,7 +411,9 @@ var _ = Describe("Tuned", func() {
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
 				It("should set by negative interface name with reserved CPUs count", func() {
-					netDeviceName := "!ens5"
+					netDeviceName := "ens5"
+					netDeviceNameInverted := "!" + netDeviceName
+
 					//regex field should be: devices_udev_regex=^INTERFACE=(?!ens5)
 					devicesUdevRegex := "\\^INTERFACE=\\(\\?!" + strings.Replace(netDeviceName, "*", "\\.\\*", -1) + "\\)"
 
@@ -419,7 +421,7 @@ var _ = Describe("Tuned", func() {
 						UserLevelNetworking: pointer.Bool(true),
 						Devices: []performancev2.Device{
 							{
-								InterfaceName: &netDeviceName,
+								InterfaceName: &netDeviceNameInverted,
 							},
 						}}
 					manifest := getTunedManifest(profile)
@@ -493,7 +495,8 @@ var _ = Describe("Tuned", func() {
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
 				It("should set by specific vendor,model and negative interface name with reserved CPUs count", func() {
-					netDeviceName := "!ens5"
+					netDeviceName := "ens5"
+					netDeviceNameInverted := "!ens5"
 					netDeviceVendorID := "0x1af4"
 					netDeviceModelID := "0x1000"
 					//regex field should be: devices_udev_regex=^ID_MODEL_ID=0x1000[\\s\\S]*^ID_VENDOR_ID=0x1af4[\\s\\S]*^INTERFACE=(?!ens5)
@@ -503,7 +506,7 @@ var _ = Describe("Tuned", func() {
 						UserLevelNetworking: pointer.Bool(true),
 						Devices: []performancev2.Device{
 							{
-								InterfaceName: &netDeviceName,
+								InterfaceName: &netDeviceNameInverted,
 								DeviceID:      &netDeviceModelID,
 								VendorID:      &netDeviceVendorID,
 							},

--- a/test/e2e/performanceprofile/functests/1_performance/netqueues.go
+++ b/test/e2e/performanceprofile/functests/1_performance/netqueues.go
@@ -205,6 +205,68 @@ var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", Ordered, func() 
 			}
 		})
 
+		It("[test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match", func() {
+			nodesDevices := make(map[string]map[string]int)
+			var device, devicePattern string
+			deviceSupport, err := checkDeviceSupport(context.TODO(), workerRTNodes, nodesDevices)
+			Expect(err).ToNot(HaveOccurred())
+			if !deviceSupport {
+				Skip("Skipping Test: There are no supported Network Devices")
+			}
+
+			// Remove nodes with only one NIC as that cannot be used to check this behavior
+			// this is done by removing the NIC entries to avoid deleting from the map while iterating
+			for node, nics := range nodesDevices {
+				if len(nics) < 2 {
+					nodesDevices[node] = nil
+				}
+			}
+
+			nodeName, device := getRandomNodeDevice(nodesDevices)
+			devicePattern = "!" + device
+			profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+			Expect(err).ToNot(HaveOccurred())
+			if profile.Spec.Net.UserLevelNetworking != nil && *profile.Spec.Net.UserLevelNetworking && len(profile.Spec.Net.Devices) == 0 {
+				By("Enable UserLevelNetworking and add Devices in Profile")
+				profile.Spec.Net = &performancev2.Net{
+					UserLevelNetworking: pointer.Bool(true),
+					Devices: []performancev2.Device{
+						{
+							InterfaceName: &devicePattern,
+						},
+					},
+				}
+				profiles.UpdateWithRetry(profile)
+			}
+			//Verify the tuned profile is created on the worker-cnf nodes:
+			tunedCmd := []string{"bash", "-c",
+				fmt.Sprintf("cat /etc/tuned/openshift-node-performance-%s/tuned.conf | grep devices_udev_regex", performanceProfileName)}
+
+			node, err := nodes.GetByName(nodeName)
+			Expect(err).ToNot(HaveOccurred())
+			tunedPod := nodes.TunedForNode(node, RunningOnSingleNode)
+
+			Eventually(func() bool {
+				out, err := pods.WaitForPodOutput(context.TODO(), testclient.K8sClient, tunedPod, tunedCmd)
+				if err != nil {
+					return false
+				}
+				return strings.ContainsAny(string(out), device)
+			}, cluster.ComputeTestTimeout(2*time.Minute, RunningOnSingleNode), 5*time.Second).Should(BeTrue(), "could not get a tuned profile set with devices_udev_regex")
+
+			nodesDevices = make(map[string]map[string]int)
+			err = checkDeviceSetWithReservedCPU(context.TODO(), workerRTNodes, nodesDevices, *profile)
+			if err != nil {
+				Skip("Skipping Test: Unable to set Network queue size to reserved cpu count")
+			}
+
+			// After at least one NIC was configured, make sure that the selected NIC was NOT it
+
+			Expect(nodesDevices).To(ContainElement(node.Name))
+			Expect(nodesDevices[node.Name]).To(ContainElement(device))
+			Expect(nodesDevices[node.Name][device]).ToNot(Equal(getReservedCPUSize(profile.Spec.CPU)))
+		})
+
 		It("[test_id:40668] Verify reserved cpu count is added to networking devices matched with vendor and Device id", func() {
 			nodesDevices := make(map[string]map[string]int)
 			deviceSupport, err := checkDeviceSupport(context.TODO(), workerRTNodes, nodesDevices)


### PR DESCRIPTION
The internal regular expression has duplicated exclamation mark that breaks the pattern.