### PR TITLE
OCPBUGS-26401: TuneD prior to kubelet in one-shot mode

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -13,17 +13,19 @@ ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}
 ENV SYSTEMD_IGNORE_CHROOT=1
 WORKDIR ${APP_ROOT}
-COPY assets ${APP_ROOT}
+COPY assets/bin /usr/local/bin
 RUN INSTALL_PKGS=" \
       tuned tuned-profiles-atomic tuned-profiles-cpu-partitioning tuned-profiles-mssql tuned-profiles-nfv tuned-profiles-nfv-guest \
       tuned-profiles-nfv-host tuned-profiles-openshift tuned-profiles-oracle tuned-profiles-postgresql tuned-profiles-realtime \
       tuned-profiles-sap tuned-profiles-sap-hana tuned-profiles-spectrumscale \
       nmap-ncat procps-ng pciutils" && \
-    mkdir -p /etc/grub.d/ /boot && \
+    mkdir -p /etc/grub.d/ /boot /var/lib/ocp-tuned && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
-    rm -rf /var/lib/ocp-tuned/{tuned,performanceprofile} && \
-    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|' /etc/tuned/tuned-main.conf && \
-    touch /etc/sysctl.conf $APP_ROOT/provider && \
+    rm -rf /etc/tuned/recommend.d && \
+    echo auto > /etc/tuned/profile_mode && \
+    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' \
+      /etc/tuned/tuned-main.conf && \
+    touch /etc/sysctl.conf && \
     dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \
     useradd -r -u 499 cluster-node-tuning-operator

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -13,17 +13,19 @@ ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}
 ENV SYSTEMD_IGNORE_CHROOT=1
 WORKDIR ${APP_ROOT}
-COPY assets ${APP_ROOT}
+COPY assets/bin /usr/local/bin
 RUN INSTALL_PKGS=" \
       tuned tuned-profiles-atomic tuned-profiles-cpu-partitioning tuned-profiles-mssql tuned-profiles-nfv tuned-profiles-nfv-guest \
       tuned-profiles-nfv-host tuned-profiles-openshift tuned-profiles-oracle tuned-profiles-postgresql tuned-profiles-realtime \
       tuned-profiles-sap tuned-profiles-sap-hana tuned-profiles-spectrumscale \
       nmap-ncat procps-ng pciutils" && \
-    mkdir -p /etc/grub.d/ /boot && \
+    mkdir -p /etc/grub.d/ /boot /var/lib/ocp-tuned && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
-    rm -rf /var/lib/ocp-tuned/{tuned,performanceprofile} && \
-    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|' /etc/tuned/tuned-main.conf && \
-    touch /etc/sysctl.conf $APP_ROOT/provider && \
+    rm -rf /etc/tuned/recommend.d && \
+    echo auto > /etc/tuned/profile_mode && \
+    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' \
+      /etc/tuned/tuned-main.conf && \
+    touch /etc/sysctl.conf && \
     dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \
     useradd -r -u 499 cluster-node-tuning-operator

--- a/assets/performanceprofile/configs/ocp-tuned-one-shot.service
+++ b/assets/performanceprofile/configs/ocp-tuned-one-shot.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=TuneD service from NTO image
+After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+# Requires is necessary to start this unit before kubelet-dependencies.target
+Requires=kubelet-dependencies.target
+Before=kubelet-dependencies.target
+ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+[Service]
+# https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+# and also "podman systemd generate" uses "forking".  However, this
+# is strongly discouraged by "man systemd.service" and results in
+# failed dependency for the kubelet service.
+Type=oneshot
+# Restart=no is the default as of systemd 252, but be explicit.
+Restart=no
+ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+ExecStartPre=/bin/bash -c " \
+  mkdir -p /run/tuned "
+ExecStart=/usr/bin/podman run \
+    --rm \
+    --name openshift-tuned \
+    --privileged \
+    --authfile /var/lib/kubelet/config.json \
+    --net=host \
+    --pid=host \
+    --security-opt label=disable \
+    --log-driver=none \
+    --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+    --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+    --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+    --volume /etc/sysconfig:/etc/sysconfig:rslave \
+    --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+    --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+    --volume /etc/systemd:/etc/systemd:rslave \
+    --volume /run/tuned:/run/tuned:rslave \
+    --volume /run/systemd:/run/systemd:rslave \
+    --volume /sys:/sys:rslave \
+    --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+    $NTO_IMAGE
+Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=-/var/lib/ocp-tuned/image.env
+ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+[Install]
+# RequiredBy causes kubelet to depend on this service.
+RequiredBy=kubelet-dependencies.target

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/klog/v2"
 
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
-	"github.com/openshift/cluster-node-tuning-operator/pkg/util"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/fsnotify.v1"
 )
