### PR TITLE
NO-JIRA: E2E: Add  systemd package to fetch properties of cgroup slice 

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/cgroup/cgroup.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/cgroup.go
@@ -1,8 +1,11 @@
 package cgroup
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,4 +53,27 @@ func BuildGetter(ctx context.Context, c client.Client, k8sClient *kubernetes.Cli
 	} else {
 		return cgroupv1.NewManager(c, k8sClient), nil
 	}
+}
+
+// PidCgroupParser parsing /proc/pid/cgroup
+func PidCgroupParser(lines []byte) (string, error) {
+	var cgroupPath string
+	for _, line := range bytes.Split(lines, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		fields := bytes.Split(line, []byte(":"))
+		if len(fields) != 3 {
+			return "", fmt.Errorf("Error parsing cgroup: expected 3 fields but got %d:\n", len(fields))
+		}
+
+		if bytes.Contains(fields[1], []byte("=")) {
+			continue
+		}
+		path := string(fields[2])
+		if len(path) > len(cgroupPath) {
+			cgroupPath = path
+		}
+	}
+	return strings.TrimSpace(cgroupPath), nil
 }

--- a/test/e2e/performanceprofile/functests/utils/cgroup/cgroup.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/cgroup.go
@@ -55,8 +55,8 @@ func BuildGetter(ctx context.Context, c client.Client, k8sClient *kubernetes.Cli
 	}
 }
 
-// PidCgroupParser parsing /proc/pid/cgroup
-func PidCgroupParser(lines []byte) (string, error) {
+// PidParser parsing /proc/pid/cgroup
+func PidParser(lines []byte) (string, error) {
 	var cgroupPath string
 	for _, line := range bytes.Split(lines, []byte("\n")) {
 		if len(line) == 0 {

--- a/test/e2e/performanceprofile/functests/utils/systemd/systemd.go
+++ b/test/e2e/performanceprofile/functests/utils/systemd/systemd.go
@@ -1,0 +1,21 @@
+package systemd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Status(ctx context.Context, unitfile string, node *corev1.Node) (string, error) {
+	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs systemctl status %s --lines=0 --no-pager", unitfile)}
+	out, err := nodes.ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+	return string(out), err
+}
+
+func ShowProperty(ctx context.Context, unitfile string, property string, node *corev1.Node) (string, error) {
+	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs systemctl show -p %s %s --no-pager", property, unitfile)}
+	out, err := nodes.ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+	return string(out), err
+}


### PR DESCRIPTION
* systemd package to fetch container's cgroup properties like AllowedCpus (cpuset.cpus), AllowedMemoryNodes (cpuset.mems) etc. T his will help us to fetch information irrespective of runtimes where the directories differ

* Add PidParser  Parser returns the container's or any Pid cgroup information which we can then traverse

* add util function to fetch Pid of a container process