### PR TITLE
CNF-12711: hypershift: enable feature gate support

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/components.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/components.go
@@ -35,8 +35,9 @@ type Handler interface {
 }
 
 type Options struct {
-	ProfileMCP    *mcov1.MachineConfigPool
-	MachineConfig MachineConfigOptions
+	ProfileMCP                  *mcov1.MachineConfigPool
+	MachineConfig               MachineConfigOptions
+	MixedCPUsFeatureGateEnabled bool
 }
 
 type MachineConfigOptions struct {

--- a/pkg/performanceprofile/controller/performanceprofile/components/handler/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/handler/handler.go
@@ -46,6 +46,8 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 		klog.Infof("Ignoring reconcile loop for pause performance profile %s", profile.Name)
 		return nil
 	}
+	// set missing options
+	opts.MachineConfig.MixedCPUsEnabled = opts.MixedCPUsFeatureGateEnabled && profileutil.IsMixedCPUsEnabled(profile)
 
 	ctrRuntime, err := h.getContainerRuntimeName(ctx, profile, opts.ProfileMCP)
 	if err != nil {

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
@@ -93,6 +93,8 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 		klog.Infof("ignoring reconcile loop for pause performance profile %s", profile.Name)
 		return nil
 	}
+	// set missing options
+	options.MachineConfig.MixedCPUsEnabled = options.MixedCPUsFeatureGateEnabled && profileutil.IsMixedCPUsEnabled(profile)
 
 	ctrRuntime, err := h.getContainerRuntimeName(ctx, profile)
 	if err != nil {

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -564,9 +564,9 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 	err = r.ComponentsHandler.Apply(ctx, instance, r.Recorder, &components.Options{
 		ProfileMCP: profileMCP,
 		MachineConfig: components.MachineConfigOptions{
-			PinningMode:      &pinningMode,
-			MixedCPUsEnabled: r.isMixedCPUsEnabled(instance),
+			PinningMode: &pinningMode,
 		},
+		MixedCPUsFeatureGateEnabled: r.isMixedCPUsFeatureGateEnabled(),
 	})
 	if err != nil {
 		klog.Errorf("failed to deploy performance profile %q components: %v", instance.GetName(), err)
@@ -585,14 +585,8 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{}, nil
 }
 
-func (r *PerformanceProfileReconciler) isMixedCPUsEnabled(object client.Object) bool {
-	if ntoconfig.InHyperShift() {
-		return false
-	}
-	if !r.FeatureGate.Enabled(apifeatures.FeatureGateMixedCPUsAllocation) {
-		return false
-	}
-	return profileutil.IsMixedCPUsEnabled(object.(*performancev2.PerformanceProfile))
+func (r *PerformanceProfileReconciler) isMixedCPUsFeatureGateEnabled() bool {
+	return r.FeatureGate.Enabled(apifeatures.FeatureGateMixedCPUsAllocation)
 }
 
 func hasFinalizer(obj client.Object, finalizer string) bool {


### PR DESCRIPTION
In order to support feature gate on Hypershift,
we need to build and provide an `eventRecorder` for the `featureGateAccessor`.
The `eventRecorder` uses the controllerRef of NTO pod when it emits an event:
https://github.com/openshift/cluster-node-tuning-operator/blob/81b7b9d35113848bbcf96758829a4cb54ac5b784/vendor/github.com/openshift/library-go/pkg/operator/events/recorder.go#L199

In order to get the controllerRef, we need to `Get()` NTO pod and extract
the ownerReference from it's metadata:
https://github.com/openshift/cluster-node-tuning-operator/blob/81b7b9d35113848bbcf96758829a4cb54ac5b784/vendor/github.com/openshift/library-go/pkg/operator/events/recorder.go#L76

Theoretically, on Hypershift we need to use the MNG client to `Get()`
NTO pod, hence we should also pass the rest config of the MNG cluster.

But NTO pod doesn't have an access to `Pod` objects under it role
on Hypershift anyway:
https://github.com/openshift/hypershift/blob/c84168e02ddc3f980ee325a790d6e5ff3b4c3f9f/control-plane-operator/controllers/hostedcontrolplane/nto/clusternodetuningoperator.go#L147-#L149

The consequence of granting access for NTO to list all pods on the NS means
that it would be able to list all the control plan pods, since on
Hypershift all the pods are under the same NS.

Considering the price we would pay from security perspective
and comparing to what other controllers are doing, it's preferred to fallback for
using the namespace as the reference name:
https://github.com/openshift/cluster-image-registry-operator/blob/master/pkg/operator/starter.go#L71

Signed-off-by: Talor Itzhak <titzhak@redhat.com>