@@ -39,7 +38,7 @@ type Server struct {
 // DumpCA writes the root certificate bundle which is used to verify client certificates
 // on incoming requests to 'authCAFile' file.
 func DumpCA(ca string) error {
-	if err := util.Mkdir(authCADir); err != nil {
+	if err := os.MkdirAll(authCADir, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create directory %q: %v", authCADir, err)
 	}
 
@@ -143,7 +142,7 @@ func RunServer(port int, ctx context.Context) error {
 
 		// In HyperShift the CA is mounted in
 		if !ntoconfig.InHyperShift() {
-			if err := util.Mkdir(authCADir); err != nil {
+			if err := os.MkdirAll(authCADir, os.ModePerm); err != nil {
 				return fmt.Errorf("failed to create directory %q: %v", authCADir, err)
 			}
 		}

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -89,12 +89,13 @@ const (
 )
 
 const (
-	systemdServiceIRQBalance  = "irqbalance.service"
-	systemdServiceKubelet     = "kubelet.service"
-	systemdServiceCrio        = "crio.service"
-	systemdServiceTypeOneshot = "oneshot"
-	systemdTargetMultiUser    = "multi-user.target"
-	systemdTrue               = "true"
+	systemdServiceIRQBalance   = "irqbalance.service"
+	systemdServiceKubelet      = "kubelet.service"
+	systemdServiceCrio         = "crio.service"
+	systemdServiceTunedOneShot = "ocp-tuned-one-shot.service"
+	systemdServiceTypeOneshot  = "oneshot"
+	systemdTargetMultiUser     = "multi-user.target"
+	systemdTrue                = "true"
 )
 
 const (
@@ -334,6 +335,14 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, opts *componen
 		Name:     getSystemdService(clearIRQBalanceBannedCPUs),
 	})
 
+	// add ocp-tuned-one-shot service
+	ocpTunedOneShotServiceContent := getTunedOneShotSystemdUnit()
+	ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
+		Contents: &ocpTunedOneShotServiceContent,
+		Enabled:  ptr.To(true),
+		Name:     systemdServiceTunedOneShot,
+	})
+
 	if ok, ovsSliceName := MoveOvsIntoOwnSlice(); ok {
 		// Create the OVS slice that will lift the cpu restrictions for better kernel networking performance
 		// This is technically not necessary as systemd is smart enough
@@ -542,6 +551,60 @@ func getRPSUnitOptions(rpsMask string) []*unit.UnitOption {
 		// ExecStart
 		unit.NewUnitOption(systemdSectionService, systemdExecStart, cmd),
 	}
+}
+
+func getTunedOneShotSystemdUnit() string {
+	const unit = `[Unit]
+Description=TuneD service from NTO image
+After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+# Requires is necessary to start this unit before kubelet-dependencies.target
+Requires=kubelet-dependencies.target
+Before=kubelet-dependencies.target
+ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+[Service]
+# https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+# and also "podman systemd generate" uses "forking".  However, this
+# is strongly discouraged by "man systemd.service" and results in
+# failed dependency for the kubelet service.
+Type=oneshot
+# Restart=no is the default as of systemd 252, but be explicit.
+Restart=no
+ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+ExecStartPre=/bin/bash -c " \
+  mkdir -p /run/tuned "
+ExecStart=/usr/bin/podman run \
+    --rm \
+    --name openshift-tuned \
+    --privileged \
+    --authfile /var/lib/kubelet/config.json \
+    --net=host \
+    --pid=host \
+    --security-opt label=disable \
+    --log-driver=none \
+    --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+    --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+    --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+    --volume /etc/sysconfig:/etc/sysconfig:rslave \
+    --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+    --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+    --volume /etc/systemd:/etc/systemd:rslave \
+    --volume /run/tuned:/run/tuned:rslave \
+    --volume /run/systemd:/run/systemd:rslave \
+    --volume /sys:/sys:rslave \
+    --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+    $NTO_IMAGE
+Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=-/var/lib/ocp-tuned/image.env
+ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+[Install]
+# RequiredBy causes kubelet to depend on this service.
+RequiredBy=kubelet-dependencies.target
+`
+
+	return unit
 }
 
 func addContent(ignitionConfig *igntypes.Config, content []byte, dst string, mode *int) {

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -336,7 +336,11 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, opts *componen
 	})
 
 	// add ocp-tuned-one-shot service
-	ocpTunedOneShotServiceContent := getTunedOneShotSystemdUnit()
+	ocpTunedOneShotServiceByteContent, err := assets.Configs.ReadFile(filepath.Join("configs", systemdServiceTunedOneShot))
+	if err != nil {
+		return nil, err
+	}
+	ocpTunedOneShotServiceContent := string(ocpTunedOneShotServiceByteContent)
 	ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
 		Contents: &ocpTunedOneShotServiceContent,
 		Enabled:  ptr.To(true),
@@ -551,60 +555,6 @@ func getRPSUnitOptions(rpsMask string) []*unit.UnitOption {
 		// ExecStart
 		unit.NewUnitOption(systemdSectionService, systemdExecStart, cmd),
 	}
-}
-
-func getTunedOneShotSystemdUnit() string {
-	const unit = `[Unit]
-Description=TuneD service from NTO image
-After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
-# Requires is necessary to start this unit before kubelet-dependencies.target
-Requires=kubelet-dependencies.target
-Before=kubelet-dependencies.target
-ConditionPathExists=/var/lib/ocp-tuned/image.env
-
-[Service]
-# https://www.redhat.com/sysadmin/podman-shareable-systemd-services
-# and also "podman systemd generate" uses "forking".  However, this
-# is strongly discouraged by "man systemd.service" and results in
-# failed dependency for the kubelet service.
-Type=oneshot
-# Restart=no is the default as of systemd 252, but be explicit.
-Restart=no
-ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
-ExecStartPre=/bin/bash -c " \
-  mkdir -p /run/tuned "
-ExecStart=/usr/bin/podman run \
-    --rm \
-    --name openshift-tuned \
-    --privileged \
-    --authfile /var/lib/kubelet/config.json \
-    --net=host \
-    --pid=host \
-    --security-opt label=disable \
-    --log-driver=none \
-    --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-    --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
-    --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
-    --volume /etc/sysconfig:/etc/sysconfig:rslave \
-    --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
-    --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
-    --volume /etc/systemd:/etc/systemd:rslave \
-    --volume /run/tuned:/run/tuned:rslave \
-    --volume /run/systemd:/run/systemd:rslave \
-    --volume /sys:/sys:rslave \
-    --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
-    $NTO_IMAGE
-Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=-/var/lib/ocp-tuned/image.env
-ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
-ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
-
-[Install]
-# RequiredBy causes kubelet to depend on this service.
-RequiredBy=kubelet-dependencies.target
-`
-
-	return unit
 }
 
 func addContent(ignitionConfig *igntypes.Config, content []byte, dst string, mode *int) {

--- a/pkg/tuned/cmd/render/render.go
+++ b/pkg/tuned/cmd/render/render.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	assets "github.com/openshift/cluster-node-tuning-operator/assets/tuned"
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
@@ -219,8 +220,7 @@ func render(inputDir []string, outputDir string, mcpName string) error {
 	}
 
 	//Should run tuned
-	tunedCmd := tunedpkg.TunedCreateCmd(false)
-	err = tunedpkg.TunedRunNoDaemon(tunedCmd)
+	err = tunedpkg.TunedRunNoDaemon(0 * time.Second)
 	if err != nil {
 		klog.Errorf("Unable to run tuned error : %v", err)
 		return err

--- a/pkg/tuned/run.go
+++ b/pkg/tuned/run.go
@@ -33,10 +33,6 @@ func TunedCreateCmdline(debug bool) (string, []string) {
 	return "/usr/sbin/tuned", args
 }
 
-func TunedCreateCmd(command string, args []string) *exec.Cmd {
-	return exec.Command(command, args...)
-}
-
 func configDaemonMode() (func(), error) {
 	daemon_key := "daemon"
 

--- a/pkg/tuned/run.go
+++ b/pkg/tuned/run.go
@@ -16,26 +16,31 @@ package tuned
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"k8s.io/klog/v2"
 )
 
-func TunedCreateCmd(debug bool) *exec.Cmd {
+func TunedCreateCmdline(debug bool) (string, []string) {
 	args := []string{"--no-dbus"}
 	if debug {
 		args = append(args, "--debug")
 	}
-	return exec.Command("/usr/sbin/tuned", args...)
+	return "/usr/sbin/tuned", args
+}
+
+func TunedCreateCmd(command string, args []string) *exec.Cmd {
+	return exec.Command(command, args...)
 }
 
 func configDaemonMode() (func(), error) {
-	tunedMainCfgFilename := tunedProfilesDirCustom + "/" + tunedMainConfFile
 	daemon_key := "daemon"
 
-	tunedMainCfg, err := iniFileLoad(tunedMainCfgFilename)
+	tunedMainCfg, err := iniFileLoad(tunedMainConfPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read global TuneD configuration file: %w", err)
 	}
@@ -46,13 +51,13 @@ func configDaemonMode() (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	err = iniFileSave(tunedMainCfgFilename, tunedMainCfg)
+	err = iniFileSave(tunedMainConfPath, tunedMainCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write global TuneD configuration file: %w", err)
 	}
 
 	restoreF := func() {
-		tunedMainCfg, err := iniFileLoad(tunedMainCfgFilename)
+		tunedMainCfg, err := iniFileLoad(tunedMainConfPath)
 		if err != nil {
 			klog.Warningf("failed to read global TuneD configuration file: %v", err)
 			return
@@ -62,7 +67,7 @@ func configDaemonMode() (func(), error) {
 			klog.Warningf("failed to set %s key to %v value: %v", daemon_key, daemon_value, err)
 			return
 		}
-		err = iniFileSave(tunedMainCfgFilename, tunedMainCfg)
+		err = iniFileSave(tunedMainConfPath, tunedMainCfg)
 		if err != nil {
 			klog.Warningf("failed to write global TuneD configuration file: %v", err)
 		}
@@ -71,8 +76,22 @@ func configDaemonMode() (func(), error) {
 	return restoreF, nil
 }
 
-func TunedRunNoDaemon(cmd *exec.Cmd) error {
-	var daemon Daemon
+func TunedRunNoDaemon(timeout time.Duration) error {
+	var (
+		cmd    *exec.Cmd
+		daemon Daemon
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	command, args := TunedCreateCmdline(false)
+	if timeout > 0 {
+		// CommandContext sets Cancel to call the Kill (SIGKILL) method on the command's Process.
+		cmd = exec.CommandContext(ctx, command, args...)
+	} else {
+		cmd = exec.Command(command, args...)
+	}
 
 	restoreFunction, err := configDaemonMode()
 	if err != nil {

--- a/pkg/util/os.go
+++ b/pkg/util/os.go
@@ -1,22 +1,8 @@
 package util
 
 import (
-	"io"
 	"os"
 )
-
-// Create a file if it does not exist.  Returns nil if 'file' already exists.
-func Create(file string) error {
-	if _, err := os.Stat(file); os.IsNotExist(err) {
-		file, err := os.Create(file)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-	}
-
-	return nil
-}
 
 // Delete a file if it exists.  Returns nil if 'file' does not exist.
 func Delete(file string) error {
@@ -26,37 +12,6 @@ func Delete(file string) error {
 	}
 
 	return err
-}
-
-// Create a directory 'dir' including its parents.  Returns nil if directory already exists.
-func Mkdir(dir string) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return os.MkdirAll(dir, os.ModePerm)
-	}
-
-	return nil
-}
-
-// Copy a file from 'src' to 'dst'.
-func Copy(src, dst string) error {
-	fin, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer fin.Close()
-
-	fout, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer fout.Close()
-
-	_, err = io.Copy(fout, fin)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // Create a symbolic link.  Returns nil if the link already exists.

--- a/pkg/util/os.go
+++ b/pkg/util/os.go
@@ -1,16 +1,71 @@
 package util
 
 import (
+	"io"
 	"os"
 )
 
-// Create a directory including its parents.  Returns nil if directory already exists.
-func Mkdir(dir string) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		err = os.MkdirAll(dir, os.ModePerm)
+// Create a file if it does not exist.  Returns nil if 'file' already exists.
+func Create(file string) error {
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		file, err := os.Create(file)
 		if err != nil {
 			return err
 		}
+		defer file.Close()
+	}
+
+	return nil
+}
+
+// Delete a file if it exists.  Returns nil if 'file' does not exist.
+func Delete(file string) error {
+	var err error
+	if err = os.Remove(file); os.IsNotExist(err) {
+		return nil
+	}
+
+	return err
+}
+
+// Create a directory 'dir' including its parents.  Returns nil if directory already exists.
+func Mkdir(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return os.MkdirAll(dir, os.ModePerm)
+	}
+
+	return nil
+}
+
+// Copy a file from 'src' to 'dst'.
+func Copy(src, dst string) error {
+	fin, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer fin.Close()
+
+	fout, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer fout.Close()
+
+	_, err = io.Copy(fout, fin)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Create a symbolic link.  Returns nil if the link already exists.
+func Symlink(target, linkName string) error {
+	if _, err := os.Lstat(linkName); err != nil {
+		if os.IsNotExist(err) {
+			return os.Symlink(target, linkName)
+		}
+		return err
 	}
 
 	return nil

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
@@ -167,6 +167,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
@@ -183,6 +183,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
@@ -182,6 +182,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null


### PR DESCRIPTION
TuneD prior to kubelet in one-shot mode

Motivation.  In case of node reboots, all pods restart again in random order.
Since there's no control on pod restart order, it is possible that tuned
pods will start after the workload pods.  This means the workload pods can
start with partial tuning which can result in degraded performance or even
cause the workload pods crash.

This change is intended mostly for Telco use cases where PerformanceProfiles
are used.  To minimize the risk of affecting other deployments by backporting
this code, TuneD will start prior to kubelet only when PerformanceProfiles
are used.

Changes:
  * Switch to /var/lib/ocp-tuned as the home directory for the operand
    (TuneD) pod on the host.  This directory now holds configuration for the
    TuneD daemon both running prior to kubelet and in the pod itself, notably
    TuneD daemon profiles and the recommended profile.
  * Use the new tuned-main.conf option "profile_dirs" to extract TuneD profiles
    to /var/lib/ocp-tuned/profiles.  This new option also allowed simplifying the
    algorithm for change detection in profilesSync() when extracting TuneD profiles.
  * Move a lot of the logic of creating the environment for TuneD to the operand
    code, so that no external script are needed for starting the operand.
  * Add ocp-tuned-one-shot.service systemd unit when using a PerformanceProfile.
  * Introduce a timeout to running TuneD in one-shot mode so that we don't block
    the kubelet indefinitely.
  * Shorten the constants names from openshift* to ocp*

Resolves: OCPBUGS-26401

