### PR TITLE
CNF-13530: controller: predicate for `containerruntimeconfig`

### DIFF
--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -33,9 +33,10 @@ const (
 	// TODO remove once HyperShift has switched to using new key.
 	tunedConfigMapConfigKeyDeprecated = "tuned"
 
-	operatorGeneratedMachineConfig = "hypershift.openshift.io/nto-generated-machine-config"
-	mcConfigMapDataKey             = "config"
-	generatedConfigMapPrefix       = "nto-mc-"
+	operatorGeneratedMachineConfig                      = "hypershift.openshift.io/nto-generated-machine-config"
+	mcConfigMapDataKey                                  = "config"
+	generatedConfigMapPrefix                            = "nto-mc-"
+	HypershiftControllerGeneratedContainerRuntimeConfig = "hypershift.openshift.io/containerruntimeconfig-config"
 )
 
 // syncHostedClusterTuneds synchronizes Tuned objects embedded in ConfigMaps


### PR DESCRIPTION
The predicate addition will trigger the reconciliation loop every time there's a change in the `ConfigMap` that holds the `containerruntimeconfig`.

Signed-off-by: Talor Itzhak [titzhak@redhat.com](mailto:titzhak@redhat.com)