### PR TITLE
CNF-7123: Enable and adjust 1_performance suite on Hypershift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ pao-functests-mixedcpus:
 pao-functests-hypershift:
 	@echo "Cluster Version"
 	hack/show-cluster-version.sh
-	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config" -p "-vv --label-filter="!openshift" -r --fail-fast --flake-attempts=2 --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
+	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/1_performance" -p "-vv --label-filter="!openshift" -r --fail-fast --flake-attempts=2 --timeout=2h --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
 
 .PHONY: cluster-clean-pao
 cluster-clean-pao:

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ pao-functests-mixedcpus:
 pao-functests-hypershift:
 	@echo "Cluster Version"
 	hack/show-cluster-version.sh
-	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config" -p "-vv -r --fail-fast --flake-attempts=2 --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
+	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config" -p "-vv --label-filter="!openshift" -r --fail-fast --flake-attempts=2 --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
 
 .PHONY: cluster-clean-pao
 cluster-clean-pao:

--- a/test/e2e/performanceprofile/functests/0_config/config.go
+++ b/test/e2e/performanceprofile/functests/0_config/config.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodepools"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profilesupdate"
 )
 
 var RunningOnSingleNode bool
@@ -258,12 +259,10 @@ func attachProfileToNodePool(ctx context.Context, performanceProfile *performanc
 	// if the profile exists, don't wait for nodePool to get into updating state
 	if !profileAlreadyExists {
 		testlog.Infof("wait for node pool %q transition into update config state", key.String())
-		err = nodepools.WaitForUpdatingConfig(ctx, testclient.ControlPlaneClient, np.Name, np.Namespace)
-		Expect(err).ToNot(HaveOccurred(), "nodePool %q is not in UpdatingConfig state", key.String())
+		profilesupdate.WaitForTuningUpdating(ctx, performanceProfile)
 	}
 	testlog.Infof("wait for node pool %q transition into config ready state", key.String())
-	err = nodepools.WaitForConfigToBeReady(ctx, testclient.ControlPlaneClient, np.Name, np.Namespace)
-	Expect(err).ToNot(HaveOccurred(), "nodePool %q config is not ready", key.String())
+	profilesupdate.WaitForTuningUpdated(ctx, performanceProfile)
 }
 
 func printEnvs() {

--- a/test/e2e/performanceprofile/functests/0_config/config.go
+++ b/test/e2e/performanceprofile/functests/0_config/config.go
@@ -20,8 +20,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	mcv1 "github.com/openshift/api/machineconfiguration/v1"
-
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
@@ -81,8 +79,15 @@ var _ = Describe("[performance][config] Performance configuration", Ordered, fun
 				return err
 			}, cluster.ComputeTestTimeout(15*time.Minute, RunningOnSingleNode), 15*time.Second).ShouldNot(HaveOccurred(), "Failed creating the performance profile")
 		}
-		unpauseMCP(context.TODO(), performanceProfile, profileAlreadyExists)
-		attachProfileToNodePool(context.TODO(), performanceProfile, profileAlreadyExists)
+		unpauseMCP(context.TODO(), performanceProfile)
+		attachProfileToNodePool(context.TODO(), performanceProfile)
+		// if the profile exists, it's likely to have been through the updating phase, so we only
+		//	wait for updated.
+		if !profileAlreadyExists {
+			profilesupdate.WaitForTuningUpdating(context.TODO(), performanceProfile)
+		}
+		profilesupdate.PostUpdateSync(context.TODO(), performanceProfile)
+
 		Expect(testclient.ControlPlaneClient.Get(context.TODO(), client.ObjectKeyFromObject(performanceProfile), performanceProfile))
 		By("Printing the updated profile")
 		testlog.Info(format.Object(performanceProfile, 2))
@@ -202,7 +207,7 @@ func testProfile() (*performancev2.PerformanceProfile, error) {
 	return profile, nil
 }
 
