### PR TITLE
NO-JIRA: E2E: modify test use HaveKey matchter instead of ContainElement

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/netqueues.go
+++ b/test/e2e/performanceprofile/functests/1_performance/netqueues.go
@@ -262,8 +262,8 @@ var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", Ordered, func() 
 
 			// After at least one NIC was configured, make sure that the selected NIC was NOT it
 
-			Expect(nodesDevices).To(ContainElement(node.Name))
-			Expect(nodesDevices[node.Name]).To(ContainElement(device))
+			Expect(nodesDevices).To(HaveKey(node.Name))
+			Expect(nodesDevices[node.Name]).To(HaveKey(device))
 			Expect(nodesDevices[node.Name][device]).ToNot(Equal(getReservedCPUSize(profile.Spec.CPU)))
 		})
 


### PR DESCRIPTION
Using ContainElement causes test to fail as it checks the map contains an Element with node.Name , however in the case map[string]map[string]int, where the node.Name contains hostname:{dev:N, dev:N}, the match fails.

HaveKey specifically checks if the map has the Key with node.Name