### PR TITLE
 [release-4.14]  OCPBUGS-25137: Add a '.snyk' to silence static code analysis warnings

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+exclude:
+  global:
+    - "vendor/github.com/onsi/ginkgo/v2/internal/suite.go"
+    - "vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go"
+    - "vendor/github.com/jaypipes/ghw/pkg/block/block_linux.go"


### PR DESCRIPTION
The '.snyk' exclude these paths under the vendor directory:

ginkgo/v2/internal/suite.go
controller-runtime/pkg/log/log.go
jaypipes/ghw/pkg/block/block_linux.go

These paths trigger a warning related to the generation of error messages containing sensitive information.
Currently, there is no available fix for these issues.