### PR TITLE
CNF-14090: Add vendor and architecture specific tuning options

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -140,6 +140,8 @@ initrd_add_dir=
 
 # overrides cpu-partitioning cmdline
 cmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+
+# No default value but will be composed conditionally based on platform
 cmdline_iommu=
 
 {{if .StaticIsolation}}
@@ -153,11 +155,13 @@ cmdline_realtime=+nohz_full=${isolated_cores} nosoftlockup skew_tick=1 rcutree.k
 {{end}}
 
 {{if .HighPowerConsumption}}
-cmdline_power_performance=${high_power_consumption_cstate}
+# No default value but will be composed conditionally based on platform
+cmdline_power_performance=
 {{end}}
 
 {{if and .HighPowerConsumption .RealTimeHint}}
-cmdline_idle_poll=+idle=poll
+# No default value but will be composed conditionally based on platform
+cmdline_idle_poll=
 {{end}}
 
 {{if .DefaultHugepagesSize}}

--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -1,12 +1,18 @@
 [main]
 summary=Openshift node optimized for deterministic performance at the cost of increased power consumption, focused on low latency network performance. Based on Tuned 2.11 and Cluster node tuning (oc 4.5)
 
-# In case real time kernel is enabled the following include section will be evaluated as:
-# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
-# Otherwise:
-# include=openshift-node,cpu-partitioning
-include=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:}
-
+# The final result of the include depends on cpu vendor, cpu architecture, and whether the real time kernel is enabled
+# The first line will be evaluated based on the CPU vendor and architecture
+# This has three possible results:
+#   include=openshift-node-performance-amd-x86;
+#   include=openshift-node-performance-arm-aarch64;
+#   include=openshift-node-performance-intel-x86;
+# The second line will be evaluated based on whether the real time kernel is enabled
+# This has two possible results:
+#     openshift-node,cpu-partitioning
+#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
+include=openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Vendor ID\:\s*ARM:arm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}-{{.PerformanceProfileName}};
+  openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:}
 
 # Inheritance of base profiles legend:
 # cpu-partitioning -> network-latency -> latency-performance
@@ -24,7 +30,6 @@ isolated_cores={{.IsolatedCpus}}
 {{end}}
 
 not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
-automatic_pstate=${f:intel_recommended_pstate}
 
 {{if .PerPodPowerManagement}}
 [cpu]
@@ -134,7 +139,8 @@ initrd_dst_img=
 initrd_add_dir=
 
 # overrides cpu-partitioning cmdline
-cmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded} intel_iommu=on iommu=pt
+cmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+cmdline_iommu=
 
 {{if .StaticIsolation}}
 cmdline_isolation=+isolcpus=domain,managed_irq,${isolated_cores}
@@ -143,11 +149,11 @@ cmdline_isolation=+isolcpus=managed_irq,${isolated_cores}
 {{end}}
 
 {{if .RealTimeHint}}
-cmdline_realtime=+nohz_full=${isolated_cores} tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11
+cmdline_realtime=+nohz_full=${isolated_cores} nosoftlockup skew_tick=1 rcutree.kthread_prio=11
 {{end}}
 
 {{if .HighPowerConsumption}}
-cmdline_power_performance=+processor.max_cstate=1 intel_idle.max_cstate=0
+cmdline_power_performance=${high_power_consumption_cstate}
 {{end}}
 
 {{if and .HighPowerConsumption .RealTimeHint}}
@@ -158,15 +164,7 @@ cmdline_idle_poll=+idle=poll
 cmdline_hugepages=+ default_hugepagesz={{.DefaultHugepagesSize}} {{end}} {{if .Hugepages}} {{.Hugepages}} {{end}}
 
 {{if .AdditionalArgs}}
