### PR TITLE
NO-JIRA:pao:hypershift: fix client implementation

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -69,9 +69,7 @@ var (
 func init() {
 	ctrl.SetLogger(zap.New())
 
-	if !config.InHyperShift() {
-		utilruntime.Must(mcov1.AddToScheme(scheme))
-	}
+	utilruntime.Must(mcov1.AddToScheme(scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(tunedv1.AddToScheme(scheme))
 	utilruntime.Must(apiconfigv1.Install(scheme))

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
@@ -25,12 +25,11 @@ import (
 )
 
 const (
-	hypershiftPerformanceProfileNameLabel = "hypershift.openshift.io/performanceProfileName"
-	hypershiftNodePoolLabel               = "hypershift.openshift.io/nodePool"
-	tunedConfigMapLabel                   = "hypershift.openshift.io/tuned-config"
-	tunedConfigMapConfigKey               = "tuning"
-	mcoConfigMapConfigKey                 = "config"
-	ntoGeneratedMachineConfigLabel        = "hypershift.openshift.io/nto-generated-machine-config"
+	hypershiftNodePoolLabel        = "hypershift.openshift.io/nodePool"
+	tunedConfigMapLabel            = "hypershift.openshift.io/tuned-config"
+	tunedConfigMapConfigKey        = "tuning"
+	mcoConfigMapConfigKey          = "config"
+	ntoGeneratedMachineConfigLabel = "hypershift.openshift.io/nto-generated-machine-config"
 )
 
 var _ components.Handler = &handler{}
@@ -249,8 +248,8 @@ func configMapMeta(name, profileName, namespace, npNamespacedName string) *corev
 			Namespace: namespace,
 			Name:      name,
 			Labels: map[string]string{
-				hypershiftPerformanceProfileNameLabel: profileName,
-				hypershiftNodePoolLabel:               parseNamespacedName(npNamespacedName),
+				hypershift.PerformanceProfileNameLabel: profileName,
+				hypershiftNodePoolLabel:                parseNamespacedName(npNamespacedName),
 			},
 			Annotations: map[string]string{
 				hypershiftNodePoolLabel: npNamespacedName,

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
@@ -17,9 +17,7 @@ import (
 
 	mcov1 "github.com/openshift/api/machineconfiguration/v1"
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
-	"github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
-	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/manifestset"
 	profileutil "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/hypershift"
@@ -73,26 +71,9 @@ func (h *handler) Delete(ctx context.Context, profileName string) error {
 }
 
 func (h *handler) Exists(ctx context.Context, profileName string) bool {
-	operatorNamespace := config.OperatorNamespace()
-	tunedName := components.GetComponentName(profileName, components.ProfileNamePerformance)
-	if _, err := resources.GetTuned(ctx, h.controlPlaneClient, tunedName, operatorNamespace); !k8serrors.IsNotFound(err) {
-		klog.Infof("Tuned %q is still exists in the namespace %q", tunedName, operatorNamespace)
-		return true
-	}
-
 	name := components.GetComponentName(profileName, components.ComponentNamePrefix)
-	if _, err := resources.GetKubeletConfig(ctx, h.controlPlaneClient, name); !k8serrors.IsNotFound(err) {
-		klog.Infof("Kubelet Config %q exists in the namespace %q", name, operatorNamespace)
-		return true
-	}
-
 	if _, err := resources.GetRuntimeClass(ctx, h.dataPlaneClient, name); !k8serrors.IsNotFound(err) {
 		klog.Infof("Runtime class %q exists in the hosted cluster", name)
-		return true
-	}
-
-	if _, err := resources.GetMachineConfig(ctx, h.controlPlaneClient, machineconfig.GetMachineConfigName(profileName)); !k8serrors.IsNotFound(err) {
-		klog.Infof("Machine Config %q exists in the namespace %q", name, operatorNamespace)
 		return true
 	}
 	return false

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
@@ -181,7 +181,7 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 	}
 
 	if runtimeClassMutated != nil {
-		err = resources.CreateOrUpdateRuntimeClass(ctx, h.dataPlaneClient, mfs.RuntimeClass)
+		err = resources.CreateOrUpdateRuntimeClass(ctx, h.dataPlaneClient, runtimeClassMutated)
 		if err != nil {
 			return err
 		}

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
@@ -113,6 +113,7 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 	if err := hypershift.DecodeManifest([]byte(s), h.scheme, profile); err != nil {
 		return err
 	}
+	klog.V(4).InfoS("PerformanceProfile decoded successfully from ConfigMap data", "PerformanceProfileName", profile.Name, "ConfigMapName", instance.GetName())
 
 	if profileutil.IsPaused(profile) {
 		klog.Infof("ignoring reconcile loop for pause performance profile %s", profile.Name)

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
@@ -23,6 +23,7 @@ const (
 	TuningKey                   = "tuning"
 	ConfigKey                   = "config"
 	HostedClustersNamespaceName = "clusters"
+	PerformanceProfileNameLabel = "hypershift.openshift.io/performanceProfileName"
 )
 
 type ControlPlaneClientImpl struct {

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
@@ -33,20 +33,20 @@ type ControlPlaneClientImpl struct {
 }
 
 func (ci *ControlPlaneClientImpl) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	if ObjIsEncapsulatedInConfigMap(obj) {
+	if IsEncapsulatedInConfigMap(obj) {
 		return ci.getFromConfigMap(ctx, key, obj, opts...)
 	}
 	return ci.Client.Get(ctx, key, obj, opts...)
 }
 
 func (ci *ControlPlaneClientImpl) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if ObjIsEncapsulatedInConfigMap(obj) {
+	if IsEncapsulatedInConfigMap(obj) {
 		return ci.createInConfigMap(ctx, obj, opts...)
 	}
 	return ci.Client.Create(ctx, obj, opts...)
 }
 
-func ObjIsEncapsulatedInConfigMap(obj runtime.Object) bool {
+func IsEncapsulatedInConfigMap(obj runtime.Object) bool {
 	switch obj.(type) {
 	case *performancev2.PerformanceProfile, *performancev2.PerformanceProfileList,
 		*machineconfigv1.KubeletConfig, *machineconfigv1.KubeletConfigList,

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,35 +68,44 @@ func NewControlPlaneClient(c client.Client, ns string) *ControlPlaneClientImpl {
 }
 
 func (ci *ControlPlaneClientImpl) getFromConfigMap(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	cm := &corev1.ConfigMap{}
-	if key.Namespace == metav1.NamespaceNone {
-		key.Namespace = ci.managementClusterNamespaceName
-	}
-	err := ci.Client.Get(ctx, key, cm, opts...)
+	cmList := &corev1.ConfigMapList{}
+	err := ci.Client.List(ctx, cmList, &client.ListOptions{
+		Namespace: ci.managementClusterNamespaceName,
+	})
 	if err != nil {
 		return err
 	}
+	for _, cm := range cmList.Items {
+		err = validateAndExtractObjectFromConfigMap(&cm, ci.Scheme(), obj)
+		if err != nil {
+			return err
+		}
+		if obj.GetName() == key.Name {
+			return nil
+		}
+	}
+	// we don't have the actual GroupResource, because it's an internal rendered into the ConfigMap data, so leave it empty.
+	return fmt.Errorf("the encapsulated object %s was not found in ConfigMap; %w", key.String(),
+		apierrors.NewNotFound(schema.GroupResource{}, key.Name))
+}
 
-	cmKey := client.ObjectKeyFromObject(cm)
-	var objAsYAML string
-	var tuningKeyFound, configKeyFound bool
-	if s, ok := cm.Data[TuningKey]; ok {
-		objAsYAML = s
-		tuningKeyFound = true
+// validateAndExtractObjectFromConfigMap validates the object if it supposes to be encapsulated in a configmap.
+// then it tries to extract the object.
+// even if extraction failed, the returned validation value is true.
+func validateAndExtractObjectFromConfigMap(cm *corev1.ConfigMap, scheme *runtime.Scheme, obj client.Object) error {
+	var manifest string
+	switch obj.(type) {
+	case *performancev2.PerformanceProfile, *tunedv1.Tuned:
+		manifest = cm.Data[TuningKey]
+	case *machineconfigv1.KubeletConfig, *machineconfigv1.MachineConfig:
+		manifest = cm.Data[ConfigKey]
+	default:
+		return fmt.Errorf("unsupported config type: %T", obj)
 	}
-	if s, ok2 := cm.Data[ConfigKey]; ok2 {
-		objAsYAML = s
-		configKeyFound = true
+	if err := DecodeManifest([]byte(manifest), scheme, obj); err != nil {
+		return fmt.Errorf("error decoding config: %w", err)
 	}
-	// can't have both
-	if tuningKeyFound && configKeyFound {
-		return fmt.Errorf("ConfigMap %s has both %s and %s keys", cmKey.String(), TuningKey, ConfigKey)
-	}
-	if !tuningKeyFound && !configKeyFound {
-		return fmt.Errorf("could not get %s from ConfigMap %s, keys %s and %s are missing",
-			obj.GetObjectKind().GroupVersionKind().Kind, cmKey.String(), TuningKey, ConfigKey)
-	}
-	return DecodeManifest([]byte(objAsYAML), scheme.Scheme, obj)
+	return nil
 }
 
 func (ci *ControlPlaneClientImpl) createInConfigMap(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift_test.go
@@ -1,0 +1,251 @@
+package hypershift
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+)
+
+func TestControlPlaneClientImpl_Get(t *testing.T) {
+	machineConfig1 := `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: config-1
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+        source: "[Service]\nType=oneshot\nExecStart=/usr/bin/echo Hello World\n\n[Install]\nWantedBy=multi-user.target"
+        filesystem: root
+        mode: 493
+        path: /usr/local/bin/file1.sh
+`
+	coreMachineConfig1 := `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: core-config-1
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+        source: "[Service]\nType=oneshot\nExecStart=/usr/bin/echo Hello Core\n\n[Install]\nWantedBy=multi-user.target"
+        filesystem: root
+        mode: 493
+        path: /usr/local/bin/core.sh
+`
+
+	kubeletConfig1 := `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: set-max-pods
+spec:
+  kubeletConfig:
+    maxPods: 100
+`
+	perfprofOne := `apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+    name: perfprofOne
+spec:
+    cpu:
+        isolated: 1,3-39,41,43-79
+        reserved: 0,2,40,42
+    machineConfigPoolSelector:
+        machineconfiguration.openshift.io/role: worker-cnf
+    nodeSelector:
+        node-role.kubernetes.io/worker-cnf: ""
+    numa:
+        topologyPolicy: restricted
+    realTimeKernel:
+        enabled: true
+    workloadHints:
+        highPowerConsumption: false
+        realTime: true
+`
+	if err := performancev2.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := machineconfigv1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+	namespace := "test"
+	testsCases := []struct {
+		name                  string
+		encapsulatedObjsToGet []client.Object
+		configMaps            []runtime.Object
+		expectedIsNotFoundErr bool
+	}{
+		{
+			name: "encapsulated object name equal to configmap name",
+			encapsulatedObjsToGet: []client.Object{
+				&machineconfigv1.MachineConfig{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-1",
+					},
+				},
+				&machineconfigv1.MachineConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "core-config-1",
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-1",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						ConfigKey: machineConfig1,
+					},
+					BinaryData: nil,
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "core-config-1",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						ConfigKey: coreMachineConfig1,
+					},
+				},
+			},
+		},
+		{
+			name: "encapsulated performanceprofile name not equal to configmap name",
+			encapsulatedObjsToGet: []client.Object{
+				&performancev2.PerformanceProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "perfprofOne",
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "configmap-performance-profile-1",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						TuningKey: perfprofOne,
+					},
+				},
+			},
+		},
+		{
+			name: "encapsulated object name not equal to configmap name",
+			encapsulatedObjsToGet: []client.Object{
+				&machineconfigv1.MachineConfig{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-1",
+					},
+				},
+				&machineconfigv1.MachineConfig{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "core-config-1",
+					},
+				},
+				&machineconfigv1.KubeletConfig{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "set-max-pods",
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-1",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						ConfigKey: machineConfig1,
+					},
+					BinaryData: nil,
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "core-config-1",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						ConfigKey: coreMachineConfig1,
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kubelet-config-1",
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						ConfigKey: kubeletConfig1,
+					},
+				},
+			},
+		},
+		{
+			name: "provided wrong hosted control plane namespace name",
+			encapsulatedObjsToGet: []client.Object{
+				&machineconfigv1.MachineConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config-1",
+					},
+				},
+			},
+			configMaps: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "config-1",
+						Namespace: "wrong-namespace",
+					},
+					Data: map[string]string{
+						ConfigKey: machineConfig1,
+					},
+					BinaryData: nil,
+				},
+			},
+			expectedIsNotFoundErr: true,
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tc.configMaps...).Build()
+			c := NewControlPlaneClient(fakeClient, namespace)
+			for _, objectToGet := range tc.encapsulatedObjsToGet {
+				err := c.Get(context.TODO(), client.ObjectKeyFromObject(objectToGet), objectToGet)
+				if !tc.expectedIsNotFoundErr && err != nil {
+					t.Errorf("failed to get object %v; err: %v", objectToGet, err)
+				}
+				if tc.expectedIsNotFoundErr && !apierrors.IsNotFound(err) {
+					t.Errorf("expected IsNotFound error, got %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift_test.go
@@ -96,7 +96,7 @@ spec:
 		name                  string
 		encapsulatedObjsToGet []client.Object
 		configMaps            []runtime.Object
-		expectedIsNotFoundErr bool
+		expectedInNotFoundErr bool
 	}{
 		{
 			name: "encapsulated object name equal to configmap name",
@@ -230,7 +230,7 @@ spec:
 					BinaryData: nil,
 				},
 			},
-			expectedIsNotFoundErr: true,
+			expectedInNotFoundErr: true,
 		},
 	}
 	for _, tc := range testsCases {
@@ -239,11 +239,11 @@ spec:
 			c := NewControlPlaneClient(fakeClient, namespace)
 			for _, objectToGet := range tc.encapsulatedObjsToGet {
 				err := c.Get(context.TODO(), client.ObjectKeyFromObject(objectToGet), objectToGet)
-				if !tc.expectedIsNotFoundErr && err != nil {
+				if !tc.expectedInNotFoundErr && err != nil {
 					t.Errorf("failed to get object %v; err: %v", objectToGet, err)
 				}
-				if tc.expectedIsNotFoundErr && !apierrors.IsNotFound(err) {
-					t.Errorf("expected IsNotFound error, got %v", err)
+				if tc.expectedInNotFoundErr && !apierrors.IsNotFound(err) {
+					t.Errorf("expected IsNotFound error, actual error %v ", err)
 				}
 			}
 		})

--- a/test/e2e/performanceprofile/functests/utils/client/dataplane.go
+++ b/test/e2e/performanceprofile/functests/utils/client/dataplane.go
@@ -14,7 +14,7 @@ type dataPlaneImpl struct {
 }
 
 func (dpi *dataPlaneImpl) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.IsEncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not be presented on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -22,7 +22,7 @@ func (dpi *dataPlaneImpl) Get(ctx context.Context, key client.ObjectKey, obj cli
 }
 
 func (dpi *dataPlaneImpl) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(list) {
+	if hypershift.IsEncapsulatedInConfigMap(list) {
 		return fmt.Errorf("the provided list of %s objects might not be presented on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", list.GetObjectKind())
 	}
@@ -30,7 +30,7 @@ func (dpi *dataPlaneImpl) List(ctx context.Context, list client.ObjectList, opts
 }
 
 func (dpi *dataPlaneImpl) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.IsEncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get created on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -38,7 +38,7 @@ func (dpi *dataPlaneImpl) Create(ctx context.Context, obj client.Object, opts ..
 }
 
 func (dpi *dataPlaneImpl) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.IsEncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get deleted on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -46,7 +46,7 @@ func (dpi *dataPlaneImpl) Delete(ctx context.Context, obj client.Object, opts ..
 }
 
 func (dpi *dataPlaneImpl) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.IsEncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get updated on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -54,7 +54,7 @@ func (dpi *dataPlaneImpl) Update(ctx context.Context, obj client.Object, opts ..
 }
 
 func (dpi *dataPlaneImpl) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.IsEncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get patched on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}
@@ -62,7 +62,7 @@ func (dpi *dataPlaneImpl) Patch(ctx context.Context, obj client.Object, patch cl
 }
 
 func (dpi *dataPlaneImpl) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
-	if hypershift.ObjIsEncapsulatedInConfigMap(obj) {
+	if hypershift.IsEncapsulatedInConfigMap(obj) {
 		return fmt.Errorf("the provided object %s/%s might not get deleted on hypershift cluster while using this client."+
 			"please use ControlPlaneClient client instead", obj.GetObjectKind(), obj.GetName())
 	}


### PR DESCRIPTION
On hypershift many objects are encapsulated in ConfigMaps.
So if we're given the name of the encapsulated object,
trying to get the ConfigMap with same name is not enough,
because the internal object's name and the ConfigMap name
doesn't have to be equal.

Hence, the client have to `List()` all the ConfigMaps in the
hosted control plane namespace, extracts the data and
compares the names.

In case it was not found, it mimics an IsNotFound error
to be compatible with the error returned from the API server.

The implementation can be improved, by caching some of the information,
but before we come with "fancy-but-not-proved-to-be-efficent" solutions
let's evaluate the simplest solution first and iterate later if needed.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>