### PR TITLE
NO-JIRA: hypershift: check updatingConfig condition to be false instead of missing

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/nodepools/nodepools.go
+++ b/test/e2e/performanceprofile/functests/utils/nodepools/nodepools.go
@@ -25,12 +25,11 @@ func WaitForUpdatingConfig(ctx context.Context, c client.Client, NpName, namespa
 func WaitForConfigToBeReady(ctx context.Context, c client.Client, NpName, namespace string) error {
 	return waitForCondition(ctx, c, NpName, namespace, func(conds []hypershiftv1beta1.NodePoolCondition) bool {
 		for _, cond := range conds {
-			// the config is ready when this condition is gone
 			if cond.Type == hypershiftv1beta1.NodePoolUpdatingConfigConditionType {
-				return false
+				return cond.Status == corev1.ConditionFalse
 			}
 		}
-		return true
+		return false
 	})
 }
 


### PR DESCRIPTION
Due to the latest changes in the hypershift nodepool conditions API (https://github.com/openshift/hypershift/commit/05a7fa17c8156585658b72fa9453a569963ee2bd) in order to check that the tuning has completed and the nodepool is ready, we need to change our check accordingly - check that the condition is false instead of missing.