### PR TITLE
NO-JIRA: Update tuned profile degraded test

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/infrastructure/vm.go
+++ b/test/e2e/performanceprofile/functests/utils/infrastructure/vm.go
@@ -1,0 +1,28 @@
+package infrastructure
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+)
+
+// IsVM checks if a given node's underlying infrastructure is a VM
+func IsVM(node *corev1.Node) (bool, error) {
+	cmd := []string{
+		"/bin/bash",
+		"-c",
+		"systemd-detect-virt > /dev/null ; echo $?",
+	}
+	output, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), node, cmd)
+	if err != nil {
+		return false, err
+	}
+
+	statusCode := strings.TrimSpace(string(output))
+	isVM := string(statusCode) == "0"
+
+	return isVM, nil
+}


### PR DESCRIPTION
Updated the tuned degradation test to fail only when the tuned profile was found degraded
on BM host.
In case of tuned profile found degraded on a VM, only a warning would be reported in the logs.
The reason for that is that the fact CI is using VMs - and some
configurations like certain kernel args can't be applied and therby lead to
the tuned profile being degraded.