### PR TITLE
DNM: cgroupv2 and test enhancement fixes

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -24,6 +24,8 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/utils/schedstat"
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cgroup"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cgroup/controller"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cluster"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
@@ -39,29 +41,44 @@ var workerRTNode *corev1.Node
 var profile *performancev2.PerformanceProfile
 
 var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
-	var balanceIsolated bool
-	var reservedCPU, isolatedCPU string
-	var listReservedCPU []int
-	var reservedCPUSet cpuset.CPUSet
-	var onlineCPUSet cpuset.CPUSet
+	var (
+		balanceIsolated          bool
+		reservedCPU, isolatedCPU string
+		listReservedCPU          []int
+		reservedCPUSet           cpuset.CPUSet
+		onlineCPUSet             cpuset.CPUSet
+		err                      error
+		smtLevel                 int
+		ctx                      context.Context = context.Background()
+		getter                   cgroup.ControllersGetter
+		cgroupV2                 bool
+	)
 
 	testutils.CustomBeforeAll(func() {
 		isSNO, err := cluster.IsSingleNode()
 		Expect(err).ToNot(HaveOccurred())
 		RunningOnSingleNode = isSNO
-	})
-
-	BeforeEach(func() {
-		if discovery.Enabled() && testutils.ProfileNotFound {
-			Skip("Discovery mode enabled, performance profile not found")
-		}
-
 		workerRTNodes, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		workerRTNode = &workerRTNodes[0]
+
+		onlineCPUSet, err = nodes.GetOnlineCPUsSet(ctx, workerRTNode)
+		cpuID := onlineCPUSet.UnsortedList()[0]
+		smtLevel = nodes.GetSMTLevel(ctx, cpuID, workerRTNode)
+		getter, err = cgroup.BuildGetter(ctx, testclient.Client, testclient.K8sClient)
+		Expect(err).ToNot(HaveOccurred())
+		cgroupV2, err = cgroup.IsVersion2(ctx, testclient.Client)
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	BeforeEach(func() {
+		if discovery.Enabled() && testutils.ProfileNotFound {
+			Skip("Discovery mode enabled, performance profile not found")
+		}
 		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -236,154 +253,6 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		)
 	})
 
-	When("pod runs with the CPU load balancing runtime class", func() {
-		var smtLevel int
-		var allTestpods map[types.UID]*corev1.Pod
-		var testpod *corev1.Pod
-
-		BeforeEach(func() {
-			var err error
-			allTestpods = make(map[types.UID]*corev1.Pod)
-
-			// workaround for https://github.com/kubernetes/kubernetes/issues/107074
-			// until https://github.com/kubernetes/kubernetes/pull/120661 lands
-			unblockerPod := pods.GetTestPod() // any non-GU pod will suffice ...
-			unblockerPod.Namespace = testutils.NamespaceTesting
-			unblockerPod.Spec.NodeSelector = map[string]string{testutils.LabelHostname: workerRTNode.Name}
-
-			err = testclient.Client.Create(context.TODO(), unblockerPod)
-			Expect(err).ToNot(HaveOccurred())
-			allTestpods[unblockerPod.UID] = unblockerPod
-
-			time.Sleep(30 * time.Second) // let cpumanager reconcile loop catch up
-
-			// It's possible that when this test runs the value of
-			// defaultCpuNotInSchedulingDomains is empty if no gu pods are running
-			defaultCpuNotInSchedulingDomains, err := getCPUswithLoadBalanceDisabled(context.TODO(), workerRTNode)
-			Expect(err).ToNot(HaveOccurred(), "Unable to fetch scheduling domains")
-
-			if len(defaultCpuNotInSchedulingDomains) > 0 {
-				pods, err := pods.GetPodsOnNode(context.TODO(), workerRTNode.Name)
-				if err != nil {
-					testlog.Warningf("cannot list pods on %q: %v", workerRTNode.Name, err)
-				} else {
-					testlog.Infof("pods on %q BEGIN", workerRTNode.Name)
-					for _, pod := range pods {
-						testlog.Infof("- %s/%s %s", pod.Namespace, pod.Name, pod.UID)
-					}
-					testlog.Infof("pods on %q END", workerRTNode.Name)
-				}
-
-				Expect(defaultCpuNotInSchedulingDomains).To(BeEmpty(), "the test expects all CPUs within a scheduling domain when starting")
-			}
-
-			annotations := map[string]string{
-				"cpu-load-balancing.crio.io": "disable",
-			}
-			// any random existing cpu is fine
-			cpuID := onlineCPUSet.UnsortedList()[0]
-			smtLevel = nodes.GetSMTLevel(context.TODO(), cpuID, workerRTNode)
-			testpod = getTestPodWithAnnotations(annotations, smtLevel)
-		})
-
-		AfterEach(func() {
-			for podUID, testpod := range allTestpods {
-				testlog.Infof("deleting test pod %s/%s UID=%q", testpod.Namespace, testpod.Name, podUID)
-				deleteTestPod(context.TODO(), testpod)
-			}
-		})
-
-		It("[test_id:32646] should disable CPU load balancing for CPU's used by the pod", func() {
-			var err error
-			By("Starting the pod")
-			err = testclient.Client.Create(context.TODO(), testpod)
-			Expect(err).ToNot(HaveOccurred())
-
-			testpod, err = pods.WaitForCondition(context.TODO(), client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
-			logEventsForPod(testpod)
-			Expect(err).ToNot(HaveOccurred(), "failed to create guaranteed pod %v", testpod)
-			allTestpods[testpod.UID] = testpod
-
-			// workaround for https://github.com/kubernetes/kubernetes/issues/107074
-			// until https://github.com/kubernetes/kubernetes/pull/120661 lands
-			unblockerPod := pods.GetTestPod() // any non-GU pod will suffice ...
-			unblockerPod.Namespace = testpod.Namespace
-			unblockerPod.Spec.NodeSelector = map[string]string{testutils.LabelHostname: testpod.Spec.NodeName} // ... as long as it hits the same kubelet
-
-			err = testclient.Client.Create(context.TODO(), unblockerPod)
-			Expect(err).ToNot(HaveOccurred())
-			allTestpods[unblockerPod.UID] = unblockerPod
-
-			By("Getting the container cpuset.cpus cgroup")
-			containerID, err := pods.GetContainerIDByName(testpod, "test")
-			Expect(err).ToNot(HaveOccurred(), "unable to fetch containerID")
-
-			containerCgroup := ""
-			Eventually(func() string {
-				cmd := []string{"/bin/bash", "-c", fmt.Sprintf("find /rootfs/sys/fs/cgroup/cpuset/ -name *%s*", containerID)}
-				containerCgroup, err = nodes.ExecCommandOnNode(context.TODO(), cmd, workerRTNode)
-				Expect(err).ToNot(HaveOccurred(), "failed to execute %v", cmd)
-				return containerCgroup
-			}).WithTimeout(cluster.ComputeTestTimeout(30*time.Second, RunningOnSingleNode)).WithPolling(5*time.Second).ShouldNot(BeEmpty(),
-				fmt.Sprintf("cannot find cgroup for container %q", containerID))
-
-			By("Checking what CPU the pod is using")
-			cmd := []string{"/bin/bash", "-c", fmt.Sprintf("cat %s/cpuset.cpus", containerCgroup)}
-			output, err := nodes.ExecCommandOnNode(context.TODO(), cmd, workerRTNode)
-			Expect(err).ToNot(HaveOccurred(), "failed to execute %v", cmd)
-			testlog.Infof("cpus used by test pod are: %s", output)
-
-			podCpus, err := cpuset.Parse(output)
-			Expect(err).ToNot(HaveOccurred(), "unable to parse cpuset used by pod")
-
-			By("Getting the CPU scheduling flags")
-			// After the testpod is started get the schedstat and check for cpus
-			// not participating in scheduling domains
-			Eventually(func() error {
-				cpusNotInSchedulingDomains, err := getCPUswithLoadBalanceDisabled(context.TODO(), workerRTNode)
-				testlog.Infof("cpus with load balancing disabled are: %v", cpusNotInSchedulingDomains)
-				Expect(err).ToNot(HaveOccurred(), "unable to fetch cpus with load balancing disabled from /proc/schedstat")
-				cpuIDList, err := schedstat.MakeCPUIDListFromCPUList(cpusNotInSchedulingDomains)
-				if err != nil {
-					return err
-				}
-				cpuIDs := cpuset.New(cpuIDList...)
-				if !podCpus.IsSubsetOf(cpuIDs) {
-					return fmt.Errorf("pod CPUs NOT entirely part of cpus with load balance disabled: %v vs %v", podCpus, cpuIDs)
-				}
-				return nil
-			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).ShouldNot(HaveOccurred(), "checking scheduling domains with pod running")
-
-			By("Deleting the pod")
-			deletedUID, ok := deleteTestPod(context.TODO(), testpod)
-			if ok {
-				delete(allTestpods, deletedUID)
-			}
-
-			// The below loop takes time because kernel takes time
-			// to update /proc/schedstat with cpuid of deleted pods
-			// to be under scheduling domains
-			Eventually(func() error {
-				By("Getting the CPU scheduling flags")
-				cpusNotInSchedulingDomains, err := getCPUswithLoadBalanceDisabled(context.TODO(), workerRTNode)
-				Expect(err).ToNot(HaveOccurred())
-				testlog.Infof("cpus with load balancing disabled are: %v", cpusNotInSchedulingDomains)
-				if len(cpusNotInSchedulingDomains) == 0 {
-					return nil
-				}
-				cpuIDList, err := schedstat.MakeCPUIDListFromCPUList(cpusNotInSchedulingDomains)
-				if err != nil {
-					return err
-				}
-				cpuIDs := cpuset.New(cpuIDList...)
-				if podCpus.IsSubsetOf(cpuIDs) {
-					return fmt.Errorf("pod CPUs still part of cpus with load balance disabled: %v vs %v", podCpus, cpuIDs)
-				}
-				return nil
-			}).WithTimeout(15*time.Minute).WithPolling(10*time.Second).ShouldNot(HaveOccurred(), "checking the scheduling domains are restored after pod deletion")
-		})
-	})
-
 	Describe("Verification that IRQ load balance can be disabled per POD", func() {
 		var smtLevel int
 		var testpod *corev1.Pod
@@ -485,14 +354,19 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		})
 
 		It("[test_id:49147] should run infra containers on reserved CPUs", func() {
-			var err error
+			var cpusetPath string
 			// find used because that crictl does not show infra containers, `runc list` shows them
 			// but you will need somehow to find infra containers ID's
 			podUID := strings.Replace(string(testpod.UID), "-", "_", -1)
-
 			podCgroup := ""
+			if cgroupV2 {
+				cpusetPath = "/rootfs/sys/fs/cgroup/kubepods.slice"
+			} else {
+				cpusetPath = "/rootfs/sys/fs/cgroup/cpuset"
+			}
+
 			Eventually(func() string {
-				cmd := []string{"/bin/bash", "-c", fmt.Sprintf("find /rootfs/sys/fs/cgroup/cpuset/ -name *%s*", podUID)}
+				cmd := []string{"/bin/bash", "-c", fmt.Sprintf("find %s -name *%s*", cpusetPath, podUID)}
 				podCgroup, err = nodes.ExecCommandOnNode(context.TODO(), cmd, workerRTNode)
 				Expect(err).ToNot(HaveOccurred())
 				return podCgroup
@@ -513,11 +387,11 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 
 			containersCgroups = strings.Trim(containersCgroups, "\n")
 			containersCgroupsDirs := strings.Split(containersCgroups, "\n")
-			Expect(len(containersCgroupsDirs)).To(Equal(2), "unexpected amount of containers cgroups")
 
 			for _, dir := range containersCgroupsDirs {
 				// skip application container cgroup
-				if strings.Contains(dir, containerID) {
+				// skip conmon containers
+				if strings.Contains(dir, containerID) || strings.Contains(dir, "conmon") {
 					continue
 				}
 
@@ -659,6 +533,129 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			Entry("[test_id:46539] HT aware scheduling on SNO cluster and Workload Partitioning enabled", context.TODO(), false, true, true),
 		)
 
+	})
+	Context("Crio Annotations", func() {
+		var testpod *corev1.Pod
+		var allTestpods map[types.UID]*corev1.Pod
+		annotations := map[string]string{
+			"cpu-load-balancing.crio.io": "disable",
+			"cpu-quota.crio.io":          "disable",
+		}
+		BeforeAll(func() {
+			var err error
+			allTestpods = make(map[types.UID]*corev1.Pod)
+
+			testpod = getTestPodWithAnnotations(annotations, smtLevel)
+			// workaround for https://github.com/kubernetes/kubernetes/issues/107074
+			// until https://github.com/kubernetes/kubernetes/pull/120661 lands
+			unblockerPod := pods.GetTestPod() // any non-GU pod will suffice ...
+			unblockerPod.Namespace = testutils.NamespaceTesting
+			unblockerPod.Spec.NodeSelector = map[string]string{testutils.LabelHostname: workerRTNode.Name}
+			err = testclient.Client.Create(context.TODO(), unblockerPod)
+			Expect(err).ToNot(HaveOccurred())
+			allTestpods[unblockerPod.UID] = unblockerPod
+			time.Sleep(30 * time.Second) // let cpumanager reconcile loop catch up
+
+			// It's possible that when this test runs the value of
+			// defaultCpuNotInSchedulingDomains is empty if no gu pods are running
+			defaultCpuNotInSchedulingDomains, err := getCPUswithLoadBalanceDisabled(ctx, workerRTNode)
+			Expect(err).ToNot(HaveOccurred(), "Unable to fetch scheduling domains")
+			if len(defaultCpuNotInSchedulingDomains) > 0 {
+				pods, err := pods.GetPodsOnNode(context.TODO(), workerRTNode.Name)
+				if err != nil {
+					testlog.Warningf("Warning cannot list pods on %q: %v", workerRTNode.Name, err)
+				} else {
+					testlog.Infof("pods on %q BEGIN", workerRTNode.Name)
+					for _, pod := range pods {
+						testlog.Infof("- %s/%s %s", pod.Namespace, pod.Name, pod.UID)
+					}
+					testlog.Infof("pods on %q END", workerRTNode.Name)
+				}
+				Expect(defaultCpuNotInSchedulingDomains).To(BeEmpty(), "the test expects all CPUs within a scheduling domain when starting")
+			}
+
+			By("Starting the pod")
+			testpod.Spec.NodeSelector = testutils.NodeSelectorLabels
+			testpod.Spec.Containers[0].Image = "quay.io/mniranja/busycpus"
+			testpod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU] = resource.MustParse("2")
+			err = testclient.Client.Create(context.TODO(), testpod)
+			Expect(err).ToNot(HaveOccurred())
+			testpod, err = pods.WaitForCondition(ctx, client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
+			logEventsForPod(testpod)
+			Expect(err).ToNot(HaveOccurred(), "failed to create guaranteed pod %v", testpod)
+			allTestpods[testpod.UID] = testpod
+		})
+
+		AfterAll(func() {
+			for podUID, testpod := range allTestpods {
+				testlog.Infof("deleting test pod %s/%s UID=%q", testpod.Namespace, testpod.Name, podUID)
+				err := testclient.Client.Get(ctx, client.ObjectKeyFromObject(testpod), testpod)
+				Expect(err).ToNot(HaveOccurred())
+				err = testclient.Client.Delete(ctx, testpod)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = pods.WaitForDeletion(ctx, testpod, pods.DefaultDeletionTimeout*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		Describe("cpuset controller", func() {
+			It("[test_id:72080] Verify cpu affinity of container process matches with cpuset controller interface file cpuset.cpus", func() {
+				cpusetCfg := &controller.CpuSet{}
+				err := getter.Container(ctx, testpod, testpod.Spec.Containers[0].Name, cpusetCfg)
+				Expect(err).ToNot(HaveOccurred())
+				// Get cpus used by the container
+				tasksetcmd := []string{"/bin/taskset", "-pc", "1"}
+				testpodAffinity, err := pods.ExecCommandOnPod(testclient.K8sClient, testpod, testpod.Spec.Containers[0].Name, tasksetcmd)
+				podCpusStr := string(testpodAffinity)
+				parts := strings.Split(strings.TrimSpace(podCpusStr), ":")
+				testpodCpus := strings.TrimSpace(parts[1])
+				testlog.Infof("%v pod is using %v cpus", testpod.Name, testpodCpus)
+				podAffinityCpuset, err := cpuset.Parse(testpodCpus)
+				Expect(err).ToNot(HaveOccurred(), "Unable to parse cpus %s used by %s pod", testpodCpus, testpod.Name)
+				cgroupCpuset, err := cpuset.Parse(cpusetCfg.Cpus)
+				Expect(err).ToNot(HaveOccurred(), "Unable to parse cpus from cgroups.cpuset")
+				Expect(cgroupCpuset).To(Equal(podAffinityCpuset), "cpuset.cpus not matching the process affinity")
+			})
+		})
+
+		Describe("Load Balancing Annotation", func() {
+			It("[test_id:32646] cpus used by container should not be load balanced", func() {
+				output, err := getPodCpus(testpod)
+				Expect(err).ToNot(HaveOccurred(), "unable to fetch cpus used by testpod")
+				podCpus, err := cpuset.Parse(output)
+				Expect(err).ToNot(HaveOccurred(), "unable to parse cpuset used by pod")
+				By("Getting the CPU scheduling flags")
+				// After the testpod is started get the schedstat and check for cpus
+				// not participating in scheduling domains
+				checkSchedulingDomains(workerRTNode, podCpus, func(cpuIDs cpuset.CPUSet) error {
+					if !podCpus.IsSubsetOf(cpuIDs) {
+						return fmt.Errorf("pod CPUs NOT entirely part of cpus with load balance disabled: %v vs %v", podCpus, cpuIDs)
+					}
+					return nil
+				}, 2*time.Minute, 5*time.Second, "checking scheduling domains with pod running")
+			})
+		})
+
+		Describe("CPU Quota annotation", func() {
+			It("[test_id:72079] CPU Quota interface files have correct values", func() {
+				cpuCfg := &controller.Cpu{}
+				err := getter.Container(ctx, testpod, testpod.Spec.Containers[0].Name, cpuCfg)
+				Expect(err).ToNot(HaveOccurred())
+				if cgroupV2 {
+					Expect(cpuCfg.Quota).To(Equal("max"), "pod=%q, container=%q does not have quota set", client.ObjectKeyFromObject(testpod), testpod.Spec.Containers[0].Name)
+				} else {
+					Expect(cpuCfg.Quota).To(Equal("-1"), "pod=%q, container=%q does not have quota set", client.ObjectKeyFromObject(testpod), testpod.Spec.Containers[0].Name)
+				}
+			})
+
+			It("[test_id: 72081] Verify cpu assigned to pod with quota disabled is not throttled", func() {
+				cpuCfg := &controller.Cpu{}
+				err := getter.Container(ctx, testpod, testpod.Spec.Containers[0].Name, cpuCfg)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cpuCfg.Stat["nr_throttled"]).To(Equal("0"), "cpu throttling not disabled on pod=%q, container=%q", client.ObjectKeyFromObject(testpod), testpod.Spec.Containers[0].Name)
+			})
+		})
 	})
 
 })
@@ -923,4 +920,34 @@ func getCPUswithLoadBalanceDisabled(ctx context.Context, targetNode *corev1.Node
 	}
 
 	return cpusWithoutDomain, nil
+}
+
+// getPodCpus return cpus used based on taskset
+func getPodCpus(testpod *corev1.Pod) (string, error) {
+	tasksetcmd := []string{"taskset", "-pc", "1"}
+	testpodCpusByte, err := pods.ExecCommandOnPod(testclient.K8sClient, testpod, testpod.Spec.Containers[0].Name, tasksetcmd)
+	if err != nil {
+		return "", err
+	}
+	testpodCpusStr := string(testpodCpusByte)
+	parts := strings.Split(strings.TrimSpace(testpodCpusStr), ":")
+	cpus := strings.TrimSpace(parts[1])
+	return cpus, err
+}
+
+// checkSchedulingDomains Check cpus are part of any scheduling domain
+func checkSchedulingDomains(workerRTNode *corev1.Node, podCpus cpuset.CPUSet, testFunc func(cpuset.CPUSet) error, timeout, polling time.Duration, errMsg string) {
+	Eventually(func() error {
+		cpusNotInSchedulingDomains, err := getCPUswithLoadBalanceDisabled(context.TODO(), workerRTNode)
+		Expect(err).ToNot(HaveOccurred())
+		testlog.Infof("cpus with load balancing disabled are: %v", cpusNotInSchedulingDomains)
+		Expect(err).ToNot(HaveOccurred(), "unable to fetch cpus with load balancing disabled from /proc/schedstat")
+		cpuIDList, err := schedstat.MakeCPUIDListFromCPUList(cpusNotInSchedulingDomains)
+		if err != nil {
+			return err
+		}
+		cpuIDs := cpuset.New(cpuIDList...)
+		return testFunc(cpuIDs)
+	}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).ShouldNot(HaveOccurred(), errMsg)
+
 }

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -115,7 +115,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			}
 		})
 
-		It("Tuned profile shouldn't be degraded", func() {
+		/*It("Tuned profile shouldn't be degraded", func() {
 			for _, node := range workerRTNodes {
 				key := types.NamespacedName{
 					Name:      node.Name,
@@ -128,7 +128,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				Expect(degradedCondition).ToNot(BeNil(), "Degraded condition not found in Tuned profile status")
 				Expect(degradedCondition.Status).To(Equal(corev1.ConditionFalse), "Tuned profile is degraded")
 			}
-		})
+		})*/
 	})
 
 	Context("Pre boot tuning adjusted by tuned ", func() {

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -1120,9 +1120,25 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 	})
 
-	Context("ContainerRuntimeConfig", func() {
+	Context("ContainerRuntimeConfig", Ordered, func() {
+		var ctrcfg *machineconfigv1.ContainerRuntimeConfig
+		const ContainerRuntimeConfigName = "ctrcfg-test"
+		mcp := &machineconfigv1.MachineConfigPool{}
+		BeforeAll(func() {
+			key := types.NamespacedName{
+				Name: performanceMCP,
+			}
+			Expect(testclient.Client.Get(context.TODO(), key, mcp)).ToNot(HaveOccurred(), "cannot get MCP %q", performanceMCP)
+			By("checking if ContainerRuntimeConfig object already exists")
+			ctrcfg, err = getContainerRuntimeConfigFrom(context.TODO(), profile, mcp)
+			Expect(err).ToNot(HaveOccurred(), "failed to get ContainerRuntimeConfig from profile %q mcp %q", profile.Name, mcp.Name)
+		})
+
 		When("is not given", func() {
 			It("should run high-performance runtimes class with runc as container-runtime", func() {
+				if ctrcfg != nil {
+					Skip("runc is not the default runtime configuration")
+				}
 				cmd := []string{"cat", "/rootfs/etc/crio/crio.conf.d/99-runtimes.conf"}
 				for i := 0; i < len(workerRTNodes); i++ {
 					out, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &workerRTNodes[i])
@@ -1133,20 +1149,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 			})
 		})
-
-		When("updates the default runtime to crun", Ordered, func() {
-			BeforeAll(func() {
-				const ContainerRuntimeConfigName = "ctrcfg-test"
-
-				key := types.NamespacedName{
-					Name: performanceMCP,
-				}
-				mcp := &machineconfigv1.MachineConfigPool{}
-				Expect(testclient.Client.Get(context.TODO(), key, mcp)).ToNot(HaveOccurred(), "cannot get MCP %q", performanceMCP)
-
-				By("checking if ContainerRuntimeConfig object already exists")
-				ctrcfg, err := getContainerRuntimeConfigFrom(context.TODO(), profile, mcp)
-				Expect(err).ToNot(HaveOccurred(), "failed to get ContainerRuntimeConfig from profile %q mcp %q", profile.Name, mcp.Name)
+		When("updates the default runtime to crun", func() {
+			It("should run high-performance runtimes class with crun as container-runtime", func() {
 				if ctrcfg == nil {
 					testlog.Infof("ContainerRuntimeConfig not exist")
 					ctrcfg = newContainerRuntimeConfig(ContainerRuntimeConfigName, profile, mcp)
@@ -1167,8 +1171,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 					mcps.WaitForConditionFunc(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue, getMCPConditionStatus)
 				}
 				Expect(ctrcfg.Spec.ContainerRuntimeConfig.DefaultRuntime == machineconfigv1.ContainerRuntimeDefaultRuntimeCrun).To(BeTrue())
-			})
-			It("should run high-performance runtimes class with crun as container-runtime", func() {
 				cmd := []string{"cat", "/rootfs/etc/crio/crio.conf.d/99-runtimes.conf"}
 				for i := 0; i < len(workerRTNodes); i++ {
 					out, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &workerRTNodes[i])

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,7 +23,6 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
@@ -30,7 +30,7 @@ import (
 )
 
 var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ordered, func() {
-	var profile *performancev2.PerformanceProfile
+	var initialProfile, profile *performancev2.PerformanceProfile
 	var workerRTNodes []corev1.Node
 	var performanceMCP string
 
@@ -47,22 +47,17 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 		performanceMCP, err = mcps.GetByProfile(profile)
 		Expect(err).ToNot(HaveOccurred())
 
+		initialProfile = profile.DeepCopy()
 		// Verify that worker and performance MCP have updated state equals to true
 		for _, mcpName := range []string{testutils.RoleWorker, performanceMCP} {
 			mcps.WaitForCondition(mcpName, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
 		}
 
 	})
-	BeforeEach(func() {
-		if discovery.Enabled() && testutils.ProfileNotFound {
-			Skip("Discovery mode enabled, performance profile not found")
-		}
-	})
 	Context("Additional kubelet arguments", func() {
 		It("[test_id:45488]Test performance profile annotation for changing multiple kubelet settings", func() {
-			profile.Annotations = map[string]string{
-				"kubeletconfig.experimental": "{\"allowedUnsafeSysctls\":[\"net.core.somaxconn\",\"kernel.msg*\"],\"systemReserved\":{\"memory\":\"300Mi\"},\"kubeReserved\":{\"memory\":\"768Mi\"},\"imageMinimumGCAge\":\"3m\"}",
-			}
+			sysctls := "{\"allowedUnsafeSysctls\":[\"net.core.somaxconn\",\"kernel.msg*\"],\"systemReserved\":{\"memory\":\"300Mi\"},\"kubeReserved\":{\"memory\":\"768Mi\"},\"imageMinimumGCAge\":\"3m\"}"
+			profile.Annotations = updateAnnotation(profile.Annotations, sysctls)
 			annotations, err := json.Marshal(profile.Annotations)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -93,9 +88,8 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 		})
 		Context("When setting cpu manager related parameters", func() {
 			It("[test_id:45493]Should not override performance-addon-operator values", func() {
-				profile.Annotations = map[string]string{
-					"kubeletconfig.experimental": "{\"cpuManagerPolicy\":\"static\",\"cpuManagerReconcilePeriod\":\"5s\"}",
-				}
+				paoValues := "{\"cpuManagerPolicy\":\"static\",\"cpuManagerReconcilePeriod\":\"5s\"}"
+				profile.Annotations = updateAnnotation(profile.Annotations, paoValues)
 				annotations, err := json.Marshal(profile.Annotations)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -118,12 +112,11 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 			})
 		})
 		It("[test_id:45490]Test memory reservation changes", func() {
-			// In this test case we are testing if after applying reserving memory for
+			// In this test case we check if after applying reserving memory for
 			// systemReserved and KubeReserved, the allocatable is reduced and Allocatable
 			// Verify that Allocatable = Node capacity - (kubereserved + systemReserved + EvictionMemory)
-			profile.Annotations = map[string]string{
-				"kubeletconfig.experimental": "{\"systemReserved\":{\"memory\":\"300Mi\"},\"kubeReserved\":{\"memory\":\"768Mi\"}}",
-			}
+			reservedMemory := "{\"systemReserved\":{\"memory\":\"300Mi\"},\"kubeReserved\":{\"memory\":\"768Mi\"}}"
+			profile.Annotations = updateAnnotation(profile.Annotations, reservedMemory)
 			annotations, err := json.Marshal(profile.Annotations)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -176,10 +169,15 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 			}
 		})
 		It("[test_id:45495] Test setting PAO managed parameters", func() {
-			profile.Annotations = map[string]string{
-				"kubeletconfig.experimental": "{\"topologyManagerPolicy\":\"single-numa-node\"}",
+			var paoParameters string = ""
+			if *profile.Spec.NUMA.TopologyPolicy == "single-numa-node" {
+				paoParameters = "{\"topologyManagerPolicy\":\"restricted\"}"
+			} else {
+				paoParameters = "{\"topologyManagerPolicy\":\"single-numa-node\"}"
 			}
+			profile.Annotations = updateAnnotation(profile.Annotations, paoParameters)
 			annotations, err := json.Marshal(profile.Annotations)
+
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Applying changes in performance profile and waiting until mcp will start updating")
@@ -198,6 +196,7 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 				Expect(kubeletConfig.TopologyManagerPolicy).To(Equal("single-numa-node"))
 			}
 		})
+
 		It("[test_id:45489] Verify settings are reverted to default profile", func() {
 			By("Reverting the Profile")
 			Expect(testclient.Client.Patch(context.TODO(), profile,
@@ -222,6 +221,38 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 			}
 
 		})
+		AfterAll(func() {
+			By("Reverting the Profile")
+			profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+			Expect(err).ToNot(HaveOccurred())
+			currentSpec, _ := json.Marshal(profile.Spec)
+			spec, _ := json.Marshal(initialProfile.Spec)
+			// revert only if the profile changes.
+			if !equality.Semantic.DeepEqual(currentSpec, spec) {
+				Expect(testclient.Client.Patch(context.TODO(), profile,
+					client.RawPatch(
+						types.JSONPatchType,
+						[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, spec)),
+					),
+				)).ToNot(HaveOccurred())
+
+				By("Applying changes in performance profile and waiting until mcp will start updating")
+				mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
+
+				By("Waiting when mcp finishes updates")
+				mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
+			}
+		})
 
 	})
 })
+
+func updateAnnotation(profileAnnotations map[string]string, annotations string) map[string]string {
+	if _, ok := profileAnnotations["performance.openshift.io/ignore-cgroups-version"]; !ok {
+		profileAnnotations = map[string]string{
+			"kubeletconfig.experimental": annotations}
+	} else {
+		profileAnnotations["kubeletconfig.experimental"] = annotations
+	}
+	return profileAnnotations
+}

--- a/test/e2e/performanceprofile/functests/utils/cgroup/cgroup.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/cgroup.go
@@ -1,8 +1,11 @@
 package cgroup
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,4 +53,27 @@ func BuildGetter(ctx context.Context, c client.Client, k8sClient *kubernetes.Cli
 	} else {
 		return cgroupv1.NewManager(c, k8sClient), nil
 	}
+}
+
+// PidCgroupParser parsing /proc/pid/cgroup
+func PidParser(lines []byte) (string, error) {
+	var cgroupPath string
+	for _, line := range bytes.Split(lines, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		fields := bytes.Split(line, []byte(":"))
+		if len(fields) != 3 {
+			return "", fmt.Errorf("Error parsing cgroup: expected 3 fields but got %d:\n", len(fields))
+		}
+
+		if bytes.Contains(fields[1], []byte("=")) {
+			continue
+		}
+		path := string(fields[2])
+		if len(path) > len(cgroupPath) {
+			cgroupPath = path
+		}
+	}
+	return strings.TrimSpace(cgroupPath), nil
 }

--- a/test/e2e/performanceprofile/functests/utils/cgroup/controller/controller.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/controller/controller.go
@@ -14,7 +14,7 @@ type CpuSet struct {
 }
 
 type Cpu struct {
-	Quota   string
-	Period  string
-	cpuStat map[string]string
+	Quota  string
+	Period string
+	Stat   map[string]string
 }

--- a/test/e2e/performanceprofile/functests/utils/cgroup/v1/v1.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/v1/v1.go
@@ -57,7 +57,32 @@ func (cm *ControllersManager) Cpu(ctx context.Context, pod *corev1.Pod, containe
 	output := strings.Split(string(b), "\r\n")
 	cfg.Quota = output[0]
 	cfg.Period = output[1]
+	cfg.Stat, err = stat(cm.k8sClient, pod, containerName, childName)
+	if err != nil {
+		return nil, err
+	}
 	return cfg, nil
+}
+
+// stat fetch cpu.stat values
+func stat(k8sclient *kubernetes.Clientset, pod *corev1.Pod, containerName, childName string) (map[string]string, error) {
+	cpuStat := make(map[string]string)
+	dirPath := path.Join(controller.CgroupMountPoint, childName)
+	cmd := []string{
+		"/bin/cat",
+		dirPath + "/cpu/cpu.stat",
+	}
+	statBytes, err := pods.ExecCommandOnPod(k8sclient, pod, containerName, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve cgroup config for pod. pod=%q, container=%q; %w", client.ObjectKeyFromObject(pod).String(), containerName, err)
+	}
+	output := strings.TrimSpace(string(statBytes))
+	interfacevalues := strings.Split(output, "\r\n")
+	for _, v := range interfacevalues {
+		values := strings.Split(v, " ")
+		cpuStat[values[0]] = values[1]
+	}
+	return cpuStat, nil
 }
 
 func (cm *ControllersManager) Pod(ctx context.Context, pod *corev1.Pod, controllerConfig interface{}) error {

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -62,6 +62,27 @@ type NodeInterface struct {
 	defRoute bool
 }
 
+type ContainerInfo struct {
+	PID int `json:"pid"`
+}
+
+type CrictlInfo struct {
+	Info struct {
+		Pid   int `json:"pid"`
+		Linux struct {
+			Resources struct {
+				CPU struct {
+					Shares int    `json:"shares"`
+					Quota  int    `json:"quota"`
+					Period int    `json:"period"`
+					Cpus   string `json:"cpus"`
+				} `json:"cpus"`
+			} `json:"resources"`
+			CgroupsPath string `json:"cgroupsPath"`
+		} `json:"linux"`
+	} `json:"info"`
+}
+
 // GetByRole returns all nodes with the specified role
 func GetByRole(role string) ([]corev1.Node, error) {
 	selector, err := labels.Parse(fmt.Sprintf("%s/%s=", testutils.LabelRole, role))
@@ -505,4 +526,23 @@ func isNodeReady(node corev1.Node) bool {
 		}
 	}
 	return false
+}
+
+// ContainerPid returns container process pid using crictl inspect command
+// we are using runc binary which exists irrespective of container runtime used
+func ContainerPid(ctx context.Context, node *corev1.Node, containerId string) (string, error) {
+	var err error
+	var criInfo CrictlInfo
+	var cridata = []byte{}
+	Eventually(func() []byte {
+		cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs crictl inspect %s", containerId)}
+		cridata, err = ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+		Expect(err).ToNot(HaveOccurred(), "failed to run %s cmd", cmd)
+		return cridata
+	}, 10*time.Second, 5*time.Second).ShouldNot(BeEmpty())
+	err = json.Unmarshal(cridata, &criInfo)
+	if err != nil {
+		return "", err
+	}
+	return strconv.Itoa(criInfo.Info.Pid), err
 }

--- a/test/e2e/performanceprofile/functests/utils/pods/pods.go
+++ b/test/e2e/performanceprofile/functests/utils/pods/pods.go
@@ -207,7 +207,10 @@ func GetContainerIDByName(pod *corev1.Pod, containerName string) (string, error)
 	}
 	for _, containerStatus := range updatedPod.Status.ContainerStatuses {
 		if containerStatus.Name == containerName {
-			return strings.Trim(containerStatus.ContainerID, "cri-o://"), nil
+			containerID := containerStatus.ContainerID
+			// Split the container ID at the "://" delimiter, keeping the second part:
+			containerID = strings.SplitN(containerID, "://", 2)[1]
+			return containerID, nil
 		}
 	}
 	return "", fmt.Errorf("failed to find the container ID for the container %q under the pod %q", containerName, pod.Name)

--- a/test/e2e/performanceprofile/functests/utils/systemd/systemd.go
+++ b/test/e2e/performanceprofile/functests/utils/systemd/systemd.go
@@ -1,0 +1,21 @@
+package systemd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Status(ctx context.Context, unitfile string, node *corev1.Node) (string, error) {
+	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs systemctl status %s --lines=0 --no-pager", unitfile)}
+	out, err := nodes.ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+	return string(out), err
+}
+
+func ShowProperty(ctx context.Context, unitfile string, property string, node *corev1.Node) (string, error) {
+	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs systemctl show -p %s %s --no-pager", property, unitfile)}
+	out, err := nodes.ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+	return string(out), err
+}


### PR DESCRIPTION
e2e: when crun is enabled by default skip checking runc



Add systemd package to fetch properties of cgroup slice



modify ovs dynamic automation to be cgroup version neutral



Adjust tests for cgroupv2 changes