### PR TITLE
OCPBUGS-32980: [release-4.14]:fix extra-reboot on upgrade with paused mcp worker

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -19,10 +19,11 @@ package controller
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
 	"reflect"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	apiconfigv1 "github.com/openshift/api/config/v1"
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
@@ -582,7 +583,7 @@ func (r *PerformanceProfileReconciler) reconcileCgroupsV1(ctx context.Context, i
 	}
 
 	// (TODO) This code can be removed in the future when the cgroupsv2 is supported
-	currentMC, err := r.getCurrentMachineConfigByMCP(ctx, profileMCP)
+	currentMC, err := r.getStagedMachineConfigByMCP(ctx, profileMCP)
 	if err != nil {
 		return reconcile.Result{}, err, true
 	}

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -632,6 +632,11 @@ var _ = Describe("Controller", func() {
 								},
 							},
 						},
+						Configuration: mcov1.MachineConfigPoolStatusConfiguration{
+							ObjectReference: corev1.ObjectReference{
+								Name: "test",
+							},
+						},
 					},
 					Status: mcov1.MachineConfigPoolStatus{
 						Conditions: []mcov1.MachineConfigPoolCondition{

--- a/pkg/performanceprofile/controller/resources.go
+++ b/pkg/performanceprofile/controller/resources.go
@@ -28,17 +28,17 @@ func mergeMaps(src map[string]string, dst map[string]string) {
 
 // TODO: we should merge all create, get and delete methods
 
-func (r *PerformanceProfileReconciler) getCurrentMachineConfigByMCP(ctx context.Context, mcp *mcov1.MachineConfigPool) (*mcov1.MachineConfig, error) {
+func (r *PerformanceProfileReconciler) getStagedMachineConfigByMCP(ctx context.Context, mcp *mcov1.MachineConfigPool) (*mcov1.MachineConfig, error) {
 	if mcp == nil {
 		return nil, fmt.Errorf("nil MachineConfigPool object")
 	}
 
-	currentMCName := mcp.Status.Configuration.Name
+	currentMCName := mcp.Spec.Configuration.Name
 	if currentMCName == "" { // should never happen
 		return nil, fmt.Errorf("MCP %q missing configuration name", mcp.Name)
 	}
 
-	klog.Infof("checking current MachineConfig %q", currentMCName)
+	klog.Infof("checking staged MachineConfig %q", currentMCName)
 
 	return r.getMachineConfig(ctx, currentMCName)
 }

--- a/pkg/performanceprofile/utils/testing/testing.go
+++ b/pkg/performanceprofile/utils/testing/testing.go
@@ -113,6 +113,11 @@ func NewProfileMCP() *mcov1.MachineConfigPool {
 			MachineConfigSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{MachineConfigLabelKey: MachineConfigLabelValue},
 			},
+			Configuration: mcov1.MachineConfigPoolStatusConfiguration{
+				ObjectReference: corev1.ObjectReference{
+					Name: "test",
+				},
+			},
 		},
 		Status: mcov1.MachineConfigPoolStatus{
 			Configuration: mcov1.MachineConfigPoolStatusConfiguration{


### PR DESCRIPTION
This PR fixes an extra-reboot when upgrading OpenShift with paused MCP "worker", for example during EUS-to-EUS upgrade. The extra-reboot occurred because PerformanceProfile controller was reconciling against rendered MC appearing in the MCP status. While this MC reflects current MCP conditions, it does not reflect the latest planned state when the MCP is paused.
Unpausing the MCP lead to one reboot when applying the target MC, and one additional reboot after the performance profile was reconciled against it.
This change eliminates this additional reboot because PerformanceProfile is now reconciling against the latest planned MC before the MCP is unpaused.
This is a manual cherry-pick from #1049 
/cc @MarSik @yanirq 

