### PR TITLE
CNF-13193: Update NTO Hugepages size validation

### DIFF
--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -131,7 +131,10 @@ type HardwareTuning struct {
 	ReservedCpuFreq *CPUfrequency `json:"reservedCpuFreq,omitempty"`
 }
 
-// HugePageSize defines size of huge pages, can be 2M or 1G.
+// HugePageSize defines size of huge pages
+// The allowed values for this depend on CPU architecture
+// For x86/amd64, the valid values are 2M and 1G
+// For aarch64, the valid values are 2M, 32M, and 512M
 type HugePageSize string
 
 // HugePages defines a set of huge pages that we want to allocate at boot.

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
@@ -30,14 +32,36 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/klog"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
 
 const (
-	hugepagesSize2M = "2M"
-	hugepagesSize1G = "1G"
+	hugepagesSize2M   = "2M"
+	hugepagesSize32M  = "32M"
+	hugepagesSize512M = "512M"
+	hugepagesSize1G   = "1G"
+	amd64             = "amd64"
+	aarch64           = "arm64"
 )
+
+var x86ValidHugepagesSizes = []string{
+	hugepagesSize2M,
+	hugepagesSize1G,
+}
+
+// Each kernel page size has only a single valid hugepage size on aarch64
+var aarch64ValidHugepagesSizes = []string{
+	hugepagesSize2M,   // With 4k kernel pages
+	hugepagesSize32M,  // With 16k kernel pages
+	hugepagesSize512M, // With 64k kernel pages
+}
+
+var validatorContext = context.TODO()
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *PerformanceProfile) ValidateCreate() (admission.Warnings, error) {
@@ -58,7 +82,7 @@ func (r *PerformanceProfile) validateCreateOrUpdate() (admission.Warnings, error
 
 	// validate node selector duplication
 	ppList := &PerformanceProfileList{}
-	if err := validatorClient.List(context.TODO(), ppList); err != nil {
+	if err := validatorClient.List(validatorContext, ppList); err != nil {
 		return admission.Warnings{}, apierrors.NewInternalError(err)
 	}
 
@@ -105,9 +129,22 @@ func (r *PerformanceProfile) validateNodeSelectorDuplication(ppList *Performance
 func (r *PerformanceProfile) ValidateBasicFields() field.ErrorList {
 	var allErrs field.ErrorList
 
+	nodes, err := r.getNodesList()
+	if err != nil {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec.nodeSelector"),
+				r.Spec.NodeSelector,
+				err.Error(),
+			),
+		)
+	}
+
 	allErrs = append(allErrs, r.validateCPUs()...)
 	allErrs = append(allErrs, r.validateSelectors()...)
-	allErrs = append(allErrs, r.validateHugePages()...)
+	allErrs = append(allErrs, r.validateAllNodesAreSameCpuArchitecture(nodes)...)
+	allErrs = append(allErrs, r.validateAllNodesAreSameCpuCapacity(nodes)...)
+	allErrs = append(allErrs, r.validateHugePages(nodes)...)
 	allErrs = append(allErrs, r.validateNUMA()...)
 	allErrs = append(allErrs, r.validateNet()...)
 	allErrs = append(allErrs, r.validateWorkloadHints()...)
@@ -201,37 +238,229 @@ func (r *PerformanceProfile) validateSelectors() field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(
 				field.NewPath("spec.nodeSelector"),
 				r.Spec.NodeSelector,
-				"machineConfigLabels or machineConfigPoolSelector are not set, but we  can not set it automatically because of an invalid NodeSelector label key that can't be split into domain/role"))
+				"machineConfigLabels or machineConfigPoolSelector are not set, but we can not set it automatically because of an invalid NodeSelector label key that can't be split into domain/role"))
 		}
 	}
 
 	return allErrs
 }
 
