### PR TITLE
NO-JIRA:hypershift: client: fix Get() call implementation

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
@@ -33,20 +33,20 @@ type ControlPlaneClientImpl struct {
 }
 
 func (ci *ControlPlaneClientImpl) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	if ObjIsEncapsulatedInConfigMap(obj) {
+	if EncapsulatedInConfigMap(obj) {
 		return ci.getFromConfigMap(ctx, key, obj, opts...)
 	}
 	return ci.Client.Get(ctx, key, obj, opts...)
 }
 
 func (ci *ControlPlaneClientImpl) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if ObjIsEncapsulatedInConfigMap(obj) {
+	if EncapsulatedInConfigMap(obj) {
 		return ci.createInConfigMap(ctx, obj, opts...)
 	}
 	return ci.Client.Create(ctx, obj, opts...)
 }
 
-func ObjIsEncapsulatedInConfigMap(obj runtime.Object) bool {
+func EncapsulatedInConfigMap(obj runtime.Object) bool {
 	switch obj.(type) {
 	case *performancev2.PerformanceProfile, *performancev2.PerformanceProfileList,
 		*machineconfigv1.KubeletConfig, *machineconfigv1.KubeletConfigList,

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift_test.go
@@ -1,0 +1,278 @@
+package hypershift
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+)
+
+func TestControlPlaneClientImpl_Get(t *testing.T) {
+	machineConfig1 := `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: config-1
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+        source: "[Service]\nType=oneshot\nExecStart=/usr/bin/echo Hello World\n\n[Install]\nWantedBy=multi-user.target"
+        filesystem: root
+        mode: 493
+        path: /usr/local/bin/file1.sh
+`
+	coreMachineConfig1 := `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: core-config-1
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+        source: "[Service]\nType=oneshot\nExecStart=/usr/bin/echo Hello Core\n\n[Install]\nWantedBy=multi-user.target"
+        filesystem: root
+        mode: 493
+        path: /usr/local/bin/core.sh
+`
+
+	kubeletConfig1 := `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: set-max-pods
+spec:
+  kubeletConfig:
+    maxPods: 100
+`
+	perfprofOne := `apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+    name: perfprofOne
+spec:
+    cpu:
+        isolated: 1,3-39,41,43-79
+        reserved: 0,2,40,42
+    machineConfigPoolSelector:
+        machineconfiguration.openshift.io/role: worker-cnf
+    nodeSelector:
+        node-role.kubernetes.io/worker-cnf: ""
+    numa:
+        topologyPolicy: restricted
+    realTimeKernel:
+        enabled: true
+    workloadHints:
+        highPowerConsumption: false
+        realTime: true
+`
+	if err := performancev2.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := machineconfigv1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+	namespace := "test"
+	testsCases := []struct {
+		name                  string
+		encapsulatedObjsToGet []client.Object
+		configMaps            []runtime.Object
+		expectedIsNotFoundErr bool
+	}{
+		{
+			name: "encapsulated object name equal to configmap name",
+			encapsulatedObjsToGet: []client.Object{
+				&machineconfigv1.MachineConfig{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-1",
+					},
+				},
+				&machineconfigv1.MachineConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "core-config-1",
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-1",
+						Namespace: namespace,
+						Labels: map[string]string{
+							ConfigMapEncapsulatedKindKey: strings.ToLower(getObjectKind(&machineconfigv1.MachineConfig{})),
+						},
+					},
+					Data: map[string]string{
+						ConfigKey: machineConfig1,
+					},
+					BinaryData: nil,
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "core-config-1",
+						Namespace: namespace,
+						Labels: map[string]string{
+							ConfigMapEncapsulatedKindKey: strings.ToLower(getObjectKind(&machineconfigv1.MachineConfig{})),
+						},
+					},
+					Data: map[string]string{
+						ConfigKey: coreMachineConfig1,
+					},
+				},
+			},
+		},
+		{
+			name: "encapsulated performanceprofile name not equal to configmap name",
+			encapsulatedObjsToGet: []client.Object{
+				&performancev2.PerformanceProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "perfprofOne",
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "configmap-performance-profile-1",
+						Namespace: namespace,
+						Labels: map[string]string{
+							hypershiftControllerGeneratedPerformanceProfile: "true",
+						},
+					},
+					Data: map[string]string{
+						TuningKey: perfprofOne,
+					},
+				},
+			},
+		},
+		{
+			name: "encapsulated object name not equal to configmap name",
+			encapsulatedObjsToGet: []client.Object{
+				&machineconfigv1.MachineConfig{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-1",
+					},
+				},
+				&machineconfigv1.MachineConfig{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "core-config-1",
+					},
+				},
+				&machineconfigv1.KubeletConfig{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "set-max-pods",
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-1",
+						Namespace: namespace,
+						Labels: map[string]string{
+							ConfigMapEncapsulatedKindKey: strings.ToLower(getObjectKind(&machineconfigv1.MachineConfig{})),
+						},
+					},
+					Data: map[string]string{
+						ConfigKey: machineConfig1,
+					},
+					BinaryData: nil,
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "core-config-1",
+						Namespace: namespace,
+						Labels: map[string]string{
+							ConfigMapEncapsulatedKindKey: strings.ToLower(getObjectKind(&machineconfigv1.MachineConfig{})),
+						},
+					},
+					Data: map[string]string{
+						ConfigKey: coreMachineConfig1,
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kubelet-config-1",
+						Namespace: namespace,
+						Labels: map[string]string{
+							ConfigMapEncapsulatedKindKey: strings.ToLower(getObjectKind(&machineconfigv1.KubeletConfig{})),
+						},
+					},
+					Data: map[string]string{
+						ConfigKey: kubeletConfig1,
+					},
+				},
+			},
+		},
+		{
+			name: "provided wrong hosted control plane namespace name",
+			encapsulatedObjsToGet: []client.Object{
+				&machineconfigv1.MachineConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-1",
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-1",
+						Namespace: "wrong-namespace",
+						Labels: map[string]string{
+							ConfigMapEncapsulatedKindKey: strings.ToLower(getObjectKind(&machineconfigv1.MachineConfig{})),
+						},
+					},
+					Data: map[string]string{
+						ConfigKey: machineConfig1,
+					},
+					BinaryData: nil,
+				},
+			},
+			expectedIsNotFoundErr: true,
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tc.configMaps...).Build()
+			c := NewControlPlaneClient(fakeClient, namespace)
+			for _, objectToGet := range tc.encapsulatedObjsToGet {
+				err := c.Get(context.TODO(), client.ObjectKeyFromObject(objectToGet), objectToGet)
+				if !tc.expectedIsNotFoundErr && err != nil {
+					t.Errorf("failed to get object %v; err: %v", objectToGet, err)
+				}
+				if tc.expectedIsNotFoundErr && !apierrors.IsNotFound(err) {
+					t.Errorf("expected IsNotFound error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+func getObjectKind(obj metav1.Object) string {
+	return reflect.TypeOf(obj).Elem().Name()
+}

--- a/test/e2e/performanceprofile/functests/utils/client/dataplane.go
+++ b/test/e2e/performanceprofile/functests/utils/client/dataplane.go
@@ -14,7 +14,7 @@ type dataPlaneImpl struct {
 }
 
 func (dpi *dataPlaneImpl) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.EncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not be presented on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -22,7 +22,7 @@ func (dpi *dataPlaneImpl) Get(ctx context.Context, key client.ObjectKey, obj cli
 }
 
 func (dpi *dataPlaneImpl) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(list) {
+	if hypershift.EncapsulatedInConfigMap(list) {
 		return fmt.Errorf("the provided list of %s objects might not be presented on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", list.GetObjectKind())
 	}
@@ -30,7 +30,7 @@ func (dpi *dataPlaneImpl) List(ctx context.Context, list client.ObjectList, opts
 }
 
 func (dpi *dataPlaneImpl) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.EncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get created on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -38,7 +38,7 @@ func (dpi *dataPlaneImpl) Create(ctx context.Context, obj client.Object, opts ..
 }
 
 func (dpi *dataPlaneImpl) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.EncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get deleted on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -46,7 +46,7 @@ func (dpi *dataPlaneImpl) Delete(ctx context.Context, obj client.Object, opts ..
 }
 
 func (dpi *dataPlaneImpl) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.EncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get updated on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -54,7 +54,7 @@ func (dpi *dataPlaneImpl) Update(ctx context.Context, obj client.Object, opts ..
 }
 
 func (dpi *dataPlaneImpl) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.EncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get patched on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -62,7 +62,7 @@ func (dpi *dataPlaneImpl) Patch(ctx context.Context, obj client.Object, patch cl
 }
 
 func (dpi *dataPlaneImpl) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.EncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get deleted on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}


### PR DESCRIPTION
There was a hidden (wrong) assumption that the `ConfigMap` name is equal to the
internal object's name which encapsulated in the `ConfigMap`.

To make sure we return the correct internal object,
we should list all the `ConfigMap`'s in the HCP namespace,
decode the data and look for the correct object name.

Since the decoding operation is relatively expesive,
we added a label `ConfigMapEncapsulatedKindKey` that would
help with listing only `ConfigMap`'s that contains the correct kind.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>