### PR TITLE
[release-4.15] [manual] OCPBUGS-30507: Add performance real time tuned template

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -1,6 +1,12 @@
 [main]
 summary=Openshift node optimized for deterministic performance at the cost of increased power consumption, focused on low latency network performance. Based on Tuned 2.11 and Cluster node tuning (oc 4.5)
-include=openshift-node,cpu-partitioning
+
+# In case real time kernel is enabled the following include section will be evaluated as:
+# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
+# Otherwise:
+# include=openshift-node,cpu-partitioning
+include=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:}
+
 
 # Inheritance of base profiles legend:
 # cpu-partitioning -> network-latency -> latency-performance
@@ -78,10 +84,6 @@ vm.stat_interval=10
 #> scheduled timers when starting a guaranteed workload (= 1)
 kernel.timer_migration=1
 #> network-latency
-# TODO once rhbz#2120328 is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll do not exist on RT kernels
-kernel.numa_balancing=0
-net.core.busy_read=50
-net.core.busy_poll=50
 net.ipv4.tcp_fastopen=3
 
 # If a workload mostly uses anonymous memory and it hits this limit, the entire

--- a/assets/performanceprofile/tuned/openshift-node-performance-rt
+++ b/assets/performanceprofile/tuned/openshift-node-performance-rt
@@ -1,0 +1,8 @@
+[main]
+summary=Real time profile to override unsupported settings
+
+[sysctl]
+#Real time kernel doesn't support the following kernel parameters.
+#The openshift-node-performance profile inherits these kernel parameters from the network-latency profile. 
+#Therefore, if the real time kernel is detected they will be dropped, meaning won't be applied.
+drop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll

--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -41,4 +41,4 @@ function rendersync() {
 rendersync manual-cluster/performance base/performance default
 rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap/no-mcp
 rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap-cluster/extra-mcp bootstrap/extra-mcp
-rendersync --owner-ref none -- base/performance manual-cluster/performance no-ref
+rendersync --owner-ref none -- base/performance manual-cluster/performance no-ref 

--- a/pkg/performanceprofile/controller/performanceprofile/components/consts.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/consts.go
@@ -21,6 +21,8 @@ const (
 	NamespaceNodeTuningOperator = "openshift-cluster-node-tuning-operator"
 	// ProfileNamePerformance defines the performance tuned profile name
 	ProfileNamePerformance = "openshift-node-performance"
+	// ProfileNamePerformanceRT defines the performance real time tuned profile name
+	ProfileNamePerformanceRT = "openshift-node-performance-rt"
 )
 
 const (

--- a/test/e2e/performanceprofile/functests/utils/infrastructure/vm.go
+++ b/test/e2e/performanceprofile/functests/utils/infrastructure/vm.go
@@ -1,0 +1,27 @@
+package infrastructure
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+)
+
+// IsVM checks if a given node's underlying infrastructure is a VM
+func IsVM(node *corev1.Node) (bool, error) {
+	cmd := []string{
+		"/bin/bash",
+		"-c",
+		"systemd-detect-virt > /dev/null ; echo $?",
+	}
+	output, err := nodes.ExecCommandOnMachineConfigDaemon(node, cmd)
+	if err != nil {
+		return false, err
+	}
+
+	statusCode := strings.TrimSpace(string(output))
+	isVM := string(statusCode) == "0"
+
+	return isVM, nil
+}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
       \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
     name: openshift-node-performance-openshift-bootstrap-master
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
       \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
     name: openshift-node-performance-openshift-bootstrap-worker
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
       \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
     name: openshift-node-performance-openshift-bootstrap-master
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
       \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
     name: openshift-node-performance-openshift-bootstrap-worker
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -10,7 +10,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -27,9 +29,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -53,6 +53,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
     name: openshift-node-performance-manual
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -8,7 +8,9 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
+      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -25,9 +27,7 @@ spec:
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
       and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
-      (= 1)\nkernel.timer_migration=1\n#> network-latency\n# TODO once rhbz#2120328
-      is solved: kernel.numa_balancing, net.core.busy_read and net.core.busy_poll
-      do not exist on RT kernels\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n\n#
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
       If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
       working set is buffered for I/O, and any more write buffering would require\n#
       swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
@@ -51,6 +51,11 @@ spec:
       tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=disable\n\n\n[rtentsk]\n"
     name: openshift-node-performance-manual
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf


### PR DESCRIPTION
This is a manual backport of PR #954 and #1005 
This PR includes both of these PR's together, because #1005 introducing a fix for the tuned profile degradation test added in #954. 

* Add performance real time tuned template

Kernel parameters that are not supported on RT kernel systems are being applied, causing errors to be logged to the tuned daemon, resulting in a degraded profile state. Therefore, I added the openshift-node-performance-rt profile that would be included if an RT kernel is detected, thereby dropping the unsupported kernel parameters before they are applied.

* Added a test that make sure the tuned profile is not degraded

This could be great to have a generic test that make sure that after performance profile is applied the tuned profile is not degraded. This would prevent future issues like OCPBUGS-23167.
The test will fail only when the tuned profile was found degraded on BM host.
In case of tuned profile found degraded on a VM, only a warning would be reported in the logs.
The reason for that is that the fact CI is using VMs - and some
configurations like certain kernel args can't be applied and therby lead to
the tuned profile being degraded.

* render-sync update

Updated render-sync to include artifacts that are needed for the e2e tests. Committing the rendered items to this commit.