-func (r *PerformanceProfile) validateHugePages() field.ErrorList {
+func (r *PerformanceProfile) validateAllNodesAreSameCpuArchitecture(nodes corev1.NodeList) field.ErrorList {
+	var allErrs field.ErrorList
+	// First check if the node list has valid elements
+	if len(nodes.Items) == 0 {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec.nodeSelector"),
+				r.Spec.NodeSelector,
+				"Failed to detect any nodes, unable to validate architecture",
+			),
+		)
+
+		// If we failed to detect any nodes we cannot do anything more here
+		return allErrs
+	}
+
+	// We need to use one of the nodes as a reference for comparing against the rest
+	// The first item in the list is simple and easy to use
+	expectedArchitecture := getCpuArchitectureForNode(nodes.Items[0])
+
+	if expectedArchitecture == "" {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec.nodeSelector"),
+				r.Spec.NodeSelector,
+				fmt.Sprintf("Failed to detect architecture for node %s", nodes.Items[0].Status.NodeInfo.MachineID),
+			),
+		)
+
+		// If we failed to detect cpu architecture there is not much point to continue
+		// We would likely just get an error for every single node with the same error
+		return allErrs
+	}
+
+	// Make sure all other nodes have the same value
+	for i := 1; i < len(nodes.Items); i++ {
+		actualArchitecture := getCpuArchitectureForNode(nodes.Items[i])
+		if actualArchitecture != expectedArchitecture {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec.nodeSelector"),
+					r.Spec.NodeSelector,
+					fmt.Sprintf("Node %s has architecture %s but was expecting %s", nodes.Items[i].Status.NodeInfo.MachineID, actualArchitecture, expectedArchitecture),
+				),
+			)
+		}
+	}
+
+	return allErrs
+}
+
+func getCpuArchitectureForNode(node corev1.Node) string {
+	return node.Status.NodeInfo.Architecture
+}
+
+func (r *PerformanceProfile) validateAllNodesAreSameCpuCapacity(nodes corev1.NodeList) field.ErrorList {
+	var allErrs field.ErrorList
+	// First check if the node list has valid elements
+	if len(nodes.Items) == 0 {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec.nodeSelector"),
+				r.Spec.NodeSelector,
+				"Failed to detect any nodes, unable to validate cpu capacity",
+			),
+		)
+
+		// If we failed to detect any nodes we cannot do anything more here
+		return allErrs
+	}
+
+	// We need to use one of the nodes as a reference for comparing against the rest
+	// The first item in the list is simple and easy to use
+	expectedCpuCapacity := getCpuCapacityForNode(nodes.Items[0])
+
+	if expectedCpuCapacity == "" {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec.nodeSelector"),
+				r.Spec.NodeSelector,
+				fmt.Sprintf("Failed to detect cpu capacity for node %s", nodes.Items[0].Status.NodeInfo.MachineID),
+			),
+		)
+
+		// If we failed to detect cpu capacity there is not much point to continue
+		// We would likely just get an error for every single node with the same error
+		return allErrs
+	}
+
+	// Make sure all other nodes have the same value
+	for i := 1; i < len(nodes.Items); i++ {
+		actualCpuCapacity := getCpuCapacityForNode(nodes.Items[i])
+		if actualCpuCapacity != expectedCpuCapacity {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec.nodeSelector"),
+					r.Spec.NodeSelector,
+					fmt.Sprintf("Node %s has CPU capacity %s but was expecting %s", nodes.Items[i].Status.NodeInfo.MachineID, actualCpuCapacity, expectedCpuCapacity),
+				),
+			)
+		}
+	}
+
+	return allErrs
+}
+
+func getCpuCapacityForNode(node corev1.Node) string {
+	return node.Status.Capacity.Cpu().String()
+}
+
+func (r *PerformanceProfile) validateHugePages(nodes corev1.NodeList) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if r.Spec.HugePages == nil {
 		return allErrs
 	}
 
