### PR TITLE
NO-JIRA: perfprof: e2e: account for node base load

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -207,7 +207,10 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			testpod.Namespace = testutils.NamespaceTesting
 
 			isolatedCPUSet, _ := cpuset.Parse(isolatedCPU)
-			if cpuRequest > isolatedCPUSet.Size() {
+			// the worker node on which the pod will be scheduled has other pods already scheduled on it, and these also use a
+			// portion of the node's isolated cpus, and scheduling a pod requesting all the isolated cpus on the node (hence =)
+			// would fail because there is already a base cpu load on the node
+			if cpuRequest >= isolatedCPUSet.Size() {
 				Skip(fmt.Sprintf("cpus request %d is greater than the isolated cpus %d", cpuRequest, isolatedCPUSet.Size()))
 			}
 


### PR DESCRIPTION
Currently the test would fail when tested on machines with exactly isolated cpus equal to the requested cpus by the pod. This is because the worker nodes has already other pods running on them and thus they are using already a portion of the isolated cpus of the node. Scheduling a pod requesting all allocatable cpus would fail due to insufficient cpus on node.

Skip the test if the testing environment is not suitable for the test's requirements.