### PR TITLE
[release-4.15] OCPBUGS-37306: set required-scc for openshift workloads

### DIFF
--- a/assets/tuned/manifests/ds-tuned.yaml
+++ b/assets/tuned/manifests/ds-tuned.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
       labels:
         openshift-app: tuned
     spec:

--- a/manifests/50-operator-ibm-cloud-managed.yaml
+++ b/manifests/50-operator-ibm-cloud-managed.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: anyuid
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-node-tuning-operator

--- a/manifests/50-operator.yaml
+++ b/manifests/50-operator.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: anyuid
       labels:
         name: cluster-node-tuning-operator
     spec:


### PR DESCRIPTION
[OCPBUGS-37306](https://issues.redhat.com/browse/OCPBUGS-37306
)
Manual cherry-pick of [#968](https://github.com/openshift/cluster-node-tuning-operator/pull/968)