-	// validate that default hugepages size has correct value, currently we support only 2M and 1G(x86_64 architecture)
+	// First check if the node list has valid elements
+	if len(nodes.Items) == 0 {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec.nodeSelector"),
+				r.Spec.NodeSelector,
+				"Failed to detect any nodes, unable to validate hugepages",
+			),
+		)
+
+		// If we failed to detect any nodes we cannot do anything more here
+		return allErrs
+	}
+
+	// `validateHugePages` implicitly relies on `validateAllNodesAreSameCpuArchitecture` to have already been run
+	// Under that assumption we can return any node from the list since they should all be the same architecture
+	// However it is simple and easy to just return the first node
+	x86 := isX86(nodes.Items[0])
+	aarch64 := isAarch64(nodes.Items[0])
+
 	if r.Spec.HugePages.DefaultHugePagesSize != nil {
 		defaultSize := *r.Spec.HugePages.DefaultHugePagesSize
-		if defaultSize != hugepagesSize1G && defaultSize != hugepagesSize2M {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("spec.hugepages.defaultHugepagesSize"), r.Spec.HugePages.DefaultHugePagesSize, fmt.Sprintf("hugepages default size should be equal to %q or %q", hugepagesSize1G, hugepagesSize2M)))
+		errField := "spec.hugepages.defaultHugepagesSize"
+		errMsg := "hugepages default size should be equal to one of"
+
+		if x86 && !slices.Contains(x86ValidHugepagesSizes, string(defaultSize)) {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath(errField),
+					r.Spec.HugePages.DefaultHugePagesSize,
+					fmt.Sprintf("%s %v", errMsg, x86ValidHugepagesSizes),
+				),
+			)
+		} else if aarch64 && !slices.Contains(aarch64ValidHugepagesSizes, string(defaultSize)) {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath(errField),
+					r.Spec.HugePages.DefaultHugePagesSize,
+					fmt.Sprintf("%s %v", errMsg, aarch64ValidHugepagesSizes),
+				),
+			)
+		} else if !x86 && !aarch64 {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath(errField),
+					r.Spec.HugePages.DefaultHugePagesSize,
+					"Failed to detect architecture, unable to validate default hugepage size",
+				),
+			)
 		}
 	}
 
 	for i, page := range r.Spec.HugePages.Pages {
-		if page.Size != hugepagesSize1G && page.Size != hugepagesSize2M {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("spec.hugepages.pages"), r.Spec.HugePages.Pages, fmt.Sprintf("the page size should be equal to %q or %q", hugepagesSize1G, hugepagesSize2M)))
+		errField := "spec.hugepages.pages"
+		errMsg := "the page size should be equal to one of"
+		if x86 && !slices.Contains(x86ValidHugepagesSizes, string(page.Size)) {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath(errField),
+					r.Spec.HugePages.Pages,
+					fmt.Sprintf("%s %v", errMsg, x86ValidHugepagesSizes),
+				),
+			)
+		} else if aarch64 && !slices.Contains(aarch64ValidHugepagesSizes, string(page.Size)) {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath(errField),
+					r.Spec.HugePages.Pages,
+					fmt.Sprintf("%s %v", errMsg, aarch64ValidHugepagesSizes),
+				),
+			)
+		} else if !x86 && !aarch64 {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath(errField),
+					r.Spec.HugePages.Pages,
+					"Failed to detect architecture, unable to validate hugepage size",
+				),
+			)
 		}
 
 		allErrs = append(allErrs, r.validatePageDuplication(&page, r.Spec.HugePages.Pages[i+1:])...)
 	}
 
 	return allErrs
+}
+
+func isX86(node corev1.Node) bool {
+	return getCpuArchitectureForNode(node) == amd64
+}
+
+func isAarch64(node corev1.Node) bool {
+	return getCpuArchitectureForNode(node) == aarch64
 }
 
 func (r *PerformanceProfile) validatePageDuplication(page *HugePage, pages []HugePage) field.ErrorList {
@@ -367,4 +596,32 @@ func (r *PerformanceProfile) validateCpuFrequency() field.ErrorList {
 	}
 
 	return allErrs
+}
+
+func (r *PerformanceProfile) getNodesList() (corev1.NodeList, error) {
+	// Get the nodes from the client using the node selector in the profile
+	nodes := &corev1.NodeList{}
+
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: r.Spec.NodeSelector,
+	})
+
+	if err != nil {
+		return corev1.NodeList{}, err
+	}
+
+	err = validatorClient.List(validatorContext, nodes, &client.ListOptions{
+		LabelSelector: selector,
+	})
+
+	if err != nil {
+		return corev1.NodeList{}, err
+	}
+
+	// If we have no nodes then consider this an error
+	if len(nodes.Items) == 0 {
+		return corev1.NodeList{}, fmt.Errorf("no nodes found with selector %s", selector)
+	}
+
+	return *nodes, nil
 }

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -5,7 +5,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -42,6 +46,50 @@ const (
 	//NetDeviceModelID defines a net device model ID for the test profile
 	NetDeviceModelID = "0x1000"
 )
