### PR TITLE
NO-JIRA: Add sync for rendering extra ctrcfgs

### DIFF
--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -41,5 +41,6 @@ function rendersync() {
 rendersync manual-cluster/performance base/performance default
 rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap/no-mcp
 rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap-cluster/extra-mcp bootstrap/extra-mcp
+rendersync bootstrap-cluster/performance pinned-cluster/default container-runtime-crun bootstrap/extra-ctrcfg
 rendersync --owner-ref none -- base/performance manual-cluster/performance no-ref 
 rendersync --owner-ref none -- base/performance manual-cluster/cpuFrequency default/cpuFrequency 


### PR DESCRIPTION
Add missing sync for rendering extra ctrcfgs under the render-sync target

This was missing from https://github.com/openshift/cluster-node-tuning-operator/pull/972 

(no backport needed) 