-cmdline_additionalArg=+{{.AdditionalArgs}} 
-{{end}}
-
-{{if .PerPodPowerManagement}}
-cmdline_pstate=+intel_pstate=passive
-{{else if .HardwareTuning}}
-cmdline_pstate=+intel_pstate=active
-{{else}}
-cmdline_pstate=+intel_pstate=${automatic_pstate}
+cmdline_additionalArg=+{{.AdditionalArgs}}
 {{end}}
 
 [rtentsk]

--- a/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
@@ -19,3 +19,7 @@ cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
 {{if .HighPowerConsumption}}
 cmdline_power_performance_amd=processor.max_cstate=1
 {{end}}
+
+{{if and .HighPowerConsumption .RealTimeHint}}
+cmdline_idle_poll_amd=idle=poll
+{{end}}

--- a/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
@@ -1,0 +1,21 @@
+[main]
+summary=Platform specific tuning for AMD x86
+
+[bootloader]
+cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+{{if .PerPodPowerManagement}}
+cmdline_pstate=amd_pstate=active
+{{else if .HardwareTuning}}
+cmdline_pstate=amd_pstate=passive
+{{else}}
+cmdline_pstate=amd_pstate=guided
+{{end}}
+
+{{if .RealTimeHint}}
+cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+{{end}}
+
+{{if .HighPowerConsumption}}
+cmdline_power_performance_amd=processor.max_cstate=1
+{{end}}

--- a/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
@@ -5,9 +5,9 @@ summary=Platform specific tuning for AMD x86
 cmdline_iommu_amd=amd_iommu=on iommu=pt
 
 {{if .PerPodPowerManagement}}
-cmdline_pstate=amd_pstate=active
-{{else if .HardwareTuning}}
 cmdline_pstate=amd_pstate=passive
+{{else if .HardwareTuning}}
+cmdline_pstate=amd_pstate=active
 {{else}}
 cmdline_pstate=amd_pstate=guided
 {{end}}

--- a/assets/performanceprofile/tuned/openshift-node-performance-arm-aarch64
+++ b/assets/performanceprofile/tuned/openshift-node-performance-arm-aarch64
@@ -1,0 +1,9 @@
+[main]
+summary=Platform specific tuning for aarch64
+
+[bootloader]
+# No cstate for ARM
+# No pstate args for ARM
+
+# aarch64 specific tuning options
+cmdline_iommu_arm=iommu.passthrough=1

--- a/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
@@ -1,0 +1,21 @@
+[main]
+summary=Platform specific tuning for Intel x86
+
+[bootloader]
+cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+{{if .PerPodPowerManagement}}
+cmdline_pstate=intel_pstate=active
+{{else if .HardwareTuning}}
+cmdline_pstate=intel_pstate=passive
+{{else}}
+cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+{{end}}
+
+{{if .RealTimeHint}}
+cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+{{end}}
+
+{{if .HighPowerConsumption}}
+cmdline_power_performance_intel=processor.max_cstate=1 intel_idle.max_cstate=0
+{{end}}

--- a/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
@@ -5,9 +5,9 @@ summary=Platform specific tuning for Intel x86
 cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 {{if .PerPodPowerManagement}}
-cmdline_pstate=intel_pstate=active
-{{else if .HardwareTuning}}
 cmdline_pstate=intel_pstate=passive
+{{else if .HardwareTuning}}
+cmdline_pstate=intel_pstate=active
 {{else}}
 cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
 {{end}}

--- a/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
@@ -19,3 +19,7 @@ cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
 {{if .HighPowerConsumption}}
 cmdline_power_performance_intel=processor.max_cstate=1 intel_idle.max_cstate=0
 {{end}}
+
+{{if and .HighPowerConsumption .RealTimeHint}}
+cmdline_idle_poll_intel=idle=poll
+{{end}}

