### PR TITLE
NO-JIRA:e2e:hypershift: remove/rename deprecated env variables

### DIFF
--- a/test/e2e/performanceprofile/functests/0_config/config.go
+++ b/test/e2e/performanceprofile/functests/0_config/config.go
@@ -253,7 +253,7 @@ func printEnvs() {
 	testlog.Infof("%s=%s", hypershift.HostedClusterNameEnv, name)
 
 	v, _ := hypershift.GetManagementClusterNamespace()
-	testlog.Infof("%s=%s", hypershift.ManagementClusterNamespaceEnv, v)
+	testlog.Infof("%s=%s", hypershift.HostedControlPlaneNamespaceEnv, v)
 
 	kcPath, _ := os.LookupEnv(hypershift.ManagementClusterKubeConfigEnv)
 	testlog.Infof("%s=%s", hypershift.ManagementClusterKubeConfigEnv, kcPath)

--- a/test/e2e/performanceprofile/functests/utils/hypershift/hypershift.go
+++ b/test/e2e/performanceprofile/functests/utils/hypershift/hypershift.go
@@ -21,7 +21,7 @@ func init() {
 const (
 	ManagementClusterKubeConfigEnv = "HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG"
 	ManagementClusterNamespaceEnv  = "HYPERSHIFT_MANAGEMENT_CLUSTER_NAMESPACE"
-	HostedClusterKubeConfigEnv     = "HYPERSHIFT_HOSTED_CLUSTER_KUBECONFIG"
+	HostedClusterKubeConfigEnv     = "KUBECONFIG"
 	HostedClusterNameEnv           = "CLUSTER_NAME"
 	NodePoolNamespace              = "clusters"
 )

--- a/test/e2e/performanceprofile/functests/utils/hypershift/hypershift.go
+++ b/test/e2e/performanceprofile/functests/utils/hypershift/hypershift.go
@@ -23,7 +23,6 @@ const (
 	HostedControlPlaneNamespaceEnv = "HYPERSHIFT_HOSTED_CONTROL_PLANE_NAMESPACE"
 	HostedClusterKubeConfigEnv     = "KUBECONFIG"
 	HostedClusterNameEnv           = "CLUSTER_NAME"
-	NodePoolNamespace              = "clusters"
 )
 
 func BuildControlPlaneClient() (client.Client, error) {

--- a/test/e2e/performanceprofile/functests/utils/hypershift/hypershift.go
+++ b/test/e2e/performanceprofile/functests/utils/hypershift/hypershift.go
@@ -20,7 +20,7 @@ func init() {
 
 const (
 	ManagementClusterKubeConfigEnv = "HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG"
-	ManagementClusterNamespaceEnv  = "HYPERSHIFT_MANAGEMENT_CLUSTER_NAMESPACE"
+	HostedControlPlaneNamespaceEnv = "HYPERSHIFT_HOSTED_CONTROL_PLANE_NAMESPACE"
 	HostedClusterKubeConfigEnv     = "KUBECONFIG"
 	HostedClusterNameEnv           = "CLUSTER_NAME"
 	NodePoolNamespace              = "clusters"
@@ -59,9 +59,9 @@ func GetHostedClusterName() (string, error) {
 }
 
 func GetManagementClusterNamespace() (string, error) {
-	ns, ok := os.LookupEnv(ManagementClusterNamespaceEnv)
+	ns, ok := os.LookupEnv(HostedControlPlaneNamespaceEnv)
 	if !ok {
-		return "", fmt.Errorf("failed to retrieve management cluster namespace; %q environment var is not set", ManagementClusterNamespaceEnv)
+		return "", fmt.Errorf("failed to retrieve management cluster namespace; %q environment var is not set", HostedControlPlaneNamespaceEnv)
 	}
 	return ns, nil
 }


### PR DESCRIPTION
* Remove deprecated environment variables in the e2e tests.
* Rename environment variables in the e2e tests to represents their meaning in more accurate way.

More details in the commits themselves.