### PR TITLE
CNF-11815: e2e: Added node inspector for inspecting nodes configuration

### DIFF
--- a/hack/run-test.sh
+++ b/hack/run-test.sh
@@ -92,6 +92,7 @@ main() {
     if [ "$ONLY_CLI_PRINT" = true ]; then
         print "Skipping execution as requested by user ... "
     else
+        trap '{ echo "Running cleanup test suite"; ginkgo test/e2e/performanceprofile/functests/Z_deconfig --flake-attempts=2 --junit-report=report.xml; }' EXIT SIGINT SIGTERM SIGSTOP
         print "Executing test suites ... "
         GOFLAGS=-mod=vendor ginkgo ${GINKGO_FLAGS}
     fi

--- a/test/e2e/performanceprofile/functests/0_config/test_suite_performance_config_test.go
+++ b/test/e2e/performanceprofile/functests/0_config/test_suite_performance_config_test.go
@@ -4,6 +4,7 @@
 package __performance_config_test
 
 import (
+	"context"
 	"flag"
 	"log"
 	"os"
@@ -14,6 +15,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -22,7 +24,10 @@ import (
 
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/images"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/k8sreporter"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/namespaces"
+	nodeInspector "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/node_inspector"
 )
 
 var (
@@ -59,6 +64,13 @@ func TestPerformanceConfig(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	Expect(testclient.ClientsEnabled).To(BeTrue())
+	// create test namespace
+	if err := testclient.DataPlaneClient.Create(context.TODO(), namespaces.NodeInspectorNamespace); !errors.IsAlreadyExists(err) {
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	err := nodeInspector.Create(testclient.DataPlaneClient, testutils.NodeInspectorNamespace, testutils.NodeInspectorName, images.Test())
+	Expect(err).ToNot(HaveOccurred())
 
 })
 

--- a/test/e2e/performanceprofile/functests/11_mixedcpus/mixedcpus.go
+++ b/test/e2e/performanceprofile/functests/11_mixedcpus/mixedcpus.go
@@ -81,7 +81,7 @@ var _ = Describe("Mixedcpus", Ordered, func() {
 			// test arbitrary one should be good enough
 			worker := &workers[0]
 			cmd := isFileExistCmd(kubeletMixedCPUsConfigFile)
-			found, err := nodes.ExecCommandOnNode(ctx, cmd, worker)
+			found, err := nodes.ExecCommandToString(ctx, cmd, worker)
 			Expect(err).ToNot(HaveOccurred(), "failed to execute command on node; cmd=%q node=%q", cmd, worker)
 			Expect(found).To(Equal("true"), "file not found; file=%q", kubeletMixedCPUsConfigFile)
 		})
@@ -112,7 +112,7 @@ var _ = Describe("Mixedcpus", Ordered, func() {
 				"-c",
 				fmt.Sprintf("/bin/awk  -F '\"' '/shared_cpuset.*/ { print $2 }' %s", runtime.CRIORuntimeConfigFile),
 			}
-			cpus, err := nodes.ExecCommandOnNode(ctx, cmd, worker)
+			cpus, err := nodes.ExecCommandToString(ctx, cmd, worker)
 			Expect(err).ToNot(HaveOccurred(), "failed to execute command on node; cmd=%q node=%q", cmd, worker)
 			cpus = strings.Trim(cpus, "\n")
 			crioShared := mustParse(cpus)
@@ -268,7 +268,7 @@ var _ = Describe("Mixedcpus", Ordered, func() {
 
 				cmd := kubeletRestartCmd()
 				// The command would fail since it aborts all the pods during restart
-				_, _ = nodes.ExecCommandOnNode(ctx, cmd, node)
+				_, _ = nodes.ExecCommandToString(ctx, cmd, node)
 				// check that the node is ready after we restart Kubelet
 				nodes.WaitForReadyOrFail("post restart", node.Name, 20*time.Minute, 3*time.Second)
 
@@ -616,7 +616,7 @@ func fetchSharedCPUsFromEnv(c *kubernetes.Clientset, p *corev1.Pod, containerNam
 // getCPUswithLoadBalanceDisabled Return cpus which are not in any scheduling domain
 func getCPUswithLoadBalanceDisabled(ctx context.Context, targetNode *corev1.Node) ([]string, error) {
 	cmd := []string{"/bin/bash", "-c", "cat /proc/schedstat"}
-	schedstatData, err := nodes.ExecCommandOnNode(ctx, cmd, targetNode)
+	schedstatData, err := nodes.ExecCommandToString(ctx, cmd, targetNode)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/performanceprofile/functests/1_performance/hugepages.go
+++ b/test/e2e/performanceprofile/functests/1_performance/hugepages.go
@@ -189,7 +189,7 @@ var _ = Describe("[performance]Hugepages", Ordered, func() {
 
 func checkHugepagesStatus(ctx context.Context, path string, workerRTNode *corev1.Node) int {
 	command := []string{"cat", path}
-	out, err := nodes.ExecCommandOnMachineConfigDaemon(ctx, workerRTNode, command)
+	out, err := nodes.ExecCommand(ctx, workerRTNode, command)
 	Expect(err).ToNot(HaveOccurred())
 	n, err := strconv.Atoi(strings.Trim(string(out), "\n\r"))
 	Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -313,7 +313,7 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 			origBannedCPUsFile := "/etc/sysconfig/orig_irq_banned_cpus"
 			By(fmt.Sprintf("Checking content of %q on node %q", origBannedCPUsFile, node.Name))
 			fullPath := filepath.Join("/", "rootfs", origBannedCPUsFile)
-			out, err := nodes.ExecCommandOnNode(context.TODO(), []string{"/usr/bin/cat", fullPath}, node)
+			out, err := nodes.ExecCommandToString(context.TODO(), []string{"/usr/bin/cat", fullPath}, node)
 			Expect(err).ToNot(HaveOccurred())
 			out = strings.TrimSuffix(out, "\r\n")
 			Expect(out).To(Equal("0"), "file %s does not contain the expect output; expected=0 actual=%s", fullPath, out)
@@ -327,7 +327,7 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 // require close attention. For the time being we reimplement a form of nodes.BannedCPUs which can handle empty ban list.
 func getIrqBalanceBannedCPUs(ctx context.Context, node *corev1.Node) (cpuset.CPUSet, error) {
 	cmd := []string{"cat", "/rootfs/etc/sysconfig/irqbalance"}
-	conf, err := nodes.ExecCommandOnNode(ctx, cmd, node)
+	conf, err := nodes.ExecCommandToString(ctx, cmd, node)
 	if err != nil {
 		return cpuset.New(), err
 	}
@@ -361,7 +361,7 @@ func getIrqBalanceBannedCPUs(ctx context.Context, node *corev1.Node) (cpuset.CPU
 
 func getIrqDefaultSMPAffinity(ctx context.Context, node *corev1.Node) (string, error) {
 	cmd := []string{"cat", "/rootfs/proc/irq/default_smp_affinity"}
-	return nodes.ExecCommandOnNode(ctx, cmd, node)
+	return nodes.ExecCommandToString(ctx, cmd, node)
 }
 
 func findIrqBalanceBannedCPUsVarFromConf(conf string) string {

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -313,8 +313,9 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 			origBannedCPUsFile := "/etc/sysconfig/orig_irq_banned_cpus"
 			By(fmt.Sprintf("Checking content of %q on node %q", origBannedCPUsFile, node.Name))
 			fullPath := filepath.Join("/", "rootfs", origBannedCPUsFile)
-			out, err := nodes.ExecCommandToString(context.TODO(), []string{"/usr/bin/cat", fullPath}, node)
+			output, err := nodes.ExecCommand(context.TODO(), node, []string{"/usr/bin/cat", fullPath})
 			Expect(err).ToNot(HaveOccurred())
+			out := testutils.ToString(output)
 			out = strings.TrimSuffix(out, "\r\n")
 			Expect(out).To(Equal("0"), "file %s does not contain the expect output; expected=0 actual=%s", fullPath, out)
 		})
@@ -327,10 +328,11 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 // require close attention. For the time being we reimplement a form of nodes.BannedCPUs which can handle empty ban list.
 func getIrqBalanceBannedCPUs(ctx context.Context, node *corev1.Node) (cpuset.CPUSet, error) {
 	cmd := []string{"cat", "/rootfs/etc/sysconfig/irqbalance"}
-	conf, err := nodes.ExecCommandToString(ctx, cmd, node)
+	out, err := nodes.ExecCommand(ctx, node, cmd)
 	if err != nil {
 		return cpuset.New(), err
 	}
+	conf := testutils.ToString(out)
 
 	keyValue := findIrqBalanceBannedCPUsVarFromConf(conf)
 	if len(keyValue) == 0 {
@@ -361,7 +363,12 @@ func getIrqBalanceBannedCPUs(ctx context.Context, node *corev1.Node) (cpuset.CPU
 
 func getIrqDefaultSMPAffinity(ctx context.Context, node *corev1.Node) (string, error) {
 	cmd := []string{"cat", "/rootfs/proc/irq/default_smp_affinity"}
-	return nodes.ExecCommandToString(ctx, cmd, node)
+	out, err := nodes.ExecCommand(ctx, node, cmd)
+	if err != nil {
+		return "", err
+	}
+	output := testutils.ToString(out)
+	return output, nil
 }
 
 func findIrqBalanceBannedCPUsVarFromConf(conf string) string {

--- a/test/e2e/performanceprofile/functests/1_performance/netqueues.go
+++ b/test/e2e/performanceprofile/functests/1_performance/netqueues.go
@@ -401,7 +401,7 @@ func getReservedCPUSize(CPU *performancev2.CPU) int {
 func getVendorID(ctx context.Context, node corev1.Node, device string) string {
 	cmd := []string{"bash", "-c",
 		fmt.Sprintf("cat /sys/class/net/%s/device/vendor", device)}
-	stdout, err := nodes.ExecCommandOnNode(ctx, cmd, &node)
+	stdout, err := nodes.ExecCommandToString(ctx, cmd, &node)
 	Expect(err).ToNot(HaveOccurred())
 	return stdout
 }
@@ -409,7 +409,7 @@ func getVendorID(ctx context.Context, node corev1.Node, device string) string {
 func getDeviceID(ctx context.Context, node corev1.Node, device string) string {
 	cmd := []string{"bash", "-c",
 		fmt.Sprintf("cat /sys/class/net/%s/device/device", device)}
-	stdout, err := nodes.ExecCommandOnNode(ctx, cmd, &node)
+	stdout, err := nodes.ExecCommandToString(ctx, cmd, &node)
 	Expect(err).ToNot(HaveOccurred())
 	return stdout
 }

--- a/test/e2e/performanceprofile/functests/1_performance/netqueues.go
+++ b/test/e2e/performanceprofile/functests/1_performance/netqueues.go
@@ -401,16 +401,18 @@ func getReservedCPUSize(CPU *performancev2.CPU) int {
 func getVendorID(ctx context.Context, node corev1.Node, device string) string {
 	cmd := []string{"bash", "-c",
 		fmt.Sprintf("cat /sys/class/net/%s/device/vendor", device)}
-	stdout, err := nodes.ExecCommandToString(ctx, cmd, &node)
+	out, err := nodes.ExecCommand(ctx, &node, cmd)
 	Expect(err).ToNot(HaveOccurred())
+	stdout := testutils.ToString(out)
 	return stdout
 }
 
 func getDeviceID(ctx context.Context, node corev1.Node, device string) string {
 	cmd := []string{"bash", "-c",
 		fmt.Sprintf("cat /sys/class/net/%s/device/device", device)}
-	stdout, err := nodes.ExecCommandToString(ctx, cmd, &node)
+	out, err := nodes.ExecCommand(ctx, &node, cmd)
 	Expect(err).ToNot(HaveOccurred())
+	stdout := testutils.ToString(out)
 	return stdout
 }
 

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -143,7 +143,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 
 		It("[test_id:31198] Should set CPU affinity kernel argument", func() {
 			for _, node := range workerRTNodes {
-				cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
+				cmdline, err := nodes.ExecCommand(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())
 				// since systemd.cpu_affinity is calculated on node level using tuned we can check only the key in this context.
 				Expect(string(cmdline)).To(ContainSubstring("systemd.cpu_affinity="))
@@ -152,7 +152,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 
 		It("[test_id:32702] Should set CPU isolcpu's kernel argument managed_irq flag", func() {
 			for _, node := range workerRTNodes {
-				cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
+				cmdline, err := nodes.ExecCommand(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())
 				if profile.Spec.CPU.BalanceIsolated != nil && *profile.Spec.CPU.BalanceIsolated == false {
 					Expect(string(cmdline)).To(ContainSubstring("isolcpus=domain,managed_irq,"))
@@ -165,7 +165,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		It("[test_id:27081][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Should set workqueue CPU mask", func() {
 			for _, node := range workerRTNodes {
 				By(fmt.Sprintf("Getting tuned.non_isolcpus kernel argument on %q", node.Name))
-				cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
+				cmdline, err := nodes.ExecCommand(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())
 				re := regexp.MustCompile(`tuned.non_isolcpus=\S+`)
 				nonIsolcpusFullArgument := re.FindString(string(cmdline))
@@ -186,13 +186,13 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				}
 
 				By(fmt.Sprintf("Getting the virtual workqueue mask (/sys/devices/virtual/workqueue/cpumask) on %q", node.Name))
-				workqueueMaskData, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"cat", "/sys/devices/virtual/workqueue/cpumask"})
+				workqueueMaskData, err := nodes.ExecCommand(context.TODO(), &node, []string{"cat", "/sys/devices/virtual/workqueue/cpumask"})
 				Expect(err).ToNot(HaveOccurred())
 				workqueueMask := getTrimmedMaskFromData("virtual", workqueueMaskData)
 				expectMasksEqual(nonIsolcpusMaskNoDelimiters, workqueueMask)
 
 				By(fmt.Sprintf("Getting the writeback workqueue mask (/sys/bus/workqueue/devices/writeback/cpumask) on %q", node.Name))
-				workqueueWritebackMaskData, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"cat", "/sys/bus/workqueue/devices/writeback/cpumask"})
+				workqueueWritebackMaskData, err := nodes.ExecCommand(context.TODO(), &node, []string{"cat", "/sys/bus/workqueue/devices/writeback/cpumask"})
 				Expect(err).ToNot(HaveOccurred())
 				workqueueWritebackMask := getTrimmedMaskFromData("workqueue", workqueueWritebackMaskData)
 				expectMasksEqual(nonIsolcpusMaskNoDelimiters, workqueueWritebackMask)
@@ -204,12 +204,12 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				// updating the field to 4 as the latest proc/cmdline has been updated to
 				// BOOT_IMAGE=(hd0,gpt3)/boot/ostree/rhcos-<imageid> instead of BOOT_IMAGE=(hd1,gpt3)/ostree/rhcos-<imageId>
 				// TODO: Modify the awk script to be resilent to these changes or check if we can remove it completely
-				rhcosId, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"awk", "-F", "/", "{printf $4}", "/rootfs/proc/cmdline"})
+				rhcosId, err := nodes.ExecCommand(context.TODO(), &node, []string{"awk", "-F", "/", "{printf $4}", "/rootfs/proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())
-				initramfsImagesPath, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"find", filepath.Join("/rootfs/boot/ostree", string(rhcosId)), "-name", "*.img"})
+				initramfsImagesPath, err := nodes.ExecCommand(context.TODO(), &node, []string{"find", filepath.Join("/rootfs/boot/ostree", string(rhcosId)), "-name", "*.img"})
 				Expect(err).ToNot(HaveOccurred())
 				modifiedImagePath := strings.TrimPrefix(strings.TrimSpace(string(initramfsImagesPath)), "/rootfs")
-				initrd, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"chroot", "/rootfs", "lsinitrd", modifiedImagePath})
+				initrd, err := nodes.ExecCommand(context.TODO(), &node, []string{"chroot", "/rootfs", "lsinitrd", modifiedImagePath})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(initrd)).ShouldNot(ContainSubstring("'/etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf'"))
 			}
@@ -224,10 +224,10 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 		It("[test_id:42400][crit:medium][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running as sched_fifo", func() {
 			for _, node := range workerRTNodes {
-				pid, err := nodes.ExecCommandOnNode(context.TODO(), []string{"pidof", "stalld"}, &node)
+				pid, err := nodes.ExecCommandToString(context.TODO(), []string{"pidof", "stalld"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pid).ToNot(BeEmpty())
-				sched_tasks, err := nodes.ExecCommandOnNode(context.TODO(), []string{"chrt", "-ap", pid}, &node)
+				sched_tasks, err := nodes.ExecCommandToString(context.TODO(), []string{"chrt", "-ap", pid}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(sched_tasks).To(ContainSubstring("scheduling policy: SCHED_FIFO"))
 				Expect(sched_tasks).To(ContainSubstring("scheduling priority: 10"))
@@ -235,20 +235,20 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 		It("[test_id:42696][crit:medium][vendor:cnf-qe@redhat.com][level:acceptance] Stalld runs in higher priority than ksoftirq and rcu{c,b}", func() {
 			for _, node := range workerRTNodes {
-				stalld_pid, err := nodes.ExecCommandOnNode(context.TODO(), []string{"pidof", "stalld"}, &node)
+				stalld_pid, err := nodes.ExecCommandToString(context.TODO(), []string{"pidof", "stalld"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stalld_pid).ToNot(BeEmpty())
-				sched_tasks, err := nodes.ExecCommandOnNode(context.TODO(), []string{"chrt", "-ap", stalld_pid}, &node)
+				sched_tasks, err := nodes.ExecCommandToString(context.TODO(), []string{"chrt", "-ap", stalld_pid}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				re := regexp.MustCompile("scheduling priority: ([0-9]+)")
 				match := re.FindStringSubmatch(sched_tasks)
 				stalld_prio, err := strconv.Atoi(match[1])
 				Expect(err).ToNot(HaveOccurred())
 
-				ksoftirq_pid, err := nodes.ExecCommandOnNode(context.TODO(), []string{"pgrep", "-f", "ksoftirqd", "-n"}, &node)
+				ksoftirq_pid, err := nodes.ExecCommandToString(context.TODO(), []string{"pgrep", "-f", "ksoftirqd", "-n"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ksoftirq_pid).ToNot(BeEmpty())
-				sched_tasks, err = nodes.ExecCommandOnNode(context.TODO(), []string{"chrt", "-ap", ksoftirq_pid}, &node)
+				sched_tasks, err = nodes.ExecCommandToString(context.TODO(), []string{"chrt", "-ap", ksoftirq_pid}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				match = re.FindStringSubmatch(sched_tasks)
 				ksoftirq_prio, err := strconv.Atoi(match[1])
@@ -263,10 +263,10 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				}
 				//rcuc/n : kthreads that are pinned to CPUs & are responsible to execute the callbacks of rcu threads .
 				//rcub/n : are boosting kthreads ,responsible to monitor per-cpu arrays of lists of tasks that were blocked while in an rcu read-side critical sections.
-				rcu_pid, err := nodes.ExecCommandOnNode(context.TODO(), []string{"pgrep", "-f", "rcu[c,b]", "-n"}, &node)
+				rcu_pid, err := nodes.ExecCommandToString(context.TODO(), []string{"pgrep", "-f", "rcu[c,b]", "-n"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rcu_pid).ToNot(BeEmpty())
-				sched_tasks, err = nodes.ExecCommandOnNode(context.TODO(), []string{"chrt", "-ap", rcu_pid}, &node)
+				sched_tasks, err = nodes.ExecCommandToString(context.TODO(), []string{"chrt", "-ap", rcu_pid}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				match = re.FindStringSubmatch(sched_tasks)
 				rcu_prio, err := strconv.Atoi(match[1])
@@ -283,7 +283,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		It("[test_id:28611][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Should set additional kernel arguments on the machine", func() {
 			if profile.Spec.AdditionalKernelArgs != nil {
 				for _, node := range workerRTNodes {
-					cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
+					cmdline, err := nodes.ExecCommand(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
 					Expect(err).ToNot(HaveOccurred())
 					for _, arg := range profile.Spec.AdditionalKernelArgs {
 						Expect(string(cmdline)).To(ContainSubstring(arg))
@@ -307,7 +307,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				}
 				// Getting the list of processes that are running on the root cgroup, filtering out the kernel threads (are presented in [square brackets]).
 				command := fmt.Sprintf("cat %s | xargs ps -o cmd | grep -v \"\\[\"", rootCgroupPath)
-				output, err := nodes.ExecCommandOnNode(context.TODO(), []string{"/bin/bash", "-c", command}, &node)
+				output, err := nodes.ExecCommandToString(context.TODO(), []string{"/bin/bash", "-c", command}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				cmds := strings.Split(output, "\n")
 				processesFound = append(processesFound, cmds[1:]...)
@@ -370,7 +370,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				for _, vethinterface := range vethInterfaces {
 					devicePath := fmt.Sprintf("%s/%s", "/rootfs/sys/devices/virtual/net", vethinterface)
 					getRPSMaskCmd := []string{"find", devicePath, "-type", "f", "-name", "rps_cpus", "-exec", "cat", "{}", ";"}
-					devsRPS, err := nodes.ExecCommandOnNode(context.TODO(), getRPSMaskCmd, &node)
+					devsRPS, err := nodes.ExecCommandToString(context.TODO(), getRPSMaskCmd, &node)
 					Expect(err).ToNot(HaveOccurred())
 					for _, devRPS := range strings.Split(devsRPS, "\n") {
 						rpsCPUs, err := components.CPUMaskToCPUSet(devRPS)
@@ -410,7 +410,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			for _, node := range workerRTNodes {
 				By("verify the systemd RPS service uses the correct RPS mask")
 				cmd := []string{"sysctl", "-n", "net.core.rps_default_mask"}
-				rpsMaskContent, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &node)
+				rpsMaskContent, err := nodes.ExecCommandToString(context.TODO(), cmd, &node)
 				Expect(err).ToNot(HaveOccurred(), "failed to exec command %q on node %q", cmd, node)
 				rpsMaskContent = strings.TrimSuffix(rpsMaskContent, "\n")
 				rpsCPUs, err := components.CPUMaskToCPUSet(rpsMaskContent)
@@ -427,7 +427,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 					"-printf", "%p ",
 					"-exec", "cat", "{}", ";",
 				}
-				devsRPSContent, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &node)
+				devsRPSContent, err := nodes.ExecCommandToString(context.TODO(), cmd, &node)
 				Expect(err).ToNot(HaveOccurred(), "failed to exec command %q on node %q", cmd, node.Name)
 				devsRPSMap := makeDevRPSMap(devsRPSContent)
 				for path, mask := range devsRPSMap {
@@ -446,7 +446,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 					"-printf", "%p ",
 					"-exec", "cat", "{}", ";",
 				}
-				devsRPSContent, err = nodes.ExecCommandOnNode(context.TODO(), cmd, &node)
+				devsRPSContent, err = nodes.ExecCommandToString(context.TODO(), cmd, &node)
 				Expect(err).ToNot(HaveOccurred(), "failed to exec command %q on node %q", cmd, node.Name)
 
 				devsRPSMap = makeDevRPSMap(devsRPSContent)
@@ -463,7 +463,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				for _, node := range workerRTNodes {
 					// Verify the systemd RPS services were not created
 					cmd := []string{"ls", "/rootfs/etc/systemd/system/update-rps@.service"}
-					_, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &node)
+					_, err := nodes.ExecCommandToString(context.TODO(), cmd, &node)
 					Expect(err).To(HaveOccurred())
 				}
 			}
@@ -1035,7 +1035,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 
 	It("[test_id:54083] Should have kernel param rcutree.kthread", func() {
 		for _, node := range workerRTNodes {
-			cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
+			cmdline, err := nodes.ExecCommand(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
 			Expect(err).ToNot(HaveOccurred(), "Failed to read /proc/cmdline")
 			Expect(string(cmdline)).To(ContainSubstring("rcutree.kthread_prio=11"), "Boot Parameters should contain rctree.kthread_prio=11")
 		}
@@ -1325,7 +1325,7 @@ func execSysctlOnWorkers(ctx context.Context, workerNodes []corev1.Node, sysctlM
 	for _, node := range workerNodes {
 		for param, expected := range sysctlMap {
 			By(fmt.Sprintf("executing the command \"sysctl -n %s\"", param))
-			out, err = nodes.ExecCommandOnMachineConfigDaemon(ctx, &node, []string{"sysctl", "-n", param})
+			out, err = nodes.ExecCommand(ctx, &node, []string{"sysctl", "-n", param})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.TrimSpace(string(out))).Should(Equal(expected), "parameter %s value is not %s.", param, expected)
 		}
@@ -1340,7 +1340,7 @@ func checkSchedKnobs(ctx context.Context, workerNodes []corev1.Node, schedKnobs 
 		for param, expected := range schedKnobs {
 			By(fmt.Sprintf("Checking scheduler knob %s", param))
 			knob := fmt.Sprintf("/rootfs/sys/kernel/debug/sched/%s", param)
-			out, err = nodes.ExecCommandOnMachineConfigDaemon(ctx, &node, []string{"cat", knob})
+			out, err = nodes.ExecCommand(ctx, &node, []string{"cat", knob})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.TrimSpace(string(out))).Should(Equal(expected), "parameter %s value is not %s.", param, expected)
 		}

--- a/test/e2e/performanceprofile/functests/1_performance/rt-kernel.go
+++ b/test/e2e/performanceprofile/functests/1_performance/rt-kernel.go
@@ -65,8 +65,9 @@ var _ = Describe("[performance]RT Kernel", Ordered, func() {
 		}
 
 		cmd := []string{"uname", "-a"}
-		kernel, err := nodes.ExecCommandToString(context.TODO(), cmd, &nonPerformancesWorkers[0])
+		out, err := nodes.ExecCommand(context.TODO(), &nonPerformancesWorkers[0], cmd)
 		Expect(err).ToNot(HaveOccurred(), "failed to execute uname")
+		kernel := testutils.ToString(out)
 		Expect(kernel).To(ContainSubstring("Linux"), "Node should have Linux string")
 
 		err = nodes.HasPreemptRTKernel(context.TODO(), &nonPerformancesWorkers[0])

--- a/test/e2e/performanceprofile/functests/1_performance/rt-kernel.go
+++ b/test/e2e/performanceprofile/functests/1_performance/rt-kernel.go
@@ -65,7 +65,7 @@ var _ = Describe("[performance]RT Kernel", Ordered, func() {
 		}
 
 		cmd := []string{"uname", "-a"}
-		kernel, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &nonPerformancesWorkers[0])
+		kernel, err := nodes.ExecCommandToString(context.TODO(), cmd, &nonPerformancesWorkers[0])
 		Expect(err).ToNot(HaveOccurred(), "failed to execute uname")
 		Expect(kernel).To(ContainSubstring("Linux"), "Node should have Linux string")
 

--- a/test/e2e/performanceprofile/functests/2_performance_update/memorymanager.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/memorymanager.go
@@ -813,7 +813,7 @@ func GetMemoryNodes(ctx context.Context, testPod *corev1.Pod, targetNode *corev1
 	}
 	pid, err := nodes.ContainerPid(context.TODO(), targetNode, containerID)
 	cmd := []string{"cat", fmt.Sprintf("/rootfs/proc/%s/cgroup", pid)}
-	out, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), targetNode, cmd)
+	out, err := nodes.ExecCommand(context.TODO(), targetNode, cmd)
 	containerCgroup, err = cgroup.PidParser(out)
 	fmt.Println("Container Cgroup = ", containerCgroup)
 	cgroupv2, err := cgroup.IsVersion2(context.TODO(), testclient.Client)
@@ -828,7 +828,7 @@ func GetMemoryNodes(ctx context.Context, testPod *corev1.Pod, targetNode *corev1
 		cpusetMemsPath = filepath.Join(fullPath, "cpuset.mems")
 	}
 	cmd = []string{"cat", cpusetMemsPath}
-	memoryNodes, err = nodes.ExecCommandOnNode(ctx, cmd, targetNode)
+	memoryNodes, err = nodes.ExecCommandToString(ctx, cmd, targetNode)
 	testlog.Infof("test pod %s with container id %s has Memory nodes %s", testPod.Name, containerID, memoryNodes)
 	return memoryNodes, err
 }

--- a/test/e2e/performanceprofile/functests/2_performance_update/memorymanager.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/memorymanager.go
@@ -828,7 +828,8 @@ func GetMemoryNodes(ctx context.Context, testPod *corev1.Pod, targetNode *corev1
 		cpusetMemsPath = filepath.Join(fullPath, "cpuset.mems")
 	}
 	cmd = []string{"cat", cpusetMemsPath}
-	memoryNodes, err = nodes.ExecCommandToString(ctx, cmd, targetNode)
+	out, err = nodes.ExecCommand(ctx, targetNode, cmd)
+	memoryNodes = testutils.ToString(out)
 	testlog.Infof("test pod %s with container id %s has Memory nodes %s", testPod.Name, containerID, memoryNodes)
 	return memoryNodes, err
 }

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -48,10 +48,10 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 	chkIrqbalance := []string{"cat", "/rootfs/etc/sysconfig/irqbalance"}
 
 	chkCmdLineFn := func(ctx context.Context, node *corev1.Node) (string, error) {
-		return nodes.ExecCommandOnNode(ctx, chkCmdLine, node)
+		return nodes.ExecCommandToString(ctx, chkCmdLine, node)
 	}
 	chkKubeletConfigFn := func(ctx context.Context, node *corev1.Node) (string, error) {
-		return nodes.ExecCommandOnNode(ctx, chkKubeletConfig, node)
+		return nodes.ExecCommandToString(ctx, chkKubeletConfig, node)
 	}
 
 	chkHugepages2MFn := func(ctx context.Context, node *corev1.Node) (string, error) {
@@ -166,7 +166,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for _, node := range workerRTNodes {
 				for i := 0; i < 2; i++ {
 					nodeCmd := []string{"cat", hugepagesPathForNode(i, 2)}
-					result, err := nodes.ExecCommandOnNode(context.TODO(), nodeCmd, &node)
+					result, err := nodes.ExecCommandToString(context.TODO(), nodeCmd, &node)
 					Expect(err).ToNot(HaveOccurred())
 
 					t, err := strconv.Atoi(result)
@@ -307,7 +307,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 
 		It("[test_id:28612]Verify that Kernel arguments can me updated (added, removed) thru performance profile", func() {
 			for _, node := range workerRTNodes {
-				cmdline, err := nodes.ExecCommandOnNode(context.TODO(), chkCmdLine, &node)
+				cmdline, err := nodes.ExecCommandToString(context.TODO(), chkCmdLine, &node)
 				Expect(err).ToNot(HaveOccurred(), "failed to execute %s", chkCmdLine)
 
 				// Verifying that new argument was added
@@ -446,7 +446,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		It("[test_id:28440]Verifies that nodeSelector can be updated in performance profile", func() {
 			kubeletConfig, err := nodes.GetKubeletConfig(context.TODO(), newCnfNode)
 			Expect(kubeletConfig.TopologyManagerPolicy).ToNot(BeEmpty())
-			cmdline, err := nodes.ExecCommandOnNode(context.TODO(), chkCmdLine, newCnfNode)
+			cmdline, err := nodes.ExecCommandToString(context.TODO(), chkCmdLine, newCnfNode)
 			Expect(err).ToNot(HaveOccurred(), "failed to execute %s", chkCmdLine)
 			Expect(cmdline).To(ContainSubstring("tuned.non_isolcpus"))
 
@@ -467,7 +467,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			err = nodes.HasPreemptRTKernel(context.TODO(), newCnfNode)
 			Expect(err).To(HaveOccurred())
 
-			cmdline, err := nodes.ExecCommandOnNode(context.TODO(), chkCmdLine, newCnfNode)
+			cmdline, err := nodes.ExecCommandToString(context.TODO(), chkCmdLine, newCnfNode)
 			Expect(err).ToNot(HaveOccurred(), "failed to execute %s", chkCmdLine)
 			Expect(cmdline).NotTo(ContainSubstring("tuned.non_isolcpus"))
 
@@ -478,7 +478,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			reservedCPU := string(*profile.Spec.CPU.Reserved)
 			cpuMask, err := components.CPUListToHexMask(reservedCPU)
 			Expect(err).ToNot(HaveOccurred(), "failed to list in Hex %s", reservedCPU)
-			irqBal, err := nodes.ExecCommandOnNode(context.TODO(), chkIrqbalance, newCnfNode)
+			irqBal, err := nodes.ExecCommandToString(context.TODO(), chkIrqbalance, newCnfNode)
 			Expect(err).ToNot(HaveOccurred(), "failed to execute %s", chkIrqbalance)
 			Expect(irqBal).NotTo(ContainSubstring(cpuMask))
 		})
@@ -558,7 +558,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			initialProfile = profile.DeepCopy()
 
 			for _, node := range workerRTNodes {
-				onlineCPUCount, err := nodes.ExecCommandOnNode(context.TODO(), []string{"nproc", "--all"}, &node)
+				onlineCPUCount, err := nodes.ExecCommandToString(context.TODO(), []string{"nproc", "--all"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 
 				onlineCPUInt, err := strconv.Atoi(onlineCPUCount)
@@ -602,7 +602,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			workerRTNodes = getUpdatedNodes()
 			//Check offlined cpus are setting correctly
 			for _, node := range workerRTNodes {
-				offlinedOutput, err := nodes.ExecCommandOnNode(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
+				offlinedOutput, err := nodes.ExecCommandToString(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				offlinedCPUSet, err := cpuset.Parse(offlinedOutput)
 				offlinedCPUSetProfile, err := cpuset.Parse(string(offlined))
@@ -670,7 +670,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			workerRTNodes = getUpdatedNodes()
 			// Check offlined cpus are setting correctly
 			for _, node := range workerRTNodes {
-				offlinedOutput, err := nodes.ExecCommandOnNode(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
+				offlinedOutput, err := nodes.ExecCommandToString(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				offlinedCPUSet, err := cpuset.Parse(offlinedOutput)
 				offlinedCPUSetProfile, err := cpuset.Parse(string(offlinedSet))
@@ -734,7 +734,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			workerRTNodes = getUpdatedNodes()
 			//Check offlined cpus are setting correctly
 			for _, node := range workerRTNodes {
-				offlinedOutput, err := nodes.ExecCommandOnNode(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
+				offlinedOutput, err := nodes.ExecCommandToString(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				offlinedCPUSet, err := cpuset.Parse(offlinedOutput)
 				offlinedCPUSetProfile, err := cpuset.Parse(string(offlinedSet))
@@ -808,7 +808,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			workerRTNodes = getUpdatedNodes()
 			//Check offlined cpus are setting correctly
 			for _, node := range workerRTNodes {
-				offlinedOutput, err := nodes.ExecCommandOnNode(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
+				offlinedOutput, err := nodes.ExecCommandToString(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				offlinedCPUSet, err := cpuset.Parse(offlinedOutput)
 				offlinedCPUSetProfile, err := cpuset.Parse(string(offlinedSet))
@@ -924,7 +924,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			workerRTNodes = getUpdatedNodes()
 			//Check offlined cpus are setting correctly
 			for _, node := range workerRTNodes {
-				offlinedOutput, err := nodes.ExecCommandOnNode(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
+				offlinedOutput, err := nodes.ExecCommandToString(context.TODO(), []string{"cat", "/sys/devices/system/cpu/offline"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				offlinedCPUSet, err := cpuset.Parse(offlinedOutput)
 				offlinedCPUSetProfile, err := cpuset.Parse(string(offlinedSet))
@@ -960,7 +960,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			findcmd := `find /sys/devices/system/cpu/cpu* -type f -name online -exec cat {} \;`
 			checkCpuStatusCmd := []string{"bash", "-c", findcmd}
 			for _, node := range workerRTNodes {
-				stdout, err := nodes.ExecCommandOnNode(context.TODO(), checkCpuStatusCmd, &node)
+				stdout, err := nodes.ExecCommandToString(context.TODO(), checkCpuStatusCmd, &node)
 				Expect(err).NotTo(HaveOccurred())
 				v := strings.Split(stdout, "\n")
 				for _, val := range v {
@@ -1006,7 +1006,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			var reserved, isolated []string
 			var onlineCPUInt int
 			for _, node := range workerRTNodes {
-				onlineCPUCount, err := nodes.ExecCommandOnNode(context.TODO(), []string{"nproc", "--all"}, &node)
+				onlineCPUCount, err := nodes.ExecCommandToString(context.TODO(), []string{"nproc", "--all"}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				onlineCPUInt, err = strconv.Atoi(onlineCPUCount)
 				Expect(err).ToNot(HaveOccurred())
@@ -1065,7 +1065,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				// Verify the systemd RPS service uses the correct RPS mask
 				var maskContent string
 				cmd := []string{"sysctl", "-n", "net.core.rps_default_mask"}
-				maskContent, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &node)
+				maskContent, err := nodes.ExecCommandToString(context.TODO(), cmd, &node)
 				Expect(err).ToNot(HaveOccurred(), "failed to exec command %q on node %q", cmd, node)
 				rpsMaskContent := strings.Trim(maskContent, "\n")
 				rpsCPUs, err := components.CPUMaskToCPUSet(rpsMaskContent)
@@ -1081,7 +1081,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 					"-name", "rps_cpus",
 					"-exec", "cat", "{}", ";",
 				}
-				devsRPS, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &node)
+				devsRPS, err := nodes.ExecCommandToString(context.TODO(), cmd, &node)
 				Expect(err).ToNot(HaveOccurred(), "failed to exec command %q on node %q", cmd, node.Name)
 				for _, devRPS := range strings.Split(devsRPS, "\n") {
 					rpsCPUs, err = components.CPUMaskToCPUSet(devRPS)
@@ -1114,7 +1114,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			for _, node := range workerRTNodes {
 				// Verify the systemd RPS services were not created
 				cmd := []string{"ls", "/rootfs/etc/systemd/system/update-rps@.service"}
-				_, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &node)
+				_, err := nodes.ExecCommandToString(context.TODO(), cmd, &node)
 				Expect(err).To(HaveOccurred())
 			}
 		})
@@ -1141,7 +1141,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 				cmd := []string{"cat", "/rootfs/etc/crio/crio.conf.d/99-runtimes.conf"}
 				for i := 0; i < len(workerRTNodes); i++ {
-					out, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &workerRTNodes[i])
+					out, err := nodes.ExecCommandToString(context.TODO(), cmd, &workerRTNodes[i])
 					Expect(err).ToNot(HaveOccurred(), "cannot get 99-runtimes.conf from %q", workerRTNodes[i].Name)
 					By(fmt.Sprintf("checking node: %q", workerRTNodes[i].Name))
 					Expect(out).To(ContainSubstring("/bin/runc"))
@@ -1173,7 +1173,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				Expect(ctrcfg.Spec.ContainerRuntimeConfig.DefaultRuntime == machineconfigv1.ContainerRuntimeDefaultRuntimeCrun).To(BeTrue())
 				cmd := []string{"cat", "/rootfs/etc/crio/crio.conf.d/99-runtimes.conf"}
 				for i := 0; i < len(workerRTNodes); i++ {
-					out, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &workerRTNodes[i])
+					out, err := nodes.ExecCommandToString(context.TODO(), cmd, &workerRTNodes[i])
 					Expect(err).ToNot(HaveOccurred(), "cannot get 99-runtimes.conf from %q", workerRTNodes[i].Name)
 					By(fmt.Sprintf("checking node: %q", workerRTNodes[i].Name))
 					Expect(out).To(ContainSubstring("/usr/bin/crun"))
@@ -1214,7 +1214,7 @@ func countHugepagesOnNode(ctx context.Context, node *corev1.Node, sizeInMb int) 
 	count := 0
 	for i := 0; i < len(numaInfo); i++ {
 		nodeCmd := []string{"cat", hugepagesPathForNode(i, sizeInMb)}
-		result, err := nodes.ExecCommandOnNode(ctx, nodeCmd, node)
+		result, err := nodes.ExecCommandToString(ctx, nodeCmd, node)
 		if err != nil {
 			return 0, err
 		}

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
@@ -96,8 +96,9 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, func() {
 			It("[test_id:64097] Activation file is created", func() {
 				cmd := []string{"ls", activation_file}
 				for _, node := range workerRTNodes {
-					out, err := nodes.ExecCommandToString(context.TODO(), cmd, &node)
+					output, err := nodes.ExecCommand(context.TODO(), &node, cmd)
 					Expect(err).ToNot(HaveOccurred(), "file %s doesn't exist ", activation_file)
+					out := testutils.ToString(output)
 					Expect(out).To(Equal(activation_file))
 				}
 			})
@@ -121,7 +122,8 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, func() {
 						containerCgroupPath = filepath.Join(controller, cgroupPathOfPid)
 					}
 					cmd = []string{"cat", fmt.Sprintf("%s", filepath.Join(containerCgroupPath, "/cpuset.cpus"))}
-					cpus, err := nodes.ExecCommandToString(ctx, cmd, workerRTNode)
+					out, err = nodes.ExecCommand(ctx, workerRTNode, cmd)
+					cpus := testutils.ToString(out)
 					containerCpuset, err := cpuset.Parse(cpus)
 					Expect(containerCpuset).To(Equal(onlineCPUSet), "Burstable pod containers cpuset.cpus do not match total online cpus")
 				}
@@ -158,8 +160,9 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, func() {
 				By("Checking Activation file")
 				cmd := []string{"ls", activation_file}
 				for _, node := range workerRTNodes {
-					out, err := nodes.ExecCommandToString(context.TODO(), cmd, &node)
+					output, err := nodes.ExecCommand(context.TODO(), &node, cmd)
 					Expect(err).ToNot(HaveOccurred(), "file %s doesn't exist ", activation_file)
+					out := testutils.ToString(output)
 					Expect(out).To(Equal(activation_file))
 				}
 			})
@@ -215,15 +218,30 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, func() {
 		chkOvsCgrpProcs := func(node *corev1.Node) (string, error) {
 			testlog.Info("Verify cgroup.procs is not empty")
 			cmd := []string{"cat", cgroupProcs}
-			return nodes.ExecCommandToString(context.TODO(), cmd, node)
+			out, err := nodes.ExecCommand(context.TODO(), node, cmd)
+			if err != nil {
+				return "", err
+			}
+			output := testutils.ToString(out)
+			return output, nil
 		}
 		chkOvsCgrpCpuset := func(node *corev1.Node) (string, error) {
 			cmd := []string{"cat", cgroupCpusetCpus}
-			return nodes.ExecCommandToString(context.TODO(), cmd, node)
+			out, err := nodes.ExecCommand(context.TODO(), node, cmd)
+			if err != nil {
+				return "", err
+			}
+			output := testutils.ToString(out)
+			return output, nil
 		}
 		chkOvsCgroupLoadBalance := func(node *corev1.Node) (string, error) {
 			cmd := []string{"cat", cgroupLoadBalance}
-			return nodes.ExecCommandToString(context.TODO(), cmd, node)
+			out, err := nodes.ExecCommand(context.TODO(), node, cmd)
+			if err != nil {
+				return "", err
+			}
+			output := testutils.ToString(out)
+			return output, nil
 		}
 
 		It("[test_id:64098] Verify cgroup layout on worker node", func() {
@@ -552,10 +570,11 @@ func cpuSpecToString(cpus *performancev2.CPU) string {
 
 // checkCpuCount check if the node has sufficient cpus
 func checkCpuCount(ctx context.Context, workerNode *corev1.Node) {
-	onlineCPUCount, err := nodes.ExecCommandToString(ctx, []string{"nproc", "--all"}, workerNode)
+	out, err := nodes.ExecCommand(ctx, workerNode, []string{"nproc", "--all"})
 	if err != nil {
 		Fail(fmt.Sprintf("Failed to fetch online CPUs: %v", err))
 	}
+	onlineCPUCount := testutils.ToString(out)
 	onlineCPUInt, err := strconv.Atoi(onlineCPUCount)
 	if err != nil {
 		Fail(fmt.Sprintf("failed to convert online CPU count to integer: %v", err))
@@ -621,10 +640,11 @@ func getCPUMaskForPids(ctx context.Context, pidList []string, targetNode *corev1
 
 	for _, pid := range pidList {
 		cmd := []string{"taskset", "-pc", pid}
-		cpumask, err := nodes.ExecCommandToString(ctx, cmd, targetNode)
+		out, err := nodes.ExecCommand(ctx, targetNode, cmd)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch cpus of %s: %s", pid, err)
 		}
+		cpumask := testutils.ToString(out)
 
 		mask := strings.SplitAfter(cpumask, " ")
 		maskSet, err := cpuset.Parse(mask[len(mask)-1])
@@ -733,8 +753,9 @@ func ovsPids(ctx context.Context, ovsSystemdServices []string, workerRTNode *cor
 // taskSet returns cpus used by the pid
 func taskSet(ctx context.Context, pid string, workerRTNode *corev1.Node) cpuset.CPUSet {
 	cmd := []string{"taskset", "-pc", pid}
-	output, err := nodes.ExecCommandToString(ctx, cmd, workerRTNode)
+	out, err := nodes.ExecCommand(ctx, workerRTNode, cmd)
 	Expect(err).ToNot(HaveOccurred(), "unable to fetch cpus using taskset")
+	output := testutils.ToString(out)
 	tasksetOutput := strings.Split(strings.TrimSpace(output), ":")
 	cpus := strings.TrimSpace(tasksetOutput[1])
 	ctnCpuset, err := cpuset.Parse(cpus)

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
@@ -81,8 +81,9 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 			}
 			kubeletArguments := []string{"/bin/bash", "-c", "ps -ef | grep kubelet | grep config"}
 			for _, node := range workerRTNodes {
-				stdout, err := nodes.ExecCommandToString(context.TODO(), kubeletArguments, &node)
+				out, err := nodes.ExecCommand(context.TODO(), &node, kubeletArguments)
 				Expect(err).ToNot(HaveOccurred())
+				stdout := testutils.ToString(out)
 				Expect(strings.Contains(stdout, "300Mi")).To(BeTrue())
 			}
 		})
@@ -215,8 +216,9 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 				Expect(kubeletConfig.ImageMinimumGCAge.Seconds()).ToNot(Equal(180))
 			}
 			for _, node := range workerRTNodes {
-				stdout, err := nodes.ExecCommandToString(context.TODO(), kubeletArguments, &node)
+				out, err := nodes.ExecCommand(context.TODO(), &node, kubeletArguments)
 				Expect(err).ToNot(HaveOccurred())
+				stdout := testutils.ToString(out)
 				Expect(strings.Contains(stdout, "300Mi")).To(BeTrue())
 			}
 

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
@@ -81,7 +81,7 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 			}
 			kubeletArguments := []string{"/bin/bash", "-c", "ps -ef | grep kubelet | grep config"}
 			for _, node := range workerRTNodes {
-				stdout, err := nodes.ExecCommandOnNode(context.TODO(), kubeletArguments, &node)
+				stdout, err := nodes.ExecCommandToString(context.TODO(), kubeletArguments, &node)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(strings.Contains(stdout, "300Mi")).To(BeTrue())
 			}
@@ -215,7 +215,7 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 				Expect(kubeletConfig.ImageMinimumGCAge.Seconds()).ToNot(Equal(180))
 			}
 			for _, node := range workerRTNodes {
-				stdout, err := nodes.ExecCommandOnNode(context.TODO(), kubeletArguments, &node)
+				stdout, err := nodes.ExecCommandToString(context.TODO(), kubeletArguments, &node)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(strings.Contains(stdout, "300Mi")).To(BeTrue())
 			}

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -341,7 +341,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				}
 
 				By("Verifying node kernel arguments")
-				cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &workerRTNodes[0], []string{"cat", "/proc/cmdline"})
+				cmdline, err := nodes.ExecCommand(context.TODO(), &workerRTNodes[0], []string{"cat", "/proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cmdline).To(ContainSubstring("intel_pstate=passive"))
 				Expect(cmdline).ToNot(ContainSubstring("intel_pstate=active"))
@@ -718,7 +718,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				containerCgroup := ""
 				pid, err := nodes.ContainerPid(context.TODO(), &workerRTNodes[0], containerID)
 				cmd := []string{"cat", fmt.Sprintf("/rootfs/proc/%s/cgroup", pid)}
-				out, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &workerRTNodes[0], cmd)
+				out, err := nodes.ExecCommand(context.TODO(), &workerRTNodes[0], cmd)
 				containerCgroup, err = cgroup.PidParser(out)
 				cgroupv2, err := cgroup.IsVersion2(context.TODO(), testclient.Client)
 				Expect(err).ToNot(HaveOccurred())
@@ -731,7 +731,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				testlog.Infof("test pod %s with container id %s cgroup path %s", testpod.Name, containerID, cpusetCpusPath)
 				By("Verify powersetting of cpus used by the pod")
 				cmd = []string{"cat", cpusetCpusPath}
-				output, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &workerRTNodes[0])
+				output, err := nodes.ExecCommandToString(context.TODO(), cmd, &workerRTNodes[0])
 				Expect(err).ToNot(HaveOccurred())
 				cpus, err := cpuset.Parse(output)
 				targetCpus := cpus.List()
@@ -822,7 +822,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 
 				pid, err := nodes.ContainerPid(context.TODO(), &workerRTNodes[0], containerID)
 				cmd := []string{"cat", fmt.Sprintf("/rootfs/proc/%s/cgroup", pid)}
-				out, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &workerRTNodes[0], cmd)
+				out, err := nodes.ExecCommand(context.TODO(), &workerRTNodes[0], cmd)
 				containerCgroup, err = cgroup.PidParser(out)
 				cgroupv2, err := cgroup.IsVersion2(context.TODO(), testclient.Client)
 				Expect(err).ToNot(HaveOccurred())
@@ -835,7 +835,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				testlog.Infof("test pod %s with container id %s cgroup path %s", testpod.Name, containerID, cpusetCpusPath)
 				By("Verify powersetting of cpus used by the pod")
 				cmd = []string{"cat", cpusetCpusPath}
-				output, err := nodes.ExecCommandOnNode(context.TODO(), cmd, &workerRTNodes[0])
+				output, err := nodes.ExecCommandToString(context.TODO(), cmd, &workerRTNodes[0])
 				Expect(err).ToNot(HaveOccurred())
 				cpus, err := cpuset.Parse(output)
 				targetCpus := cpus.List()
@@ -939,13 +939,13 @@ func deleteTestPod(ctx context.Context, testpod *corev1.Pod) {
 func checkCpuGovernorsAndResumeLatency(ctx context.Context, cpus []int, targetNode *corev1.Node, pm_qos string, governor string) error {
 	for _, cpu := range cpus {
 		cmd := []string{"/bin/bash", "-c", fmt.Sprintf("cat /sys/devices/system/cpu/cpu%d/power/pm_qos_resume_latency_us", cpu)}
-		output, err := nodes.ExecCommandOnNode(ctx, cmd, targetNode)
+		output, err := nodes.ExecCommandToString(ctx, cmd, targetNode)
 		if err != nil {
 			return err
 		}
 		Expect(output).To(Equal(pm_qos))
 		cmd = []string{"/bin/bash", "-c", fmt.Sprintf("cat /sys/devices/system/cpu/cpu%d/cpufreq/scaling_governor", cpu)}
-		output, err = nodes.ExecCommandOnNode(ctx, cmd, targetNode)
+		output, err = nodes.ExecCommandToString(ctx, cmd, targetNode)
 		if err != nil {
 			return err
 		}
@@ -964,7 +964,7 @@ func checkHardwareCapability(ctx context.Context, workerRTNodes []corev1.Node) {
 			Skip(fmt.Sprintf("This test need 2 NUMA nodes.The number of NUMA nodes on node %s < 2", node.Name))
 		}
 		// Additional check so that test gets skipped on vm with fake numa
-		onlineCPUCount, err := nodes.ExecCommandOnNode(ctx, []string{"nproc", "--all"}, &node)
+		onlineCPUCount, err := nodes.ExecCommandToString(ctx, []string{"nproc", "--all"}, &node)
 		Expect(err).ToNot(HaveOccurred())
 		onlineCPUInt, err := strconv.Atoi(onlineCPUCount)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/performanceprofile/functests/9_reboot/devices.go
+++ b/test/e2e/performanceprofile/functests/9_reboot/devices.go
@@ -377,7 +377,7 @@ func waitForNodeReadyOrFail(tag, nodeName string, timeout, polling time.Duration
 
 func runCommandOnNodeThroughMCD(ctx context.Context, node *corev1.Node, description, command string) (string, error) {
 	testlog.Infof("node %q: before %s", node.Name, description)
-	out, err := testnodes.ExecCommandOnMachineConfigDaemon(ctx, node, []string{"sh", "-c", command})
+	out, err := testnodes.ExecCommand(ctx, node, []string{"sh", "-c", command})
 	testlog.Infof("node %q: output=[%s]", node.Name, string(out))
 	testlog.Infof("node %q: after %s", node.Name, description)
 	return string(out), err

--- a/test/e2e/performanceprofile/functests/Z_deconfig/Z_deconfig_suite_test.go
+++ b/test/e2e/performanceprofile/functests/Z_deconfig/Z_deconfig_suite_test.go
@@ -1,0 +1,13 @@
+package Z_deconfig_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestZDeconfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ZDeconfig Suite")
+}

--- a/test/e2e/performanceprofile/functests/Z_deconfig/deconfig.go
+++ b/test/e2e/performanceprofile/functests/Z_deconfig/deconfig.go
@@ -1,0 +1,24 @@
+package Z_deconfig
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
+	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/namespaces"
+	nodeInspector "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/node_inspector"
+)
+
+// This test suite is designed to perform cleanup actions that should occur after all test suites have been executed.
+
+var _ = Describe("Deconfig", func() {
+	It("should delete the node inspector and its namespace", func() {
+		err := nodeInspector.Delete(testclient.DataPlaneClient, testutils.NodeInspectorNamespace, testutils.NodeInspectorName)
+		Expect(err).ToNot(HaveOccurred())
+		err = namespaces.WaitForDeletion(testutils.NodeInspectorNamespace, 5*time.Minute)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/test/e2e/performanceprofile/functests/utils/cgroup/runtime/runtime.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/runtime/runtime.go
@@ -32,7 +32,7 @@ func GetContainerRuntimeTypeFor(ctx context.Context, c client.Client, pod *corev
 		"-c",
 		fmt.Sprintf("/bin/awk -F '\"'  '/runtime_path.*/ { print $2 }' %s", CRIORuntimeConfigFile),
 	}
-	out, err := nodes.ExecCommandOnNode(ctx, cmd, node)
+	out, err := nodes.ExecCommandToString(ctx, cmd, node)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute command on node; cmd=%q node=%q err=%v", cmd, node.Name, err)
 	}

--- a/test/e2e/performanceprofile/functests/utils/cgroup/runtime/runtime.go
+++ b/test/e2e/performanceprofile/functests/utils/cgroup/runtime/runtime.go
@@ -9,6 +9,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
 )
 
@@ -32,9 +33,10 @@ func GetContainerRuntimeTypeFor(ctx context.Context, c client.Client, pod *corev
 		"-c",
 		fmt.Sprintf("/bin/awk -F '\"'  '/runtime_path.*/ { print $2 }' %s", CRIORuntimeConfigFile),
 	}
-	out, err := nodes.ExecCommandToString(ctx, cmd, node)
+	output, err := nodes.ExecCommand(ctx, node, cmd)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute command on node; cmd=%q node=%q err=%v", cmd, node.Name, err)
 	}
+	out := testutils.ToString(output)
 	return filepath.Base(out), nil
 }

--- a/test/e2e/performanceprofile/functests/utils/consts.go
+++ b/test/e2e/performanceprofile/functests/utils/consts.go
@@ -102,6 +102,12 @@ const (
 	// NamespaceTesting contains the name of the testing namespace
 	NamespaceTesting = "performance-addon-operators-testing"
 )
+const (
+	// NodeInspectorName contains the name of node inspector name
+	NodeInspectorName = "node-inspector"
+	// NodeInspectorNamespace contains the name of node inspector namespace
+	NodeInspectorNamespace = "node-inspector-ns"
+)
 
 const (
 	// FilePathKubeletConfig contains the kubelet.conf file path

--- a/test/e2e/performanceprofile/functests/utils/infrastructure/vm.go
+++ b/test/e2e/performanceprofile/functests/utils/infrastructure/vm.go
@@ -16,7 +16,7 @@ func IsVM(node *corev1.Node) (bool, error) {
 		"-c",
 		"systemd-detect-virt > /dev/null ; echo $?",
 	}
-	output, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), node, cmd)
+	output, err := nodes.ExecCommand(context.TODO(), node, cmd)
 	if err != nil {
 		return false, err
 	}

--- a/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
+++ b/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
@@ -42,6 +42,13 @@ var TestingNamespace = &corev1.Namespace{
 	},
 }
 
+// NodeInspectorNamespace is the namespace used for deploying a daemonset that will be used to executing commands on nodes.
+var NodeInspectorNamespace = &corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: testutils.NodeInspectorNamespace,
+	},
+}
+
 // WaitForDeletion waits until the namespace will be removed from the cluster
 func WaitForDeletion(name string, timeout time.Duration) error {
 	key := types.NamespacedName{

--- a/test/e2e/performanceprofile/functests/utils/node_inspector/inspector.go
+++ b/test/e2e/performanceprofile/functests/utils/node_inspector/inspector.go
@@ -1,0 +1,186 @@
+package node_inspector
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/daemonset"
+)
+
+const serviceAccountSuffix = "sa"
+const clusterRoleSuffix = "cr"
+const clusterRoleBindingSuffix = "crb"
+
+func Create(cli client.Client, namespace, name, image string) error {
+	serviceAccountName := fmt.Sprintf("%s-%s", name, serviceAccountSuffix)
+	sa := createServiceAccount(serviceAccountName, namespace)
+	if err := cli.Create(context.Background(), sa); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	clusterRoleName := fmt.Sprintf("%s-%s", name, clusterRoleSuffix)
+	cr := createClusterRole(clusterRoleName)
+	if err := cli.Create(context.Background(), cr); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	clusterRoleBindingName := fmt.Sprintf("%s-%s", name, clusterRoleBindingSuffix)
+	rb := createClusterRoleBinding(clusterRoleBindingName, namespace, serviceAccountName, clusterRoleName)
+	if err := cli.Create(context.Background(), rb); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	ds := createDaemonSet(name, namespace, serviceAccountName, image)
+	if err := cli.Create(context.Background(), ds); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	if err := daemonset.WaitToBeRunning(cli, namespace, name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Delete(cli client.Client, namespace, name string) error {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	if err := cli.Delete(context.Background(), ns); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", name, clusterRoleSuffix)}}
+	if err := cli.Delete(context.Background(), cr); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func IsRunning(cli client.Client, namespace, name string) (bool,error){
+	return daemonset.IsRunning(cli, namespace, name)
+}
+
+func createDaemonSet(name, namespace, serviceAccountName, image string) *appsv1.DaemonSet {
+	MountPropagationHostToContainer := corev1.MountPropagationHostToContainer
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"name": name,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": name,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+					},
+					Labels: map[string]string{
+						"name": name,
+					},
+				},
+				Spec: corev1.PodSpec{
+					HostPID:                       true,
+					HostNetwork:                   true,
+					ServiceAccountName:            serviceAccountName,
+					TerminationGracePeriodSeconds: pointer.Int64(0),
+					NodeSelector:                  map[string]string{"kubernetes.io/os": "linux"},
+					Containers: []corev1.Container{
+						{
+							Name:            "node-daemon",
+							Image:           image,
+							Command:         []string{"/bin/bash", "-c", "sleep INF"},
+							ImagePullPolicy: corev1.PullAlways,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("20m"),
+									"memory": resource.MustParse("50Mi"),
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged:             pointer.Bool(true),
+								ReadOnlyRootFilesystem: pointer.Bool(true),
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									MountPath:        "/rootfs",
+									Name:             "rootfs",
+									MountPropagation: &MountPropagationHostToContainer,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "rootfs",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/",
+								},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createServiceAccount(name, namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func createClusterRole(name string) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"security.openshift.io"},
+				ResourceNames: []string{"privileged"},
+				Resources:     []string{"securitycontextconstraints"},
+				Verbs:         []string{"use"},
+			},
+		},
+	}
+}
+
+func createClusterRoleBinding(name, namespace, serviceAccountName, clusterRoleName string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccountName,
+				Namespace: namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+}

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -28,7 +28,7 @@ import (
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cluster"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
-	testpods "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/pods"
+	nodeInspector "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/node_inspector"
 )
 
 const (
@@ -140,39 +140,14 @@ func GetNonPerformancesWorkers(nodeSelectorLabels map[string]string) ([]corev1.N
 	return nonPerformanceWorkerNodes, err
 }
 
-// GetMachineConfigDaemonByNode returns the machine-config-daemon pod that runs on the specified node
-func GetMachineConfigDaemonByNode(node *corev1.Node) (*corev1.Pod, error) {
-	listOptions := &client.ListOptions{
-		Namespace:     testutils.NamespaceMachineConfigOperator,
-		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}),
-		LabelSelector: labels.SelectorFromSet(labels.Set{"k8s-app": "machine-config-daemon"}),
-	}
-
-	mcds := &corev1.PodList{}
-	if err := testclient.Client.List(context.TODO(), mcds, listOptions); err != nil {
-		return nil, err
-	}
-
-	if len(mcds.Items) < 1 {
-		return nil, fmt.Errorf("failed to get machine-config-daemon pod for the node %q", node.Name)
-	}
-	return &mcds.Items[0], nil
+// ExecCommand returns the output of the command execution as a []byte
+func ExecCommand(ctx context.Context, node *corev1.Node, command []string) ([]byte, error) {
+	return nodeInspector.ExecCommand(ctx, node, command)
 }
 
-// ExecCommandOnMachineConfigDaemon returns the output of the command execution on the machine-config-daemon pod that runs on the specified node
-func ExecCommandOnMachineConfigDaemon(ctx context.Context, node *corev1.Node, command []string) ([]byte, error) {
-	mcd, err := GetMachineConfigDaemonByNode(node)
-	if err != nil {
-		return nil, err
-	}
-	testlog.Infof("found mcd %s for node %s", mcd.Name, node.Name)
-
-	return testpods.WaitForPodOutput(ctx, testclient.K8sClient, mcd, command)
-}
-
-// ExecCommandOnNode executes given command on given node and returns the result
-func ExecCommandOnNode(ctx context.Context, cmd []string, node *corev1.Node) (string, error) {
-	out, err := ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+// ExecCommandToString returns the output of the command execution in a string format
+func ExecCommandToString(ctx context.Context, cmd []string, node *corev1.Node) (string, error) {
+	out, err := ExecCommand(ctx, node, cmd)
 	if err != nil {
 		return "", err
 	}
@@ -184,7 +159,7 @@ func ExecCommandOnNode(ctx context.Context, cmd []string, node *corev1.Node) (st
 // GetKubeletConfig returns KubeletConfiguration loaded from the node /etc/kubernetes/kubelet.conf
 func GetKubeletConfig(ctx context.Context, node *corev1.Node) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
 	command := []string{"cat", path.Join("/rootfs", testutils.FilePathKubeletConfig)}
-	kubeletBytes, err := ExecCommandOnMachineConfigDaemon(ctx, node, command)
+	kubeletBytes, err := ExecCommand(ctx, node, command)
 	if err != nil {
 		return nil, err
 	}
@@ -242,12 +217,12 @@ func HasPreemptRTKernel(ctx context.Context, node *corev1.Node) error {
 	// with rpm-ostree rpm -q is telling you what you're booted into always,
 	// because ostree binds together (kernel, userspace) as a single commit.
 	cmd := []string{"chroot", "/rootfs", "rpm", "-q", "kernel-rt-core"}
-	if _, err := ExecCommandOnNode(ctx, cmd, node); err != nil {
+	if _, err := ExecCommandToString(ctx, cmd, node); err != nil {
 		return err
 	}
 
 	cmd = []string{"/bin/bash", "-c", "cat /rootfs/sys/kernel/realtime"}
-	out, err := ExecCommandOnNode(ctx, cmd, node)
+	out, err := ExecCommandToString(ctx, cmd, node)
 	if err != nil {
 		return err
 	}
@@ -261,7 +236,7 @@ func HasPreemptRTKernel(ctx context.Context, node *corev1.Node) error {
 
 func GetDefaultSmpAffinityRaw(ctx context.Context, node *corev1.Node) (string, error) {
 	cmd := []string{"cat", "/proc/irq/default_smp_affinity"}
-	return ExecCommandOnNode(ctx, cmd, node)
+	return ExecCommandToString(ctx, cmd, node)
 }
 
 // GetDefaultSmpAffinitySet returns the default smp affinity mask for the node
@@ -281,7 +256,7 @@ func GetDefaultSmpAffinitySet(ctx context.Context, node *corev1.Node) (cpuset.CP
 // GetOnlineCPUsSet returns the list of online (being scheduled) CPUs on the node
 func GetOnlineCPUsSet(ctx context.Context, node *corev1.Node) (cpuset.CPUSet, error) {
 	command := []string{"cat", sysDevicesOnlineCPUs}
-	onlineCPUs, err := ExecCommandOnNode(ctx, command, node)
+	onlineCPUs, err := ExecCommandToString(ctx, command, node)
 	if err != nil {
 		return cpuset.New(), err
 	}
@@ -292,7 +267,7 @@ func GetOnlineCPUsSet(ctx context.Context, node *corev1.Node) (cpuset.CPUSet, er
 // Use a random cpuID from the return value of GetOnlineCPUsSet if not sure
 func GetSMTLevel(ctx context.Context, cpuID int, node *corev1.Node) int {
 	cmd := []string{"/bin/sh", "-c", fmt.Sprintf("cat /sys/devices/system/cpu/cpu%d/topology/thread_siblings_list | tr -d \"\n\r\"", cpuID)}
-	threadSiblingsList, err := ExecCommandOnNode(ctx, cmd, node)
+	threadSiblingsList, err := ExecCommandToString(ctx, cmd, node)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	// how many thread sibling you have = SMT level
 	// example: 2-way SMT means 2 threads sibling for each thread
@@ -304,7 +279,7 @@ func GetSMTLevel(ctx context.Context, cpuID int, node *corev1.Node) int {
 // GetNumaNodes returns the number of numa nodes and the associated cpus as list on the node
 func GetNumaNodes(ctx context.Context, node *corev1.Node) (map[int][]int, error) {
 	lscpuCmd := []string{"lscpu", "-e=node,core,cpu", "-J"}
-	cmdout, err := ExecCommandOnNode(ctx, lscpuCmd, node)
+	cmdout, err := ExecCommandToString(ctx, lscpuCmd, node)
 	var numaNode, cpu int
 	if err != nil {
 		return nil, err
@@ -330,7 +305,7 @@ func GetNumaNodes(ctx context.Context, node *corev1.Node) (map[int][]int, error)
 // GetCoreSiblings returns the siblings of core per numa node
 func GetCoreSiblings(ctx context.Context, node *corev1.Node) (map[int]map[int][]int, error) {
 	lscpuCmd := []string{"lscpu", "-e=node,core,cpu", "-J"}
-	out, err := ExecCommandOnNode(ctx, lscpuCmd, node)
+	out, err := ExecCommandToString(ctx, lscpuCmd, node)
 	var result NumaNodes
 	var numaNode, core, cpu int
 	coreSiblings := make(map[int]map[int][]int)
@@ -465,17 +440,17 @@ func GetNumaRanges(cpuString string) string {
 func GetNodeInterfaces(ctx context.Context, node corev1.Node) ([]NodeInterface, error) {
 	var nodeInterfaces []NodeInterface
 	listNetworkInterfacesCmd := []string{"/bin/sh", "-c", fmt.Sprintf("ls -l /sys/class/net")}
-	networkInterfaces, err := ExecCommandOnMachineConfigDaemon(ctx, &node, listNetworkInterfacesCmd)
+	networkInterfaces, err := ExecCommand(ctx, &node, listNetworkInterfacesCmd)
 	if err != nil {
 		return nil, err
 	}
 	ipLinkShowCmd := []string{"ip", "link", "show"}
-	interfaceLinksStatus, err := ExecCommandOnMachineConfigDaemon(ctx, &node, ipLinkShowCmd)
+	interfaceLinksStatus, err := ExecCommand(ctx, &node, ipLinkShowCmd)
 	if err != nil {
 		return nil, err
 	}
 	defaultRouteCmd := []string{"ip", "route", "show", "0.0.0.0/0"}
-	defaultRoute, err := ExecCommandOnMachineConfigDaemon(ctx, &node, defaultRouteCmd)
+	defaultRoute, err := ExecCommand(ctx, &node, defaultRouteCmd)
 	if err != nil {
 		return nil, err
 	}
@@ -541,7 +516,7 @@ func ContainerPid(ctx context.Context, node *corev1.Node, containerId string) (s
 	var cridata = []byte{}
 	Eventually(func() []byte {
 		cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs crictl inspect %s", containerId)}
-		cridata, err = ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+		cridata, err = ExecCommand(ctx, node, cmd)
 		Expect(err).ToNot(HaveOccurred(), "failed to run %s cmd", cmd)
 		return cridata
 	}, 10*time.Second, 5*time.Second).ShouldNot(BeEmpty())
@@ -557,7 +532,7 @@ func CpuManagerCpuSet(ctx context.Context, node *corev1.Node) (cpuset.CPUSet, er
 	stateFilePath := "/var/lib/kubelet/cpu_manager_state"
 	var stateData CpuManagerStateInfo
 	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs cat %s", stateFilePath)}
-	data, err := ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+	data, err := ExecCommand(ctx, node, cmd)
 	err = json.Unmarshal(data, &stateData)
 	if err != nil {
 		return cpuset.New(), err

--- a/test/e2e/performanceprofile/functests/utils/systemd/systemd.go
+++ b/test/e2e/performanceprofile/functests/utils/systemd/systemd.go
@@ -10,12 +10,12 @@ import (
 
 func Status(ctx context.Context, unitfile string, node *corev1.Node) (string, error) {
 	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs systemctl status %s --lines=0 --no-pager", unitfile)}
-	out, err := nodes.ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+	out, err := nodes.ExecCommand(ctx, node, cmd)
 	return string(out), err
 }
 
 func ShowProperty(ctx context.Context, unitfile string, property string, node *corev1.Node) (string, error) {
 	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs systemctl show -p %s %s --no-pager", property, unitfile)}
-	out, err := nodes.ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
+	out, err := nodes.ExecCommand(ctx, node, cmd)
 	return string(out), err
 }

--- a/test/e2e/performanceprofile/functests/utils/utils.go
+++ b/test/e2e/performanceprofile/functests/utils/utils.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/bugzilla"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/jira"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/bugzilla"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/jira"
 
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 
@@ -112,4 +113,9 @@ func KnownIssueBugzilla(bugId int) {
 	} else {
 		testlog.Infof(fmt.Sprintf("Test is linked to a closed Bugzilla bug rhbz#%d - %s", bug.Id, bug.Summary))
 	}
+}
+
+func ToString(b []byte) string {
+	trimmedString := strings.Trim(string(b), "\n")
+	return strings.ReplaceAll(trimmedString, "\r", "")
 }


### PR DESCRIPTION
On hypershift there is no MCO, hence there are no machine-config-daemon pods.
A different resolution is needed for accessing the underlying node for inspecting configurations.
This commit introduces a node inspector implemented as a daemonset.
Upon execution of test suites, a pod with elevated privileges and host filesystem mounted will be deployed on every node.
Also I have added Z-deconfig suite ('Z' prefix, will guarantee that it will be the last suite run) that will be used for cleanup.
This API will be used for both hypershift and non-hypershift systems.