### PR TITLE
OCPBUGS-33682: right-hand-side profile_dirs take precedence

### DIFF
--- a/hack/dockerfile_install_support.sh
+++ b/hack/dockerfile_install_support.sh
@@ -25,7 +25,7 @@ if [[ "${ID}" == "centos" ]]; then
   dnf --setopt=tsflags=nodocs -y install /root/rpms/*.rpm
   rm -rf /etc/tuned/recommend.d
   echo auto > /etc/tuned/profile_mode
-  sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' /etc/tuned/tuned-main.conf;
+  sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /usr/lib/tuned,/var/lib/ocp-tuned/profiles|' /etc/tuned/tuned-main.conf;
 
   # Clean up build tools to remove image footprint
   dnf remove --setopt=protected_packages= -y ${BUILD_INSTALL_PKGS}
@@ -44,7 +44,7 @@ else
   dnf install --setopt=tsflags=nodocs -y ${INSTALL_PKGS}
   rm -rf /etc/tuned/recommend.d
   echo auto > /etc/tuned/profile_mode
-  sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' /etc/tuned/tuned-main.conf;
+  sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /usr/lib/tuned,/var/lib/ocp-tuned/profiles|' /etc/tuned/tuned-main.conf;
 
 fi
 


### PR DESCRIPTION
The new TuneD option profile_dirs defines custom TuneD directories.  Fix the order of the directories so that the system TuneD directory (/usr/lib/tuned) is the first one (searched last), and the custom TuneD directory (/var/lib/ocp-tuned/profiles) is the last one (searched first).

Resolves: OCPBUGS-33682