### PR TITLE
NO-JIRA: PPC: Add relatedObjects status field

### DIFF
--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -761,6 +761,32 @@ spec:
                   - type
                   type: object
                 type: array
+              relatedObjects:
+                description: 'relatedObjects is a list of objects that are "interesting"
+                  or related to this operator.  Common uses are: 1. the detailed resource
+                  driving the operator 2. operator namespaces 3. operand namespaces'
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    group:
+                      description: group of the referent.
+                      type: string
+                    name:
+                      description: name of the referent.
+                      type: string
+                    namespace:
+                      description: namespace of the referent.
+                      type: string
+                    resource:
+                      description: resource of the referent.
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - resource
+                  type: object
+                type: array
               runtimeClass:
                 description: RuntimeClass contains the name of the RuntimeClass resource
                   created by the operator.

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v2
 
 import (
+	apiconfigv1 "github.com/openshift/api/config/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -222,6 +223,12 @@ type PerformanceProfileStatus struct {
 	Tuned *string `json:"tuned,omitempty"`
 	// RuntimeClass contains the name of the RuntimeClass resource created by the operator.
 	RuntimeClass *string `json:"runtimeClass,omitempty"`
+	// relatedObjects is a list of objects that are "interesting" or related to this operator.  Common uses are:
+	// 1. the detailed resource driving the operator
+	// 2. operator namespaces
+	// 3. operand namespaces
+	// +optional
+	RelatedObjects []apiconfigv1.ObjectReference `json:"relatedObjects,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
@@ -6,6 +6,7 @@
 package v2
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/custom-resource-status/conditions/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -368,6 +369,11 @@ func (in *PerformanceProfileStatus) DeepCopyInto(out *PerformanceProfileStatus) 
 		in, out := &in.RuntimeClass, &out.RuntimeClass
 		*out = new(string)
 		**out = **in
+	}
+	if in.RelatedObjects != nil {
+		in, out := &in.RelatedObjects, &out.RelatedObjects
+		*out = make([]configv1.ObjectReference, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/performanceprofile/controller/performanceprofile/status/status.go
+++ b/pkg/performanceprofile/controller/performanceprofile/status/status.go
@@ -5,13 +5,16 @@ import (
 	"context"
 	"time"
 
+	apiconfigv1 "github.com/openshift/api/config/v1"
 	mcov1 "github.com/openshift/api/machineconfiguration/v1"
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/resources"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
+	nodev1 "k8s.io/api/node/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -260,4 +263,34 @@ func removeUnMatchedTunedProfiles(nodes []corev1.Node, profiles []tunedv1.Profil
 		}
 	}
 	return filteredProfiles
+}
+
+func getRelatedObjects(profile *performancev2.PerformanceProfile) []apiconfigv1.ObjectReference {
+	// 'Resource' should be in lowercase and plural
+	// See BZ1851214
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+	ret := []apiconfigv1.ObjectReference{
+		{
+			Group:    mcov1.GroupName,
+			Resource: "kubeletconfigs",
+			Name:     components.GetComponentName(profile.Name, components.ComponentNamePrefix),
+		},
+		{
+			Group:    mcov1.GroupName,
+			Resource: "machineconfigs",
+			Name:     machineconfig.GetMachineConfigName(profile.Name),
+		},
+		{
+			Group:     tunedv1.SchemeGroupVersion.Group,
+			Resource:  "tuneds",
+			Name:      components.GetComponentName(profile.Name, components.ProfileNamePerformance),
+			Namespace: components.NamespaceNodeTuningOperator,
+		},
+		{
+			Group:    nodev1.SchemeGroupVersion.Group,
+			Resource: "runtimeclasses",
+			Name:     components.GetComponentName(profile.Name, components.ComponentNamePrefix),
+		},
+	}
+	return ret
 }

--- a/pkg/performanceprofile/controller/performanceprofile/status/writer.go
+++ b/pkg/performanceprofile/controller/performanceprofile/status/writer.go
@@ -124,6 +124,11 @@ func (w *writer) update(ctx context.Context, profile *performancev2.PerformanceP
 		modified = true
 	}
 
+	if profileCopy.Status.RelatedObjects == nil {
+		profileCopy.Status.RelatedObjects = getRelatedObjects(profile)
+		modified = true
+	}
+
 	if !modified {
 		return nil
 	}

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -160,6 +160,48 @@ var _ = Describe("Controller", func() {
 			Expect(availableCondition.Status).To(Equal(corev1.ConditionTrue))
 		})
 
+		It("should update relatedObject in the profile status", func() {
+			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator)
+
+			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
+
+			updatedProfile := &performancev2.PerformanceProfile{}
+			key := types.NamespacedName{
+				Name:      profile.Name,
+				Namespace: metav1.NamespaceNone,
+			}
+			Expect(r.Get(context.TODO(), key, updatedProfile)).ToNot(HaveOccurred())
+
+			expectedComponentName := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
+			expectedTunedName := components.GetComponentName(profile.Name, components.ProfileNamePerformance)
+			expectedTunedOperatorNs := "openshift-cluster-node-tuning-operator"
+
+			Expect(updatedProfile.Status.RelatedObjects).To(HaveLen(4))
+			mcor := apiconfigv1.ObjectReference{
+				Group:    "machineconfiguration.openshift.io",
+				Resource: "machineconfigs",
+				Name:     machineconfig.GetMachineConfigName(updatedProfile.Name),
+			}
+
+			kcor := apiconfigv1.ObjectReference{
+				Group:    "machineconfiguration.openshift.io",
+				Resource: "kubeletconfigs",
+				Name:     expectedComponentName,
+			}
+			tdor := apiconfigv1.ObjectReference{
+				Group:     "tuned.openshift.io",
+				Resource:  "tuneds",
+				Name:      expectedTunedName,
+				Namespace: expectedTunedOperatorNs,
+			}
+			rtcor := apiconfigv1.ObjectReference{
+				Group:    "node.k8s.io",
+				Resource: "runtimeclasses",
+				Name:     expectedComponentName,
+			}
+			Expect(updatedProfile.Status.RelatedObjects).To(ContainElements(mcor, kcor, tdor, rtcor))
+		})
+
 		It("should promote kubelet config failure condition", func() {
 			r := newFakeReconciler(profile, profileMCP, infra, clusterOperator)
 			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))


### PR DESCRIPTION
Add relatedObjects support to better integrate with must-gather

relatedObjects is a list of objects that are "interesting" or related to this operator.
must-gather uses this field to collect data from these object when data from the operator is collected.

**Note**: this is a cherry-pick from this [abandoned PR](https://github.com/openshift/cluster-node-tuning-operator/pull/819)