--- a/pkg/performanceprofile/controller/performanceprofile/components/consts.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/consts.go
@@ -23,6 +23,12 @@ const (
 	ProfileNamePerformance = "openshift-node-performance"
 	// ProfileNamePerformanceRT defines the performance real time tuned profile name
 	ProfileNamePerformanceRT = "openshift-node-performance-rt"
+	// ProfileNameAmdX86 defines the AMD X86 specific tuning parameters
+	ProfileNameAmdX86 = "openshift-node-performance-amd-x86"
+	// ProfileNameArmAarch64 defines the ARM Aarch64 specific tuning parameters
+	ProfileNameArmAarch64 = "openshift-node-performance-arm-aarch64"
+	// ProfileNameIntelX86 defines the Intel X86 specific tuning parameters
+	ProfileNameIntelX86 = "openshift-node-performance-intel-x86"
 )
 
 const (

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
@@ -218,13 +218,32 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 	if err != nil {
 		return nil, err
 	}
+	name := components.GetComponentName(profile.Name, components.ProfileNamePerformance)
 
 	RealTimeKernelProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNamePerformanceRT), templateArgs)
 	if err != nil {
 		return nil, err
 	}
-	name := components.GetComponentName(profile.Name, components.ProfileNamePerformance)
 	RealTimeKernelProfileName := components.GetComponentName(profile.Name, components.ProfileNamePerformanceRT)
