### PR TITLE
OCPBUGS-30812: Ignore scheduler plugin IRQs when globally enabled

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -66,8 +66,8 @@ group.ktimers=0:f:11:*:ktimers.*
 sched_migration_cost_ns=5000000
 {{if not .GloballyDisableIrqLoadBalancing}}
 default_irq_smp_affinity = ignore
-{{end}}
 irq_process=false
+{{end}}
 
 [sysctl]
 {{if .RealTimeHint}}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -24,7 +24,7 @@ spec:
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
-      = ignore\n\nirq_process=false\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -24,7 +24,7 @@ spec:
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
-      = ignore\n\nirq_process=false\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -24,7 +24,7 @@ spec:
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
-      = ignore\n\nirq_process=false\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -24,7 +24,7 @@ spec:
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
-      = ignore\n\nirq_process=false\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -24,7 +24,7 @@ spec:
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
-      = ignore\n\nirq_process=false\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -24,7 +24,7 @@ spec:
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
-      = ignore\n\nirq_process=false\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -22,7 +22,7 @@ spec:
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
-      = ignore\n\nirq_process=false\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -24,7 +24,7 @@ spec:
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
-      = ignore\n\nirq_process=false\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -22,7 +22,7 @@ spec:
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
       It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
-      = ignore\n\nirq_process=false\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
       RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning


### PR DESCRIPTION
Disable irq affinity setting by scheduler plugin ONLY when GloballyDisableIrqLoadBalancing=false (default)