### PR TITLE
CNF-6517: [Part 2] Hypershift PAO adoption

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -17,7 +17,9 @@ import (
 	performancev1alpha1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v1alpha1"
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	paocontroller "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/handler"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/status"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/spf13/cobra"
@@ -176,10 +178,11 @@ func operatorRun() {
 			klog.Exitf("failed to setup feature gates: %v", err)
 		}
 		if err = (&paocontroller.PerformanceProfileReconciler{
-			Client:      mgr.GetClient(),
-			Scheme:      mgr.GetScheme(),
-			Recorder:    mgr.GetEventRecorderFor("performance-profile-controller"),
-			FeatureGate: fg,
+			Client:            mgr.GetClient(),
+			Recorder:          mgr.GetEventRecorderFor("performance-profile-controller"),
+			FeatureGate:       fg,
+			ComponentsHandler: handler.NewHandler(mgr.GetClient(), mgr.GetScheme()),
+			StatusWriter:      status.NewWriter(mgr.GetClient()),
 		}).SetupWithManager(mgr); err != nil {
 			klog.Exitf("unable to create PerformanceProfile controller: %v", err)
 		}

--- a/pkg/performanceprofile/controller/performanceprofile/components/components.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/components.go
@@ -17,9 +17,22 @@
 package components
 
 import (
+	"context"
+
 	apiconfigv1 "github.com/openshift/api/config/v1"
 	mcov1 "github.com/openshift/api/machineconfiguration/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type Handler interface {
+	// Delete deletes the components owned by the controller
+	Delete(ctx context.Context, profileName string) error
+	// Exists checks for the existences of the components owned by the controller
+	Exists(ctx context.Context, profileName string) bool
+	// Apply applies the desired state to the components owned by the controller, or creates them if not exists
+	Apply(ctx context.Context, obj client.Object, recorder record.EventRecorder, options *Options) error
+}
 
 type Options struct {
 	ProfileMCP    *mcov1.MachineConfigPool

--- a/pkg/performanceprofile/controller/performanceprofile/components/handler/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/handler/handler.go
@@ -1,0 +1,211 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serros "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	mcov1 "github.com/openshift/api/machineconfiguration/v1"
+	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/manifestset"
+	profileutil "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/resources"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/status"
+)
+
+var _ components.Handler = &handler{}
+
+type handler struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+func NewHandler(cli client.Client, scheme *runtime.Scheme) components.Handler {
+	return &handler{Client: cli, scheme: scheme}
+}
+
+func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.EventRecorder, opts *components.Options) error {
+	profile, ok := obj.(*performancev2.PerformanceProfile)
+	if !ok {
+		return fmt.Errorf("wrong type conversion; want=PerformanceProfile got=%T", obj)
+	}
+
+	if profileutil.IsPaused(profile) {
+		klog.Infof("Ignoring reconcile loop for pause performance profile %s", profile.Name)
+		return nil
+	}
+
+	ctrRuntime, err := h.getContainerRuntimeName(ctx, profile, opts.ProfileMCP)
+	if err != nil {
+		return fmt.Errorf("could not determine high-performance runtime class container-runtime for profile %q; %w", profile.Name, err)
+	}
+	klog.Infof("using %q as high-performance runtime class container-runtime for profile %q", ctrRuntime, profile.Name)
+
+	opts.MachineConfig.DefaultRuntime = ctrRuntime
+	components, err := manifestset.GetNewComponents(profile, opts)
+	if err != nil {
+		return err
+	}
+	for _, componentObj := range components.ToObjects() {
+		if err := controllerutil.SetControllerReference(profile, componentObj, h.scheme); err != nil {
+			return err
+		}
+	}
+
+	// get mutated machine config
+	mcMutated, err := resources.GetMutatedMachineConfig(ctx, h.Client, components.MachineConfig)
+	if err != nil {
+		return err
+	}
+
+	// get mutated kubelet config
+	kcMutated, err := resources.GetMutatedKubeletConfig(ctx, h.Client, components.KubeletConfig)
+	if err != nil {
+		return err
+	}
+
+	// get mutated performance tuned
+	performanceTunedMutated, err := resources.GetMutatedTuned(ctx, h.Client, components.Tuned)
+	if err != nil {
+		return err
+	}
+
+	// get mutated RuntimeClass
+	runtimeClassMutated, err := resources.GetMutatedRuntimeClass(ctx, h.Client, components.RuntimeClass)
+	if err != nil {
+		return err
+	}
+
+	updated := mcMutated != nil ||
+		kcMutated != nil ||
+		performanceTunedMutated != nil ||
+		runtimeClassMutated != nil
+
+	// does not update any resources if it no changes to relevant objects and continue to the status update
+	if !updated {
+		return nil
+	}
+
+	if mcMutated != nil {
+		if err := resources.CreateOrUpdateMachineConfig(ctx, h.Client, mcMutated); err != nil {
+			return err
+		}
+	}
+
+	if performanceTunedMutated != nil {
+		if err := resources.CreateOrUpdateTuned(ctx, h.Client, performanceTunedMutated, profile.Name); err != nil {
+			return err
+		}
+	}
+
+	if kcMutated != nil {
+		if err := resources.CreateOrUpdateKubeletConfig(ctx, h.Client, kcMutated); err != nil {
+			return err
+		}
+	}
+
+	if runtimeClassMutated != nil {
+		if err := resources.CreateOrUpdateRuntimeClass(ctx, h.Client, runtimeClassMutated); err != nil {
+			return err
+		}
+	}
+	recorder.Eventf(profile, corev1.EventTypeNormal, "Creation succeeded", "Succeeded to create all components")
+	return nil
+}
+
+func (h *handler) Delete(ctx context.Context, profileName string) error {
+	tunedName := components.GetComponentName(profileName, components.ProfileNamePerformance)
+	if err := resources.DeleteTuned(ctx, h.Client, tunedName, components.NamespaceNodeTuningOperator); err != nil {
+		return err
+	}
+
+	name := components.GetComponentName(profileName, components.ComponentNamePrefix)
+	if err := resources.DeleteKubeletConfig(ctx, h.Client, name); err != nil {
+		return err
+	}
+	if err := resources.DeleteRuntimeClass(ctx, h.Client, name); err != nil {
+		return err
+	}
+	if err := resources.DeleteMachineConfig(ctx, h.Client, machineconfig.GetMachineConfigName(profileName)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *handler) Exists(ctx context.Context, profileName string) bool {
+	tunedName := components.GetComponentName(profileName, components.ProfileNamePerformance)
+	if _, err := resources.GetTuned(ctx, h.Client, tunedName, components.NamespaceNodeTuningOperator); !k8serros.IsNotFound(err) {
+		klog.Infof("Tuned %q custom resource is still exists under the namespace %q", tunedName, components.NamespaceNodeTuningOperator)
+		return true
+	}
+
+	name := components.GetComponentName(profileName, components.ComponentNamePrefix)
+	if _, err := resources.GetKubeletConfig(ctx, h.Client, name); !k8serros.IsNotFound(err) {
+		klog.Infof("Kubelet Config %q exists under the cluster", name)
+		return true
+	}
+
+	if _, err := resources.GetRuntimeClass(ctx, h.Client, name); !k8serros.IsNotFound(err) {
+		klog.Infof("Runtime class %q exists under the cluster", name)
+		return true
+	}
+
+	if _, err := resources.GetMachineConfig(ctx, h.Client, machineconfig.GetMachineConfigName(profileName)); !k8serros.IsNotFound(err) {
+		klog.Infof("Machine Config %q exists under the cluster", name)
+		return true
+	}
+	return false
+}
+
+func (h *handler) getContainerRuntimeName(ctx context.Context, profile *performancev2.PerformanceProfile, mcp *mcov1.MachineConfigPool) (mcov1.ContainerRuntimeDefaultRuntime, error) {
+	ctrcfgList := &mcov1.ContainerRuntimeConfigList{}
+	if err := h.Client.List(ctx, ctrcfgList); err != nil {
+		return "", err
+	}
+
+	if len(ctrcfgList.Items) == 0 {
+		return mcov1.ContainerRuntimeDefaultRuntimeRunc, nil
+	}
+
+	var ctrcfgs []*mcov1.ContainerRuntimeConfig
+	mcpSetLabels := labels.Set(mcp.Labels)
+	for i := 0; i < len(ctrcfgList.Items); i++ {
+		ctrcfg := &ctrcfgList.Items[i]
+		ctrcfgSelector, err := metav1.LabelSelectorAsSelector(ctrcfg.Spec.MachineConfigPoolSelector)
+		if err != nil {
+			return "", err
+		}
+		if ctrcfgSelector.Matches(mcpSetLabels) {
+			ctrcfgs = append(ctrcfgs, ctrcfg)
+		}
+	}
+
+	if len(ctrcfgs) == 0 {
+		klog.Infof("no ContainerRuntimeConfig found that matches MCP labels %s that associated with performance profile %q; using default container runtime", mcpSetLabels.String(), profile.Name)
+		return mcov1.ContainerRuntimeDefaultRuntimeRunc, nil
+	}
+
+	if len(ctrcfgs) > 1 {
+		return "", fmt.Errorf("more than one ContainerRuntimeConfig found that matches MCP labels %s that associated with performance profile %q", mcpSetLabels.String(), profile.Name)
+	}
+
+	condition := status.GetLatestContainerRuntimeConfigCondition(ctrcfgs[0].Status.Conditions)
+	if condition == nil {
+		return "", fmt.Errorf("ContainerRuntimeConfig: %q no conditions reported (yet)", ctrcfgs[0].Name)
+	}
+	if condition.Type != mcov1.ContainerRuntimeConfigSuccess || condition.Status != corev1.ConditionTrue {
+		return "", fmt.Errorf("ContainerRuntimeConfig: %q failed to be applied: message=%q", ctrcfgs[0].Name, condition.Message)
+	}
+	return ctrcfgs[0].Spec.ContainerRuntimeConfig.DefaultRuntime, nil
+}

--- a/pkg/performanceprofile/controller/performanceprofile/status/status.go
+++ b/pkg/performanceprofile/controller/performanceprofile/status/status.go
@@ -32,6 +32,13 @@ const (
 	ConditionFailedGettingTunedProfileStatus = "GettingTunedStatusFailed"
 )
 
+type Writer interface {
+	// Update updates the status reported by the controller
+	Update(ctx context.Context, object client.Object, conditions []conditionsv1.Condition) error
+	// UpdateOwnedConditions updates the conditions of the components owned by the controller
+	UpdateOwnedConditions(ctx context.Context, object client.Object) error
+}
+
 func Update(ctx context.Context, client client.Client, profile *performancev2.PerformanceProfile, conditions []conditionsv1.Condition) error {
 	profileCopy := profile.DeepCopy()
 

--- a/pkg/performanceprofile/controller/performanceprofile/status/status.go
+++ b/pkg/performanceprofile/controller/performanceprofile/status/status.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,57 +36,6 @@ type Writer interface {
 	Update(ctx context.Context, object client.Object, conditions []conditionsv1.Condition) error
 	// UpdateOwnedConditions updates the conditions of the components owned by the controller
 	UpdateOwnedConditions(ctx context.Context, object client.Object) error
-}
-
-func Update(ctx context.Context, client client.Client, profile *performancev2.PerformanceProfile, conditions []conditionsv1.Condition) error {
-	profileCopy := profile.DeepCopy()
-
-	if conditions != nil {
-		profileCopy.Status.Conditions = conditions
-	}
-
-	// check if we need to update the status
-	modified := false
-
-	// since we always set the same four conditions, we don't need to check if we need to remove old conditions
-	for _, newCondition := range profileCopy.Status.Conditions {
-		oldCondition := conditionsv1.FindStatusCondition(profile.Status.Conditions, newCondition.Type)
-		if oldCondition == nil {
-			modified = true
-			break
-		}
-
-		// ignore timestamps to avoid infinite reconcile loops
-		if oldCondition.Status != newCondition.Status ||
-			oldCondition.Reason != newCondition.Reason ||
-			oldCondition.Message != newCondition.Message {
-			modified = true
-			break
-		}
-	}
-
-	if profileCopy.Status.Tuned == nil {
-		tunedNamespacedname := types.NamespacedName{
-			Name:      components.GetComponentName(profile.Name, components.ProfileNamePerformance),
-			Namespace: components.NamespaceNodeTuningOperator,
-		}
-		tunedStatus := tunedNamespacedname.String()
-		profileCopy.Status.Tuned = &tunedStatus
-		modified = true
-	}
-
-	if profileCopy.Status.RuntimeClass == nil {
-		runtimeClassName := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
-		profileCopy.Status.RuntimeClass = &runtimeClassName
-		modified = true
-	}
-
-	if !modified {
-		return nil
-	}
-
-	klog.Infof("Updating the performance profile %q status", profile.Name)
-	return client.Status().Update(ctx, profileCopy)
 }
 
 func GetAvailableConditions(message string) []conditionsv1.Condition {

--- a/pkg/performanceprofile/controller/performanceprofile/status/writer.go
+++ b/pkg/performanceprofile/controller/performanceprofile/status/writer.go
@@ -1,0 +1,133 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/resources"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+)
+
+var _ Writer = &writer{}
+
+type writer struct {
+	client.Client
+}
+
+func NewWriter(c client.Client) Writer {
+	return &writer{Client: c}
+}
+
+func (w *writer) Update(ctx context.Context, object client.Object, conditions []conditionsv1.Condition) error {
+	profile, ok := object.(*performancev2.PerformanceProfile)
+	if !ok {
+		return fmt.Errorf("wrong type conversion; want=PerformanceProfile got=%T", object)
+	}
+	return w.update(ctx, profile, conditions)
+}
+
+func (w *writer) UpdateOwnedConditions(ctx context.Context, object client.Object) error {
+	profile, ok := object.(*performancev2.PerformanceProfile)
+	if !ok {
+		return fmt.Errorf("wrong type conversion; want=PerformanceProfile got=%T", object)
+	}
+
+	// get kubelet false condition
+	conditions, err := GetKubeletConditionsByProfile(ctx, w.Client, profile.Name)
+	if err != nil {
+		return w.updateDegradedCondition(profile, ConditionFailedGettingKubeletStatus, err)
+	}
+
+	// get MCP degraded conditions
+	profileMCP, err := resources.GetMachineConfigPoolByProfile(ctx, w.Client, profile)
+	if err != nil {
+		return nil
+	}
+
+	if conditions == nil {
+		conditions, err = GetMCPDegradedCondition(profileMCP)
+		if err != nil {
+			return w.updateDegradedCondition(profile, ConditionFailedGettingMCPStatus, err)
+		}
+	}
+
+	// get tuned profile degraded conditions
+	if conditions == nil {
+		conditions, err = GetTunedConditionsByProfile(ctx, w.Client, profile)
+		if err != nil {
+			return w.updateDegradedCondition(profile, ConditionFailedGettingTunedProfileStatus, err)
+		}
+	}
+
+	// if conditions were not added due to machine config pool status change then set as available
+	if conditions == nil {
+		conditions = GetAvailableConditions("")
+	}
+	return w.Update(ctx, profile, conditions)
+}
+
+func (w *writer) updateDegradedCondition(instance client.Object, conditionState string, conditionError error) error {
+	conditions := GetDegradedConditions(conditionState, conditionError.Error())
+	if err := w.Update(context.TODO(), instance, conditions); err != nil {
+		klog.Errorf("failed to update performance profile %q status: %v", instance.GetName(), err)
+		return err
+	}
+	return conditionError
+}
+
+func (w *writer) update(ctx context.Context, profile *performancev2.PerformanceProfile, conditions []conditionsv1.Condition) error {
+	profileCopy := profile.DeepCopy()
+
+	if conditions != nil {
+		profileCopy.Status.Conditions = conditions
+	}
+
+	// check if we need to update the status
+	modified := false
+
+	// since we always set the same four conditions, we don't need to check if we need to remove old conditions
+	for _, newCondition := range profileCopy.Status.Conditions {
+		oldCondition := conditionsv1.FindStatusCondition(profile.Status.Conditions, newCondition.Type)
+		if oldCondition == nil {
+			modified = true
+			break
+		}
+
+		// ignore timestamps to avoid infinite reconcile loops
+		if oldCondition.Status != newCondition.Status ||
+			oldCondition.Reason != newCondition.Reason ||
+			oldCondition.Message != newCondition.Message {
+			modified = true
+			break
+		}
+	}
+
+	if profileCopy.Status.Tuned == nil {
+		tunedNamespacedname := types.NamespacedName{
+			Name:      components.GetComponentName(profile.Name, components.ProfileNamePerformance),
+			Namespace: components.NamespaceNodeTuningOperator,
+		}
+		tunedStatus := tunedNamespacedname.String()
+		profileCopy.Status.Tuned = &tunedStatus
+		modified = true
+	}
+
+	if profileCopy.Status.RuntimeClass == nil {
+		runtimeClassName := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
+		profileCopy.Status.RuntimeClass = &runtimeClassName
+		modified = true
+	}
+
+	if !modified {
+		return nil
+	}
+
+	klog.Infof("Updating the performance profile %q status", profile.Name)
+	return w.Client.Status().Update(ctx, profileCopy)
+}

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -439,7 +439,7 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	profileMCP, err := getMachineConfigPoolByProfile(ctx, r.Client, instance)
+	profileMCP, err := resources.GetMachineConfigPoolByProfile(ctx, r.Client, instance)
 	if err != nil {
 		conditions := status.GetDegradedConditions(status.ConditionFailedToFindMachineConfigPool, err.Error())
 		if err := status.Update(ctx, r.Client, instance, conditions); err != nil {
@@ -699,58 +699,6 @@ func namespacedName(obj metav1.Object) types.NamespacedName {
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}
-}
-
-func getMachineConfigPoolByProfile(ctx context.Context, client client.Client, profile *performancev2.PerformanceProfile) (*mcov1.MachineConfigPool, error) {
-	nodeSelector := labels.Set(profile.Spec.NodeSelector)
-
-	mcpList := &mcov1.MachineConfigPoolList{}
-	if err := client.List(ctx, mcpList); err != nil {
-		return nil, err
-	}
-
-	filteredMCPList := filterMCPDuplications(mcpList.Items)
-
-	var profileMCPs []*mcov1.MachineConfigPool
-	for i := range filteredMCPList {
-		mcp := &mcpList.Items[i]
-
-		if mcp.Spec.NodeSelector == nil {
-			continue
-		}
-
-		mcpNodeSelector, err := metav1.LabelSelectorAsSelector(mcp.Spec.NodeSelector)
-		if err != nil {
-			return nil, err
-		}
-
-		if mcpNodeSelector.Matches(nodeSelector) {
-			profileMCPs = append(profileMCPs, mcp)
-		}
-	}
-
-	if len(profileMCPs) == 0 {
-		return nil, fmt.Errorf("failed to find MCP with the node selector that matches labels %q", nodeSelector.String())
-	}
-
-	if len(profileMCPs) > 1 {
-		return nil, fmt.Errorf("more than one MCP found that matches performance profile node selector %q", nodeSelector.String())
-	}
-
-	return profileMCPs[0], nil
-}
-
-func filterMCPDuplications(mcps []mcov1.MachineConfigPool) []mcov1.MachineConfigPool {
-	var filtered []mcov1.MachineConfigPool
-	items := map[string]mcov1.MachineConfigPool{}
-	for _, mcp := range mcps {
-		if _, exists := items[mcp.Name]; !exists {
-			items[mcp.Name] = mcp
-			filtered = append(filtered, mcp)
-		}
-	}
-
-	return filtered
 }
 
 func validateProfileMachineConfigPool(profile *performancev2.PerformanceProfile, profileMCP *mcov1.MachineConfigPool) error {

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -31,8 +31,6 @@ import (
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
-	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
-	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/manifestset"
 	profileutil "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/resources"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/status"
@@ -45,7 +43,6 @@ import (
 	k8serros "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
@@ -53,7 +50,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -65,9 +61,10 @@ const finalizer = "foreground-deletion"
 // PerformanceProfileReconciler reconciles a PerformanceProfile object
 type PerformanceProfileReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	Recorder    record.EventRecorder
-	FeatureGate featuregates.FeatureGate
+	Recorder          record.EventRecorder
+	FeatureGate       featuregates.FeatureGate
+	ComponentsHandler components.Handler
+	StatusWriter      status.Writer
 }
 
 // SetupWithManager creates a new PerformanceProfile Controller and adds it to the Manager.
@@ -295,48 +292,6 @@ func getInfraPartitioningMode(ctx context.Context, client client.Client) (pinnin
 	return infra.Status.CPUPartitioning, nil
 }
 
-func getContainerRuntimeName(ctx context.Context, client client.Client, mcpLabels map[string]string, profileName string) (mcov1.ContainerRuntimeDefaultRuntime, error) {
-	ctrcfgList := &mcov1.ContainerRuntimeConfigList{}
-	if err := client.List(ctx, ctrcfgList); err != nil {
-		return "", err
-	}
-
-	if len(ctrcfgList.Items) == 0 {
-		return mcov1.ContainerRuntimeDefaultRuntimeRunc, nil
-	}
-
-	var ctrcfgs []*mcov1.ContainerRuntimeConfig
-	mcpSetLabels := labels.Set(mcpLabels)
-	for i := 0; i < len(ctrcfgList.Items); i++ {
-		ctrcfg := &ctrcfgList.Items[i]
-		ctrcfgSelector, err := metav1.LabelSelectorAsSelector(ctrcfg.Spec.MachineConfigPoolSelector)
-		if err != nil {
-			return "", err
-		}
-		if ctrcfgSelector.Matches(mcpSetLabels) {
-			ctrcfgs = append(ctrcfgs, ctrcfg)
-		}
-	}
-
-	if len(ctrcfgs) == 0 {
-		klog.Infof("no ContainerRuntimeConfig found that matches MCP labels %s that associated with performance profile %q; using default container runtime", mcpSetLabels.String(), profileName)
-		return mcov1.ContainerRuntimeDefaultRuntimeRunc, nil
-	}
-
-	if len(ctrcfgs) > 1 {
-		return "", fmt.Errorf("more than one ContainerRuntimeConfig found that matches MCP labels %s that associated with performance profile %q", mcpSetLabels.String(), profileName)
-	}
-
-	condition := status.GetLatestContainerRuntimeConfigCondition(ctrcfgs[0].Status.Conditions)
-	if condition == nil {
-		return "", fmt.Errorf("ContainerRuntimeConfig: %q no conditions reported (yet)", ctrcfgs[0].Name)
-	}
-	if condition.Type != mcov1.ContainerRuntimeConfigSuccess || condition.Status != corev1.ConditionTrue {
-		return "", fmt.Errorf("ContainerRuntimeConfig: %q failed to be applied: message=%q", ctrcfgs[0].Name, condition.Message)
-	}
-	return ctrcfgs[0].Spec.ContainerRuntimeConfig.DefaultRuntime, nil
-}
-
 func validateUpdateEvent(e *event.UpdateEvent) bool {
 	if e.ObjectOld == nil {
 		klog.Error("Update event has no old runtime object to update")
@@ -400,14 +355,14 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	if instance.DeletionTimestamp != nil {
 		// delete components
-		if err := r.deleteComponents(instance.GetName()); err != nil {
+		if err := r.ComponentsHandler.Delete(ctx, instance.GetName()); err != nil {
 			klog.Errorf("failed to delete components: %v", err)
 			r.Recorder.Eventf(instance, corev1.EventTypeWarning, "Deletion failed", "Failed to delete components: %v", err)
 			return reconcile.Result{}, err
 		}
 		r.Recorder.Eventf(instance, corev1.EventTypeNormal, "Deletion succeeded", "Succeeded to delete all components")
 
-		if r.isComponentsExist(instance.GetName()) {
+		if r.ComponentsHandler.Exists(ctx, instance.GetName()) {
 			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
@@ -439,39 +394,16 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	profileMCP, err := resources.GetMachineConfigPoolByProfile(ctx, r.Client, instance)
-	if err != nil {
-		conditions := status.GetDegradedConditions(status.ConditionFailedToFindMachineConfigPool, err.Error())
-		if err := status.Update(ctx, r.Client, instance, conditions); err != nil {
-			klog.Errorf("failed to update performance profile %q status: %v", instance.GetName(), err)
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{}, nil
-	}
-
-	ctrRuntime, err := getContainerRuntimeName(ctx, r.Client, profileMCP.Labels, instance.GetName())
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("could not determine high-performance runtime class container-runtime for profile %q; %w", instance.GetName(), err)
-	}
-	klog.Infof("using %q as high-performance runtime class container-runtime for profile %q", ctrRuntime, instance.GetName())
-
-	if err := validateProfileMachineConfigPool(instance, profileMCP); err != nil {
-		conditions := status.GetDegradedConditions(status.ConditionBadMachineConfigLabels, err.Error())
-		if err := status.Update(ctx, r.Client, instance, conditions); err != nil {
-			klog.Errorf("failed to update performance profile %q status: %v", instance.GetName(), err)
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{}, nil
+	profileMCP, result, err := r.getAndValidateMCP(ctx, instance)
+	if result != nil {
+		return *result, err
 	}
 
 	// apply components
-	result, err := r.applyComponents(instance, &components.Options{
+	err = r.ComponentsHandler.Apply(ctx, instance, r.Recorder, &components.Options{
 		ProfileMCP: profileMCP,
 		MachineConfig: components.MachineConfigOptions{
 			PinningMode:      &pinningMode,
-			DefaultRuntime:   ctrRuntime,
 			MixedCPUsEnabled: r.isMixedCPUsEnabled(instance),
 		},
 	})
@@ -479,189 +411,18 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		klog.Errorf("failed to deploy performance profile %q components: %v", instance.GetName(), err)
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "Creation failed", "Failed to create all components: %v", err)
 		conditions := status.GetDegradedConditions(status.ConditionReasonComponentsCreationFailed, err.Error())
-		if err := status.Update(ctx, r.Client, instance, conditions); err != nil {
+		if err := r.StatusWriter.Update(ctx, instance, conditions); err != nil {
 			klog.Errorf("failed to update performance profile %q status: %v", instance.GetName(), err)
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{}, err
 	}
+	err = r.StatusWriter.UpdateOwnedConditions(ctx, instance)
 
-	// get kubelet false condition
-	conditions, err := status.GetKubeletConditionsByProfile(ctx, r.Client, instance.GetName())
 	if err != nil {
-		return r.updateDegradedCondition(instance, status.ConditionFailedGettingKubeletStatus, err)
-	}
-
-	// get MCP degraded conditions
-	if conditions == nil {
-		conditions, err = status.GetMCPDegradedCondition(profileMCP)
-		if err != nil {
-			return r.updateDegradedCondition(instance, status.ConditionFailedGettingMCPStatus, err)
-		}
-	}
-
-	// get tuned profile degraded conditions
-	if conditions == nil {
-		conditions, err = status.GetTunedConditionsByProfile(ctx, r.Client, instance)
-		if err != nil {
-			return r.updateDegradedCondition(instance, status.ConditionFailedGettingTunedProfileStatus, err)
-		}
-	}
-
-	// if conditions were not added due to machine config pool status change then set as available
-	if conditions == nil {
-		conditions = status.GetAvailableConditions("")
-	}
-
-	if err := status.Update(ctx, r.Client, instance, conditions); err != nil {
 		klog.Errorf("failed to update performance profile %q status: %v", instance.GetName(), err)
-		// we still want to requeue after some, also in case of error, to avoid chance of multiple reboots
-		if result != nil {
-			return *result, nil
-		}
-
-		return reconcile.Result{}, err
 	}
-
-	if result != nil {
-		return *result, nil
-	}
-
 	return ctrl.Result{}, nil
-}
-
-func (r *PerformanceProfileReconciler) updateDegradedCondition(instance *performancev2.PerformanceProfile, conditionState string, conditionError error) (ctrl.Result, error) {
-	conditions := status.GetDegradedConditions(conditionState, conditionError.Error())
-	if err := status.Update(context.TODO(), r.Client, instance, conditions); err != nil {
-		klog.Errorf("failed to update performance profile %q status: %v", instance.GetName(), err)
-		return reconcile.Result{}, err
-	}
-	return reconcile.Result{}, conditionError
-}
-
-func (r *PerformanceProfileReconciler) applyComponents(profile *performancev2.PerformanceProfile, opts *components.Options) (*reconcile.Result, error) {
-	if profileutil.IsPaused(profile) {
-		klog.Infof("Ignoring reconcile loop for pause performance profile %s", profile.Name)
-		return nil, nil
-	}
-	components, err := manifestset.GetNewComponents(profile, opts)
-	if err != nil {
-		return nil, err
-	}
-	for _, componentObj := range components.ToObjects() {
-		if err := controllerutil.SetControllerReference(profile, componentObj, r.Scheme); err != nil {
-			return nil, err
-		}
-	}
-
-	// get mutated machine config
-	mcMutated, err := resources.GetMutatedMachineConfig(context.TODO(), r.Client, components.MachineConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// get mutated kubelet config
-	kcMutated, err := resources.GetMutatedKubeletConfig(context.TODO(), r.Client, components.KubeletConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// get mutated performance tuned
-	performanceTunedMutated, err := resources.GetMutatedTuned(context.TODO(), r.Client, components.Tuned)
-	if err != nil {
-		return nil, err
-	}
-
-	// get mutated RuntimeClass
-	runtimeClassMutated, err := resources.GetMutatedRuntimeClass(context.TODO(), r.Client, components.RuntimeClass)
-	if err != nil {
-		return nil, err
-	}
-
-	updated := mcMutated != nil ||
-		kcMutated != nil ||
-		performanceTunedMutated != nil ||
-		runtimeClassMutated != nil
-
-	// does not update any resources, if it no changes to relevant objects and just continue to the status update
-	if !updated {
-		return nil, nil
-	}
-
-	if mcMutated != nil {
-		if err := resources.CreateOrUpdateMachineConfig(context.TODO(), r.Client, mcMutated); err != nil {
-			return nil, err
-		}
-	}
-
-	if performanceTunedMutated != nil {
-		if err := resources.CreateOrUpdateTuned(context.TODO(), r.Client, performanceTunedMutated, profile.Name); err != nil {
-			return nil, err
-		}
-	}
-
-	if kcMutated != nil {
-		if err := resources.CreateOrUpdateKubeletConfig(context.TODO(), r.Client, kcMutated); err != nil {
-			return nil, err
-		}
-	}
-
-	if runtimeClassMutated != nil {
-		if err := resources.CreateOrUpdateRuntimeClass(context.TODO(), r.Client, runtimeClassMutated); err != nil {
-			return nil, err
-		}
-	}
-
-	r.Recorder.Eventf(profile, corev1.EventTypeNormal, "Creation succeeded", "Succeeded to create all components")
-	return &reconcile.Result{}, nil
-}
-
-func (r *PerformanceProfileReconciler) deleteComponents(profileName string) error {
-	tunedName := components.GetComponentName(profileName, components.ProfileNamePerformance)
-	if err := resources.DeleteTuned(context.TODO(), r.Client, tunedName, components.NamespaceNodeTuningOperator); err != nil {
-		return err
-	}
-
-	name := components.GetComponentName(profileName, components.ComponentNamePrefix)
-	if err := resources.DeleteKubeletConfig(context.TODO(), r.Client, name); err != nil {
-		return err
-	}
-
-	if err := resources.DeleteRuntimeClass(context.TODO(), r.Client, name); err != nil {
-		return err
-	}
-
-	if err := resources.DeleteMachineConfig(context.TODO(), r.Client, machineconfig.GetMachineConfigName(profileName)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (r *PerformanceProfileReconciler) isComponentsExist(profileName string) bool {
-	tunedName := components.GetComponentName(profileName, components.ProfileNamePerformance)
-	if _, err := resources.GetTuned(context.TODO(), r.Client, tunedName, components.NamespaceNodeTuningOperator); !k8serros.IsNotFound(err) {
-		klog.Infof("Tuned %q custom resource is still exists under the namespace %q", tunedName, components.NamespaceNodeTuningOperator)
-		return true
-	}
-
-	name := components.GetComponentName(profileName, components.ComponentNamePrefix)
-	if _, err := resources.GetKubeletConfig(context.TODO(), r.Client, name); !k8serros.IsNotFound(err) {
-		klog.Infof("Kubelet Config %q exists under the cluster", name)
-		return true
-	}
-
-	if _, err := resources.GetRuntimeClass(context.TODO(), r.Client, name); !k8serros.IsNotFound(err) {
-		klog.Infof("Runtime class %q exists under the cluster", name)
-		return true
-	}
-
-	if _, err := resources.GetMachineConfig(context.TODO(), r.Client, machineconfig.GetMachineConfigName(profileName)); !k8serros.IsNotFound(err) {
-		klog.Infof("Machine Config %q exists under the cluster", name)
-		return true
-	}
-
-	return false
 }
 
 func (r *PerformanceProfileReconciler) isMixedCPUsEnabled(profile *performancev2.PerformanceProfile) bool {
@@ -681,6 +442,34 @@ func hasFinalizer(profile *performancev2.PerformanceProfile, finalizer string) b
 		}
 	}
 	return false
+}
+
+func (r *PerformanceProfileReconciler) getAndValidateMCP(ctx context.Context, instance client.Object) (*mcov1.MachineConfigPool, *reconcile.Result, error) {
+	profile, ok := instance.(*performancev2.PerformanceProfile)
+	// can happen on Hypershift, which expects ConfigMap instead.
+	// but on hypershift we do not have MCPs anyway, so it's fine to return empty here.
+	if !ok {
+		return nil, nil, nil
+	}
+	profileMCP, err := resources.GetMachineConfigPoolByProfile(ctx, r.Client, profile)
+	if err != nil {
+		conditions := status.GetDegradedConditions(status.ConditionFailedToFindMachineConfigPool, err.Error())
+		if err := r.StatusWriter.Update(ctx, profile, conditions); err != nil {
+			klog.Errorf("failed to update performance profile %q status: %v", profile.GetName(), err)
+			return nil, &reconcile.Result{}, err
+		}
+		return nil, &reconcile.Result{}, nil
+	}
+
+	if err := validateProfileMachineConfigPool(profile, profileMCP); err != nil {
+		conditions := status.GetDegradedConditions(status.ConditionBadMachineConfigLabels, err.Error())
+		if err := r.StatusWriter.Update(ctx, profile, conditions); err != nil {
+			klog.Errorf("failed to update performance profile %q status: %v", profile.GetName(), err)
+			return nil, &reconcile.Result{}, err
+		}
+		return nil, &reconcile.Result{}, nil
+	}
+	return profileMCP, nil, nil
 }
 
 func removeFinalizer(profile *performancev2.PerformanceProfile, finalizer string) {

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -18,6 +18,7 @@ import (
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/handler"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/kubeletconfig"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/runtimeclass"
@@ -1137,9 +1138,10 @@ func newFakeReconciler(profile client.Object, initObjects ...runtime.Object) *Pe
 	fakeFeatureGateAccessor := featuregates.NewHardcodedFeatureGateAccessForTesting(nil, []configv1.FeatureGateName{configv1.FeatureGateMixedCPUsAllocation}, make(chan struct{}), nil)
 	fg, _ := fakeFeatureGateAccessor.CurrentFeatureGates()
 	return &PerformanceProfileReconciler{
-		Client:      fakeClient,
-		Scheme:      scheme.Scheme,
-		Recorder:    fakeRecorder,
-		FeatureGate: fg,
+		Client:            fakeClient,
+		Recorder:          fakeRecorder,
+		FeatureGate:       fg,
+		ComponentsHandler: handler.NewHandler(fakeClient, scheme.Scheme),
+		StatusWriter:      status.NewWriter(fakeClient),
 	}
 }


### PR DESCRIPTION
Since the controller implementation diverged on Hypershift platform, we need to add an abstraction layer
in order to handle a different type of implementation.

In this PR we introduce 2 interfaces:
1. `components.Handler` - which provides an API for handling the different components the controller owns.
2. `status.Writer` which provides an API for reporting the different statuses by the controller.

This PR doesn't add any new functionality but implementing the old reconciliation loop using the new interfaces introduced above.


