### PR TITLE
WIP: OCPBUGS-28647: consume deferred updates from performance profile

### DIFF
--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -34,6 +34,18 @@ const PerformanceProfileEnablePhysicalRpsAnnotation = "performance.openshift.io/
 // that ignores the removal of all RPS settings when realtime workload hint is explicitly set to false.
 const PerformanceProfileEnableRpsAnnotation = "performance.openshift.io/enable-rps"
 
+// PerformanceProfileDeferredUpdateAnnotation is an advanced annotation which request the
+// object generated and govenred by PerformanceProfile to be updated in a deferred way,
+// minimizing the number of reboots. Please check the `DeferredUpdate*` constants to
+// learn which objects support deferred updates.
+const PerformanceProfileDeferredUpdateAnnotation = "performance.openshift.io/deferred"
+
+const (
+	// DeferredUpdateTuned requests the tuned object generated from performanceprofile
+	// to be applied in a deferred way, minimizing the node reboots.
+	DeferredUpdateTuned = "tuned"
+)
+
 // PerformanceProfileSpec defines the desired state of PerformanceProfile.
 type PerformanceProfileSpec struct {
 	// CPU defines a set of CPU related parameters.

--- a/pkg/performanceprofile/controller/performanceprofile/components/components.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/components.go
@@ -38,6 +38,11 @@ type Options struct {
 	ProfileMCP                  *mcov1.MachineConfigPool
 	MachineConfig               MachineConfigOptions
 	MixedCPUsFeatureGateEnabled bool
+	Tuned                       TunedOptions
+}
+
+type TunedOptions struct {
+	DeferredEnabled bool
 }
 
 type MachineConfigOptions struct {

--- a/pkg/performanceprofile/controller/performanceprofile/components/handler/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/handler/handler.go
@@ -50,7 +50,7 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 	}
 	// set missing options
 	opts.MachineConfig.MixedCPUsEnabled = opts.MixedCPUsFeatureGateEnabled && profileutil.IsMixedCPUsEnabled(profile)
-	opts.Tuned.DeferredEnabled = ntoutil.HasDeferredUpdateAnnotation(profile.Annotations)
+	opts.Tuned.DeferredEnabled = ntoutil.HasAnnotation(profile.Annotations, performancev2.PerformanceProfileDeferredUpdateAnnotation, performancev2.DeferredUpdateTuned)
 
 	ctrRuntime, err := h.getContainerRuntimeName(ctx, profile, opts.ProfileMCP)
 	if err != nil {

--- a/pkg/performanceprofile/controller/performanceprofile/components/handler/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/handler/handler.go
@@ -14,6 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	ntoutil "github.com/openshift/cluster-node-tuning-operator/pkg/util"
+
 	mcov1 "github.com/openshift/api/machineconfiguration/v1"
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
@@ -48,6 +50,7 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 	}
 	// set missing options
 	opts.MachineConfig.MixedCPUsEnabled = opts.MixedCPUsFeatureGateEnabled && profileutil.IsMixedCPUsEnabled(profile)
+	opts.Tuned.DeferredEnabled = ntoutil.HasDeferredUpdateAnnotation(profile.Annotations)
 
 	ctrRuntime, err := h.getContainerRuntimeName(ctx, profile, opts.ProfileMCP)
 	if err != nil {

--- a/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/manifestset/manifestset.go
@@ -67,7 +67,7 @@ func GetNewComponents(profile *performancev2.PerformanceProfile, opts *component
 		return nil, err
 	}
 
-	performanceTuned, err := tuned.NewNodePerformance(profile)
+	performanceTuned, err := tuned.NewNodePerformance(profile, &opts.Tuned)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -45,7 +45,8 @@ var _ = Describe("Tuned", func() {
 	})
 
 	getTunedManifest := func(profile *performancev2.PerformanceProfile) string {
-		tuned, err := NewNodePerformance(profile)
+		opts := OptionsFromPerformanceProfile(profile)
+		tuned, err := NewNodePerformance(profile, &opts)
 		Expect(err).ToNot(HaveOccurred())
 		y, err := yaml.Marshal(tuned)
 		Expect(err).ToNot(HaveOccurred())
@@ -53,7 +54,8 @@ var _ = Describe("Tuned", func() {
 	}
 
 	getTunedStructuredData := func(profile *performancev2.PerformanceProfile) *ini.File {
-		tuned, err := NewNodePerformance(profile)
+		opts := OptionsFromPerformanceProfile(profile)
+		tuned, err := NewNodePerformance(profile, &opts)
 		Expect(err).ToNot(HaveOccurred())
 		tunedData := []byte(*tuned.Spec.Profile[0].Data)
 		cfg, err := ini.Load(tunedData)
@@ -198,7 +200,8 @@ var _ = Describe("Tuned", func() {
 						HighPowerConsumption:  pointer.Bool(true),
 						PerPodPowerManagement: pointer.Bool(true),
 					}
-					_, err := NewNodePerformance(profile)
+					opts := OptionsFromPerformanceProfile(profile)
+					_, err := NewNodePerformance(profile, &opts)
 					Expect(err.Error()).To(ContainSubstring("Invalid WorkloadHints configuration: HighPowerConsumption is true and PerPodPowerManagement is true"))
 				})
 			})

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
@@ -95,6 +95,7 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 	}
 	// set missing options
 	options.MachineConfig.MixedCPUsEnabled = options.MixedCPUsFeatureGateEnabled && profileutil.IsMixedCPUsEnabled(profile)
+	// deferred updates not supported in hypershift yet
 
 	ctrRuntime, err := h.getContainerRuntimeName(ctx, profile)
 	if err != nil {

--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -596,6 +596,7 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 			PinningMode: &pinningMode,
 		},
 		MixedCPUsFeatureGateEnabled: r.isMixedCPUsFeatureGateEnabled(),
+		Tuned:                       components.TunedOptions{}, // ensure not nil. The handler will fill later in the flow.
 	})
 	if err != nil {
 		klog.Errorf("failed to deploy performance profile %q components: %v", instance.GetName(), err)

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -845,7 +845,7 @@ var _ = Describe("Controller", func() {
 				skipForHypershift() // deferred updates not supported in hypershift yet
 
 				prof := profile.DeepCopy()
-				prof.Annotations = ntoutil.ToggleDeferredUpdateAnnotation(prof.Annotations, true)
+				prof.Annotations = ntoutil.AddAnnotation(prof.Annotations, performancev2.PerformanceProfileDeferredUpdateAnnotation, performancev2.DeferredUpdateTuned)
 				r := newFakeReconciler(prof, profileMCP, infra, clusterOperator)
 
 				Expect(reconcileTimes(r, request, 2)).To(Equal(reconcile.Result{}))

--- a/pkg/tuned/cmd/render/render.go
+++ b/pkg/tuned/cmd/render/render.go
@@ -173,7 +173,8 @@ func render(inputDir []string, outputDir string, mcpName string) error {
 		klog.Infof("No PerformanceProfile found for MachineConfigPool %s", mcpName)
 	}
 	for _, pp := range filteredPerformanceProfiles {
-		tunedFromPP, err := tuned.NewNodePerformance(pp)
+		tunedOpts := tuned.OptionsFromPerformanceProfile(pp)
+		tunedFromPP, err := tuned.NewNodePerformance(pp, &tunedOpts)
 		if err != nil {
 			e := fmt.Errorf("unable to get tuned from PerformanceProfile:%s. error: %w", pp.Name, err)
 			klog.Error(e)

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -915,7 +915,8 @@ func getNodeNames(nodes []corev1.Node) []string {
 }
 
 func getTunedStructuredData(profile *performancev2.PerformanceProfile) *ini.File {
-	tuned, err := tuned.NewNodePerformance(profile)
+	opts := tuned.OptionsFromPerformanceProfile(profile)
+	tuned, err := tuned.NewNodePerformance(profile, &opts)
 	Expect(err).ToNot(HaveOccurred())
 	tunedData := []byte(*tuned.Spec.Profile[0].Data)
 	cfg, err := ini.Load(tunedData)


### PR DESCRIPTION
Consume the deferred updates support from the performance profile. The idea is that if the annotation (the same as NTO) is found on performanceprofile, it is passed throught the generated tuned object.

Initially we don't support hypershift