### PR TITLE
PSAP-1354: Updated a script for deploying a custom NTO image to a cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN INSTALL_PKGS=" \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
-    find /root/rpms -name \*.rpm -exec basename {} .rpm \; | xargs rpm -e --justdb && \
     rm -rf /var/lib/ocp-tuned/{tuned,performanceprofile} && \
     sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|' /etc/tuned/tuned-main.conf && \
     touch /etc/sysctl.conf $APP_ROOT/provider && \


### PR DESCRIPTION
 Updated a script to deploy a custom NTO image to a cluster
* Using this script developers could easily test their code.
Running it will replace the NTO image in the current running operator deployment with the custom image.

 Updated HACKING.md to build & deploy custom NTO image
* It is important to make sure this file contains correct steps, and does not turn outdated.
Therefore, a new contributor reading HACKING.md file is able to deploy a custom version of NTO.