+
+// This type is used to define the inputs for the validator client
+type NodeSpecifications struct {
+	architecture string
+	cpuCapacity  int64
+	name         string
+}
+
+// Get a fake node object with a specified architecture and cpu capacity
+func GetFakeNode(specs NodeSpecifications) corev1.Node {
+	Expect(specs.architecture).To(BeElementOf([2]string{amd64, aarch64}))
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            specs.name,
+			ResourceVersion: "1.0",
+			Labels: map[string]string{
+				"nodekey": "nodeValue",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU: *resource.NewMilliQuantity(specs.cpuCapacity, resource.DecimalSI),
+			},
+			NodeInfo: corev1.NodeSystemInfo{
+				Architecture: specs.architecture,
+			},
+		},
+	}
+}
+
+func GetFakeValidatorClient(nodeSpecs []NodeSpecifications) client.Client {
+	// Create all the nodes first from the provided specifications
+	nodes := []corev1.Node{}
+	for _, node := range nodeSpecs {
+		nodes = append(nodes, GetFakeNode(node))
+	}
+
+	// Convert the slice of nodes into a NodeList object
+	nodeList := corev1.NodeList{}
+	nodeList.Items = nodes
+
+	// Build the client with the new NodeList included
+	return fake.NewClientBuilder().WithLists(&nodeList).Build()
+}
 
 // NewPerformanceProfile returns new performance profile object that used for tests
 func NewPerformanceProfile(name string) *PerformanceProfile {
@@ -323,30 +371,224 @@ var _ = Describe("PerformanceProfile", func() {
 		})
 	})
 
