### PR TITLE
No-JIRA: e2e:run-test.sh: match ginkgo CLI to ginkgo package

### DIFF
--- a/hack/run-test.sh
+++ b/hack/run-test.sh
@@ -73,7 +73,8 @@ main() {
     which ginkgo
     if [ $? -ne 0 ]; then
         echo "Downloading ginkgo tool"
-        go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.6.1
+        GINKGO_VERSION=$(go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
+        go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@"${GINKGO_VERSION}"
         ginkgo version
     fi
 


### PR DESCRIPTION
We are usually having a mismatch between the ginkgo CLI and ginkgo package, because we are updating the ginkgo package on the go.mod but forget to do the same on our test's script.
something like:
```
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.6.1
  Mismatched package versions found:
    2.17.1 used by 0_config, 1_performance, 6_mustgather_testing, 10_performance_ppc
```

let's automate the process to save some work and avoid bugs that might happens due to breaking changes between versions which are not matching