### PR TITLE
PSAP-1471: Add support for setting operand verbosity

### DIFF
--- a/manifests/20-profile.crd.yaml
+++ b/manifests/20-profile.crd.yaml
@@ -71,6 +71,9 @@ spec:
                   tunedProfile:
                     description: TuneD profile to apply
                     type: string
+                  verbosity:
+                    description: klog logging verbosity
+                    type: integer
                 required:
                 - tunedProfile
                 type: object

--- a/manifests/20-tuned.crd.yaml
+++ b/manifests/20-tuned.crd.yaml
@@ -133,6 +133,9 @@ spec:
                                 for the TuneD daemon: true/false'
                               type: boolean
                           type: object
+                        verbosity:
+                          description: klog logging verbosity
+                          type: integer
                       type: object
                     priority:
                       description: Tuned profile priority. Highest priority is 0.

--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -113,6 +113,10 @@ type OperandConfig struct {
 	// +optional
 	Debug bool `json:"debug,omitempty"`
 
+	// klog logging verbosity
+	// +optional
+	Verbosity int `json:"verbosity,omitempty"`
+
 	// +optional
 	TuneDConfig TuneDConfig `json:"tunedConfig,omitempty"`
 }
@@ -164,6 +168,9 @@ type ProfileConfig struct {
 	// option to debug TuneD daemon execution
 	// +optional
 	Debug bool `json:"debug"`
+	// klog logging verbosity
+	// +optional
+	Verbosity int `json:"verbosity"`
 	// +optional
 	TuneDConfig TuneDConfig `json:"tunedConfig,omitempty"`
 	// Name of the cloud provider as taken from the Node providerID: <ProviderName>://<ProviderSpecificNodeID>

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -647,6 +647,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 			klog.V(2).Infof("syncProfile(): Profile %s not found, creating one [%s]", profileMf.Name, computed.TunedProfileName)
 			profileMf.Spec.Config.TunedProfile = computed.TunedProfileName
 			profileMf.Spec.Config.Debug = computed.Operand.Debug
+			profileMf.Spec.Config.Verbosity = computed.Operand.Verbosity
 			profileMf.Spec.Config.TuneDConfig = computed.Operand.TuneDConfig
 			profileMf.Spec.Profile = computed.AllProfiles
 			profileMf.Status.Conditions = tunedpkg.InitializeStatusConditions()
@@ -708,6 +709,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	// Minimize updates
 	if profile.Spec.Config.TunedProfile == computed.TunedProfileName &&
 		profile.Spec.Config.Debug == computed.Operand.Debug &&
+		profile.Spec.Config.Verbosity == computed.Operand.Verbosity &&
 		reflect.DeepEqual(profile.Spec.Config.TuneDConfig, computed.Operand.TuneDConfig) &&
 		reflect.DeepEqual(profile.Spec.Profile, computed.AllProfiles) &&
 		profile.Spec.Config.ProviderName == providerName {
@@ -717,6 +719,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	profile = profile.DeepCopy() // never update the objects from cache
 	profile.Spec.Config.TunedProfile = computed.TunedProfileName
 	profile.Spec.Config.Debug = computed.Operand.Debug
+	profile.Spec.Config.Verbosity = computed.Operand.Verbosity
 	profile.Spec.Config.TuneDConfig = computed.Operand.TuneDConfig
 	profile.Spec.Config.ProviderName = providerName
 	profile.Spec.Profile = computed.AllProfiles

--- a/pkg/operator/profilecalculator.go
+++ b/pkg/operator/profilecalculator.go
@@ -164,7 +164,7 @@ type ComputedProfile struct {
 // * the tuned daemon profile name
 // * the list of all TunedProfiles out of which the tuned profile was calculated
 // * MachineConfig labels if the profile was selected by machineConfigLabels
-// * whether to run the Tuned daemon in debug mode on node nodeName
+// * operand configuration as defined by tunedv1.OperandConfig
 // * an error if any
 func (pc *ProfileCalculator) calculateProfile(nodeName string) (ComputedProfile, error) {
 	klog.V(3).Infof("calculateProfile(%s)", nodeName)
@@ -288,7 +288,7 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (ComputedProfile,
 // * the tuned daemon profile name
 // * the list of all TunedProfiles out of which the tuned profile was calculated
 // * the NodePool name for this Node
-// * whether to run the Tuned daemon in debug mode on node nodeName
+// * operand configuration as defined by tunedv1.OperandConfig
 // * an error if any
 func (pc *ProfileCalculator) calculateProfileHyperShift(nodeName string) (ComputedProfile, error) {
 	klog.V(3).Infof("calculateProfileHyperShift(%s)", nodeName)

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -281,6 +281,10 @@ func (c *Controller) sync(key wqKeyKube) error {
 		change.provider = profile.Spec.Config.ProviderName
 		change.recommendedProfile = profile.Spec.Config.TunedProfile
 		change.debug = profile.Spec.Config.Debug
+		err = util.SetLogLevel(profile.Spec.Config.Verbosity)
+		if err != nil {
+			klog.Errorf("failed to set log level %d: %v", profile.Spec.Config.Verbosity, err)
+		}
 		change.reapplySysctl = true
 		if profile.Spec.Config.TuneDConfig.ReapplySysctl != nil {
 			change.reapplySysctl = *profile.Spec.Config.TuneDConfig.ReapplySysctl

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"flag"
+	"fmt"
+
+	"k8s.io/klog/v2"
+)
+
+// SetLogLevel was lifted with minor modifications from library-go.  In their own words,
+// it is a nasty hack and attempt to manipulate the global flags as klog does not expose
+// a way to dynamically change the loglevel in runtime.
+func SetLogLevel(targetLevel int) error {
+	var level *klog.Level
+
+	verbosity := fmt.Sprintf("%d", targetLevel)
+
+	// First, if the '-v' was specified in command line, attempt to acquire the level pointer from it.
+	if f := flag.CommandLine.Lookup("v"); f != nil {
+		if flagValue, ok := f.Value.(*klog.Level); ok {
+			level = flagValue
+		}
+	}
+
+	// Second, if the '-v' was not set but is still present in flags defined for the command, attempt to acquire it
+	// by visiting all flags.
+	if level == nil {
+		flag.VisitAll(func(f *flag.Flag) {
+			if level != nil {
+				return
+			}
+			if levelFlag, ok := f.Value.(*klog.Level); ok {
+				level = levelFlag
+			}
+		})
+	}
+
+	if level != nil {
+		return level.Set(verbosity)
+	}
+
+	// Third, if modifying the flag value (which is recommended by klog) fails, then fallback to modifying
+	// the internal state of klog using the empty new level.
+	var newLevel klog.Level
+	if err := newLevel.Set(verbosity); err != nil {
+		return fmt.Errorf("failed set klog.logging.verbosity %s: %v", verbosity, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds support for setting NTO operand (ocp-tuned) klog logging verbosity via configuring Tuned CR.

Example recommend section:

```
      recommend:
      - match:
        - label: profile
        priority: 20
        profile: openshift-profile
        operand:
          verbosity: 2
```

This is on a per Profile/node basis and no operand/`TuneD` restarts are required.