### PR TITLE
NO-JIRA:Dockerfile:bump go-builder to 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.20 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 RUN make update-tuned-submodule


### PR DESCRIPTION
In the `go.mod` file, we are using the `toolchain` directive, which is not recognized by golang 1.20.