### PR TITLE
OCPBUGS-36870: Remove tuned/rendered object

### DIFF
--- a/manifests/20-profile.crd.yaml
+++ b/manifests/20-profile.crd.yaml
@@ -73,6 +73,25 @@ spec:
                 required:
                 - tunedProfile
                 type: object
+              profile:
+                description: Tuned profiles.
+                items:
+                  description: A Tuned profile.
+                  properties:
+                    data:
+                      description: Specification of the Tuned profile to be consumed
+                        by the Tuned daemon.
+                      type: string
+                    name:
+                      description: Name of the Tuned profile to be used in the recommend
+                        section.
+                      minLength: 1
+                      type: string
+                  required:
+                  - data
+                  - name
+                  type: object
+                type: array
             required:
             - config
             type: object

--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -153,6 +153,9 @@ type Profile struct {
 
 type ProfileSpec struct {
 	Config ProfileConfig `json:"config"`
+	// Tuned profiles.
+	// +optional
+	Profile []TunedProfile `json:"profile"`
 }
 
 type ProfileConfig struct {

--- a/pkg/apis/tuned/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/tuned/v1/zz_generated.deepcopy.go
@@ -108,6 +108,13 @@ func (in *ProfileList) DeepCopyObject() runtime.Object {
 func (in *ProfileSpec) DeepCopyInto(out *ProfileSpec) {
 	*out = *in
 	in.Config.DeepCopyInto(&out.Config)
+	if in.Profile != nil {
+		in, out := &in.Profile, &out.Profile
+		*out = make([]TunedProfile, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/generated/informers/externalversions/factory.go
+++ b/pkg/generated/informers/externalversions/factory.go
@@ -26,6 +26,7 @@ type sharedInformerFactory struct {
 	lock             sync.Mutex
 	defaultResync    time.Duration
 	customResync     map[reflect.Type]time.Duration
+	transform        cache.TransformFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -60,6 +61,14 @@ func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFu
 func WithNamespace(namespace string) SharedInformerOption {
 	return func(factory *sharedInformerFactory) *sharedInformerFactory {
 		factory.namespace = namespace
+		return factory
+	}
+}
+
+// WithTransform sets a transform on all informers.
+func WithTransform(transform cache.TransformFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.transform = transform
 		return factory
 	}
 }
@@ -150,7 +159,7 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
+// InformerFor returns the SharedIndexInformer for obj using an internal
 // client.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
@@ -168,6 +177,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	}
 
 	informer = newFunc(f.client, resyncPeriod)
+	informer.SetTransform(f.transform)
 	f.informers[informerType] = informer
 
 	return informer
@@ -223,7 +233,7 @@ type SharedInformerFactory interface {
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
 
-	// InternalInformerFor returns the SharedIndexInformer for obj using an internal
+	// InformerFor returns the SharedIndexInformer for obj using an internal
 	// client.
 	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
 

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -388,10 +388,11 @@ func (c *Controller) sync(key wqKey) error {
 		}
 	}
 
-	klog.V(2).Infof("sync(): Tuned %s", tunedv1.TunedRenderedResourceName)
-	err = c.syncTunedRendered(cr)
+	klog.V(2).Infof("sync(): enableInformers")
+	// Enable/disable node/pod informers based on existing TuneD CRs.
+	err = c.enableInformers()
 	if err != nil {
-		return fmt.Errorf("failed to sync Tuned %s: %v", tunedv1.TunedRenderedResourceName, err)
+		return fmt.Errorf("failed to enable/disable informers: %v", err)
 	}
 
 	if key.name != tunedv1.TunedDefaultResourceName {
@@ -417,11 +418,6 @@ func (c *Controller) sync(key wqKey) error {
 	err = c.enqueueProfileUpdates()
 	if err != nil {
 		return err
-	}
-
-	if key.name == tunedv1.TunedRenderedResourceName {
-		// Do not start unused MachineConfig pruning unnecessarily for the rendered resource
-		return nil
 	}
 
 	// Tuned CR change can also mean some MachineConfigs the operator created are no longer needed;
@@ -505,15 +501,11 @@ func (c *Controller) syncTunedDefault() (*tunedv1.Tuned, error) {
 	return cr, nil
 }
 
-func (c *Controller) syncTunedRendered(tuned *tunedv1.Tuned) error {
+func (c *Controller) enableInformers() error {
 	tunedList, err := c.listers.TunedResources.List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("failed to list Tuned: %v", err)
 	}
-
-	crMf := ntomf.TunedRenderedResource(tunedList)
-	crMf.ObjectMeta.OwnerReferences = getDefaultTunedRefs(tuned)
-	crMf.Name = tunedv1.TunedRenderedResourceName
 
 	nodeLabelsUsed := c.pc.tunedsUseNodeLabels(tunedList)
 	if err = c.enableNodeInformer(nodeLabelsUsed); err != nil {
@@ -526,35 +518,6 @@ func (c *Controller) syncTunedRendered(tuned *tunedv1.Tuned) error {
 	if err = c.enablePodInformer(podLabelsUsed); err != nil {
 		return fmt.Errorf("failed to enable Pod informer: %v", err)
 	}
-
-	cr, err := c.listers.TunedResources.Get(tunedv1.TunedRenderedResourceName)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			klog.V(2).Infof("syncTunedRendered(): Tuned %s not found, creating one", crMf.Name)
-			_, err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Create(context.TODO(), crMf, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to create Tuned %s: %v", crMf.Name, err)
-			}
-			// Tuned created successfully
-			klog.Infof("created Tuned %s", crMf.Name)
-			return nil
-		}
-		return fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedRenderedResourceName, err)
-	}
-
-	if reflect.DeepEqual(crMf.Spec.Profile, cr.Spec.Profile) {
-		klog.V(2).Infof("syncTunedRendered(): Tuned %s doesn't need updating", crMf.Name)
-		return nil
-	}
-	cr = cr.DeepCopy() // never update the objects from cache
-	cr.Spec = crMf.Spec
-
-	klog.V(2).Infof("syncTunedRendered(): updating Tuned %s", cr.Name)
-	_, err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Update(context.TODO(), cr, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to update Tuned %s: %v", cr.Name, err)
-	}
-	klog.Infof("updated Tuned %s", cr.Name)
 
 	return nil
 }
@@ -618,6 +581,7 @@ func (c *Controller) syncDaemonSet(tuned *tunedv1.Tuned) error {
 func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	var (
 		tunedProfileName string
+		profilesAll      []tunedv1.TunedProfile
 		mcLabels         map[string]string
 		operand          tunedv1.OperandConfig
 		nodePoolName     string
@@ -652,22 +616,18 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	}
 
 	if ntoconfig.InHyperShift() {
-		tunedProfileName, nodePoolName, operand, err = c.pc.calculateProfileHyperShift(nodeName)
+		tunedProfileName, profilesAll, nodePoolName, operand, err = c.pc.calculateProfileHyperShift(nodeName)
 		if err != nil {
 			return err
 		}
 	} else {
-		tunedProfileName, mcLabels, operand, err = c.pc.calculateProfile(nodeName)
+		tunedProfileName, profilesAll, mcLabels, operand, err = c.pc.calculateProfile(nodeName)
 		if err != nil {
 			return err
 		}
 	}
 
 	metrics.ProfileCalculated(profileMf.Name, tunedProfileName)
-
-	if err != nil {
-		return fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedRenderedResourceName, err)
-	}
 
 	profile, err := c.listers.TunedProfiles.Get(profileMf.Name)
 	if err != nil {
@@ -685,6 +645,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 			profileMf.Spec.Config.TunedProfile = tunedProfileName
 			profileMf.Spec.Config.Debug = operand.Debug
 			profileMf.Spec.Config.TuneDConfig = operand.TuneDConfig
+			profileMf.Spec.Profile = profilesAll
 			profileMf.Status.Conditions = tunedpkg.InitializeStatusConditions()
 			_, err = c.clients.Tuned.TunedV1().Profiles(ntoconfig.WatchNamespace()).Create(context.TODO(), profileMf, metav1.CreateOptions{})
 			if err != nil {
@@ -745,6 +706,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	if profile.Spec.Config.TunedProfile == tunedProfileName &&
 		profile.Spec.Config.Debug == operand.Debug &&
 		reflect.DeepEqual(profile.Spec.Config.TuneDConfig, operand.TuneDConfig) &&
+		reflect.DeepEqual(profile.Spec.Profile, profilesAll) &&
 		profile.Spec.Config.ProviderName == providerName {
 		klog.V(2).Infof("syncProfile(): no need to update Profile %s", nodeName)
 		return nil
@@ -753,6 +715,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	profile.Spec.Config.TunedProfile = tunedProfileName
 	profile.Spec.Config.Debug = operand.Debug
 	profile.Spec.Config.TuneDConfig = operand.TuneDConfig
+	profile.Spec.Profile = profilesAll
 	profile.Spec.Config.ProviderName = providerName
 	profile.Status.Conditions = tunedpkg.InitializeStatusConditions()
 
@@ -1265,6 +1228,30 @@ func (c *Controller) enablePodInformer(enable bool) error {
 	return nil
 }
 
+// Remove this function and associated code in the future.  This is for cleanup during upgrades only.
+// The rendered resource is no longer used.
+func (c *Controller) removeTunedRendered() error {
+	var err error
+
+	_, err = c.listers.TunedResources.Get(tunedv1.TunedRenderedResourceName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Do not create any noise when TunedRenderedResourceName is not found (was already removed).
+			err = nil
+		} else {
+			err = fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedRenderedResourceName, err)
+		}
+	} else {
+		err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Delete(context.TODO(), tunedv1.TunedRenderedResourceName, metav1.DeleteOptions{})
+		if err != nil {
+			err = fmt.Errorf("failed to delete Tuned %s: %v", tunedv1.TunedRenderedResourceName, err)
+		} else {
+			klog.Infof("deleted Tuned %s", tunedv1.TunedRenderedResourceName)
+		}
+	}
+	return err
+}
+
 func (c *Controller) removeResources() error {
 	var lastErr error
 	dsMf := ntomf.TunedDaemonSet()
@@ -1284,18 +1271,10 @@ func (c *Controller) removeResources() error {
 		}
 	}
 
-	_, err = c.listers.TunedResources.Get(tunedv1.TunedRenderedResourceName)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			lastErr = fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedRenderedResourceName, err)
-		}
-	} else {
-		err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Delete(ctx, tunedv1.TunedRenderedResourceName, metav1.DeleteOptions{})
-		if err != nil {
-			lastErr = fmt.Errorf("failed to delete Tuned %s: %v", tunedv1.TunedRenderedResourceName, err)
-		} else {
-			klog.Infof("deleted Tuned %s", tunedv1.TunedRenderedResourceName)
-		}
+	// Remove this code in the future.  This is for cleanup during upgrades only.
+	// The rendered resource is no longer used.
+	if err := c.removeTunedRendered(); err != nil {
+		lastErr = err
 	}
 
 	profileList, err := c.listers.TunedProfiles.List(labels.Everything())
@@ -1440,6 +1419,12 @@ func (c *Controller) run(ctx context.Context) error {
 	ok := cache.WaitForCacheSync(ctx.Done(), InformerFuncs...)
 	if !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	// Remove this code in the future.  This is for cleanup during upgrades only.
+	// The rendered resource is no longer used.
+	if err := c.removeTunedRendered(); err != nil {
+		klog.Error(err)
 	}
 
 	klog.V(1).Info("starting events processor")

--- a/pkg/operator/hypershift.go
+++ b/pkg/operator/hypershift.go
@@ -102,7 +102,7 @@ func (c *Controller) syncHostedClusterTuneds() error {
 	}
 	// Anything left in hcMap should be deleted
 	for tunedName := range hcTunedMap {
-		if tunedName != tunedv1.TunedDefaultResourceName && tunedName != tunedv1.TunedRenderedResourceName {
+		if tunedName != tunedv1.TunedDefaultResourceName {
 			klog.V(1).Infof("deleting stale Tuned %s in hosted cluster", tunedName)
 			err = c.clients.Tuned.TunedV1().Tuneds(ntoconfig.WatchNamespace()).Delete(context.TODO(), tunedName, metav1.DeleteOptions{})
 			if err != nil {

--- a/pkg/operator/profilecalculator.go
+++ b/pkg/operator/profilecalculator.go
@@ -154,19 +154,21 @@ func (pc *ProfileCalculator) nodeChangeHandler(nodeName string) (bool, error) {
 //
 // Returns
 // * the tuned daemon profile name
+// * the list of all TunedProfiles out of which the tuned profile was calculated
 // * MachineConfig labels if the profile was selected by machineConfigLabels
 // * whether to run the Tuned daemon in debug mode on node nodeName
 // * an error if any
-func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[string]string, tunedv1.OperandConfig, error) {
+func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, []tunedv1.TunedProfile, map[string]string, tunedv1.OperandConfig, error) {
 	var operand tunedv1.OperandConfig
 
 	klog.V(3).Infof("calculateProfile(%s)", nodeName)
 	tunedList, err := pc.listers.TunedResources.List(labels.Everything())
 
 	if err != nil {
-		return "", nil, operand, fmt.Errorf("failed to list Tuned: %v", err)
+		return "", nil, nil, operand, fmt.Errorf("failed to list Tuned: %v", err)
 	}
 
+	profilesAll := TunedProfiles(tunedList)
 	recommendAll := TunedRecommend(tunedList)
 	recommendProfile := func(nodeName string, iStart int) (int, string, map[string]string, tunedv1.OperandConfig, error) {
 		var i int
@@ -221,10 +223,10 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[stri
 		// in the "recommend" section to select the default profile for the tuned daemon.
 		_, err = pc.listers.TunedResources.Get(tunedv1.TunedDefaultResourceName)
 		if err != nil {
-			return defaultProfile, nil, operand, fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedDefaultResourceName, err)
+			return defaultProfile, nil, nil, operand, fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedDefaultResourceName, err)
 		}
 
-		return defaultProfile, nil, operand, fmt.Errorf("the default Tuned CR misses a catch-all profile selection")
+		return defaultProfile, nil, nil, operand, fmt.Errorf("the default Tuned CR misses a catch-all profile selection")
 	}
 
 	// Make sure we do not have multiple matching profiles with the same priority.  If so, report a warning.
@@ -260,29 +262,30 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (string, map[stri
 		}
 	}
 
-	return tunedProfileName, mcLabels, operand, err
+	return tunedProfileName, profilesAll, mcLabels, operand, err
 }
 
 // calculateProfileHyperShift calculates a tuned profile for Node nodeName.
 //
 // Returns
 // * the tuned daemon profile name
+// * the list of all TunedProfiles out of which the tuned profile was calculated
 // * the NodePool name for this Node
 // * whether to run the Tuned daemon in debug mode on node nodeName
 // * an error if any
-func (pc *ProfileCalculator) calculateProfileHyperShift(nodeName string) (string, string, tunedv1.OperandConfig, error) {
+func (pc *ProfileCalculator) calculateProfileHyperShift(nodeName string) (string, []tunedv1.TunedProfile, string, tunedv1.OperandConfig, error) {
 	var operand tunedv1.OperandConfig
 
 	klog.V(3).Infof("calculateProfileHyperShift(%s)", nodeName)
 
 	node, err := pc.listers.Nodes.Get(nodeName)
 	if err != nil {
-		return "", "", operand, err
+		return "", nil, "", operand, err
 	}
 
 	nodePoolName, err := pc.getNodePoolNameForNode(node)
 	if err != nil {
-		return "", "", operand, err
+		return "", nil, "", operand, err
 	}
 
 	// In HyperShift, we only consider the default profile and
@@ -292,14 +295,15 @@ func (pc *ProfileCalculator) calculateProfileHyperShift(nodeName string) (string
 			hypershiftNodePoolNameLabel: nodePoolName,
 		}))
 	if err != nil {
-		return "", "", operand, fmt.Errorf("failed to list Tuneds in NodePool %s: %v", nodePoolName, err)
+		return "", nil, "", operand, fmt.Errorf("failed to list Tuneds in NodePool %s: %v", nodePoolName, err)
 	}
 	defaultTuned, err := pc.listers.TunedResources.Get(tunedv1.TunedDefaultResourceName)
 	if err != nil {
-		return defaultProfile, "", operand, fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedDefaultResourceName, err)
+		return defaultProfile, nil, "", operand, fmt.Errorf("failed to get Tuned %s: %v", tunedv1.TunedDefaultResourceName, err)
 	}
 	tunedList = append(tunedList, defaultTuned)
 
+	profilesAll := TunedProfiles(tunedList)
 	recommendAll := TunedRecommend(tunedList)
 	recommendProfile := func(nodeName string, iStart int) (int, string, string, tunedv1.OperandConfig, error) {
 		var i int
@@ -328,7 +332,7 @@ func (pc *ProfileCalculator) calculateProfileHyperShift(nodeName string) (string
 	iStop, tunedProfileName, nodePoolName, operand, err := recommendProfile(nodeName, 0)
 
 	if iStop == len(recommendAll) {
-		return defaultProfile, "", operand, fmt.Errorf("the default Tuned CR misses a catch-all profile selection")
+		return defaultProfile, profilesAll, "", operand, fmt.Errorf("the default Tuned CR misses a catch-all profile selection")
 	}
 
 	// Make sure we do not have multiple matching profiles with the same priority.  If so, report a warning.
@@ -364,7 +368,7 @@ func (pc *ProfileCalculator) calculateProfileHyperShift(nodeName string) (string
 		}
 	}
 
-	return tunedProfileName, nodePoolName, operand, err
+	return tunedProfileName, profilesAll, nodePoolName, operand, err
 }
 
 // profileMatches returns true, if Node 'nodeName' fulfills all the necessary
@@ -624,6 +628,44 @@ func (pc *ProfileCalculator) getNodePoolNameForNode(node *corev1.Node) (string, 
 	nodePoolName := node.GetLabels()[hypershiftNodePoolLabel]
 	klog.V(3).Infof("calculated nodePoolName: %s for node %s", nodePoolName, node.Name)
 	return nodePoolName, nil
+}
+
+// TunedRecommend returns a name-sorted TunedProfile slice out of
+// a slice of Tuned objects.
+func TunedProfiles(tunedSlice []*tunedv1.Tuned) []tunedv1.TunedProfile {
+	tunedProfiles := []tunedv1.TunedProfile{}
+	m := map[string]tunedv1.TunedProfile{}
+
+	for _, tuned := range tunedSlice {
+		if tuned.Spec.Profile == nil {
+			continue
+		}
+		for _, v := range tuned.Spec.Profile {
+			if v.Name == nil || v.Data == nil {
+				continue
+			}
+			if existingProfile, found := m[*v.Name]; found {
+				if *v.Data == *existingProfile.Data {
+					klog.Infof("duplicate profiles names %s but they have the same contents", *v.Name)
+				} else {
+					klog.Errorf("ERROR: duplicate profiles named %s with different contents found in Tuned CR %q", *v.Name, tuned.Name)
+				}
+			}
+			m[*v.Name] = v
+		}
+	}
+	for _, tunedProfile := range m {
+		tunedProfiles = append(tunedProfiles, tunedProfile)
+	}
+
+	// The order of Tuned resources is variable and so is the order of profiles
+	// within the resource itself.  Sort the rendered profiles by their names for
+	// simpler change detection.
+	sort.Slice(tunedProfiles, func(i, j int) bool {
+		return *tunedProfiles[i].Name < *tunedProfiles[j].Name
+	})
+
+	return tunedProfiles
 }
 
 // TunedRecommend returns a priority-sorted TunedRecommend slice out of

--- a/pkg/operator/profilecalculator_test.go
+++ b/pkg/operator/profilecalculator_test.go
@@ -1,0 +1,137 @@
+package operator
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/pointer"
+
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+)
+
+func tunedProfileToString(tunedProfile tunedv1.TunedProfile) string {
+	var (
+		name, data string
+		sb         strings.Builder
+	)
+
+	if tunedProfile.Name == nil {
+		name = "<nil>"
+	} else {
+		name = *tunedProfile.Name
+	}
+	if tunedProfile.Data == nil {
+		data = "<nil>"
+	} else {
+		data = *tunedProfile.Data
+	}
+	sb.WriteString(fmt.Sprintf("Name: %s; Data: %s", name, data))
+
+	return sb.String()
+}
+
+func tunedProfilesToString(tunedProfiles []tunedv1.TunedProfile) string {
+	var sb strings.Builder
+
+	for i, tunedProfile := range tunedProfiles {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(tunedProfileToString(tunedProfile))
+	}
+
+	return sb.String()
+}
+
+func TestTunedProfiles(t *testing.T) {
+	profileData := "[main] # a dummy TuneD profile with no configuration"
+	profilePriority := uint64(20)
+
+	var (
+		tests = []struct {
+			input          []*tunedv1.Tuned
+			expectedOutput []tunedv1.TunedProfile
+		}{
+			{
+				input: []*tunedv1.Tuned{
+					{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: tunedv1.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "profile-b",
+							Namespace: "openshift-cluster-node-tuning-operator",
+							UID:       types.UID(utilrand.String(5)),
+						},
+						Spec: tunedv1.TunedSpec{
+							Profile: []tunedv1.TunedProfile{
+								{
+									Name: pointer.String("b"),
+									Data: &profileData,
+								},
+							},
+							Recommend: []tunedv1.TunedRecommend{
+								{
+									Priority: pointer.Uint64(profilePriority),
+									Profile:  pointer.String("b"),
+								},
+							},
+						},
+					},
+					{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: tunedv1.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "profile-a",
+							Namespace: "openshift-cluster-node-tuning-operator",
+							UID:       types.UID(utilrand.String(5)),
+						},
+						Spec: tunedv1.TunedSpec{
+							Profile: []tunedv1.TunedProfile{
+								{
+									Name: pointer.String("a"),
+									Data: &profileData,
+								},
+							},
+							Recommend: []tunedv1.TunedRecommend{
+								{
+									Priority: pointer.Uint64(profilePriority),
+									Profile:  pointer.String("a"),
+								},
+							},
+						},
+					},
+				},
+				expectedOutput: []tunedv1.TunedProfile{
+					{
+						Name: pointer.String("a"),
+						Data: &profileData,
+					},
+					{
+						Name: pointer.String("b"),
+						Data: &profileData,
+					},
+				},
+			},
+		}
+	)
+
+	for i, tc := range tests {
+		tunedProfilesSorted := TunedProfiles(tc.input)
+
+		if !reflect.DeepEqual(tc.expectedOutput, tunedProfilesSorted) {
+			t.Errorf(
+				"failed test case %d:\n\twant:\n%s\n\thave:\n%s",
+				i+1,
+				tunedProfilesToString(tc.expectedOutput),
+				tunedProfilesToString(tunedProfilesSorted),
+			)
+		}
+	}
+}

--- a/pkg/tuned/cmd/render/render.go
+++ b/pkg/tuned/cmd/render/render.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
-	"github.com/openshift/cluster-node-tuning-operator/pkg/manifests"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/operator"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/tuned"
 	"sigs.k8s.io/yaml"
@@ -173,9 +172,12 @@ func render(inputDir []string, outputDir string, mcpName string) error {
 		return fmt.Errorf("error writing recommended profile %q : %w", recommendedProfile, err)
 	}
 
-	t := manifests.TunedRenderedResource(tuneD)
 	//extract all the profiles.
-	_, _, _, err = tunedpkg.ProfilesExtract(t.Spec.Profile, recommendedProfile)
+	tunedProfiles := []tunedv1.TunedProfile{}
+	for _, t := range tuneD {
+		tunedProfiles = append(tunedProfiles, t.Spec.Profile...)
+	}
+	_, _, _, err = tunedpkg.ProfilesExtract(tunedProfiles, recommendedProfile)
 	if err != nil {
 		klog.Errorf("error extracting tuned profiles : %v", err)
 		return fmt.Errorf("error extracting tuned profiles: %w", err)

--- a/test/e2e/performanceprofile/functests/6_mustgather_testing/mustgather.go
+++ b/test/e2e/performanceprofile/functests/6_mustgather_testing/mustgather.go
@@ -46,7 +46,6 @@ var _ = Describe("[rfe_id: 50649] Performance Addon Operator Must Gather", func(
 				"version",
 				"cluster-scoped-resources/config.openshift.io/featuregates/cluster.yaml",
 				"namespaces/openshift-cluster-node-tuning-operator/tuned.openshift.io/tuneds/default.yaml",
-				"namespaces/openshift-cluster-node-tuning-operator/tuned.openshift.io/tuneds/rendered.yaml",
 			}
 
 			By(fmt.Sprintf("Checking Folder: %q\n", mgContentFolder))


### PR DESCRIPTION
This is a manual backport of https://github.com/openshift/cluster-node-tuning-operator/pull/1036 .  Changes from #1036: using the current (deprecated) `k8s.io/utils/pointer` package and adjusted the test code to use it.

The NTO operand is controlled by the operator by updates to two resources.  Its corresponding k8s Tuned Profile resource and tuned/rendered object, which contains a list of all TuneD (daemon) profiles.

While this setup works for most cases, there is a problem with this approach when a cluster administator changes both a current TuneD profile content and (at the same) time switches to a new TuneD profile completely.  Then, depending on the k8s object update timing, we could see two TuneD daemon reloads instead of just one.

Remove the tuned/rendered object and carry TuneD (daemon) profiles directly in the Tuned Profile k8s objects.

Resolves: OCPBUGS-36870