### PR TITLE
CNF-11646: makefile:hypershift: initial make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,11 @@ pao-functests-mixedcpus:
 	hack/show-cluster-version.sh
 	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/11_mixedcpus" -p "-v -r --fail-fast --flake-attempts=2 --junit-report=report.xml" -m "Running MixedCPUs Tests"
 
+.PHONY: pao-functests-hypershift
+pao-functests-hypershift:
+	@echo "Cluster Version"
+	hack/show-cluster-version.sh
+
 .PHONY: cluster-clean-pao
 cluster-clean-pao:
 	@echo "Cleaning up performance addons artifacts"

--- a/hack/show-cluster-version.sh
+++ b/hack/show-cluster-version.sh
@@ -3,7 +3,25 @@
 # expect oc to be in PATH by default
 OC_TOOL="${OC_TOOL:-oc}"
 
-echo "Cluster version"
-${OC_TOOL} version || :
-${OC_TOOL} get nodes -o custom-columns=VERSION:.status.nodeInfo.kubeletVersion || :
-${OC_TOOL} get clusterversion || :
+function cluster_version_info() {
+    local msg="${1}"
+    local kubeconfig="${2}"
+
+    echo "${msg}"
+    if [[ -n "${kubeconfig}"  ]]; then
+          kubeconfig_arg="--kubeconfig=${kubeconfig}"
+    fi
+    ${OC_TOOL} "${kubeconfig_arg}" version || :
+    ${OC_TOOL} "${kubeconfig_arg}" get nodes -o custom-columns=VERSION:.status.nodeInfo.kubeletVersion || :
+    ${OC_TOOL} "${kubeconfig_arg}" get clusterversion || :
+}
+
+if [[ ${CLUSTER_TYPE} == "hypershift" ]]; then
+  # on u/s ci, the cli directory path is different
+  CLI_DIR="${CLI_DIR:-/usr/bin}"
+  OC_TOOL="${CLI_DIR}"/oc
+  cluster_version_info "Management cluster version" "${HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG}"
+  cluster_version_info "Hosted cluster version" "${HYPERSHIFT_HOSTED_CLUSTER_KUBECONFIG}"
+else
+  cluster_version_info "Cluster version"
+fi


### PR DESCRIPTION
Add initial make target for running e2e tests on hypershift environment.

On later PR an actual call for the e2e tests will be added.

`HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG` and
`HYPERSHIFT_HOSTED_CLUSTER_KUBECONFIG` are defined
by the u/s ci and provided the kubeconfig file path for the management and hostet cluster respectively.

