### PR TITLE
PSAP-1428: read only root filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,10 @@ COPY hack/dockerfile_install_support.sh /tmp
 RUN /bin/bash /tmp/dockerfile_install_support.sh
 
 COPY manifests/*.yaml manifests/image-references /manifests/
-ENV APP_ROOT=/var/lib/ocp-tuned
-ENV PATH=${APP_ROOT}/bin:${PATH}
-ENV HOME=${APP_ROOT}
+ENV HOME=/run/ocp-tuned
 ENV SYSTEMD_IGNORE_CHROOT=1
-WORKDIR ${APP_ROOT}
+WORKDIR ${HOME}
+
 RUN dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \
     useradd -r -u 499 cluster-node-tuning-operator

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -15,11 +15,9 @@ COPY hack/dockerfile_install_support.sh /tmp
 RUN /bin/bash /tmp/dockerfile_install_support.sh
 
 COPY manifests/*.yaml manifests/image-references /manifests/
-ENV APP_ROOT=/var/lib/ocp-tuned
-ENV PATH=${APP_ROOT}/bin:${PATH}
-ENV HOME=${APP_ROOT}
+ENV HOME=/run/ocp-tuned
 ENV SYSTEMD_IGNORE_CHROOT=1
-WORKDIR ${APP_ROOT}
+WORKDIR ${HOME}
 
 RUN dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \

--- a/assets/performanceprofile/configs/ocp-tuned-one-shot.service
+++ b/assets/performanceprofile/configs/ocp-tuned-one-shot.service
@@ -28,7 +28,8 @@ ExecStart=/usr/bin/podman run \
     --security-opt label=disable \
     --log-driver=none \
     --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-    --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+    --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+    --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
     --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
     --volume /etc/sysconfig:/etc/sysconfig:rslave \
     --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \

--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -33,6 +33,7 @@ spec:
         name: tuned
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -57,12 +58,16 @@ spec:
         - mountPath: /etc/systemd
           name: etc-systemd
           mountPropagation: HostToContainer
+        - mountPath: /etc/tuned
+          name: etc-tuned
         - mountPath: /run
           name: run
           mountPropagation: HostToContainer
         - mountPath: /sys
           name: sys
           mountPropagation: HostToContainer
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /lib/modules
           name: lib-modules
           mountPropagation: HostToContainer
@@ -136,6 +141,12 @@ spec:
         hostPath:
           path: /
           type: Directory
+      - name: etc-tuned
+        emptyDir:
+          medium: Memory
+      - name: tmp
+        emptyDir:
+          medium: Memory
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux

--- a/hack/dockerfile_install_support.sh
+++ b/hack/dockerfile_install_support.sh
@@ -52,8 +52,11 @@ else
 fi
 
 # TuneD post-installation steps
-rm -rf /etc/tuned/recommend.d
+rm -rf /etc/tuned/recommend.d /var/lib/tuned
 echo auto > /etc/tuned/profile_mode
 sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /usr/lib/tuned/profiles,/usr/lib/tuned,/var/lib/ocp-tuned/profiles|' \
   /etc/tuned/tuned-main.conf
+mv /etc/tuned /etc/tuned.orig
+ln -s /host/var/lib/ocp-tuned /var/lib/ocp-tuned
+ln -s /host/var/lib/tuned /var/lib/tuned
 touch /etc/sysctl.conf

--- a/pkg/tuned/run.go
+++ b/pkg/tuned/run.go
@@ -72,6 +72,24 @@ func configDaemonMode() (func(), error) {
 	return restoreF, nil
 }
 
+// TunedRsyncEtcToHost propagates the changes from container's read-only TuneD /etc/tuned.orig
+// directory to the container's Memory-backed read-write TuneD /etc/tuned directory.
+// This function only serves the purpose to enable readOnlyRootFilesystem for the NTO operand.
+func TunedRsyncEtc() error {
+	const (
+		source = "/etc/tuned.orig/"
+		target = tunedEtcDir
+	)
+
+	cmd := exec.Command("rsync", "--delete", "-av", source, target)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("rsync of %q to %q failed: %v\n%s", source, target, err, out)
+	}
+
+	return nil
+}
+
 func TunedRunNoDaemon(timeout time.Duration) error {
 	var (
 		cmd    *exec.Cmd

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
@@ -196,7 +196,8 @@ spec:
               --security-opt label=disable \
               --log-driver=none \
               --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
               --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
               --volume /etc/sysconfig:/etc/sysconfig:rslave \
               --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
@@ -196,7 +196,8 @@ spec:
               --security-opt label=disable \
               --log-driver=none \
               --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
               --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
               --volume /etc/sysconfig:/etc/sysconfig:rslave \
               --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -196,7 +196,8 @@ spec:
               --security-opt label=disable \
               --log-driver=none \
               --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
               --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
               --volume /etc/sysconfig:/etc/sysconfig:rslave \
               --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -196,7 +196,8 @@ spec:
               --security-opt label=disable \
               --log-driver=none \
               --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
               --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
               --volume /etc/sysconfig:/etc/sysconfig:rslave \
               --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -196,7 +196,8 @@ spec:
               --security-opt label=disable \
               --log-driver=none \
               --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
               --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
               --volume /etc/sysconfig:/etc/sysconfig:rslave \
               --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -196,7 +196,8 @@ spec:
               --security-opt label=disable \
               --log-driver=none \
               --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
               --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
               --volume /etc/sysconfig:/etc/sysconfig:rslave \
               --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
@@ -198,7 +198,8 @@ spec:
               --security-opt label=disable \
               --log-driver=none \
               --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
               --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
               --volume /etc/sysconfig:/etc/sysconfig:rslave \
               --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
@@ -214,7 +214,8 @@ spec:
               --security-opt label=disable \
               --log-driver=none \
               --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
               --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
               --volume /etc/sysconfig:/etc/sysconfig:rslave \
               --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
@@ -213,7 +213,8 @@ spec:
               --security-opt label=disable \
               --log-driver=none \
               --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
-              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
               --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
               --volume /etc/sysconfig:/etc/sysconfig:rslave \
               --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \


### PR DESCRIPTION
In line with the "Principle of least privilege", add
readOnlyRootFilesystem to the NTO operand's container securityContext.

Key changes:
  * NTO's operand daemonset sets the readOnlyRootFilesystem container
    securityContext.
  * Use memory-backed emptyDir for /etc/tuned.
  * /tmp uses memory-backed emptyDir now to allow the operand's TuneD
    daemon writing temporary files when using profiles such as the
    cpu-partitioning profile.
  * TuneD container's home directory is now /run/ocp-tuned with a link to
    host's ocp-tuned persistent directory:
    persist -> /host/var/lib/ocp-tuned
  * Make /var/lib/tuned directory persistent on the host by:
    /var/lib/tuned -> /host/var/lib/tuned
    The persistent directory is populated by files such as ksm-masked coming
    from cpu-partitioning profile.
  * Change the ocp-tuned-one-shot systemd service to mount the hosts's
    persistent host /var/lib/{ocp-,}tuned directories to
    /host/var/lib/{ocp-,}tuned to simplify the operand code.
