### PR TITLE
OCPBUGS-34972: perfprof: bump verbosiness of logs

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/resources/resources.go
+++ b/pkg/performanceprofile/controller/performanceprofile/resources/resources.go
@@ -83,7 +83,7 @@ func GetClusterOperator(ctx context.Context, cli client.Client) (*apiconfigv1.Cl
 func CreateOrUpdateMachineConfig(ctx context.Context, cli client.Client, mc *mcov1.MachineConfig) error {
 	_, err := GetMachineConfig(ctx, cli, mc.Name)
 	if errors.IsNotFound(err) {
-		klog.Infof("Create machine-config %q", mc.Name)
+		klog.V(1).Infof("Create machine-config %q", mc.Name)
 		if err := cli.Create(ctx, mc); err != nil {
 			return err
 		}
@@ -94,7 +94,7 @@ func CreateOrUpdateMachineConfig(ctx context.Context, cli client.Client, mc *mco
 		return err
 	}
 
-	klog.Infof("Update machine-config %q", mc.Name)
+	klog.V(2).Infof("Update machine-config %q", mc.Name)
 	return cli.Update(ctx, mc)
 }
 
@@ -162,7 +162,7 @@ func GetMutatedKubeletConfig(ctx context.Context, cli client.Client, kc *mcov1.K
 func CreateOrUpdateKubeletConfig(ctx context.Context, cli client.Client, kc *mcov1.KubeletConfig) error {
 	_, err := GetKubeletConfig(ctx, cli, kc.Name)
 	if errors.IsNotFound(err) {
-		klog.Infof("Create kubelet-config %q", kc.Name)
+		klog.V(1).Infof("Create kubelet-config %q", kc.Name)
 		if err := cli.Create(ctx, kc); err != nil {
 			return err
 		}
@@ -173,7 +173,7 @@ func CreateOrUpdateKubeletConfig(ctx context.Context, cli client.Client, kc *mco
 		return err
 	}
 
-	klog.Infof("Update kubelet-config %q", kc.Name)
+	klog.V(2).Infof("Update kubelet-config %q", kc.Name)
 	return cli.Update(ctx, kc)
 }
 
@@ -232,7 +232,7 @@ func CreateOrUpdateTuned(ctx context.Context, cli client.Client, tuned *tunedv1.
 
 	_, err := GetTuned(ctx, cli, tuned.Name, tuned.Namespace)
 	if errors.IsNotFound(err) {
-		klog.Infof("Create tuned %q under the namespace %q", tuned.Name, tuned.Namespace)
+		klog.V(1).Infof("Create tuned %q in the namespace %q", tuned.Name, tuned.Namespace)
 		if err := cli.Create(ctx, tuned); err != nil {
 			return err
 		}
@@ -243,7 +243,7 @@ func CreateOrUpdateTuned(ctx context.Context, cli client.Client, tuned *tunedv1.
 		return err
 	}
 
-	klog.Infof("Update tuned %q under the namespace %q", tuned.Name, tuned.Namespace)
+	klog.V(2).Infof("Update tuned %q in the namespace %q", tuned.Name, tuned.Namespace)
 	return cli.Update(ctx, tuned)
 }
 
@@ -320,7 +320,7 @@ func GetMutatedRuntimeClass(ctx context.Context, cli client.Client, runtimeClass
 func CreateOrUpdateRuntimeClass(ctx context.Context, cli client.Client, runtimeClass *nodev1.RuntimeClass) error {
 	_, err := GetRuntimeClass(ctx, cli, runtimeClass.Name)
 	if errors.IsNotFound(err) {
-		klog.Infof("Create runtime class %q", runtimeClass.Name)
+		klog.V(1).Infof("Create runtime class %q", runtimeClass.Name)
 		if err := cli.Create(ctx, runtimeClass); err != nil {
 			return err
 		}
@@ -331,7 +331,7 @@ func CreateOrUpdateRuntimeClass(ctx context.Context, cli client.Client, runtimeC
 		return err
 	}
 
-	klog.Infof("Update runtime class %q", runtimeClass.Name)
+	klog.V(2).Infof("Update runtime class %q", runtimeClass.Name)
 	return cli.Update(ctx, runtimeClass)
 }
 

--- a/pkg/performanceprofile/controller/performanceprofile/status/writer.go
+++ b/pkg/performanceprofile/controller/performanceprofile/status/writer.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/resources"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -128,6 +129,6 @@ func (w *writer) update(ctx context.Context, profile *performancev2.PerformanceP
 		return nil
 	}
 
-	klog.Infof("Updating the performance profile %q status", profile.Name)
+	klog.V(4).Infof("Updating the performance profile %q status", profile.Name)
 	return w.Client.Status().Update(ctx, profileCopy)
 }

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -290,7 +290,7 @@ func (r *PerformanceProfileReconciler) ctrRuntimeConfToPerformanceProfile(ctx co
 		klog.Errorf("failed to get container runtime config; name=%q err=%v", ctrRuntimeConfObj.GetName(), err)
 		return nil
 	}
-	klog.Infof("reconciling from ContainerRuntimeConfig %q", ctrcfg.Name)
+	klog.V(2).Infof("reconciling from ContainerRuntimeConfig %q", ctrcfg.Name)
 
 	selector, err := metav1.LabelSelectorAsSelector(ctrcfg.Spec.MachineConfigPoolSelector)
 	if err != nil {
@@ -309,7 +309,7 @@ func (r *PerformanceProfileReconciler) ctrRuntimeConfToPerformanceProfile(ctx co
 		return nil
 	}
 
-	klog.Infof("reconciling from ContainerRuntimeConfig %q selector %v: %d MCPs", ctrcfg.Name, ctrcfg.Spec.MachineConfigPoolSelector, len(mcps.Items))
+	klog.V(2).Infof("reconciling from ContainerRuntimeConfig %q selector %v: %d MCPs", ctrcfg.Name, ctrcfg.Spec.MachineConfigPoolSelector, len(mcps.Items))
 
 	profiles := &performancev2.PerformanceProfileList{}
 	err = r.List(ctx, profiles)
@@ -383,7 +383,7 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 	operatorReleaseVersion := os.Getenv("RELEASE_VERSION")
 	operandReleaseVersion := operatorv1helpers.FindOperandVersion(co.Status.Versions, tunedv1.TunedOperandName)
 	if operandReleaseVersion == nil || operatorReleaseVersion != operandReleaseVersion.Version {
-		// Upgrade in progress
+		// Upgrade in progress. Should happen rarely, so we omit V()
 		klog.Infof("operator and operand release versions do not match")
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}


### PR DESCRIPTION
Increase the verbosiness required to emit log messages to reduce the log amount.
Note this change doesn't address the reason for periodic reconciles, we only review the verbosiness of log messages.