### PR TITLE
[release-4.14] OCPBUGS-30153: fix rendering extra ctrcfgs

### DIFF
--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -40,3 +40,4 @@ function rendersync() {
 
 rendersync manual-cluster/performance base/performance default
 rendersync --owner-ref none -- base/performance manual-cluster/performance no-ref 
+rendersync base/performance manual-cluster/performance container-runtime-crun bootstrap/extra-ctrcfg

--- a/test/e2e/performanceprofile/cluster-setup/container-runtime-crun/enable-crun-worker-cnf.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/container-runtime-crun/enable-crun-worker-cnf.yaml
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: enable-crun-worker-cnf
+spec:
+  containerRuntimeConfig:
+    defaultRuntime: crun
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-cnf: ""
+status: {}

--- a/test/e2e/performanceprofile/functests-render-command/1_render_command/render_test.go
+++ b/test/e2e/performanceprofile/functests-render-command/1_render_command/render_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -19,12 +20,13 @@ const (
 )
 
 var (
-	assetsOutDir       string
-	assetsInDirs       []string
-	ppDir              string
-	testDataPath       string
-	defaultPinnedDir   string
-	snoLegacyPinnedDir string
+	assetsOutDir              string
+	assetsInDirs              []string
+	ppDir                     string
+	testDataPath              string
+	defaultPinnedDir          string
+	snoLegacyPinnedDir        string
+	containerRuntimeConfigDir string
 )
 
 var _ = Describe("render command e2e test", func() {
@@ -36,6 +38,7 @@ var _ = Describe("render command e2e test", func() {
 		defaultPinnedDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "pinned-cluster", "default")
 		snoLegacyPinnedDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "pinned-cluster", "single-node-legacy")
 		testDataPath = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "testdata")
+		containerRuntimeConfigDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "container-runtime-crun")
 		assetsInDirs = []string{assetsInDir, ppDir}
 	})
 
