### PR TITLE
OCPBUGS-34720: Add tier0 and tier1 tags to non reboot test cases

### DIFF
--- a/test/e2e/performanceprofile/functests/0_config/config.go
+++ b/test/e2e/performanceprofile/functests/0_config/config.go
@@ -30,6 +30,7 @@ import (
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cluster"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
@@ -45,7 +46,7 @@ var _ = Describe("[performance][config] Performance configuration", Ordered, fun
 		RunningOnSingleNode = isSNO
 	})
 
-	It("Should successfully deploy the performance profile", func() {
+	It("Should successfully deploy the performance profile", Label(string(label.Tier0)), func() {
 
 		performanceProfile, err := testProfile()
 		Expect(err).ToNot(HaveOccurred(), "failed to build performance profile: %v", err)

--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/events"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/images"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/pods"
@@ -107,7 +108,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	Describe("Verification of configuration on the worker node", func() {
+	Describe("Verification of configuration on the worker node", Label(string(label.Tier0)), func() {
 		It("[test_id:28528][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Verify CPU reservation on the node", func() {
 			By(fmt.Sprintf("Allocatable CPU should be less than capacity by %d", len(listReservedCPU)))
 			capacityCPU, _ := workerRTNode.Status.Capacity.Cpu().AsInt64()
@@ -175,7 +176,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 
 	})
 
-	Describe("Verification of cpu manager functionality", func() {
+	Describe("Verification of cpu manager functionality", Label(string(label.Tier0)), func() {
 		var testpod *corev1.Pod
 		var discoveryFailed bool
 
@@ -261,7 +262,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		)
 	})
 
-	Describe("Verification of cpu_manager_state file", func() {
+	Describe("Verification of cpu_manager_state file", Label(string(label.Tier0)), func() {
 		var testpod *corev1.Pod
 		BeforeEach(func() {
 			testpod = pods.GetTestPod()
@@ -310,7 +311,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		})
 	})
 
-	Describe("Verification that IRQ load balance can be disabled per POD", func() {
+	Describe("Verification that IRQ load balance can be disabled per POD", Label(string(label.Tier0)), func() {
 		var smtLevel int
 		var testpod *corev1.Pod
 
@@ -393,7 +394,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		})
 	})
 
-	When("reserved CPUs specified", func() {
+	When("reserved CPUs specified", Label(string(label.Tier0)), func() {
 		var testpod *corev1.Pod
 
 		BeforeEach(func() {
@@ -465,7 +466,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		})
 	})
 
-	When("strict NUMA aligment is requested", func() {
+	When("strict NUMA aligment is requested", Label(string(label.Tier0)), func() {
 		var testpod *corev1.Pod
 
 		BeforeEach(func() {
@@ -517,7 +518,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			Expect(isSMTAlignmentError(updatedPod)).To(BeTrue(), "pod %s failed for wrong reason: %q", updatedPod.Name, updatedPod.Status.Reason)
 		})
 	})
-	Describe("Hyper-thread aware scheduling for guaranteed pods", func() {
+	Describe("Hyper-thread aware scheduling for guaranteed pods", Label(string(label.Tier1)), func() {
 		var testpod *corev1.Pod
 
 		BeforeEach(func() {
@@ -591,7 +592,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		)
 
 	})
-	Context("Crio Annotations", func() {
+	Context("Crio Annotations", Label(string(label.Tier0)), func() {
 		var testpod *corev1.Pod
 		var allTestpods map[types.UID]*corev1.Pod
 		var busyCpusImage string

--- a/test/e2e/performanceprofile/functests/1_performance/hugepages.go
+++ b/test/e2e/performanceprofile/functests/1_performance/hugepages.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cluster"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/images"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/pods"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
@@ -70,7 +71,7 @@ var _ = Describe("[performance]Hugepages", Ordered, func() {
 
 	// We have multiple hugepages e2e tests under the upstream, so the only thing that we should check, if the PAO configure
 	// correctly number of hugepages that will be available on the node
-	Context("[rfe_id:27369]when NUMA node specified", func() {
+	Context("[rfe_id:27369]when NUMA node specified", Label(string(label.Tier0)), func() {
 		It("[test_id:27752][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] should be allocated on the specifed NUMA node", func() {
 			for _, page := range profile.Spec.HugePages.Pages {
 				if page.Node == nil {
@@ -92,7 +93,7 @@ var _ = Describe("[performance]Hugepages", Ordered, func() {
 		})
 	})
 
-	Context("with multiple sizes", func() {
+	Context("with multiple sizes", Label(string(label.Tier0)), func() {
 		It("[test_id:34080] should be supported and available for the container usage", func() {
 			for _, page := range profile.Spec.HugePages.Pages {
 				hugepagesSize, err := machineconfig.GetHugepagesSizeKilobytes(page.Size)
@@ -121,7 +122,7 @@ var _ = Describe("[performance]Hugepages", Ordered, func() {
 		})
 	})
 
-	Context("[rfe_id:27354]Huge pages support for container workloads", func() {
+	Context("[rfe_id:27354]Huge pages support for container workloads", Label(string(label.Tier0)), func() {
 		var testpod *corev1.Pod
 
 		AfterEach(func() {

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -27,6 +27,7 @@ import (
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
@@ -73,7 +74,7 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 		By(fmt.Sprintf("verifying worker node %q", targetNode.Name))
 	})
 
-	Context("Verify GloballyDisableIrqLoadBalancing Spec field", func() {
+	Context("Verify GloballyDisableIrqLoadBalancing Spec field", Label(string(label.Tier0)), func() {
 		It("[test_id:36150] Verify that IRQ load balancing is enabled/disabled correctly", func() {
 
 			irqLoadBalancingDisabled := profile.Spec.GloballyDisableIrqLoadBalancing != nil && *profile.Spec.GloballyDisableIrqLoadBalancing
@@ -180,7 +181,7 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 		})
 	})
 
-	Context("Verify irqbalance configuration handling", func() {
+	Context("Verify irqbalance configuration handling", Label(string(label.Tier0)), func() {
 		It("Should not overwrite the banned CPU set on tuned restart", func() {
 			if profile.Status.RuntimeClass == nil {
 				Skip("runtime class not generated")

--- a/test/e2e/performanceprofile/functests/1_performance/netqueues.go
+++ b/test/e2e/performanceprofile/functests/1_performance/netqueues.go
@@ -24,6 +24,7 @@ import (
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cluster"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/pods"
@@ -32,7 +33,7 @@ import (
 
 const tunedprofilesDirectory string = "/var/lib/ocp-tuned/profiles"
 
-var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", Ordered, func() {
+var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", Ordered, Label(string(label.Tier1)), func() {
 	var workerRTNodes []corev1.Node
 	var profile, initialProfile *performancev2.PerformanceProfile
 	var tunedConfPath, performanceProfileName string

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cluster"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/infrastructure"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
@@ -78,7 +79,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred(), "cannot get profile by node labels %v", testutils.NodeSelectorLabels)
 	})
 
-	Context("Tuned CRs generated from profile", func() {
+	Context("Tuned CRs generated from profile", Label(string(label.Tier0)), func() {
 		tunedExpectedName := components.GetComponentName(testutils.PerformanceProfileName, components.ProfileNamePerformance)
 		It("[test_id:31748] Should have the expected name for tuned from the profile owner object", func() {
 			tunedList := &tunedv1.TunedList{}
@@ -139,7 +140,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Pre boot tuning adjusted by tuned ", func() {
+	Context("Pre boot tuning adjusted by tuned ", Label(string(label.Tier0)), func() {
 
 		It("[test_id:31198] Should set CPU affinity kernel argument", func() {
 			for _, node := range workerRTNodes {
@@ -279,7 +280,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 
 	})
 
-	Context("Additional kernel arguments added from perfomance profile", func() {
+	Context("Additional kernel arguments added from perfomance profile", Label(string(label.Tier0)), func() {
 		It("[test_id:28611][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Should set additional kernel arguments on the machine", func() {
 			if profile.Spec.AdditionalKernelArgs != nil {
 				for _, node := range workerRTNodes {
@@ -293,7 +294,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Using performance profile", func() {
+	Context("Using performance profile", Label(string(label.Tier0)), func() {
 		It("Should have system services running on the system.slice cgroup", func() {
 			for _, node := range workerRTNodes {
 				processesFound := make([]string, 0)
@@ -316,7 +317,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Tuned kernel parameters", func() {
+	Context("Tuned kernel parameters", Label(string(label.Tier0)), func() {
 		It("[test_id:28466][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Should contain configuration injected through openshift-node-performance profile", func() {
 			sysctlMap := map[string]string{
 				"kernel.hung_task_timeout_secs": "600",
@@ -338,7 +339,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("RPS configuration", func() {
+	Context("RPS configuration", Label(string(label.Tier1)), func() {
 		BeforeEach(func() {
 			if profile.Spec.CPU == nil || profile.Spec.CPU.Reserved == nil {
 				Skip("Test Skipped due nil Reserved cpus")
@@ -470,7 +471,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Network latency parameters adjusted by the Node Tuning Operator", func() {
+	Context("Network latency parameters adjusted by the Node Tuning Operator", Label(string(label.Tier0)), func() {
 		It("[test_id:28467][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Should contain configuration injected through the openshift-node-performance profile", func() {
 			sysctlMap := map[string]string{
 				"net.ipv4.tcp_fastopen":     "3",
@@ -494,7 +495,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Create second performance profiles on a cluster", func() {
+	Context("Create second performance profiles on a cluster", Label(string(label.Tier0)), func() {
 		var secondMCP *mcov1.MachineConfigPool
 		var secondProfile *performancev2.PerformanceProfile
 		var newRole = "worker-new"
@@ -647,7 +648,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Verify API Conversions", func() {
+	Context("Verify API Conversions", Label(string(label.Tier0)), func() {
 		verifyV2V1 := func() {
 			By("Checking v2 -> v1 conversion")
 			v1Profile := &performancev1.PerformanceProfile{}
@@ -842,7 +843,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Validation webhook", func() {
+	Context("Validation webhook", Label(string(label.Tier0)), func() {
 		BeforeEach(func() {
 			if discovery.Enabled() {
 				Skip("Discovery mode enabled, test skipped because it creates incorrect profiles")
@@ -914,7 +915,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			})
 		})
 
-		Context("with API version v1 profile", func() {
+		Context("with API version v1 profile", Label(string(label.Tier0)), func() {
 			var v1Profile *performancev1.PerformanceProfile
 
 			BeforeEach(func() {
@@ -973,7 +974,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			})
 		})
 
-		Context("with profile version v2", func() {
+		Context("with profile version v2", Label(string(label.Tier0)), func() {
 			var v2Profile *performancev2.PerformanceProfile
 
 			BeforeEach(func() {
@@ -1033,7 +1034,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	It("[test_id:54083] Should have kernel param rcutree.kthread", func() {
+	It("[test_id:54083] Should have kernel param rcutree.kthread", Label(string(label.Tier0)), func() {
 		for _, node := range workerRTNodes {
 			cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &node, []string{"cat", "/proc/cmdline"})
 			Expect(err).ToNot(HaveOccurred(), "Failed to read /proc/cmdline")

--- a/test/e2e/performanceprofile/functests/1_performance/rt-kernel.go
+++ b/test/e2e/performanceprofile/functests/1_performance/rt-kernel.go
@@ -10,10 +10,11 @@ import (
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
 )
 
-var _ = Describe("[performance]RT Kernel", Ordered, func() {
+var _ = Describe("[performance]RT Kernel", Ordered, Label(string(label.Tier0)), func() {
 	var discoveryFailed bool
 	var profile *performancev2.PerformanceProfile
 	var err error


### PR DESCRIPTION
This PR categorizes different tests under  0_config and 1_performance as tier0, tier1 using ginkgo labels. 

This tagging helps in executing set of test cases filtered using labels defined under utils/labels.go 

Definition of these tiers are found under utils/labels.go
