### PR TITLE
[release-4.15] OCPBUGS-33929: Negative net interface name fix

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
@@ -143,7 +143,8 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 			if device.InterfaceName != nil {
 				deviceNameAmendedRegex := strings.Replace(*device.InterfaceName, "*", ".*", -1)
 				if strings.HasPrefix(*device.InterfaceName, "!") {
-					devices = append(devices, "^INTERFACE="+"(?!"+deviceNameAmendedRegex+")")
+					// Strip the exclamation sign from the regex to avoid duplicating it
+					devices = append(devices, "^INTERFACE="+"(?!"+deviceNameAmendedRegex[1:]+")")
 				} else {
 					devices = append(devices, "^INTERFACE="+deviceNameAmendedRegex)
 				}

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -406,7 +406,9 @@ var _ = Describe("Tuned", func() {
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
 				It("should set by negative interface name with reserved CPUs count", func() {
-					netDeviceName := "!ens5"
+					netDeviceName := "ens5"
+					netDeviceNameInverted := "!" + netDeviceName
+
 					//regex field should be: devices_udev_regex=^INTERFACE=(?!ens5)
 					devicesUdevRegex := "\\^INTERFACE=\\(\\?!" + strings.Replace(netDeviceName, "*", "\\.\\*", -1) + "\\)"
 
@@ -414,7 +416,7 @@ var _ = Describe("Tuned", func() {
 						UserLevelNetworking: pointer.BoolPtr(true),
 						Devices: []performancev2.Device{
 							{
-								InterfaceName: &netDeviceName,
+								InterfaceName: &netDeviceNameInverted,
 							},
 						}}
 					manifest := getTunedManifest(profile)
@@ -488,7 +490,8 @@ var _ = Describe("Tuned", func() {
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
 				It("should set by specific vendor,model and negative interface name with reserved CPUs count", func() {
-					netDeviceName := "!ens5"
+					netDeviceName := "ens5"
+					netDeviceNameInverted := "!ens5"
 					netDeviceVendorID := "0x1af4"
 					netDeviceModelID := "0x1000"
 					//regex field should be: devices_udev_regex=^ID_MODEL_ID=0x1000[\\s\\S]*^ID_VENDOR_ID=0x1af4[\\s\\S]*^INTERFACE=(?!ens5)
@@ -498,7 +501,7 @@ var _ = Describe("Tuned", func() {
 						UserLevelNetworking: pointer.BoolPtr(true),
 						Devices: []performancev2.Device{
 							{
-								InterfaceName: &netDeviceName,
+								InterfaceName: &netDeviceNameInverted,
 								DeviceID:      &netDeviceModelID,
 								VendorID:      &netDeviceVendorID,
 							},


### PR DESCRIPTION
Negative net interface name does not reduce queues

This is a semi-automated cherry-pick of #973 and replaces #1062

The internal regular expression has duplicated exclamation mark that breaks the pattern.