+
+	AmdX86ProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNameAmdX86), templateArgs)
+	if err != nil {
+		return nil, err
+	}
+	AmdX86ProfileName := components.GetComponentName(profile.Name, components.ProfileNameAmdX86)
+
+	ArmAarch64ProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNameArmAarch64), templateArgs)
+	if err != nil {
+		return nil, err
+	}
+	ArmAarch64ProfileName := components.GetComponentName(profile.Name, components.ProfileNameArmAarch64)
+
+	IntelX86ProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNameIntelX86), templateArgs)
+	if err != nil {
+		return nil, err
+	}
+	IntelX86ProfileName := components.GetComponentName(profile.Name, components.ProfileNameIntelX86)
+
 	profiles := []tunedv1.TunedProfile{
 		{
 			Name: &name,
@@ -233,6 +252,18 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 		{
 			Name: &RealTimeKernelProfileName,
 			Data: &RealTimeKernelProfileData,
+		},
+		{
+			Name: &AmdX86ProfileName,
+			Data: &AmdX86ProfileData,
+		},
+		{
+			Name: &ArmAarch64ProfileName,
+			Data: &ArmAarch64ProfileData,
+		},
+		{
+			Name: &IntelX86ProfileName,
+			Data: &IntelX86ProfileData,
 		},
 	}
 

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -27,14 +27,15 @@ var (
 	cmdlineAmdHighPowerConsumption   = "processor.max_cstate=1"
 	cmdlineAmdPstateActive           = "amd_pstate=active"
 	cmdlineAmdPstateAutomatic        = "amd_pstate=guided"
+	cmdlineAmdPstatePassive          = "amd_pstate=passive"
 	cmdlineCPUsPartitioning          = "+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}"
 	cmdlineDummy2MHugePages          = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=0"
-	cmdlineHighPowerConsumption      = "${high_power_consumption_cstate}"
 	cmdlineHugepages                 = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4"
 	cmdlineIdlePoll                  = "idle=poll"
 	cmdlineIntelHighPowerConsumption = "processor.max_cstate=1 intel_idle.max_cstate=0"
 	cmdlineIntelPstateActive         = "intel_pstate=active"
 	cmdlineIntelPstateAutomatic      = "intel_pstate=${f:intel_recommended_pstate}"
+	cmdlineIntelPstatePassive        = "intel_pstate=passive"
 	cmdlineMultipleHugePages         = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=128"
 	cmdlineRealtime                  = "+nohz_full=${isolated_cores} nosoftlockup skew_tick=1 rcutree.kthread_prio=11"
 	cmdlineWithoutStaticIsolation    = "+isolcpus=managed_irq,${isolated_cores}"
@@ -550,12 +551,12 @@ var _ = Describe("Tuned", func() {
 			})
 		})
 		When("perPodPowerManagement Hint is true", func() {
-			It("should contain amd_pstate set to active", func() {
+			It("should contain amd_pstate set to passive", func() {
 				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(true)
 				tunedData := getTunedStructuredData(profile, components.ProfileNameAmdX86)
 				bootloaderSection, err := tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineAmdPstateActive))
+				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineAmdPstatePassive))
 			})
 		})
 		When("realtime workload enabled and high power consumption is enabled", func() {
@@ -631,12 +632,12 @@ var _ = Describe("Tuned", func() {
 			})
 		})
 		When("perPodPowerManagement Hint is true", func() {
-			It("should contain intel_pstate set to active", func() {
+			It("should contain intel_pstate set to passive", func() {
 				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(true)
 				tunedData := getTunedStructuredData(profile, components.ProfileNameIntelX86)
 				bootloaderSection, err := tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineIntelPstateActive))
+				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineIntelPstatePassive))
 			})
 		})
 		When("realtime workload enabled and high power consumption is enabled", func() {

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,59 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-master
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -55,7 +55,8 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
@@ -76,6 +77,8 @@ spec:
 
 
       cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 
@@ -104,6 +107,8 @@ spec:
 
 
       cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -55,7 +55,8 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
@@ -76,6 +77,8 @@ spec:
 
 
       cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 
@@ -104,6 +107,8 @@ spec:
 
 
       cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,59 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-worker
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,59 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-master
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -55,7 +55,8 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
@@ -76,6 +77,8 @@ spec:
 
 
       cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 
@@ -104,6 +107,8 @@ spec:
 
 
       cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -55,7 +55,8 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
@@ -76,6 +77,8 @@ spec:
 
 
       cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 
@@ -104,6 +107,8 @@ spec:
 
 
       cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,59 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-worker
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,59 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-master
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -55,7 +55,8 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
@@ -76,6 +77,8 @@ spec:
 
 
       cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 
@@ -104,6 +107,8 @@ spec:
 
 
       cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -55,7 +55,8 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
@@ -76,6 +77,8 @@ spec:
 
 
       cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 
@@ -104,6 +107,8 @@ spec:
 
 
       cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,59 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-worker
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -72,7 +72,7 @@ spec:
       cmdline_iommu_amd=amd_iommu=on iommu=pt
 
 
-      cmdline_pstate=amd_pstate=passive
+      cmdline_pstate=amd_pstate=active
 
 
 
@@ -102,7 +102,7 @@ spec:
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
-      cmdline_pstate=intel_pstate=passive
+      cmdline_pstate=intel_pstate=active
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -8,16 +8,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=2-3\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=2-3\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -46,10 +53,9 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=active\n\n\n[rtentsk]\n\n\n[sysfs]\n#
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n[sysfs]\n#
       sets provided frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
@@ -57,6 +63,51 @@ spec:
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=passive
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-amd-x86-manual
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=passive
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-intel-x86-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -53,7 +53,8 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n[sysfs]\n#
       sets provided frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
@@ -76,6 +77,8 @@ spec:
 
 
       cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 
@@ -104,6 +107,8 @@ spec:
 
 
       cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,60 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-amd-x86-manual
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-intel-x86-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -55,7 +55,8 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
@@ -77,6 +78,8 @@ spec:
 
 
       cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 
@@ -105,6 +108,8 @@ spec:
 
 
       cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -53,7 +53,8 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
       nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
       default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
@@ -75,6 +76,8 @@ spec:
 
 
       cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 
@@ -103,6 +106,8 @@ spec:
 
 
       cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
 
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -8,16 +8,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -46,16 +53,60 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-amd-x86-manual
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+    name: openshift-node-performance-intel-x86-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf


### PR DESCRIPTION
- This makes use of a new helper function in tuned that was added in tuned 2.24 to get cpu information from lscpu
- Adds separate tuning files for AMD/X86, ARM/AArch64, and Intel/X86
- Platform specific tuning can be added to the appropriate tuning file and will loaded automatically by the openshift-node-performance profile
- Tuning for AMD and ARM should be considered not final at this time