@@ -132,6 +135,22 @@ var _ = Describe("render command e2e test", func() {
 			cmd := exec.Command(cmdline[0], cmdline[1:]...)
 			runAndCompare(cmd, pinnedExpectedDir)
 
+		})
+	})
+
+	Context("With performance profile and matching extra ContainerRuntimeConfig during bootstrap", func() {
+		It("should render ContainerRuntimeConfig", func() {
+			renderDirs := append(assetsInDirs, containerRuntimeConfigDir)
+			cmdline := []string{
+				filepath.Join(binPath, "cluster-node-tuning-operator"),
+				"render",
+				"--asset-input-dir", strings.Join(renderDirs, ","),
+				"--asset-output-dir", assetsOutDir,
+			}
+			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			runAndCompare(cmd, path.Join(bootstrapExpectedDir, "extra-ctrcfg"))
 		})
 	})
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_kubeletconfig.yaml
@@ -1,0 +1,65 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: performance-manual
+spec:
+  kubeletConfig:
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous: {}
+      webhook:
+        cacheTTL: 0s
+      x509: {}
+    authorization:
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    containerRuntimeEndpoint: ""
+    cpuManagerPolicy: static
+    cpuManagerPolicyOptions:
+      full-pcpus-only: "true"
+    cpuManagerReconcilePeriod: 5s
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 0s
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      memory: 500Mi
+    logging:
+      flushFrequency: 0
+      options:
+        json:
+          infoBufferSize: "0"
+      verbosity: 0
+    memoryManagerPolicy: Static
+    memorySwap: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    reservedMemory:
+    - limits:
+        memory: 1100Mi
+      numaNode: 0
+    reservedSystemCPUs: "0"
+    runtimeRequestTimeout: 0s
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      memory: 500Mi
+    topologyManagerPolicy: single-numa-node
+    volumeStatsAggPeriod: 0s
+  machineConfigPoolSelector:
+    matchLabels:
+      machineconfiguration.openshift.io/role: worker-cnf
+status:
+  conditions: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_machineconfig.yaml
@@ -1,0 +1,190 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: 50-performance-manual
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCm5vZGVzX3BhdGg9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vbm9kZSIKaHVnZXBhZ2VzX2ZpbGU9IiR7bm9kZXNfcGF0aH0vbm9kZSR7TlVNQV9OT0RFfS9odWdlcGFnZXMvaHVnZXBhZ2VzLSR7SFVHRVBBR0VTX1NJWkV9a0IvbnJfaHVnZXBhZ2VzIgoKaWYgWyAhIC1mICIke2h1Z2VwYWdlc19maWxlfSIgXTsgdGhlbgogIGVjaG8gIkVSUk9SOiAke2h1Z2VwYWdlc19maWxlfSBkb2VzIG5vdCBleGlzdCIKICBleGl0IDEKZmkKCnRpbWVvdXQ9NjAKc2FtcGxlPTEKY3VycmVudF90aW1lPTAKd2hpbGUgWyAiJChjYXQgIiR7aHVnZXBhZ2VzX2ZpbGV9IikiIC1uZSAiJHtIVUdFUEFHRVNfQ09VTlR9IiBdOyBkbwogIGVjaG8gIiR7SFVHRVBBR0VTX0NPVU5UfSIgPiIke2h1Z2VwYWdlc19maWxlfSIKCiAgY3VycmVudF90aW1lPSQoKGN1cnJlbnRfdGltZSArIHNhbXBsZSkpCiAgaWYgWyAkY3VycmVudF90aW1lIC1ndCAkdGltZW91dCBdOyB0aGVuCiAgICBlY2hvICJFUlJPUjogJHtodWdlcGFnZXNfZmlsZX0gZG9lcyBub3QgaGF2ZSB0aGUgZXhwZWN0ZWQgbnVtYmVyIG9mIGh1Z2VwYWdlcyAke0hVR0VQQUdFU19DT1VOVH0iCiAgICBleGl0IDEKICBmaQoKICBzbGVlcCAkc2FtcGxlCmRvbmUK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/hugepages-allocation.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZnVuY3Rpb24gc2V0X3F1ZXVlX3Jwc19tYXNrKCkgewojIHJlcGxhY2UgeDJkIHdpdGggaHlwaGVuICgtKSB3aGljaCBpcyBhbiBlc2NhcGVkIGNoYXJhY3RlcgojIHRoYXQgd2FzIGFkZGVkIGJ5IHN5c3RlbWQtZXNjYXBlIGluIG9yZGVyIHRvIGVzY2FwZSB0aGUgc3lzdGVtZCB1bml0IG5hbWUgdGhhdCBpbnZva2VzIHRoaXMgc2NyaXB0CnBhdGg9JHtwYXRoL3gyZC8tfQojIHNldCBycHMgYWZmaW5pdHkgZm9yIHRoZSBxdWV1ZQplY2hvICIke21hc2t9IiAgMj4gL2Rldi9udWxsID4gIi9zeXMvJHtwYXRofS9ycHNfY3B1cyIKIyB3ZSByZXR1cm4gMCBiZWNhdXNlIHRoZSAnZWNobycgY29tbWFuZCBtaWdodCBmYWlsIGlmIHRoZSBkZXZpY2UgcGF0aCB0byB3aGljaCB0aGUgcXVldWUgYmVsb25ncyBoYXMgY2hhbmdlZC4KIyB0aGlzIGNhbiBoYXBwZW4gaW4gY2FzZSBvZiBTUkktT1YgZGV2aWNlcyByZW5hbWluZy4KcmV0dXJuIDAKfQoKZnVuY3Rpb24gc2V0X25ldF9kZXZfcnBzX21hc2soKSB7CiAgIyBpbiBjYXNlIG9mIGRldmljZSB3ZSB3YW50IHRvIGl0ZXJhdGUgdGhyb3VnaCBhbGwgcXVldWVzCmZvciBpIGluIC9zeXMvIiR7cGF0aH0iL3F1ZXVlcy9yeC0qOyBkbwogIGVjaG8gIiR7bWFza30iIDI+IC9kZXYvbnVsbCA+ICIke2l9L3Jwc19jcHVzIgpkb25lCiMgd2UgcmV0dXJuIDAgYmVjYXVzZSB0aGUgJ2VjaG8nIGNvbW1hbmQgbWlnaHQgZmFpbCBpZiB0aGUgZGV2aWNlIHBhdGggdG8gd2hpY2ggdGhlIHF1ZXVlIGJlbG9uZ3MgaGFzIGNoYW5nZWQuCiMgdGhpcyBjYW4gaGFwcGVuIGluIGNhc2Ugb2YgU1JJLU9WIGRldmljZXMgcmVuYW1pbmcuCnJldHVybiAwCiB9CgpwYXRoPSR7MX0KWyAtbiAiJHtwYXRofSIgXSB8fCB7IGVjaG8gIlRoZSBkZXZpY2UgcGF0aCBhcmd1bWVudCBpcyBtaXNzaW5nIiA+JjIgOyBleGl0IDE7IH0KCm1hc2s9JHsyfQpbIC1uICIke21hc2t9IiBdIHx8IHsgZWNobyAiVGhlIG1hc2sgYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgppZiBbWyAiJHtwYXRofSIgPX4gInF1ZXVlcyIgXV07IHRoZW4KIHNldF9xdWV1ZV9ycHNfbWFzawplbHNlCiBzZXRfbmV0X2Rldl9ycHNfbWFzawpmaQo=
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-rps-mask.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9iYXNoCgpzZXQgLWV1byBwaXBlZmFpbAoKZm9yIGNwdSBpbiAke09GRkxJTkVfQ1BVUy8vLC8gfTsKICBkbwogICAgb25saW5lX2NwdV9maWxlPSIvc3lzL2RldmljZXMvc3lzdGVtL2NwdS9jcHUkY3B1L29ubGluZSIKICAgIGlmIFsgISAtZiAiJHtvbmxpbmVfY3B1X2ZpbGV9IiBdOyB0aGVuCiAgICAgIGVjaG8gIkVSUk9SOiAke29ubGluZV9jcHVfZmlsZX0gZG9lcyBub3QgZXhpc3QsIGFib3J0IHNjcmlwdCBleGVjdXRpb24iCiAgICAgIGV4aXQgMQogICAgZmkKICBkb25lCgplY2hvICJBbGwgY3B1cyBvZmZsaW5lZCBleGlzdHMsIHNldCB0aGVtIG9mZmxpbmUiCgpmb3IgY3B1IGluICR7T0ZGTElORV9DUFVTLy8sLyB9OwogIGRvCiAgICBvbmxpbmVfY3B1X2ZpbGU9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vY3B1L2NwdSRjcHUvb25saW5lIgogICAgZWNobyAwID4gIiR7b25saW5lX2NwdV9maWxlfSIKICAgIGVjaG8gIm9mZmxpbmUgY3B1IG51bSAkY3B1IgogIGRvbmUKCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-cpus-offline.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLWV1byBwaXBlZmFpbApzZXQgLXgKCiMgY29uc3QKU0VEPSIvdXNyL2Jpbi9zZWQiCiMgdHVuYWJsZSAtIG92ZXJyaWRhYmxlIGZvciB0ZXN0aW5nIHB1cnBvc2VzCklSUUJBTEFOQ0VfQ09ORj0iJHsxOi0vZXRjL3N5c2NvbmZpZy9pcnFiYWxhbmNlfSIKQ1JJT19PUklHX0JBTk5FRF9DUFVTPSIkezI6LS9ldGMvc3lzY29uZmlnL29yaWdfaXJxX2Jhbm5lZF9jcHVzfSIKTk9ORT0wCgpbICEgLWYgIiR7SVJRQkFMQU5DRV9DT05GfSIgXSAmJiBleGl0IDAKCiR7U0VEfSAtaSAnL15ccypJUlFCQUxBTkNFX0JBTk5FRF9DUFVTXGIvZCcgIiR7SVJRQkFMQU5DRV9DT05GfSIgfHwgZXhpdCAwCiMgQ1BVIG51bWJlcnMgd2hpY2ggaGF2ZSB0aGVpciBjb3JyZXNwb25kaW5nIGJpdHMgc2V0IHRvIG9uZSBpbiB0aGlzIG1hc2sKIyB3aWxsIG5vdCBoYXZlIGFueSBpcnEncyBhc3NpZ25lZCB0byB0aGVtIG9uIHJlYmFsYW5jZS4KIyBzbyB6ZXJvIG1lYW5zIGFsbCBjcHVzIGFyZSBwYXJ0aWNpcGF0aW5nIGluIGxvYWQgYmFsYW5jaW5nLgplY2hvICJJUlFCQUxBTkNFX0JBTk5FRF9DUFVTPSR7Tk9ORX0iID4+ICIke0lSUUJBTEFOQ0VfQ09ORn0iCgojIHdlIG5vdyBvd24gdGhpcyBjb25maWd1cmF0aW9uLiBCdXQgQ1JJLU8gaGFzIGNvZGUgdG8gcmVzdG9yZSB0aGUgY29uZmlndXJhdGlvbiwKIyBhbmQgdW50aWwgaXQgZ2FpbnMgdGhlIG9wdGlvbiB0byBkaXNhYmxlIHRoaXMgcmVzdG9yZSBmbG93LCB3ZSBuZWVkIHRvIG1ha2UKIyB0aGUgY29uZmlndXJhdGlvbiBjb25zaXN0ZW50IHN1Y2ggYXMgdGhlIENSSS1PIHJlc3RvcmUgd2lsbCBkbyBub3RoaW5nLgppZiBbIC1uICIke0NSSU9fT1JJR19CQU5ORURfQ1BVU30iIF0gJiYgWyAtZiAiJHtDUklPX09SSUdfQkFOTkVEX0NQVVN9IiBdOyB0aGVuCgllY2hvICIke05PTkV9IiA+ICIke0NSSU9fT1JJR19CQU5ORURfQ1BVU30iCmZpCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/clear-irqbalance-banned-cpus.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMCIKCgojIFdlIHNob3VsZCBjb3B5IHBhc3RlIHRoZSBkZWZhdWx0IHJ1bnRpbWUgYmVjYXVzZSB0aGlzIHNuaXBwZXQgd2lsbCBvdmVycmlkZSB0aGUgd2hvbGUgcnVudGltZXMgc2VjdGlvbgpbY3Jpby5ydW50aW1lLnJ1bnRpbWVzLnJ1bmNdCnJ1bnRpbWVfcGF0aCA9ICIiCnJ1bnRpbWVfdHlwZSA9ICJvY2kiCnJ1bnRpbWVfcm9vdCA9ICIvcnVuL3J1bmMiCgojIFRoZSBDUkktTyB3aWxsIGNoZWNrIHRoZSBhbGxvd2VkX2Fubm90YXRpb25zIHVuZGVyIHRoZSBydW50aW1lIGhhbmRsZXIgYW5kIGFwcGx5IGhpZ2gtcGVyZm9ybWFuY2UgaG9va3Mgd2hlbiBvbmUgb2YKIyBoaWdoLXBlcmZvcm1hbmNlIGFubm90YXRpb25zIHByZXNlbnRzIHVuZGVyIGl0LgojIFdlIHNob3VsZCBwcm92aWRlIHRoZSBydW50aW1lX3BhdGggYmVjYXVzZSB3ZSBuZWVkIHRvIGluZm9ybSB0aGF0IHdlIHdhbnQgdG8gcmUtdXNlIHJ1bmMgYmluYXJ5IGFuZCB3ZQojIGRvIG5vdCBoYXZlIGhpZ2gtcGVyZm9ybWFuY2UgYmluYXJ5IHVuZGVyIHRoZSAkUEFUSCB0aGF0IHdpbGwgcG9pbnQgdG8gaXQuCltjcmlvLnJ1bnRpbWUucnVudGltZXMuaGlnaC1wZXJmb3JtYW5jZV0KcnVudGltZV9wYXRoID0gIi9iaW4vcnVuYyIKcnVudGltZV90eXBlID0gIm9jaSIKcnVudGltZV9yb290ID0gIi9ydW4vcnVuYyIKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LWMtc3RhdGVzLmNyaW8uaW8iLCAiY3B1LWZyZXEtZ292ZXJub3IuY3Jpby5pbyJdCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-runtimes.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBBcHBseSB0aGUgUlBTIG1hc2sgb24gdGhlIHZpcnR1YWwgaW50ZXJmYWNlcyBvZiB0aGUgaG9zdCBieSBkZWZhdWx0LCBiZWNhc3VlCiMgZnJvbSB0aGUgY29udGFpbmVyIHBlcnNwZWN0aXZlIHRoZSBSUFMgbWFzayB0aGUgd2lsbCBiZSBjb25zdWx0ZWQsIGlzIHRoZSBvbmUgb24gdGhlIFJYIHNpZGUgb2YgdGhlIHZldGggaW4gdGhlIGhvc3QuCiMgQ29uc2lkZXIgdGhlIGZvbGxvd2luZyBkaWFncmFtOgojIFBvZCBBIDx2ZXRoMSAtIHZldGgyPiBob3N0IDx2ZXRoMyAtIHZldGg0PiBQb2QgQgojICB2ZXRoMidzIFJQUyBhZmZpbml0eSBpcyB0aGUgb25lIGRldGVybWluaW5nIHRoZSBDUFVzIHRoYXQgYXJlIGhhbmRsaW5nIHRoZSBwYWNrZXQgcHJvY2Vzc2luZyB3aGVuIHNlbmRpbmcgZGF0YSBmcm9tIFBvZCBBIHRvIHBvZCBCLgojIEFkZGl0aW9uYWwgY29tbW9uIHNjZW5hcmlvczoKIyAxLiBQb2QgQSA9IHNlbmRlciwgaG9zdCA9IHJlY2VpdmVyCiMgIFRoZSBSUFMgYWZmaW5pdHkgb2YgdGhlIGhvc3Qgc2lkZSBzaG91bGQgYmUgY29uc3VsdGVkIChiZWNhdXNlIGl04oCZcyB0aGUgcmVjZWl2ZXIpIGFuZCBpdCBzaG91bGQgYmUgc2V0IHRvIGNwdXMgbm90IHNlbnNpdGl2ZSB0byBwcmVlbXB0aW9uIChyZXNlcnZlZCBwb29sKS4KIyAyLiBQb2QgQSA9IHJlY2VpdmVyLCBob3N0ID0gc2VuZGVyCiMgIEluIGNhc2Ugb2Ygbm8gUlBTIG1hc2sgb24gdGhlIHJlY2VpdmVyIHNpZGUsIHRoZSBzZW5kZXIgbmVlZHMgdG8gcGF5IHRoZSBwcmljZSBhbmQgZG8gYWxsIHRoZSBwcm9jZXNzaW5nIG9uIGl0cyBjb3Jlcy4KbmV0LmNvcmUucnBzX2RlZmF1bHRfbWFzayA9IDAwMDAwMDAxCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysctl.d/99-default-rps-mask.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0icXVldWVzIiwgQUNUSU9OPT0iYWRkIiwgRU5We0RFVlBBVEh9PT0iL2RldmljZXMvcGNpKi9xdWV1ZXMvcngqIiwgVEFHKz0ic3lzdGVtZCIsIFBST0dSQU09Ii9iaW4vc3lzdGVtZC1lc2NhcGUgLS1wYXRoIC0tdGVtcGxhdGU9dXBkYXRlLXJwc0Auc2VydmljZSAkZW52e0RFVlBBVEh9IiwgRU5We1NZU1RFTURfV0FOVFN9PSIlYyIKCiMgU1ItSU9WIGRldmljZXMgYXJlIG1vdmVkIChyZW5hbWVkKSwgaGVuY2Ugd2Ugd2FudCB0byBjYXRjaCB0aGlzIGV2ZW50IGFzIHdlbGwKU1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0ibW92ZSIsIEVOVntERVZQQVRIfSE9Ii9kZXZpY2VzL3ZpcnR1YWwvbmV0LyoiLCBUQUcrPSJzeXN0ZW1kIiwgUFJPR1JBTT0iL2Jpbi9zeXN0ZW1kLWVzY2FwZSAtLXBhdGggLS10ZW1wbGF0ZT11cGRhdGUtcnBzQC5zZXJ2aWNlICRlbnZ7REVWUEFUSH0iLCBFTlZ7U1lTVEVNRF9XQU5UU309IiVjIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/99-netdev-physical-rps.rules
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCiMgY3B1c2V0LWNvbmZpZ3VyZS5zaCBjb25maWd1cmVzIHRocmVlIGNwdXNldHMgaW4gcHJlcGFyYXRpb24gZm9yIGFsbG93aW5nIGNvbnRhaW5lcnMgdG8gaGF2ZSBjcHUgbG9hZCBiYWxhbmNpbmcgZGlzYWJsZWQuCiMgVG8gY29uZmlndXJlIGEgY3B1c2V0IHRvIGhhdmUgbG9hZCBiYWxhbmNlIGRpc2FibGVkIChvbiBjZ3JvdXAgdjEpLCBhIGNwdXNldCBjZ3JvdXAgbXVzdCBoYXZlIGBjcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlYAojIHNldCB0byAwIChkaXNhYmxlKSwgYW5kIGFueSBjcHVzZXQgdGhhdCBjb250YWlucyB0aGUgc2FtZSBzZXQgYXMgYGNwdXNldC5jcHVzYCBtdXN0IGFsc28gaGF2ZSBgY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZWAgc2V0IHRvIGRpc2FibGVkLgoKc2V0IC1ldW8gcGlwZWZhaWwKCnJvb3Q9L3N5cy9mcy9jZ3JvdXAvY3B1c2V0CnN5c3RlbT0iJHJvb3QiL3N5c3RlbS5zbGljZQptYWNoaW5lPSIkcm9vdCIvbWFjaGluZS5zbGljZQoKb3Zzc2xpY2U9IiR7cm9vdH0vb3ZzLnNsaWNlIgpvdnNzbGljZV9zeXN0ZW1kPSIvc3lzL2ZzL2Nncm91cC9waWRzL292cy5zbGljZSIKCiMgQXMgc3VjaCwgdGhlIHJvb3QgY2dyb3VwIG5lZWRzIHRvIGhhdmUgY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZT0wLiAKZWNobyAwID4gIiRyb290Ii9jcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlCgojIEhvd2V2ZXIsIHRoaXMgd291bGQgcHJlc2VudCBhIHByb2JsZW0gZm9yIHN5c3RlbSBkYWVtb25zLCB3aGljaCBzaG91bGQgaGF2ZSBsb2FkIGJhbGFuY2luZyBlbmFibGVkLgojIEFzIHN1Y2gsIGEgc2Vjb25kIGNwdXNldCBtdXN0IGJlIGNyZWF0ZWQsIGhlcmUgZHViYmVkIGBzeXN0ZW1gLCB3aGljaCB3aWxsIHRha2UgYWxsIHN5c3RlbSBkYWVtb25zLgojIFNpbmNlIHN5c3RlbWQgc3RhcnRzIGl0cyBjaGlsZHJlbiB3aXRoIHRoZSBjcHVzZXQgaXQgaXMgaW4sIG1vdmluZyBzeXN0ZW1kIHdpbGwgZW5zdXJlIGFsbCBwcm9jZXNzZXMgc3lzdGVtZCBiZWdpbnMgd2lsbCBiZSBpbiB0aGUgY29ycmVjdCBjZ3JvdXAuCm1rZGlyIC1wICIkc3lzdGVtIgojIGNwdXNldC5tZW1zIG11c3QgYmUgaW5pdGlhbGl6ZWQgb3IgcHJvY2Vzc2VzIHdpbGwgZmFpbCB0byBiZSBtb3ZlZCBpbnRvIGl0LgpjYXQgIiRyb290L2NwdXNldC5tZW1zIiA+ICIkc3lzdGVtIi9jcHVzZXQubWVtcwojIFJldHJpZXZlIHRoZSBjcHVzZXQgb2Ygc3lzdGVtZCwgYW5kIHdyaXRlIGl0IHRvIGNwdXNldC5jcHVzIG9mIHRoZSBzeXN0ZW0gY2dyb3VwLgpyZXNlcnZlZF9zZXQ9JCh0YXNrc2V0IC1jcCAgMSAgfCBhd2sgJ05GeyBwcmludCAkTkYgfScpCmVjaG8gIiRyZXNlcnZlZF9zZXQiID4gIiRzeXN0ZW0iL2NwdXNldC5jcHVzCgojIEFuZCBtb3ZlIHRoZSBzeXN0ZW0gcHJvY2Vzc2VzIGludG8gaXQuCiMgTm90ZSwgc29tZSBrZXJuZWwgdGhyZWFkcyB3aWxsIGZhaWwgdG8gYmUgbW92ZWQgd2l0aCAiSW52YWxpZCBBcmd1bWVudCIuIFRoaXMgc2hvdWxkIGJlIGlnbm9yZWQuCmZvciBwcm9jZXNzIGluICQoY2F0ICIkcm9vdCIvY2dyb3VwLnByb2NzIHwgc29ydCAtcik7IGRvCgllY2hvICRwcm9jZXNzID4gIiRzeXN0ZW0iL2Nncm91cC5wcm9jcyAyPiYxIHwgZ3JlcCAtdiAiSW52YWxpZCBBcmd1bWVudCIgfHwgdHJ1ZTsKZG9uZQoKIyBGaW5hbGx5LCBhIHRoZSBgbWFjaGluZS5zbGljZWAgY2dyb3VwIG11c3QgYmUgcHJlY29uZmlndXJlZC4gUG9kbWFuIHdpbGwgY3JlYXRlIGNvbnRhaW5lcnMgYW5kIG1vdmUgdGhlbSBpbnRvIHRoZSBgbWFjaGluZS5zbGljZWAsIGJ1dCB0aGVyZSdzCiMgbm8gd2F5IHRvIHRlbGwgcG9kbWFuIHRvIHVwZGF0ZSBtYWNoaW5lLnNsaWNlIHRvIG5vdCBoYXZlIHRoZSBmdWxsIHNldCBvZiBjcHVzLiBJbnN0ZWFkIG9mIGRpc2FibGluZyBsb2FkIGJhbGFuY2luZyBpbiBpdCwgd2UgY2FuIHByZS1jcmVhdGUgaXQuCiMgd2l0aCB0aGUgcmVzZXJ2ZWQgQ1BVcyBzZXQgYWhlYWQgb2YgdGltZSwgc28gd2hlbiBpc29sYXRlZCBwcm9jZXNzZXMgYmVnaW4sIHRoZSBjZ3JvdXAgZG9lcyBub3QgaGF2ZSBhbiBvdmVybGFwcGluZyBjcHVzZXQgYmV0d2VlbiBtYWNoaW5lLnNsaWNlIGFuZCBpc29sYXRlZCBjb250YWluZXJzLgpta2RpciAtcCAiJG1hY2hpbmUiCgojIEl0J3MgdW5saWtlbHksIGJ1dCBwb3NzaWJsZSwgdGhhdCB0aGlzIGNwdXNldCBhbHJlYWR5IGV4aXN0ZWQuIEl0ZXJhdGUganVzdCBpbiBjYXNlLgpmb3IgZmlsZSBpbiAkKGZpbmQgIiRtYWNoaW5lIiAtbmFtZSBjcHVzZXQuY3B1cyB8IHNvcnQgLXIpOyBkbyBlY2hvICIkcmVzZXJ2ZWRfc2V0IiA+ICIkZmlsZSI7IGRvbmUKCiMgT1ZTIGlzIHJ1bm5pbmcgaW4gaXRzIG93biBzbGljZSB0aGF0IHNwYW5zIGFsbCBjcHVzLiBUaGUgcmVhbCBhZmZpbml0eSBpcyBtYW5hZ2VkIGJ5IE9WTi1LIG92bmt1YmUtbm9kZSBkYWVtb25zZXQKIyBNYWtlIHN1cmUgdGhpcyBzbGljZSB3aWxsIG5vdCBlbmFibGUgY3B1IGJhbGFuY2luZyBmb3Igb3RoZXIgc2xpY2UgY29uZmlndXJlZCBieSB0aGlzIHNjcmlwdC4KIyBUaGlzIG1pZ2h0IHNlZW0gY291bnRlci1pbnR1aXRpdmUsIGJ1dCB0aGlzIHdpbGwgYWN0dWFsbHkgTk9UIGRpc2FibGUgY3B1IGJhbGFuY2luZyBmb3IgT1ZTIGl0c2VsZi4KIyAtIE9WUyBoYXMgYWNjZXNzIHRvIHJlc2VydmVkIGNwdXMsIGJ1dCB0aG9zZSBoYXZlIGJhbGFuY2luZyBlbmFibGVkIHZpYSB0aGUgYHN5c3RlbWAgY2dyb3VwIGNyZWF0ZWQgYWJvdmUKIyAtIE9WUyBoYXMgYWNjZXNzIHRvIGlzb2xhdGVkIGNwdXMgdGhhdCBhcmUgY3VycmVudGx5IG5vdCBhc3NpZ25lZCB0byBwaW5uZWQgcG9kcy4gVGhvc2UgaGF2ZSBiYWxhbmNpbmcgZW5hYmxlZCBieSB0aGUKIyAgIHBvZHMgcnVubmluZyB0aGVyZSAoYnVyc3RhYmxlIGFuZCBiZXN0LWVmZm9ydCBwb2RzIGhhdmUgYmFsYW5jaW5nIGVuYWJsZWQgaW4gdGhlIGNvbnRhaW5lciBjZ3JvdXAgYW5kIGFjY2VzcyB0byBhbGwKIyAgIHVucGlubmVkIGNwdXMpLgoKIyBzeXN0ZW1kIGRvZXMgbm90IG1hbmFnZSB0aGUgY3B1c2V0IGNncm91cCBjb250cm9sbGVyLCBzbyBtb3ZlIGV2ZXJ5dGhpbmcgZnJvbSB0aGUgbWFuYWdlZCBwaWRzIGNvbnRyb2xsZXIncyBvdnMuc2xpY2UKIyB0byB0aGUgY3B1c2V0IGNvbnRyb2xsZXIuCgojIENyZWF0ZSB0aGUgb3ZzLnNsaWNlCm1rZGlyIC1wICIkb3Zzc2xpY2UiCmVjaG8gMCA+ICIkb3Zzc2xpY2UiL2NwdXNldC5zY2hlZF9sb2FkX2JhbGFuY2UKY2F0ICIkcm9vdCIvY3B1c2V0LmNwdXMgPiAiJG92c3NsaWNlIi9jcHVzZXQuY3B1cwpjYXQgIiRyb290Ii9jcHVzZXQubWVtcyA+ICIkb3Zzc2xpY2UiL2NwdXNldC5tZW1zCgojIE1vdmUgT1ZTIG92ZXIKZm9yIHByb2Nlc3MgaW4gJChjYXQgIiRvdnNzbGljZV9zeXN0ZW1kIi8qL2Nncm91cC5wcm9jcyB8IHNvcnQgLXIpOyBkbwogICAgICAgIGVjaG8gJHByb2Nlc3MgPiAiJG92c3NsaWNlIi9jZ3JvdXAucHJvY3MgMj4mMSB8IGdyZXAgLXYgIkludmFsaWQgQXJndW1lbnQiIHx8IHRydWU7CmRvbmU=
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/cpuset-configure.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs.slice
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/openvswitch.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs-vswitchd.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovsdb-server.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBUaGlzIGZpbGUgZW5hYmxlcyB0aGUgZHluYW1pYyBjcHUgYWZmaW5pdHkgbWFuYWdlbWVudCBvZiB0aGUgT1ZTIHNlcnZpY2VzCiMKIyBJdCBpcyByZWFkIGJ5IHRoZSBPVk4ncyBvdm5rdWJlLW5vZGUgRGFlbW9uU2V0IGNvbnRhaW5lciBhbmQgdGhlIGZlYXR1cmUKIyBpcyBlbmFibGVkIHdoZW4gdGhpcyBmaWxlIGV4aXN0cyBhbmQgaXMgbm90IGVtcHR5ICh0aGlzIGNvbW1lbnRhcnkgdGV4dAojIGVuc3VyZXMgdGhhdCkKIwojIEZvciBkaXNhYmxpbmcgdGhpcyBmZWF0dXJlIGluIGVtZXJnZW5jaWVzLCBlaXRoZXI6CiMgMSkgZGVsZXRlIHRoaXMgZmlsZSBhbmQgc2V0IHRoZSBjcHUgYWZmaW5pdHkgb2YgT1ZTIHNlcnZpY2VzIG1hbnVhbGx5CiMgMikgb3IgcmVwbGFjZSB0aGUgY29udGVudHMgb2YgdGhpcyBmaWxlIHdpdGggYW4gZW1wdHkgc3RyaW5nCiMgICAgdmlhIGEgTWFjaGluZUNvbmZpZwo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
+        user: {}
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Sets network devices RPS mask
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/set-rps-mask.sh %I 0
+        name: update-rps@.service
+      - contents: |
+          [Unit]
+          Description=Hugepages-1048576kB allocation on the node 0
+          Before=kubelet.service
+
+          [Service]
+          Environment=HUGEPAGES_COUNT=1
+          Environment=HUGEPAGES_SIZE=1048576
+          Environment=NUMA_NODE=0
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/hugepages-allocation.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: hugepages-allocation-1048576kB-NUMA0.service
+      - contents: |
+          [Unit]
+          Description=Move services to reserved cpuset
+          Before=kubelet.service
+          After=crio.service
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/cpuset-configure.sh
+
+          [Install]
+          WantedBy=multi-user.target crio.service
+        enabled: true
+        name: cpuset-configure.service
+      - contents: |
+          [Unit]
+          Description=Set cpus offline: 2,3
+          Before=kubelet.service
+
+          [Service]
+          Environment=OFFLINE_CPUS=2,3
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/set-cpus-offline.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: set-cpus-offline.service
+      - contents: |
+          [Unit]
+          Description=Clear the IRQBalance Banned CPU mask early in the boot
+          Before=kubelet.service
+          Before=irqbalance.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/clear-irqbalance-banned-cpus.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: clear-irqbalance-banned-cpus.service
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: realtime
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_node.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_node.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  creationTimestamp: null
+  labels:
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: cluster
+spec:
+  cgroupMode: v1
+status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_runtimeclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: node.k8s.io/v1
+handler: high-performance
+kind: RuntimeClass
+metadata:
+  creationTimestamp: null
+  labels:
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: performance-manual
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/manual_tuned.yaml
@@ -1,0 +1,69 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  creationTimestamp: null
+  labels:
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: openshift-node-performance-manual
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: "[main]\nsummary=Openshift node optimized for deterministic performance
+      at the cost of increased power consumption, focused on low latency network performance.
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
+      Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
+      -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
+      All values are mapped with a comment where a parent profile contains them.\n#
+      Different values will override the original values in parent profiles.\n\n[variables]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
+      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
+      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
+      plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
+      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
+      RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
+      If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
+      working set is buffered for I/O, and any more write buffering would require\n#
+      swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
+      that mostly use file mappings may be able to use even higher values.\n#\n# The
+      generator of dirty data starts writeback at this percentage (system default\n#
+      is 20%)\n#> latency-performance\nvm.dirty_ratio=10\n\n# Start background writeback
+      (via writeback threads) at this percentage (system\n# default is 10%)\n#> latency-performance\nvm.dirty_background_ratio=3\n\n#
+      The swappiness parameter controls the tendency of the kernel to move\n# processes
+      out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
+      swapping processes out of physical memory\n# for as long as possible\n# 100
+      tells the kernel to aggressively swap processes out of physical memory\n# and
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
+      configured via a sysctl.d file\n# placed here for documentation purposes and
+      commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
+    name: openshift-node-performance-manual
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-manual
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: worker-cnf
+    operand:
+      tunedConfig:
+        reapply_sysctl: null
+    priority: 20
+    profile: openshift-node-performance-manual
+status: {}


### PR DESCRIPTION
This is a manual cherry-pick of #975 
Fix bootstrap error  of "more than one ContainerRuntimeConfig found that matches MCP labels" when an additional ContainerRuntimeConfig is provided by user.

/cc @yanirq @MarSik 