### PR TITLE
NO-JIRA: Remove vestiges of annotation ignore-cgroups-version from tests

### DIFF
--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
@@ -251,11 +251,9 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 })
 
 func updateKubeletConfigOverrideAnnotations(profileAnnotations map[string]string, annotations string) map[string]string {
-	if _, ok := profileAnnotations["performance.openshift.io/ignore-cgroups-version"]; !ok {
-		profileAnnotations = map[string]string{
-			"kubeletconfig.experimental": annotations}
-	} else {
-		profileAnnotations["kubeletconfig.experimental"] = annotations
+	if profileAnnotations == nil {
+		profileAnnotations = map[string]string{}
 	}
+	profileAnnotations["kubeletconfig.experimental"] = annotations
 	return profileAnnotations
 }


### PR DESCRIPTION
 Remove vestiges of annotation ignore-cgroups-version from tests

Annotation performance.openshift.io/ignore-cgroups-version was added as
a switch that could be used during development of cgroups v2 related
code. One of the E2E tests was not cleaned up when support for the
annotation was removed. Clean up this E2E test now.