-func unpauseMCP(ctx context.Context, performanceProfile *performancev2.PerformanceProfile, profileAlreadyExists bool) {
+func unpauseMCP(ctx context.Context, performanceProfile *performancev2.PerformanceProfile) {
 	GinkgoHelper()
 	// no MCPs on hypershift
 	if hypershift.IsHypershiftCluster() {
@@ -230,18 +235,9 @@ func unpauseMCP(ctx context.Context, performanceProfile *performancev2.Performan
 
 	By("Waiting for the MCP to pick the PerformanceProfile's MC")
 	mcps.WaitForProfilePickedUp(performanceMCP.Name, performanceProfile)
-
-	// If the profile is already there, it's likely to have been through the updating phase, so we only
-	// wait for updated.
-	if !profileAlreadyExists {
-		By("Waiting for MCP starting to update")
-		mcps.WaitForCondition(performanceMCP.Name, mcv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
-	}
-	By("Waiting for MCP being updated")
-	mcps.WaitForCondition(performanceMCP.Name, mcv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
 }
 
-func attachProfileToNodePool(ctx context.Context, performanceProfile *performancev2.PerformanceProfile, profileAlreadyExists bool) {
+func attachProfileToNodePool(ctx context.Context, performanceProfile *performancev2.PerformanceProfile) {
 	GinkgoHelper()
 	// no NodePools on none-hypershift
 	if !hypershift.IsHypershiftCluster() {
@@ -255,14 +251,6 @@ func attachProfileToNodePool(ctx context.Context, performanceProfile *performanc
 	Expect(err).ToNot(HaveOccurred())
 	np.Spec.TuningConfig = []corev1.LocalObjectReference{{Name: performanceProfile.Name}}
 	Expect(testclient.ControlPlaneClient.Update(ctx, np)).To(Succeed())
-	key := client.ObjectKeyFromObject(np)
-	// if the profile exists, don't wait for nodePool to get into updating state
-	if !profileAlreadyExists {
-		testlog.Infof("wait for node pool %q transition into update config state", key.String())
-		profilesupdate.WaitForTuningUpdating(ctx, performanceProfile)
-	}
-	testlog.Infof("wait for node pool %q transition into config ready state", key.String())
-	profilesupdate.WaitForTuningUpdated(ctx, performanceProfile)
 }
 
 func printEnvs() {

--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -75,9 +75,9 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 		onlineCPUSet, err = nodes.GetOnlineCPUsSet(ctx, workerRTNode)
 		cpuID := onlineCPUSet.UnsortedList()[0]
 		smtLevel = nodes.GetSMTLevel(ctx, cpuID, workerRTNode)
-		getter, err = cgroup.BuildGetter(ctx, testclient.Client, testclient.K8sClient)
+		getter, err = cgroup.BuildGetter(ctx, testclient.DataPlaneClient, testclient.K8sClient)
 		Expect(err).ToNot(HaveOccurred())
-		cgroupV2, err = cgroup.IsVersion2(ctx, testclient.Client)
+		cgroupV2, err = cgroup.IsVersion2(ctx, testclient.DataPlaneClient)
 		Expect(err).ToNot(HaveOccurred())
 
 	})
@@ -244,7 +244,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 
 			By(fmt.Sprintf("create a %s QoS stress pod requesting %d cpus", expectedQos, cpuRequest))
 			var err error
-			err = testclient.Client.Create(ctx, testpod)
+			err = testclient.DataPlaneClient.Create(ctx, testpod)
 			Expect(err).ToNot(HaveOccurred())
 
 			testpod, err = pods.WaitForCondition(ctx, client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
@@ -252,7 +252,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			updatedPod := &corev1.Pod{}
-			err = testclient.Client.Get(ctx, client.ObjectKeyFromObject(testpod), updatedPod)
+			err = testclient.DataPlaneClient.Get(ctx, client.ObjectKeyFromObject(testpod), updatedPod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updatedPod.Status.QOSClass).To(Equal(expectedQos),
 				"unexpected QoS Class for %s/%s: %s (looking for %s)",
@@ -286,7 +286,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 					corev1.ResourceCPU:    resource.MustParse("2"),
 				},
 			}
-			err := testclient.Client.Create(context.TODO(), testpod)
+			err := testclient.DataPlaneClient.Create(context.TODO(), testpod)
 			testpod, err = pods.WaitForCondition(context.TODO(), client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
 			logEventsForPod(testpod)
 			Expect(err).ToNot(HaveOccurred())
@@ -361,7 +361,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			}
 			testpod = getTestPodWithAnnotations(annotations, smtLevel)
 
-			err = testclient.Client.Create(context.TODO(), testpod)
+			err = testclient.DataPlaneClient.Create(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 			testpod, err = pods.WaitForCondition(context.TODO(), client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
 			logEventsForPod(testpod)
@@ -416,7 +416,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			testpod.Spec.NodeSelector = map[string]string{testutils.LabelHostname: workerRTNode.Name}
 			testpod.Spec.ShareProcessNamespace = pointer.Bool(true)
 
-			err := testclient.Client.Create(context.TODO(), testpod)
+			err := testclient.DataPlaneClient.Create(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 
 			testpod, err = pods.WaitForCondition(context.TODO(), client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
@@ -514,7 +514,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			testpod = promotePodToGuaranteed(getStressPod(workerRTNode.Name, cpuCount))
 			testpod.Namespace = testutils.NamespaceTesting
 
-			err := testclient.Client.Create(context.TODO(), testpod)
+			err := testclient.DataPlaneClient.Create(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 
 			currentPod, err := pods.WaitForPredicate(context.TODO(), client.ObjectKeyFromObject(testpod), 10*time.Minute, func(pod *corev1.Pod) (bool, error) {
@@ -526,7 +526,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), "expected the pod to keep pending, but its current phase is %s", currentPod.Status.Phase)
 
 			updatedPod := &corev1.Pod{}
-			err = testclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(testpod), updatedPod)
+			err = testclient.DataPlaneClient.Get(context.TODO(), client.ObjectKeyFromObject(testpod), updatedPod)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(updatedPod.Status.Phase).To(Equal(corev1.PodFailed), "pod %s not failed: %v", updatedPod.Name, updatedPod.Status)
@@ -626,7 +626,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			unblockerPod := pods.GetTestPod() // any non-GU pod will suffice ...
 			unblockerPod.Namespace = testutils.NamespaceTesting
 			unblockerPod.Spec.NodeSelector = map[string]string{testutils.LabelHostname: workerRTNode.Name}
-			err = testclient.Client.Create(context.TODO(), unblockerPod)
+			err = testclient.DataPlaneClient.Create(context.TODO(), unblockerPod)
 			Expect(err).ToNot(HaveOccurred())
 			allTestpods[unblockerPod.UID] = unblockerPod
 			time.Sleep(30 * time.Second) // let cpumanager reconcile loop catch up
@@ -655,22 +655,22 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			testpod.Spec.RuntimeClassName = &runtimeClass
 			testpod.Spec.Containers[0].Image = busyCpusImage
 			testpod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU] = resource.MustParse("2")
-			err = testclient.Client.Create(context.TODO(), testpod)
+			err = testclient.DataPlaneClient.Create(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 			testpod, err = pods.WaitForCondition(ctx, client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
 			logEventsForPod(testpod)
 			Expect(err).ToNot(HaveOccurred(), "failed to create guaranteed pod %v", testpod)
 			allTestpods[testpod.UID] = testpod
-			err = testclient.Client.Get(ctx, client.ObjectKey{Name: testpod.Spec.NodeName}, targetNode)
+			err = testclient.DataPlaneClient.Get(ctx, client.ObjectKey{Name: testpod.Spec.NodeName}, targetNode)
 			Expect(err).ToNot(HaveOccurred(), "failed to fetch the node on which pod %v is running", testpod)
 		})
 
 		AfterAll(func() {
 			for podUID, testpod := range allTestpods {
 				testlog.Infof("deleting test pod %s/%s UID=%q", testpod.Namespace, testpod.Name, podUID)
-				err := testclient.Client.Get(ctx, client.ObjectKeyFromObject(testpod), testpod)
+				err := testclient.DataPlaneClient.Get(ctx, client.ObjectKeyFromObject(testpod), testpod)
 				Expect(err).ToNot(HaveOccurred())
-				err = testclient.Client.Delete(ctx, testpod)
+				err = testclient.DataPlaneClient.Delete(ctx, testpod)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = pods.WaitForDeletion(ctx, testpod, pods.DefaultDeletionTimeout*time.Second)
@@ -844,7 +844,7 @@ func startHTtestPod(ctx context.Context, cpuCount int) *corev1.Pod {
 
 	By(fmt.Sprintf("Creating test pod with %d cpus", cpuCount))
 	testlog.Info(pods.DumpResourceRequirements(testpod))
-	err := testclient.Client.Create(ctx, testpod)
+	err := testclient.DataPlaneClient.Create(ctx, testpod)
 	Expect(err).ToNot(HaveOccurred())
 	testpod, err = pods.WaitForCondition(ctx, client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
 	logEventsForPod(testpod)
@@ -942,14 +942,14 @@ func getTestPodWithAnnotations(annotations map[string]string, cpus int) *corev1.
 
 func deleteTestPod(ctx context.Context, testpod *corev1.Pod) (types.UID, bool) {
 	// it possible that the pod already was deleted as part of the test, in this case we want to skip teardown
-	err := testclient.Client.Get(ctx, client.ObjectKeyFromObject(testpod), testpod)
+	err := testclient.DataPlaneClient.Get(ctx, client.ObjectKeyFromObject(testpod), testpod)
 	if errors.IsNotFound(err) {
 		return "", false
 	}
 
 	testpodUID := testpod.UID
 
-	err = testclient.Client.Delete(ctx, testpod)
+	err = testclient.DataPlaneClient.Delete(ctx, testpod)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = pods.WaitForDeletion(ctx, testpod, pods.DefaultDeletionTimeout*time.Second)
@@ -985,7 +985,7 @@ func cpuSpecToString(cpus *performancev2.CPU) (string, error) {
 }
 
 func logEventsForPod(testPod *corev1.Pod) {
-	evs, err := events.GetEventsForObject(testclient.Client, testPod.Namespace, testPod.Name, string(testPod.UID))
+	evs, err := events.GetEventsForObject(testclient.DataPlaneClient, testPod.Namespace, testPod.Name, string(testPod.UID))
 	if err != nil {
 		testlog.Error(err)
 	}

--- a/test/e2e/performanceprofile/functests/1_performance/hugepages.go
+++ b/test/e2e/performanceprofile/functests/1_performance/hugepages.go
@@ -44,7 +44,7 @@ var _ = Describe("[performance]Hugepages", Ordered, func() {
 		isSNO, err := cluster.IsSingleNode()
 		Expect(err).ToNot(HaveOccurred())
 		RunningOnSingleNode = isSNO
-		cgroupV2, err = cgroup.IsVersion2(ctx, testclient.Client)
+		cgroupV2, err = cgroup.IsVersion2(ctx, testclient.DataPlaneClient)
 		Expect(err).ToNot(HaveOccurred())
 
 	})
@@ -126,7 +126,7 @@ var _ = Describe("[performance]Hugepages", Ordered, func() {
 		var testpod *corev1.Pod
 
 		AfterEach(func() {
-			err := testclient.Client.Delete(context.TODO(), testpod)
+			err := testclient.DataPlaneClient.Delete(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = pods.WaitForDeletion(context.TODO(), testpod, pods.DefaultDeletionTimeout*time.Second)
@@ -162,7 +162,7 @@ var _ = Describe("[performance]Hugepages", Ordered, func() {
 				corev1.ResourceName(fmt.Sprintf("hugepages-%si", hpSize)): resource.MustParse(fmt.Sprintf("%si", hpSize)),
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
 			}
-			err = testclient.Client.Create(context.TODO(), testpod)
+			err = testclient.DataPlaneClient.Create(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 			testpod, err = pods.WaitForCondition(context.TODO(), client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -96,7 +96,7 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 
 					condStatus := corev1.ConditionUnknown
 					EventuallyWithOffset(1, context.TODO(), func() bool {
-						tunedProfile, err := e2etuned.GetProfile(context.TODO(), testclient.Client, components.NamespaceNodeTuningOperator, node.Name)
+						tunedProfile, err := e2etuned.GetProfile(context.TODO(), testclient.DataPlaneClient, components.NamespaceNodeTuningOperator, node.Name)
 						Expect(err).ToNot(HaveOccurred(), "failed to get Tuned Profile for node %q", node.Name)
 						for _, cond := range tunedProfile.Status.Conditions {
 							if cond.Type != tunedv1.TunedProfileApplied {
@@ -228,7 +228,7 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 			data, _ := json.Marshal(testpod)
 			testlog.Infof("using testpod:\n%s", string(data))
 
-			err = testclient.Client.Create(context.TODO(), testpod)
+			err = testclient.DataPlaneClient.Create(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				if testpod != nil {

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/cpuset"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -146,14 +145,8 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 
 			defer func() { // return initial configuration
 				By("reverting the profile into its initial state")
-				spec, err := json.Marshal(initialProfile.Spec)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(testclient.Client.Patch(context.TODO(), profile,
-					client.RawPatch(
-						types.JSONPatchType,
-						[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, spec)),
-					),
-				)).ToNot(HaveOccurred())
+				profile.Spec = initialProfile.Spec
+				profiles.UpdateWithRetry(profile)
 				// in the initial profile `GloballyDisableIrqLoadBalancing` value should be false,
 				// so we expect the banned cpu set to be empty
 				Eventually(verifyNodes).WithArguments(false).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).ShouldNot(HaveOccurred())
@@ -166,17 +159,7 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 			profile.Spec.GloballyDisableIrqLoadBalancing = &irqLoadBalancingDisabled
 
 			By(fmt.Sprintf("Modifying profile: irqLoadBalancingDisabled switched to %v", irqLoadBalancingDisabled))
-
-			spec, err := json.Marshal(profile.Spec)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("Applying changes in performance profile and waiting until mcp will start updating")
-			Expect(testclient.Client.Patch(context.TODO(), profile,
-				client.RawPatch(
-					types.JSONPatchType,
-					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, spec)),
-				),
-			)).ToNot(HaveOccurred())
+			profiles.UpdateWithRetry(profile)
 			Eventually(verifyNodes).WithArguments(irqLoadBalancingDisabled).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).ShouldNot(HaveOccurred())
 		})
 	})

--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -58,7 +58,7 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 
 		initialProfile = profile.DeepCopy()
 
-		profilesupdate.WaitForTuningUpdated(context.TODO(), profile)
+		profilesupdate.PostUpdateSync(context.TODO(), profile)
 
 		nodeIdx := pickNodeIdx(workerRTNodes)
 		targetNode = &workerRTNodes[nodeIdx]

--- a/test/e2e/performanceprofile/functests/1_performance/netqueues.go
+++ b/test/e2e/performanceprofile/functests/1_performance/netqueues.go
@@ -2,7 +2,6 @@ package __performance
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -10,11 +9,9 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/cpuset"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -86,14 +83,8 @@ var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", Ordered, Label(s
 
 	AfterEach(func() {
 		By("Reverting the Profile")
-		spec, err := json.Marshal(initialProfile.Spec)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(testclient.Client.Patch(context.TODO(), profile,
-			client.RawPatch(
-				types.JSONPatchType,
-				[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, spec)),
-			),
-		)).ToNot(HaveOccurred())
+		profile.Spec = initialProfile.Spec
+		profiles.UpdateWithRetry(profile)
 	})
 
 	Context("Updating performance profile for netqueues", func() {

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -590,13 +590,13 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				Namespace: metav1.NamespaceNone,
 			}
 			kubeletConfig := &machineconfigv1.KubeletConfig{}
-			err := testclient.GetWithRetry(context.TODO(), configKey, kubeletConfig)
+			err := testclient.GetWithRetry(context.TODO(), testclient.ControlPlaneClient, configKey, kubeletConfig)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find KubeletConfig object %s", configKey.Name))
 			Expect(kubeletConfig.Spec.MachineConfigPoolSelector.MatchLabels[machineconfigv1.MachineConfigRoleLabelKey]).Should(Equal(newRole))
 			Expect(kubeletConfig.Spec.KubeletConfig.Raw).Should(ContainSubstring("restricted"), "Can't find value in KubeletConfig")
 
 			runtimeClass := &nodev1.RuntimeClass{}
-			err = testclient.GetWithRetry(context.TODO(), configKey, runtimeClass)
+			err = testclient.GetWithRetry(context.TODO(), testclient.DataPlaneClient, configKey, runtimeClass)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find RuntimeClass profile object %s", runtimeClass.Name))
 			Expect(runtimeClass.Handler).Should(Equal(machineconfig.HighPerformanceRuntime))
 
@@ -605,7 +605,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				Namespace: metav1.NamespaceNone,
 			}
 			machineConfig := &machineconfigv1.MachineConfig{}
-			err = testclient.GetWithRetry(context.TODO(), machineConfigKey, machineConfig)
+			err = testclient.GetWithRetry(context.TODO(), testclient.ControlPlaneClient, machineConfigKey, machineConfig)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find MachineConfig object %s", configKey.Name))
 			Expect(machineConfig.Labels[machineconfigv1.MachineConfigRoleLabelKey]).Should(Equal(newRole))
 
@@ -615,7 +615,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				Namespace: components.NamespaceNodeTuningOperator,
 			}
 			tunedProfile := &tunedv1.Tuned{}
-			err = testclient.GetWithRetry(context.TODO(), tunedKey, tunedProfile)
+			err = testclient.GetWithRetry(context.TODO(), testclient.ControlPlaneClient, tunedKey, tunedProfile)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find Tuned profile object %s", tunedKey.Name))
 			Expect(tunedProfile.Spec.Recommend[0].MachineConfigLabels[machineconfigv1.MachineConfigRoleLabelKey]).Should(Equal(newRole))
 			Expect(*tunedProfile.Spec.Profile[0].Data).Should(ContainSubstring("NEW_ARGUMENT"), "Can't find value in Tuned profile")
@@ -648,14 +648,14 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				Name:      components.GetComponentName(profile.Name, components.ComponentNamePrefix),
 				Namespace: components.NamespaceNodeTuningOperator,
 			}
-			err = testclient.GetWithRetry(context.TODO(), initialKey, &machineconfigv1.KubeletConfig{})
+			err = testclient.GetWithRetry(context.TODO(), testclient.ControlPlaneClient, initialKey, &machineconfigv1.KubeletConfig{})
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find KubeletConfig object %s", initialKey.Name))
 
 			initialMachineConfigKey := types.NamespacedName{
 				Name:      machineconfig.GetMachineConfigName(profile.Name),
 				Namespace: metav1.NamespaceNone,
 			}
-			err = testclient.GetWithRetry(context.TODO(), initialMachineConfigKey, &machineconfigv1.MachineConfig{})
+			err = testclient.GetWithRetry(context.TODO(), testclient.ControlPlaneClient, initialMachineConfigKey, &machineconfigv1.MachineConfig{})
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find MachineConfig object %s", initialKey.Name))
 		})
 	})
@@ -694,7 +694,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), "Failed getting v1Profile")
 
 			v2Profile := &performancev2.PerformanceProfile{}
-			err = testclient.GetWithRetry(context.TODO(), key, v2Profile)
+			err = testclient.GetWithRetry(context.TODO(), testclient.ControlPlaneClient, key, v2Profile)
 			Expect(err).ToNot(HaveOccurred(), "Failed getting v2Profile")
 			Expect(verifyV2Conversion(v2Profile, v1Profile)).ToNot(HaveOccurred())
 		}
@@ -740,7 +740,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			}()
 
 			v1Profile = &performancev1.PerformanceProfile{}
-			err = testclient.GetWithRetry(context.TODO(), key, v1Profile)
+			err = testclient.GetWithRetry(context.TODO(), testclient.ControlPlaneClient, key, v1Profile)
 			Expect(err).ToNot(HaveOccurred(), "Failed getting v1profile")
 			Expect(verifyV1alpha1Conversion(v1alpha1Profile, v1Profile)).ToNot(HaveOccurred())
 		}

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -507,7 +507,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Create second performance profiles on a cluster", Label(string(label.Tier0)), func() {
+	Context("Create second performance profiles on a cluster", Label(string(label.Tier0), string(label.OpenShift)), func() {
 		var secondMCP *mcov1.MachineConfigPool
 		var secondProfile *performancev2.PerformanceProfile
 		var newRole = "worker-new"
@@ -660,7 +660,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Verify API Conversions", Label(string(label.Tier0)), func() {
+	Context("Verify API Conversions", Label(string(label.Tier0), string(label.OpenShift)), func() {
 		verifyV2V1 := func() {
 			By("Checking v2 -> v1 conversion")
 			v1Profile := &performancev1.PerformanceProfile{}
@@ -855,7 +855,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 		})
 	})
 
-	Context("Validation webhook", Label(string(label.Tier0)), func() {
+	Context("Validation webhook", Label(string(label.Tier0), string(label.OpenShift)), func() {
 		BeforeEach(func() {
 			if discovery.Enabled() {
 				Skip("Discovery mode enabled, test skipped because it creates incorrect profiles")
@@ -927,7 +927,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			})
 		})
 
-		Context("with API version v1 profile", Label(string(label.Tier0)), func() {
+		Context("with API version v1 profile", Label(string(label.Tier0), string(label.OpenShift)), func() {
 			var v1Profile *performancev1.PerformanceProfile
 
 			BeforeEach(func() {

--- a/test/e2e/performanceprofile/functests/1_performance/rt-kernel.go
+++ b/test/e2e/performanceprofile/functests/1_performance/rt-kernel.go
@@ -55,7 +55,7 @@ var _ = Describe("[performance]RT Kernel", Ordered, Label(string(label.Tier0)), 
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("[test_id:28526][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] a node without performance profile applied should not have RT kernel installed", func() {
+	It("[test_id:28526][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] a node without performance profile applied should not have RT kernel installed", Label(string(label.OpenShift)), func() {
 
 		By("Skipping test if cluster does not have another available worker node")
 		nonPerformancesWorkers, err := nodes.GetNonPerformancesWorkers(profile.Spec.NodeSelector)

--- a/test/e2e/performanceprofile/functests/1_performance/test_suite_performance_test.go
+++ b/test/e2e/performanceprofile/functests/1_performance/test_suite_performance_test.go
@@ -43,7 +43,7 @@ func init() {
 var _ = BeforeSuite(func() {
 	Expect(testclient.ClientsEnabled).To(BeTrue(), "package client not enabled")
 	// create test namespace
-	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
+	err := testclient.DataPlaneClient.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {
 		testlog.Warning("test namespace already exists, that is unexpected")
 		return
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	err := testclient.Client.Delete(context.TODO(), namespaces.TestingNamespace)
+	err := testclient.DataPlaneClient.Delete(context.TODO(), namespaces.TestingNamespace)
 	Expect(err).ToNot(HaveOccurred())
 	err = namespaces.WaitForDeletion(testutils.NamespaceTesting, 5*time.Minute)
 	nodeinspector.Delete(context.TODO())

--- a/test/e2e/performanceprofile/functests/3_performance_status/status.go
+++ b/test/e2e/performanceprofile/functests/3_performance_status/status.go
@@ -64,7 +64,7 @@ var _ = Describe("Status testing of performance profile", Ordered, func() {
 				Namespace: components.NamespaceNodeTuningOperator,
 			}
 			tuned := &tunedv1.Tuned{}
-			err = testclient.GetWithRetry(context.TODO(), key, tuned)
+			err = testclient.GetWithRetry(context.TODO(), testclient.Client, key, tuned)
 			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator Tuned object "+key.String())
 			tunedNamespacedname := types.NamespacedName{
 				Name:      components.GetComponentName(profile.Name, components.ProfileNamePerformance),
@@ -84,7 +84,7 @@ var _ = Describe("Status testing of performance profile", Ordered, func() {
 				Namespace: metav1.NamespaceAll,
 			}
 			runtimeClass := &nodev1.RuntimeClass{}
-			err = testclient.GetWithRetry(context.TODO(), key, runtimeClass)
+			err = testclient.GetWithRetry(context.TODO(), testclient.Client, key, runtimeClass)
 			Expect(err).ToNot(HaveOccurred(), "cannot find the RuntimeClass object "+key.String())
 
 			Expect(profile.Status.RuntimeClass).NotTo(BeNil())

--- a/test/e2e/performanceprofile/functests/utils/client/clients.go
+++ b/test/e2e/performanceprofile/functests/utils/client/clients.go
@@ -149,10 +149,10 @@ func NewK8s() (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
-func GetWithRetry(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+func GetWithRetry(ctx context.Context, cli client.Client, key client.ObjectKey, obj client.Object) error {
 	var err error
 	EventuallyWithOffset(1, func() error {
-		err = Client.Get(ctx, key, obj)
+		err = cli.Get(ctx, key, obj)
 		if err != nil {
 			testlog.Infof("Getting %s failed, retrying: %v", key.Name, err)
 		}

--- a/test/e2e/performanceprofile/functests/utils/cluster/cluster.go
+++ b/test/e2e/performanceprofile/functests/utils/cluster/cluster.go
@@ -13,7 +13,7 @@ import (
 // IsSingleNode validates if the environment is single node cluster
 func IsSingleNode() (bool, error) {
 	nodes := &corev1.NodeList{}
-	if err := testclient.Client.List(context.TODO(), nodes, &client.ListOptions{}); err != nil {
+	if err := testclient.DataPlaneClient.List(context.TODO(), nodes, &client.ListOptions{}); err != nil {
 		return false, err
 	}
 	return len(nodes.Items) == 1, nil

--- a/test/e2e/performanceprofile/functests/utils/discovery/discovery.go
+++ b/test/e2e/performanceprofile/functests/utils/discovery/discovery.go
@@ -54,7 +54,7 @@ func getDiscoveryPerformanceProfile(performanceProfiles []performancev2.Performa
 		selector := labels.SelectorFromSet(profile.Spec.NodeSelector)
 
 		profileNodes := &corev1.NodeList{}
-		if err := testclient.Client.List(context.TODO(), profileNodes, &client.ListOptions{LabelSelector: selector}); err != nil {
+		if err := testclient.DataPlaneClient.List(context.TODO(), profileNodes, &client.ListOptions{LabelSelector: selector}); err != nil {
 			return nil, err
 		}
 

--- a/test/e2e/performanceprofile/functests/utils/mcps/mcps.go
+++ b/test/e2e/performanceprofile/functests/utils/mcps/mcps.go
@@ -75,7 +75,7 @@ func GetByName(name string) (*machineconfigv1.MachineConfigPool, error) {
 		Name:      name,
 		Namespace: metav1.NamespaceNone,
 	}
-	err := testclient.GetWithRetry(context.TODO(), key, mcp)
+	err := testclient.GetWithRetry(context.TODO(), testclient.DataPlaneClient, key, mcp)
 	return mcp, err
 }
 

--- a/test/e2e/performanceprofile/functests/utils/nodepools/nodepools.go
+++ b/test/e2e/performanceprofile/functests/utils/nodepools/nodepools.go
@@ -2,6 +2,7 @@ package nodepools
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,4 +44,22 @@ func waitForCondition(ctx context.Context, c client.Client, NpName, namespace st
 		}
 		return conditionFunc(np.Status.Conditions), nil
 	})
+}
+
+func GetByClusterName(ctx context.Context, c client.Client, hostedClusterName string) (*hypershiftv1beta1.NodePool, error) {
+	npList := &hypershiftv1beta1.NodePoolList{}
+	if err := c.List(ctx, npList); err != nil {
+		return nil, err
+	}
+	var np *hypershiftv1beta1.NodePool
+	for i := 0; i < len(npList.Items); i++ {
+		if npList.Items[i].Spec.ClusterName == hostedClusterName {
+			np = &npList.Items[i]
+			break
+		}
+	}
+	if np == nil {
+		return nil, fmt.Errorf("failed to find nodePool associated with cluster %q; existing nodePools are: %+v", hostedClusterName, npList.Items)
+	}
+	return np, nil
 }

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -101,7 +101,7 @@ func GetByRole(role string) ([]corev1.Node, error) {
 // GetBySelector returns all nodes with the specified selector
 func GetBySelector(selector labels.Selector) ([]corev1.Node, error) {
 	nodes := &corev1.NodeList{}
-	if err := testclient.Client.List(context.TODO(), nodes, &client.ListOptions{LabelSelector: selector}); err != nil {
+	if err := testclient.DataPlaneClient.List(context.TODO(), nodes, &client.ListOptions{LabelSelector: selector}); err != nil {
 		return nil, err
 	}
 	return nodes.Items, nil
@@ -119,7 +119,7 @@ func GetByName(nodeName string) (*corev1.Node, error) {
 	key := types.NamespacedName{
 		Name: nodeName,
 	}
-	if err := testclient.Client.Get(context.TODO(), key, node); err != nil {
+	if err := testclient.DataPlaneClient.Get(context.TODO(), key, node); err != nil {
 		return nil, fmt.Errorf("failed to get node for the node %q", nodeName)
 	}
 	return node, nil
@@ -341,7 +341,7 @@ func TunedForNode(node *corev1.Node, sno bool) *corev1.Pod {
 
 	tunedList := &corev1.PodList{}
 	Eventually(func() bool {
-		if err := testclient.Client.List(context.TODO(), tunedList, listOptions); err != nil {
+		if err := testclient.DataPlaneClient.List(context.TODO(), tunedList, listOptions); err != nil {
 			return false
 		}
 

--- a/test/e2e/performanceprofile/functests/utils/pods/pods.go
+++ b/test/e2e/performanceprofile/functests/utils/pods/pods.go
@@ -55,7 +55,7 @@ func GetTestPod() *corev1.Pod {
 // WaitForDeletion waits until the pod will be removed from the cluster
 func WaitForDeletion(ctx context.Context, pod *corev1.Pod, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		if err := testclient.Client.Get(ctx, client.ObjectKeyFromObject(pod), pod); errors.IsNotFound(err) {
+		if err := testclient.DataPlaneClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); errors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, nil
@@ -66,7 +66,7 @@ func WaitForDeletion(ctx context.Context, pod *corev1.Pod, timeout time.Duration
 func WaitForCondition(ctx context.Context, podKey client.ObjectKey, conditionType corev1.PodConditionType, conditionStatus corev1.ConditionStatus, timeout time.Duration) (*corev1.Pod, error) {
 	updatedPod := &corev1.Pod{}
 	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		if err := testclient.Client.Get(ctx, podKey, updatedPod); err != nil {
+		if err := testclient.DataPlaneClient.Get(ctx, podKey, updatedPod); err != nil {
 			return false, nil
 		}
 		for _, c := range updatedPod.Status.Conditions {
@@ -83,7 +83,7 @@ func WaitForCondition(ctx context.Context, podKey client.ObjectKey, conditionTyp
 func WaitForPredicate(ctx context.Context, podKey client.ObjectKey, timeout time.Duration, pred func(pod *corev1.Pod) (bool, error)) (*corev1.Pod, error) {
 	updatedPod := &corev1.Pod{}
 	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		if err := testclient.Client.Get(ctx, podKey, updatedPod); err != nil {
+		if err := testclient.DataPlaneClient.Get(ctx, podKey, updatedPod); err != nil {
 			return false, nil
 		}
 
@@ -100,7 +100,7 @@ func WaitForPredicate(ctx context.Context, podKey client.ObjectKey, timeout time
 func WaitForPhase(ctx context.Context, podKey client.ObjectKey, phase corev1.PodPhase, timeout time.Duration) (*corev1.Pod, error) {
 	updatedPod := &corev1.Pod{}
 	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		if err := testclient.Client.Get(ctx, podKey, updatedPod); err != nil {
+		if err := testclient.DataPlaneClient.Get(ctx, podKey, updatedPod); err != nil {
 			return false, nil
 		}
 
@@ -202,7 +202,7 @@ func GetContainerIDByName(pod *corev1.Pod, containerName string) (string, error)
 		Name:      pod.Name,
 		Namespace: pod.Namespace,
 	}
-	if err := testclient.Client.Get(context.TODO(), key, updatedPod); err != nil {
+	if err := testclient.DataPlaneClient.Get(context.TODO(), key, updatedPod); err != nil {
 		return "", err
 	}
 	// Find the container by name
@@ -237,7 +237,7 @@ func GetPodsOnNode(ctx context.Context, nodeName string) ([]corev1.Pod, error) {
 	listOptions := &client.ListOptions{
 		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}),
 	}
-	err := testclient.Client.List(ctx, &pods, listOptions)
+	err := testclient.DataPlaneClient.List(ctx, &pods, listOptions)
 	return pods.Items, err
 }
 

--- a/test/e2e/performanceprofile/functests/utils/profilesupdate/profile_update.go
+++ b/test/e2e/performanceprofile/functests/utils/profilesupdate/profile_update.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -15,8 +17,10 @@ import (
 	profilecontroller "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/hypershift"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodepools"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 )
 
@@ -76,4 +80,52 @@ func ApplyProfile(profile *performancev2.PerformanceProfile) error {
 		return fmt.Errorf("the profile %q was not updated as expected", updatedProfile.Name)
 	}
 	return nil
+}
+
+// WaitForTuningUpdating is waiting for the cluster to transition into tuning configuration update state
+// done by PerformanceProfile application.
+func WaitForTuningUpdating(ctx context.Context, profile *performancev2.PerformanceProfile) {
+	GinkgoHelper()
+	// In case we are on OCP, we can query the MCP to determine if the update has started.
+	if !hypershift.IsHypershiftCluster() {
+		performanceMCP, err := mcps.GetByProfile(profile)
+		Expect(err).ToNot(HaveOccurred())
+		testlog.Info("waiting for MCP starting to update")
+		mcps.WaitForCondition(performanceMCP, mcv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
+		return
+	}
+
+	// On hypershift we can check the nodepool UpdatingConfig condition to determine if the update has started.
+	hostedClusterName, err := hypershift.GetHostedClusterName()
+	Expect(err).ToNot(HaveOccurred())
+	np, err := nodepools.GetByClusterName(ctx, testclient.ControlPlaneClient, hostedClusterName)
+	Expect(err).ToNot(HaveOccurred())
+	testlog.Infof("wait for node pool %q transition into update config state", client.ObjectKeyFromObject(np).String())
+	err = nodepools.WaitForUpdatingConfig(ctx, testclient.ControlPlaneClient, np.Name, np.Namespace)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// WaitForTuningUpdated is waiting for the cluster to come back from tuning configuration
+// done by PerformanceProfile application.
+// This is a lower lever function and should not be used directly.
+// Use PostUpdateSync instead
+func WaitForTuningUpdated(ctx context.Context, profile *performancev2.PerformanceProfile) {
+	GinkgoHelper()
+	// In case we are on OCP, we can query the MCP to determine if the update has completed.
+	if !hypershift.IsHypershiftCluster() {
+		performanceMCP, err := mcps.GetByProfile(profile)
+		Expect(err).ToNot(HaveOccurred())
+		testlog.Infof("waiting for MCP being updated")
+		mcps.WaitForCondition(performanceMCP, mcv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
+		return
+	}
+
+	// On hypershift, we can check the nodepool UpdatingConfig condition to determine if the update has completed.
+	hostedClusterName, err := hypershift.GetHostedClusterName()
+	Expect(err).ToNot(HaveOccurred())
+	np, err := nodepools.GetByClusterName(ctx, testclient.ControlPlaneClient, hostedClusterName)
+	Expect(err).ToNot(HaveOccurred())
+	testlog.Infof("wait for node pool %q transition into config ready state", client.ObjectKeyFromObject(np).String())
+	err = nodepools.WaitForConfigToBeReady(ctx, testclient.ControlPlaneClient, np.Name, np.Namespace)
+	Expect(err).ToNot(HaveOccurred())
 }

--- a/test/e2e/performanceprofile/functests/utils/profilesupdate/profile_update.go
+++ b/test/e2e/performanceprofile/functests/utils/profilesupdate/profile_update.go
@@ -8,7 +8,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mcv1 "github.com/openshift/api/machineconfiguration/v1"
 
@@ -21,6 +24,7 @@ import (
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodepools"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 )
 
@@ -128,4 +132,39 @@ func WaitForTuningUpdated(ctx context.Context, profile *performancev2.Performanc
 	testlog.Infof("wait for node pool %q transition into config ready state", client.ObjectKeyFromObject(np).String())
 	err = nodepools.WaitForConfigToBeReady(ctx, testclient.ControlPlaneClient, np.Name, np.Namespace)
 	Expect(err).ToNot(HaveOccurred())
+}
+
+// EnforceNodeLabels make sure to enforce that one of the worker nodes
+// has the labels that are needed for the test to run properly.
+// This is useful on a Hypershift platform when the nodes get recreated
+// after tuning updates and the labels (besides the default one) are gone.
+func EnforceNodeLabels() {
+	GinkgoHelper()
+	workers, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
+	Expect(err).ToNot(HaveOccurred())
+	if len(workers) != 0 {
+		return
+	}
+	testlog.Infof("no worker nodes found with labels %s\n", testutils.NodeSelectorLabels)
+	nodesList := &corev1.NodeList{}
+	Expect(testclient.DataPlaneClient.List(context.TODO(), nodesList)).To(Succeed())
+	// choose one arbitrary
+	node := &nodesList.Items[0]
+	testlog.Infof("labeling node %s with labels %s\n", node.Name, labels.SelectorFromValidatedSet(testutils.NodeSelectorLabels).String())
+	Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		err := testclient.DataPlaneClient.Get(context.TODO(), client.ObjectKeyFromObject(node), node)
+		if err != nil {
+			return err
+		}
+		node.Labels = labels.Merge(node.Labels, testutils.NodeSelectorLabels)
+		return testclient.DataPlaneClient.Update(context.TODO(), node)
+	})).To(Succeed())
+	testlog.Infof("node %s labels are: %v\n", node.Name, node.Labels)
+}
+
+// PostUpdateSync is performing operations that are needed
+// after PerformanceProfile updated. It must be called after WaitForTuningUpdating
+func PostUpdateSync(ctx context.Context, profile *performancev2.PerformanceProfile) {
+	WaitForTuningUpdated(ctx, profile)
+	EnforceNodeLabels()
 }

--- a/test/e2e/performanceprofile/functests/utils/tuned/tuned.go
+++ b/test/e2e/performanceprofile/functests/utils/tuned/tuned.go
@@ -32,7 +32,7 @@ func GetPod(ctx context.Context, node *corev1.Node) (*corev1.Pod, error) {
 		LabelSelector: labels.SelectorFromSet(labels.Set{"openshift-app": "tuned"}),
 	}
 
-	if err := testclient.Client.List(ctx, podList, opts); err != nil {
+	if err := testclient.DataPlaneClient.List(ctx, podList, opts); err != nil {
 		return nil, fmt.Errorf("couldn't get a list of TuneD Pods; %w", err)
 	}
 
@@ -90,7 +90,7 @@ func CheckParameters(ctx context.Context, node *corev1.Node, sysctlMap map[strin
 	}
 
 	tuned := &tunedv1.Tuned{}
-	ExpectWithOffset(1, testclient.Client.Get(context.TODO(), key, tuned)).ToNot(HaveOccurred(),
+	ExpectWithOffset(1, testclient.ControlPlaneClient.Get(context.TODO(), key, tuned)).ToNot(HaveOccurred(),
 		"cannot find the cluster Node Tuning Operator object "+key.String())
 
 	if stalld {


### PR DESCRIPTION
This PR includes all the necessary adaptations for the `1_performance` suite to be compatible with Hypershift. These changes encompass modifications to some of the utility functions used by the suite, as well as updates to the tests within the suite itself. Additionally, this PR integrates this suite to run alongside the `0_config` suite in the Hypershift lane.