### PR TITLE
OCPBUGS-30647: Remove TuneD timeout code and reload on ERRORs

### DIFF
--- a/pkg/tuned/run.go
+++ b/pkg/tuned/run.go
@@ -148,8 +148,8 @@ func TunedRun(cmd *exec.Cmd, daemon *Daemon, onDaemonReload func()) error {
 	}()
 
 	daemon.reloading = true
-	// Clear the set out of which Profile status conditions are created. Keep timeout condition if already set.
-	daemon.status &= scTimeout
+	// Clear the set out of which Profile status conditions are created.
+	daemon.status = 0
 	daemon.stderr = ""
 	if err = cmd.Start(); err != nil {
 		return fmt.Errorf("error starting tuned: %w", err)

--- a/pkg/tuned/status.go
+++ b/pkg/tuned/status.go
@@ -118,10 +118,6 @@ func computeStatusConditions(status Bits, stderr string, conditions []tunedv1.Pr
 		tunedDegradedCondition.Status = corev1.ConditionTrue // treat overrides as regular errors; users should use "reapply_sysctl: true" or remove conflicting sysctls
 		tunedDegradedCondition.Reason = "TunedSysctlOverride"
 		tunedDegradedCondition.Message = "TuneD daemon issued one or more sysctl override message(s) during profile application. Use reapply_sysctl=true or remove conflicting sysctl " + stderr
-	} else if (status & scTimeout) != 0 {
-		tunedDegradedCondition.Status = corev1.ConditionTrue
-		tunedDegradedCondition.Reason = "TimeoutWaitingForProfileApplied"
-		tunedDegradedCondition.Message = "Timeout waiting for profile to be applied"
 	} else if (status & scWarn) != 0 {
 		tunedDegradedCondition.Status = corev1.ConditionFalse // consider warnings from TuneD as non-fatal
 		tunedDegradedCondition.Reason = "TunedWarning"


### PR DESCRIPTION
In the past, there were reports of TuneD being stuck during profile application (e.g. rhbz#2013940).  As a workaround a timeout with exponential backoff was implemented to restart TuneD if it was ever stuck not finishing profile application.  However, with some TuneD profiles and hardware configurations, it can take very long for a TuneD profile to be applied.  In environments, such as latency-sensitive deployments a repeated profile application can make things matters worse. Therefore, remove the timeout functionality.

Also, remove the reload on TuneD ERRORs.  This is an openshift-tuned bug.