### PR TITLE
NO-JIRA: e2e:labels: add platform type labels

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/label/label.go
+++ b/test/e2e/performanceprofile/functests/utils/label/label.go
@@ -79,3 +79,15 @@ const (
 	// QE maintains tests and reviews result
 	Tier3 Tier = "tier-3"
 )
+
+// Platform is a label that used to specify the type of platform on which
+// tests are supposed to run
+type Platform string
+
+const (
+	// OpenShift means that tests are relevant only for OpenShift platform
+	OpenShift Platform = "openshift"
+
+	// HyperShift means that tests relevant only for HyperShift platform
+	HyperShift Platform = "hypershift"
+)


### PR DESCRIPTION
Platform labels are used to indicate that test are only valid for a specific platform.
A test which doens't contain any `Platfrom` label, is a platform agnostic test.

These new label type will use to filter/focus e2e tests, based on the tested platform.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>