### PR TITLE
NO-JIRA:e2e:document: how to run locally on HCP platform

### DIFF
--- a/test/e2e/performanceprofile/functests/README.md
+++ b/test/e2e/performanceprofile/functests/README.md
@@ -22,4 +22,22 @@ DISCOVERY_MODE: to get an already deployed performanceProfile.
 If DISCOVERY_MODE set to true the suites will search for a PerformanceProfile on the cluster and use it.
 If no PerformanceProfile is found, that suites will be skipped.
 
-RESERVED_CPU_SET, ISOLATED_CPU_SET, OFFLINED_CPU_SET: strings that present the CPU sets distributed between reserved, isolated, and offlined CPU profile specifications. The runner is responsible for validating that these values are compatible with the testing environment. 
+RESERVED_CPU_SET, ISOLATED_CPU_SET, OFFLINED_CPU_SET: strings that present the CPU sets distributed between reserved, isolated, and offlined CPU profile specifications. The runner is responsible for validating that these values are compatible with the testing environment.
+
+### Running Tests on HyperShift Platform
+
+When running e2e tests locally on a HyperShift platform, or in any environment that is different from the standard CI,
+there are a couple of environment variables that should be set in advance:
+
+* `CLUSTER_TYPE=hypershift`: A const that used to configure the e2e tests for running on HyperShift.
+
+* `CLUSTER_NAME`: Represents the name of the hosted-cluster.
+When running locally,
+the name is the output of  `oc get hc <name-of-your-hosted-cluster> -n clusters --no-headers -o custom-columns=NAME:.metadata.name`
+
+* `HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG`: The path for the kubeconfig file of the management/hub cluster.
+
+* `KUBECONFIG`: The path for the kubeconfig file of the hosted cluster.
+
+* `HYPERSHIFT_HOSTED_CONTROL_PLANE_NAMESPACE`: The name of the namespace where all the control-plane components reside.
+This namespace name usually is `clusters-$CLUSTER_NAME`  


### PR DESCRIPTION
Documents all the the environment variables that are required for running e2e locally when NTO is running on Hypershift platform.