### PR TITLE
CNF-6517: [Part 1]  Hypershift PAO adoption 

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -119,7 +119,7 @@ const (
 
 // New returns new machine configuration object for performance sensitive workloads
 func New(profile *performancev2.PerformanceProfile, opts *components.MachineConfigOptions) (*machineconfigv1.MachineConfig, error) {
-	name := GetMachineConfigName(profile)
+	name := GetMachineConfigName(profile.Name)
 	mc := &machineconfigv1.MachineConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: machineconfigv1.GroupVersion.String(),
@@ -157,8 +157,8 @@ func New(profile *performancev2.PerformanceProfile, opts *components.MachineConf
 }
 
 // GetMachineConfigName generates machine config name from the performance profile
-func GetMachineConfigName(profile *performancev2.PerformanceProfile) string {
-	name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
+func GetMachineConfigName(profileName string) string {
+	name := components.GetComponentName(profileName, components.ComponentNamePrefix)
 	return fmt.Sprintf("50-%s", name)
 }
 

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -282,13 +282,13 @@ func (r *PerformanceProfileReconciler) ctrRuntimeConfToPerformanceProfile(ctx co
 	return allRequests
 }
 
-func (r *PerformanceProfileReconciler) getInfraPartitioningMode() (pinning apiconfigv1.CPUPartitioningMode, err error) {
+func getInfraPartitioningMode(ctx context.Context, client client.Client) (pinning apiconfigv1.CPUPartitioningMode, err error) {
 	key := types.NamespacedName{
 		Name: "cluster",
 	}
 	infra := &apiconfigv1.Infrastructure{}
 
-	if err = r.Client.Get(context.Background(), key, infra); err != nil {
+	if err = client.Get(ctx, key, infra); err != nil {
 		return
 	}
 
@@ -434,7 +434,7 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return reconcile.Result{}, nil
 	}
 
-	pinningMode, err := r.getInfraPartitioningMode()
+	pinningMode, err := getInfraPartitioningMode(ctx, r.Client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Controller", func() {
 			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
 			key := types.NamespacedName{
-				Name:      machineconfig.GetMachineConfigName(profile),
+				Name:      machineconfig.GetMachineConfigName(profile.Name),
 				Namespace: metav1.NamespaceNone,
 			}
 
@@ -380,7 +380,7 @@ var _ = Describe("Controller", func() {
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
 				key := types.NamespacedName{
-					Name:      machineconfig.GetMachineConfigName(profile),
+					Name:      machineconfig.GetMachineConfigName(profile.Name),
 					Namespace: metav1.NamespaceNone,
 				}
 
@@ -532,7 +532,7 @@ var _ = Describe("Controller", func() {
 
 				By("Verifying MC update")
 				key = types.NamespacedName{
-					Name:      machineconfig.GetMachineConfigName(profile),
+					Name:      machineconfig.GetMachineConfigName(profile.Name),
 					Namespace: metav1.NamespaceNone,
 				}
 				mc := &mcov1.MachineConfig{}
@@ -886,7 +886,7 @@ var _ = Describe("Controller", func() {
 
 			By("Verifying MC update")
 			key := types.NamespacedName{
-				Name:      machineconfig.GetMachineConfigName(profile),
+				Name:      machineconfig.GetMachineConfigName(profile.Name),
 				Namespace: metav1.NamespaceNone,
 			}
 			mc = &mcov1.MachineConfig{}
@@ -1002,7 +1002,7 @@ var _ = Describe("Controller", func() {
 
 			By("Verifying MC update")
 			key := types.NamespacedName{
-				Name:      machineconfig.GetMachineConfigName(profile),
+				Name:      machineconfig.GetMachineConfigName(profile.Name),
 				Namespace: metav1.NamespaceNone,
 			}
 			mc = &mcov1.MachineConfig{}
@@ -1048,7 +1048,7 @@ var _ = Describe("Controller", func() {
 
 			By("Verifying MC update")
 			key := types.NamespacedName{
-				Name:      machineconfig.GetMachineConfigName(profile),
+				Name:      machineconfig.GetMachineConfigName(profile.Name),
 				Namespace: metav1.NamespaceNone,
 			}
 			mc = &mcov1.MachineConfig{}

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/runtimeclass"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/tuned"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/status"
 	testutils "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/utils/testing"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
@@ -203,7 +204,7 @@ var _ = Describe("Controller", func() {
 			degradedCondition := conditionsv1.FindStatusCondition(updatedProfile.Status.Conditions, conditionsv1.ConditionDegraded)
 			Expect(degradedCondition.Status).To(Equal(corev1.ConditionTrue))
 			Expect(degradedCondition.Message).To(Equal("Test failure condition"))
-			Expect(degradedCondition.Reason).To(Equal(conditionKubeletFailed))
+			Expect(degradedCondition.Reason).To(Equal(status.ConditionKubeletFailed))
 		})
 
 		It("should not promote old failure condition", func() {
@@ -660,7 +661,7 @@ var _ = Describe("Controller", func() {
 				degradedCondition := conditionsv1.FindStatusCondition(updatedProfile.Status.Conditions, conditionsv1.ConditionDegraded)
 				Expect(degradedCondition).ToNot(BeNil())
 				Expect(degradedCondition.Status).To(Equal(corev1.ConditionTrue))
-				Expect(degradedCondition.Reason).To(Equal(conditionReasonMCPDegraded))
+				Expect(degradedCondition.Reason).To(Equal(status.ConditionReasonMCPDegraded))
 				Expect(degradedCondition.Message).To(ContainSubstring(mcpMessage))
 			})
 
@@ -726,7 +727,7 @@ var _ = Describe("Controller", func() {
 				degradedCondition := conditionsv1.FindStatusCondition(updatedProfile.Status.Conditions, conditionsv1.ConditionDegraded)
 				Expect(degradedCondition).ToNot(BeNil())
 				Expect(degradedCondition.Status).To(Equal(corev1.ConditionTrue))
-				Expect(degradedCondition.Reason).To(Equal(conditionReasonTunedDegraded))
+				Expect(degradedCondition.Reason).To(Equal(status.ConditionReasonTunedDegraded))
 				Expect(degradedCondition.Message).To(ContainSubstring(tunedMessage))
 			})
 		})
@@ -753,7 +754,7 @@ var _ = Describe("Controller", func() {
 				degradedCondition := conditionsv1.FindStatusCondition(updatedProfile.Status.Conditions, conditionsv1.ConditionDegraded)
 				Expect(degradedCondition).ToNot(BeNil())
 				Expect(degradedCondition.Status).To(Equal(corev1.ConditionTrue))
-				Expect(degradedCondition.Reason).To(Equal(conditionBadMachineConfigLabels))
+				Expect(degradedCondition.Reason).To(Equal(status.ConditionBadMachineConfigLabels))
 				Expect(degradedCondition.Message).To(ContainSubstring("provided via profile.spec.machineConfigLabel do not match the MachineConfigPool"))
 			})
 		})
@@ -781,7 +782,7 @@ var _ = Describe("Controller", func() {
 				degradedCondition := conditionsv1.FindStatusCondition(updatedProfile.Status.Conditions, conditionsv1.ConditionDegraded)
 				Expect(degradedCondition).ToNot(BeNil())
 				Expect(degradedCondition.Status).To(Equal(corev1.ConditionTrue))
-				Expect(degradedCondition.Reason).To(Equal(conditionBadMachineConfigLabels))
+				Expect(degradedCondition.Reason).To(Equal(status.ConditionBadMachineConfigLabels))
 				Expect(degradedCondition.Message).To(ContainSubstring("generated from the profile.spec.nodeSelector"))
 			})
 		})

--- a/pkg/performanceprofile/controller/status.go
+++ b/pkg/performanceprofile/controller/status.go
@@ -196,8 +196,8 @@ func (r *PerformanceProfileReconciler) getMCPDegradedCondition(profileMCP *mcov1
 	return r.getDegradedConditions(conditionReasonMCPDegraded, messageString), nil
 }
 
-func (r *PerformanceProfileReconciler) getKubeletConditionsByProfile(profile *performancev2.PerformanceProfile) ([]conditionsv1.Condition, error) {
-	name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
+func (r *PerformanceProfileReconciler) getKubeletConditionsByProfile(profileName string) ([]conditionsv1.Condition, error) {
+	name := components.GetComponentName(profileName, components.ComponentNamePrefix)
 	kc, err := resources.GetKubeletConfig(context.TODO(), r.Client, name)
 
 	// do not drop an error when kubelet config does not exist

--- a/pkg/performanceprofile/controller/status.go
+++ b/pkg/performanceprofile/controller/status.go
@@ -83,7 +83,7 @@ func (r *PerformanceProfileReconciler) updateStatus(profile *performancev2.Perfo
 	return r.Status().Update(context.TODO(), profileCopy)
 }
 
-func (r *PerformanceProfileReconciler) getAvailableConditions(message string) []conditionsv1.Condition {
+func getAvailableConditions(message string) []conditionsv1.Condition {
 	now := time.Now()
 	return []conditionsv1.Condition{
 		{
@@ -114,7 +114,7 @@ func (r *PerformanceProfileReconciler) getAvailableConditions(message string) []
 	}
 }
 
-func (r *PerformanceProfileReconciler) getDegradedConditions(reason string, message string) []conditionsv1.Condition {
+func getDegradedConditions(reason string, message string) []conditionsv1.Condition {
 	now := time.Now()
 	return []conditionsv1.Condition{
 		{
@@ -146,7 +146,7 @@ func (r *PerformanceProfileReconciler) getDegradedConditions(reason string, mess
 	}
 }
 
-func (r *PerformanceProfileReconciler) getProgressingConditions(reason string, message string) []conditionsv1.Condition {
+func getProgressingConditions(reason string, message string) []conditionsv1.Condition {
 	now := time.Now()
 
 	return []conditionsv1.Condition{
@@ -175,7 +175,7 @@ func (r *PerformanceProfileReconciler) getProgressingConditions(reason string, m
 	}
 }
 
-func (r *PerformanceProfileReconciler) getMCPDegradedCondition(profileMCP *mcov1.MachineConfigPool) ([]conditionsv1.Condition, error) {
+func getMCPDegradedCondition(profileMCP *mcov1.MachineConfigPool) ([]conditionsv1.Condition, error) {
 	message := bytes.Buffer{}
 	for _, condition := range profileMCP.Status.Conditions {
 		if (condition.Type == mcov1.MachineConfigPoolNodeDegraded || condition.Type == mcov1.MachineConfigPoolRenderDegraded) && condition.Status == corev1.ConditionTrue {
@@ -193,7 +193,7 @@ func (r *PerformanceProfileReconciler) getMCPDegradedCondition(profileMCP *mcov1
 		return nil, nil
 	}
 
-	return r.getDegradedConditions(conditionReasonMCPDegraded, messageString), nil
+	return getDegradedConditions(conditionReasonMCPDegraded, messageString), nil
 }
 
 func (r *PerformanceProfileReconciler) getKubeletConditionsByProfile(profileName string) ([]conditionsv1.Condition, error) {
@@ -218,7 +218,7 @@ func (r *PerformanceProfileReconciler) getKubeletConditionsByProfile(profileName
 		return nil, nil
 	}
 
-	return r.getDegradedConditions(conditionKubeletFailed, latestCondition.Message), nil
+	return getDegradedConditions(conditionKubeletFailed, latestCondition.Message), nil
 }
 
 func (r *PerformanceProfileReconciler) getTunedConditionsByProfile(profile *performancev2.PerformanceProfile) ([]conditionsv1.Condition, error) {
@@ -271,7 +271,7 @@ func (r *PerformanceProfileReconciler) getTunedConditionsByProfile(profile *perf
 		return nil, nil
 	}
 
-	return r.getDegradedConditions(conditionReasonTunedDegraded, messageString), nil
+	return getDegradedConditions(conditionReasonTunedDegraded, messageString), nil
 }
 
 func getLatestKubeletConfigCondition(conditions []mcov1.KubeletConfigCondition) *mcov1.KubeletConfigCondition {

--- a/pkg/performanceprofile/controller/status.go
+++ b/pkg/performanceprofile/controller/status.go
@@ -9,6 +9,7 @@ import (
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/resources"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -197,7 +198,7 @@ func (r *PerformanceProfileReconciler) getMCPDegradedCondition(profileMCP *mcov1
 
 func (r *PerformanceProfileReconciler) getKubeletConditionsByProfile(profile *performancev2.PerformanceProfile) ([]conditionsv1.Condition, error) {
 	name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
-	kc, err := r.getKubeletConfig(name)
+	kc, err := resources.GetKubeletConfig(context.TODO(), r.Client, name)
 
 	// do not drop an error when kubelet config does not exist
 	if errors.IsNotFound(err) {

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -588,7 +588,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			Expect(runtimeClass.Handler).Should(Equal(machineconfig.HighPerformanceRuntime))
 
 			machineConfigKey := types.NamespacedName{
-				Name:      machineconfig.GetMachineConfigName(secondProfile),
+				Name:      machineconfig.GetMachineConfigName(secondProfile.Name),
 				Namespace: metav1.NamespaceNone,
 			}
 			machineConfig := &machineconfigv1.MachineConfig{}
@@ -639,7 +639,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find KubeletConfig object %s", initialKey.Name))
 
 			initialMachineConfigKey := types.NamespacedName{
-				Name:      machineconfig.GetMachineConfigName(profile),
+				Name:      machineconfig.GetMachineConfigName(profile.Name),
 				Namespace: metav1.NamespaceNone,
 			}
 			err = testclient.GetWithRetry(context.TODO(), initialMachineConfigKey, &machineconfigv1.MachineConfig{})

--- a/test/e2e/performanceprofile/functests/utils/mcps/mcps.go
+++ b/test/e2e/performanceprofile/functests/utils/mcps/mcps.go
@@ -263,7 +263,7 @@ func WaitForProfilePickedUp(mcpName string, profile *performancev2.PerformancePr
 			return false
 		}
 		for _, source := range mcp.Spec.Configuration.Source {
-			if source.Name == machineconfig.GetMachineConfigName(profile) {
+			if source.Name == machineconfig.GetMachineConfigName(profile.Name) {
 				return true
 			}
 		}


### PR DESCRIPTION
Before we start with the implementation itself we should do some preliminary  work in order to generalize some of the functions and flows so they could fit for the controller when it runs on  hypershift platform.

The main work done here, is extracting bits which are specific for non-hypershift platform and replacing methods with functions.

For example we want to pass the `client` from the caller because on hypershift the client is different than on non-hypershift platform.

NOTE: whether we decide to go with unified controller for both hypershift and none-hypertshift or a separate controller for each, this PR is good improvement in general and will allow us to reuse more code.
This is the main reason for dedicating a separate PR for this code changes.