### PR TITLE
NO-JIRA: Stop exposing the entire host filesystem

### DIFF
--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -71,8 +71,8 @@ spec:
           name: var-lib-kubelet
           mountPropagation: HostToContainer
           readOnly: true
-        - mountPath: /host
-          name: host
+        - mountPath: /host/var/lib
+          name: host-var-lib
           mountPropagation: HostToContainer
         env:
           - name: WATCH_NAMESPACE
@@ -132,10 +132,10 @@ spec:
           path: /var/lib/kubelet
           type: Directory
         name: var-lib-kubelet
-      - name: host
-        hostPath:
-          path: /
+      - hostPath:
+          path: /var/lib
           type: Directory
+        name: host-var-lib
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux

--- a/test/e2e/basic/metrics_cert_rotation.go
+++ b/test/e2e/basic/metrics_cert_rotation.go
@@ -59,9 +59,8 @@ var _ = ginkgo.Describe("[basic][metrics] Node Tuning Operator certificate rotat
 				secretCertContents := string(tlsSecret.Data["tls.crt"])
 
 				operatorPodIP := operatorPod.Status.PodIP
-				// We need chroot because host may be using system libraries incompatible with the container
-				// image system libraries.  Alternatively, use container-shipped openssl.
-				opensslCmd := "/usr/sbin/chroot /host /usr/bin/openssl s_client -connect " + operatorPodIP + ":60000 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'"
+				// Use container-shipped openssl.
+				opensslCmd := "/usr/bin/openssl s_client -connect " + operatorPodIP + ":60000 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'"
 
 				serverCertContents, err := util.ExecCmdInPod(tunedPod, "/bin/bash", "-c", opensslCmd)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/core/cluster_version.go
+++ b/test/e2e/core/cluster_version.go
@@ -17,7 +17,7 @@ var _ = ginkgo.Describe("[core][cluster_version] Node Tuning Operator host, cont
 		node *coreapi.Node
 	)
 
-	ginkgo.It("host, container OS and cluster version retrievable", func() {
+	ginkgo.It("container OS and cluster version retrievable", func() {
 		ginkgo.By("getting a list of worker nodes")
 		nodes, err := util.GetNodesByRole(cs, "worker")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -28,13 +28,8 @@ var _ = ginkgo.Describe("[core][cluster_version] Node Tuning Operator host, cont
 		pod, err := util.GetTunedForNode(cs, node)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		ginkgo.By(fmt.Sprintf("getting the host OS version on node %s", node.Name))
-		out, err := util.ExecCmdInPod(pod, "cat", "/host/etc/os-release")
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		util.Logf("%s", out)
-
 		ginkgo.By("getting the TuneD container OS version")
-		out, err = util.ExecCmdInPod(pod, "cat", "/etc/os-release")
+		out, err := util.ExecCmdInPod(pod, "cat", "/etc/os-release")
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		util.Logf("%s", out)
 


### PR DESCRIPTION
With the principle of least privilege in mind, stop exposing the
entirety of the host filesystem.  Previously, we were mounting
the entire host filesystem to "/host".  With this change, only
the necessary host directories for using TuneD are mounted and
a host's /var/lib directory for the operand's persistent
/var/lib/ocp-tuned directory.

Other changes
  * For e2e tests, use MCD to write to host's /etc/sysctl.d/ since
    we are no longer exposing the entire host filesystem for the NTO
    operand.
