### PR TITLE
NO-JIRA: E2E: use strings.CutPrefix instead of trim function to get containerID

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/pods/pods.go
+++ b/test/e2e/performanceprofile/functests/utils/pods/pods.go
@@ -207,7 +207,11 @@ func GetContainerIDByName(pod *corev1.Pod, containerName string) (string, error)
 	}
 	for _, containerStatus := range updatedPod.Status.ContainerStatuses {
 		if containerStatus.Name == containerName {
-			return strings.Trim(containerStatus.ContainerID, "cri-o://"), nil
+			containerID := containerStatus.ContainerID
+			// Split the container ID at the "://" delimiter, keeping the second part:
+			containerID = strings.SplitN(containerID, "://", 2)[1]
+			return containerID, nil
+
 		}
 	}
 	return "", fmt.Errorf("failed to find the container ID for the container %q under the pod %q", containerName, pod.Name)


### PR DESCRIPTION
earlier when using strings.Trim , if the containerID contains any  characters from "cri-o://" it can remove these characters giving us invalid containerID

Instead of using Trim use the strings.CutPrefix method to fetch the containerID