### PR TITLE
OCPBUGS-30647: NTO operand (openshift-tuned) fixes

### DIFF
--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -445,28 +445,19 @@ func providerExtract(provider string) error {
 // match 'provider'.  Returns indication whether the 'provider' changed and
 // an error if any.
 func providerSync(provider string) (bool, error) {
-	var providerCurrent string
-
-	f, err := os.Open(openshiftTunedProvider)
+	providerCurrent, err := os.ReadFile(openshiftTunedProvider)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// The provider file hasn't been created yet.
 			return len(provider) > 0, providerExtract(provider)
 		}
 		return false, err
 	}
-	defer f.Close()
 
-	var scanner = bufio.NewScanner(f)
-	for scanner.Scan() {
-		providerCurrent = strings.TrimSpace(scanner.Text())
+	if provider == string(providerCurrent) {
+		return false, nil
 	}
 
-	if provider != providerCurrent {
-		return true, providerExtract(provider)
-	}
-
-	return false, nil
+	return true, providerExtract(provider)
 }
 
 func TunedRecommendFileWrite(profileName string) error {


### PR DESCRIPTION
Changes:
  * fix logging in `updateTunedProfile()` and optimize the calls to update node annotations and update Profile.Status
  * clean up `tunedStop()` to return only one value
  * during `TuneD` process shutdown, handle the fact the `TuneD` process might have already exitted
  * the openshift-tuned operand now no longer unnecessarily exits when `TuneD` process exits; when `TuneD` process exits, wait for k8s object changes and only then restart `TuneD`
  * do not use buffered channels
  * the indication that `TuneD` is reloading is now a status bit potentially reportable back to the operator
  * introduce Change type for the `TuneD` event processor to avoid races, where it was previously possible to change `TuneD` configuration during `TuneD` profile reload
  * register the fact `TuneD` finished reloading in case the primary `TuneD` profile does not exist
  * conditional `TuneD` reload when Cloud Provider changes
  * minor logging and comment improvements