+	Describe("The getNodesList helper function", func() {
+		It("should not return any errors when at least one node is detected", func() {
+			// Get client with one node to test this case
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			// There should be a non-empty node list and no error present
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+			Expect(nodes.Items).ToNot(BeEmpty())
+		})
+		It("should return an error when nothing is detected", func() {
+			// Get client with no nodes to test this case
+			nodeSpecs := []NodeSpecifications{}
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			// There should be an empty node list and error present
+			nodes, err := profile.getNodesList()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("no nodes found with selector"))
+			Expect(nodes.Items).To(BeEmpty())
+		})
+	})
+
+	Describe("Same CPU Architecture validation", func() {
+		It("should pass when both nodes are the same architecture (x86)", func() {
+			// Get client with two x86 nodes
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node1"})
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node2"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+
+			errors := profile.validateAllNodesAreSameCpuArchitecture(nodes)
+			Expect(errors).To(BeEmpty())
+		})
+		It("should pass when both nodes are the same architecture (aarch64)", func() {
+			// Get client with two aarch64 nodes
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: aarch64, cpuCapacity: 1000, name: "node1"})
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: aarch64, cpuCapacity: 1000, name: "node2"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+
+			errors := profile.validateAllNodesAreSameCpuArchitecture(nodes)
+			Expect(errors).To(BeEmpty())
+		})
+		It("should fail when nodes are the different architecture", func() {
+			// Get client with two different nodes: one x86 and one aarch64
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node1"})
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: aarch64, cpuCapacity: 1000, name: "node2"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+
+			errors := profile.validateAllNodesAreSameCpuArchitecture(nodes)
+			Expect(errors).ToNot(BeEmpty())
+		})
+		It("should fail when no nodes are detected", func() {
+			// Get client with zero nodes
+			nodeSpecs := []NodeSpecifications{}
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("no nodes found with selector"))
+
+			errors := profile.validateAllNodesAreSameCpuArchitecture(nodes)
+			Expect(errors).ToNot(BeEmpty())
+			Expect(errors[0].Error()).To(ContainSubstring(("Failed to detect any nodes")))
+		})
+	})
+
+	Describe("Same CPU Capacity validation", func() {
+		It("should pass when both nodes are the same capacity", func() {
+			// Get client with two nodes with the same cpu capacity
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node1"})
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node2"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+
+			errors := profile.validateAllNodesAreSameCpuCapacity(nodes)
+			Expect(errors).To(BeEmpty())
+		})
+		It("should fail when nodes are the different capacity", func() {
+			// Get client with two nodes with different cpu capacity
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node1"})
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 2000, name: "node2"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+
+			errors := profile.validateAllNodesAreSameCpuCapacity(nodes)
+			Expect(errors).ToNot(BeEmpty())
+		})
+		It("should fail when no nodes are detected", func() {
+			// Get client with zero nodes
+			nodeSpecs := []NodeSpecifications{}
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("no nodes found with selector"))
+
+			errors := profile.validateAllNodesAreSameCpuCapacity(nodes)
+			Expect(errors).ToNot(BeEmpty())
+			Expect(errors[0].Error()).To(ContainSubstring(("Failed to detect any nodes")))
+		})
+	})
+
 	Describe("Hugepages validation", func() {
-		It("should reject on incorrect default hugepages size", func() {
+		It("should reject on incorrect default hugepages size (x86)", func() {
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+
 			incorrectDefaultSize := HugePageSize("!#@")
 			profile.Spec.HugePages.DefaultHugePagesSize = &incorrectDefaultSize
 
-			errors := profile.validateHugePages()
+			errors := profile.validateHugePages(nodes)
 			Expect(errors).NotTo(BeEmpty(), "should have validation error when default huge pages size has invalid value")
 			Expect(errors[0].Error()).To(ContainSubstring("hugepages default size should be equal"))
 		})
 
-		It("should reject hugepages allocation with unexpected page size", func() {
+		It("should reject on incorrect default hugepages size (aarch64)", func() {
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: aarch64, cpuCapacity: 1000, name: "node"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+
+			incorrectDefaultSize := HugePageSize("!#@")
+			profile.Spec.HugePages.DefaultHugePagesSize = &incorrectDefaultSize
+
+			errors := profile.validateHugePages(nodes)
+			Expect(errors).NotTo(BeEmpty(), "should have validation error when default huge pages size has invalid value")
+			Expect(errors[0].Error()).To(ContainSubstring("hugepages default size should be equal"))
+		})
+
+		It("should reject hugepages allocation with unexpected page size (x86)", func() {
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+
 			profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, HugePage{
 				Count: 128,
 				Node:  pointer.Int32(0),
 				Size:  "14M",
 			})
-			errors := profile.validateHugePages()
+			errors := profile.validateHugePages(nodes)
 			Expect(errors).NotTo(BeEmpty(), "should have validation error when page with invalid format presents")
-			Expect(errors[0].Error()).To(ContainSubstring(fmt.Sprintf("the page size should be equal to %q or %q", hugepagesSize1G, hugepagesSize2M)))
+			Expect(errors[0].Error()).To(ContainSubstring(fmt.Sprintf("the page size should be equal to one of %v", x86ValidHugepagesSizes)))
+		})
+
+		It("should reject hugepages allocation with unexpected page size (aarch64)", func() {
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: aarch64, cpuCapacity: 1000, name: "node"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+
+			defaultSize := HugePageSize(hugepagesSize2M)
+			profile.Spec.HugePages.DefaultHugePagesSize = &defaultSize
+
+			profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, HugePage{
+				Count: 128,
+				Node:  pointer.Int32(0),
+				Size:  "14M",
+			})
+			errors := profile.validateHugePages(nodes)
+			Expect(errors).NotTo(BeEmpty(), "should have validation error when page with invalid format presents")
+			Expect(errors[0].Error()).To(ContainSubstring(fmt.Sprintf("the page size should be equal to one of %v", aarch64ValidHugepagesSizes)))
+		})
+
+		It("should fail when no nodes are detected", func() {
+			// Get client with zero nodes
+			nodeSpecs := []NodeSpecifications{}
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+			nodes, err := profile.getNodesList()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("no nodes found with selector"))
+
+			errors := profile.validateHugePages(nodes)
+			Expect(errors).ToNot(BeEmpty())
+			Expect(errors[0].Error()).To(ContainSubstring(("Failed to detect any nodes")))
 		})
 
 		When("pages have duplication", func() {
 			Context("with specified NUMA node", func() {
-				It("should raise the validation error", func() {
+				It("should raise the validation error (x86)", func() {
+					nodeSpecs := []NodeSpecifications{}
+					nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node"})
+					validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+					nodes, err := profile.getNodesList()
+					Expect(err).To(BeNil())
+
 					profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, HugePage{
 						Count: 128,
 						Size:  hugepagesSize1G,
@@ -357,26 +599,40 @@ var _ = Describe("PerformanceProfile", func() {
 						Size:  hugepagesSize1G,
 						Node:  pointer.Int32(0),
 					})
-					errors := profile.validateHugePages()
+					errors := profile.validateHugePages(nodes)
 					Expect(errors).NotTo(BeEmpty())
 					Expect(errors[0].Error()).To(ContainSubstring(fmt.Sprintf("the page with the size %q and with specified NUMA node 0, has duplication", hugepagesSize1G)))
 				})
 			})
 
 			Context("without specified NUMA node", func() {
-				It("should raise the validation error", func() {
+				It("should raise the validation error (x86)", func() {
+					nodeSpecs := []NodeSpecifications{}
+					nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node"})
+					validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+					nodes, err := profile.getNodesList()
+					Expect(err).To(BeNil())
+
 					profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, HugePage{
 						Count: 128,
 						Size:  hugepagesSize1G,
 					})
-					errors := profile.validateHugePages()
+					errors := profile.validateHugePages(nodes)
 					Expect(errors).NotTo(BeEmpty())
 					Expect(errors[0].Error()).To(ContainSubstring(fmt.Sprintf("the page with the size %q and without the specified NUMA node, has duplication", hugepagesSize1G)))
 				})
 			})
 
 			Context("with not sequentially duplication blocks", func() {
-				It("should raise the validation error", func() {
+				It("should raise the validation error (x86)", func() {
+					nodeSpecs := []NodeSpecifications{}
+					nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node"})
+					validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+					nodes, err := profile.getNodesList()
+					Expect(err).To(BeNil())
+
 					profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, HugePage{
 						Count: 128,
 						Size:  hugepagesSize2M,
@@ -385,7 +641,7 @@ var _ = Describe("PerformanceProfile", func() {
 						Count: 128,
 						Size:  hugepagesSize1G,
 					})
-					errors := profile.validateHugePages()
+					errors := profile.validateHugePages(nodes)
 					Expect(errors).NotTo(BeEmpty())
 					Expect(errors[0].Error()).To(ContainSubstring(fmt.Sprintf("the page with the size %q and without the specified NUMA node, has duplication", hugepagesSize1G)))
 				})
@@ -463,7 +719,11 @@ var _ = Describe("PerformanceProfile", func() {
 	})
 
 	Describe("validation of validateFields function", func() {
-		It("should check all fields", func() {
+		It("should check all fields (x86)", func() {
+			nodeSpecs := []NodeSpecifications{}
+			nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node"})
+			validatorClient = GetFakeValidatorClient(nodeSpecs)
+
 			// config all specs to rise an error in every func inside validateFields()
 			reservedCPUs := CPUSet("")
 			isolatedCPUs := CPUSet("0-6")
@@ -498,7 +758,7 @@ var _ = Describe("PerformanceProfile", func() {
 
 			errorMsgs["reserved CPUs can not be empty"] = member
 			errorMsgs["you should provide only 1 MachineConfigLabel"] = member
-			errorMsgs[`hugepages default size should be equal to "1G" or "2M"`] = member
+			errorMsgs[fmt.Sprintf("hugepages default size should be equal to one of %v", x86ValidHugepagesSizes)] = member
 			errorMsgs["device name cannot be empty"] = member
 			errorMsgs[fmt.Sprintf("device vendor ID %s has an invalid format. Vendor ID should be represented as 0x<4 hexadecimal digits> (16 bit representation)", invalidVendor)] = member
 			errorMsgs[fmt.Sprintf("device model ID %s has an invalid format. Model ID should be represented as 0x<4 hexadecimal digits> (16 bit representation)", invalidDevice)] = member


### PR DESCRIPTION
- Include valid sizes for both x86 and aarch64 in the validation check
- Included notes for aarch64 where each kernel page size includes only a single valid hugepage size
- After discusion on Slack I have also added some additional validations:
-- Verify all nodes in the list have the same cpu architecture
-- Verify all nodes in the list have the same cpu capacity
-- Verify that the selected hugepage size is valid for the cpu architecture