### PR TITLE
OCPBUGS-36868: TuneD prior to kubelet in one-shot mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,19 +26,21 @@ ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}
 ENV SYSTEMD_IGNORE_CHROOT=1
 WORKDIR ${APP_ROOT}
-COPY --from=tuned   /root/assets ${APP_ROOT}
-COPY --from=tuned   /root/rpmbuild/RPMS/noarch /root/rpms
+COPY --from=tuned /root/assets/bin /usr/local/bin
+COPY --from=tuned /root/rpmbuild/RPMS/noarch /root/rpms
 RUN INSTALL_PKGS=" \
       nmap-ncat procps-ng pciutils \
       " && \
-    mkdir -p /etc/grub.d/ /boot && \
+    mkdir -p /etc/grub.d/ /boot /var/lib/ocp-tuned && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf --setopt=tsflags=nodocs -y install /root/rpms/*.rpm && \
     find /root/rpms -name \*.rpm -exec basename {} .rpm \; | xargs rpm -e --justdb && \
-    rm -rf /var/lib/ocp-tuned/{tuned,performanceprofile} && \
-    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|' /etc/tuned/tuned-main.conf && \
-    touch /etc/sysctl.conf $APP_ROOT/provider && \
+    rm -rf /etc/tuned/recommend.d && \
+    echo auto > /etc/tuned/profile_mode && \
+    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' \
+      /etc/tuned/tuned-main.conf && \
+    touch /etc/sysctl.conf && \
     dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \
     useradd -r -u 499 cluster-node-tuning-operator

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -13,17 +13,19 @@ ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}
 ENV SYSTEMD_IGNORE_CHROOT=1
 WORKDIR ${APP_ROOT}
-COPY assets ${APP_ROOT}
+COPY assets/bin /usr/local/bin
 RUN INSTALL_PKGS=" \
       tuned tuned-profiles-atomic tuned-profiles-cpu-partitioning tuned-profiles-mssql tuned-profiles-nfv tuned-profiles-nfv-guest \
       tuned-profiles-nfv-host tuned-profiles-openshift tuned-profiles-oracle tuned-profiles-postgresql tuned-profiles-realtime \
       tuned-profiles-sap tuned-profiles-sap-hana tuned-profiles-spectrumscale \
       nmap-ncat procps-ng pciutils" && \
-    mkdir -p /etc/grub.d/ /boot && \
+    mkdir -p /etc/grub.d/ /boot /var/lib/ocp-tuned && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
-    rm -rf /var/lib/ocp-tuned/{tuned,performanceprofile} && \
-    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|' /etc/tuned/tuned-main.conf && \
-    touch /etc/sysctl.conf $APP_ROOT/provider && \
+    rm -rf /etc/tuned/recommend.d && \
+    echo auto > /etc/tuned/profile_mode && \
+    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' \
+      /etc/tuned/tuned-main.conf && \
+    touch /etc/sysctl.conf && \
     dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \
     useradd -r -u 499 cluster-node-tuning-operator

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -13,17 +13,19 @@ ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}
 ENV SYSTEMD_IGNORE_CHROOT=1
 WORKDIR ${APP_ROOT}
-COPY assets ${APP_ROOT}
+COPY assets/bin /usr/local/bin
 RUN INSTALL_PKGS=" \
       tuned tuned-profiles-atomic tuned-profiles-cpu-partitioning tuned-profiles-mssql tuned-profiles-nfv tuned-profiles-nfv-guest \
       tuned-profiles-nfv-host tuned-profiles-openshift tuned-profiles-oracle tuned-profiles-postgresql tuned-profiles-realtime \
       tuned-profiles-sap tuned-profiles-sap-hana tuned-profiles-spectrumscale \
       nmap-ncat procps-ng pciutils" && \
-    mkdir -p /etc/grub.d/ /boot && \
+    mkdir -p /etc/grub.d/ /boot /var/lib/ocp-tuned && \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
-    rm -rf /var/lib/ocp-tuned/{tuned,performanceprofile} && \
-    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|' /etc/tuned/tuned-main.conf && \
-    touch /etc/sysctl.conf $APP_ROOT/provider && \
+    rm -rf /etc/tuned/recommend.d && \
+    echo auto > /etc/tuned/profile_mode && \
+    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' \
+      /etc/tuned/tuned-main.conf && \
+    touch /etc/sysctl.conf && \
     dnf clean all && \
     rm -rf /var/cache/yum ~/patches /root/rpms && \
     useradd -r -u 499 cluster-node-tuning-operator

--- a/assets/performanceprofile/configs/ocp-tuned-one-shot.service
+++ b/assets/performanceprofile/configs/ocp-tuned-one-shot.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=TuneD service from NTO image
+After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+# Requires is necessary to start this unit before kubelet-dependencies.target
+Requires=kubelet-dependencies.target
+Before=kubelet-dependencies.target
+ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+[Service]
+# https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+# and also "podman systemd generate" uses "forking".  However, this
+# is strongly discouraged by "man systemd.service" and results in
+# failed dependency for the kubelet service.
+Type=oneshot
+# Restart=no is the default as of systemd 252, but be explicit.
+Restart=no
+ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+ExecStartPre=/bin/bash -c " \
+  mkdir -p /run/tuned "
+ExecStart=/usr/bin/podman run \
+    --rm \
+    --name openshift-tuned \
+    --privileged \
+    --authfile /var/lib/kubelet/config.json \
+    --net=host \
+    --pid=host \
+    --security-opt label=disable \
+    --log-driver=none \
+    --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+    --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+    --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+    --volume /etc/sysconfig:/etc/sysconfig:rslave \
+    --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+    --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+    --volume /etc/systemd:/etc/systemd:rslave \
+    --volume /run/tuned:/run/tuned:rslave \
+    --volume /run/systemd:/run/systemd:rslave \
+    --volume /sys:/sys:rslave \
+    --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+    $NTO_IMAGE
+Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=-/var/lib/ocp-tuned/image.env
+ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+[Install]
+# RequiredBy causes kubelet to depend on this service.
+RequiredBy=kubelet-dependencies.target

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/klog/v2"
 
 	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
-	"github.com/openshift/cluster-node-tuning-operator/pkg/util"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/fsnotify.v1"
 )
@@ -39,7 +38,7 @@ type Server struct {
 // DumpCA writes the root certificate bundle which is used to verify client certificates
 // on incoming requests to 'authCAFile' file.
 func DumpCA(ca string) error {
-	if err := util.Mkdir(authCADir); err != nil {
+	if err := os.MkdirAll(authCADir, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create directory %q: %v", authCADir, err)
 	}
 
@@ -143,7 +142,7 @@ func RunServer(port int, ctx context.Context) error {
 
 		// In HyperShift the CA is mounted in
 		if !ntoconfig.InHyperShift() {
-			if err := util.Mkdir(authCADir); err != nil {
+			if err := os.MkdirAll(authCADir, os.ModePerm); err != nil {
 				return fmt.Errorf("failed to create directory %q: %v", authCADir, err)
 			}
 		}

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -89,12 +89,13 @@ const (
 )
 
 const (
-	systemdServiceIRQBalance  = "irqbalance.service"
-	systemdServiceKubelet     = "kubelet.service"
-	systemdServiceCrio        = "crio.service"
-	systemdServiceTypeOneshot = "oneshot"
-	systemdTargetMultiUser    = "multi-user.target"
-	systemdTrue               = "true"
+	systemdServiceIRQBalance   = "irqbalance.service"
+	systemdServiceKubelet      = "kubelet.service"
+	systemdServiceCrio         = "crio.service"
+	systemdServiceTunedOneShot = "ocp-tuned-one-shot.service"
+	systemdServiceTypeOneshot  = "oneshot"
+	systemdTargetMultiUser     = "multi-user.target"
+	systemdTrue                = "true"
 )
 
 const (
@@ -332,6 +333,18 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, opts *componen
 		Contents: &clearIRQBalanceBannedCPUsService,
 		Enabled:  pointer.Bool(true),
 		Name:     getSystemdService(clearIRQBalanceBannedCPUs),
+	})
+
+	// add ocp-tuned-one-shot service
+	ocpTunedOneShotServiceByteContent, err := assets.Configs.ReadFile(filepath.Join("configs", systemdServiceTunedOneShot))
+	if err != nil {
+		return nil, err
+	}
+	ocpTunedOneShotServiceContent := string(ocpTunedOneShotServiceByteContent)
+	ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
+		Contents: &ocpTunedOneShotServiceContent,
+		Enabled:  pointer.Bool(true),
+		Name:     systemdServiceTunedOneShot,
 	})
 
 	if ok, ovsSliceName := MoveOvsIntoOwnSlice(); ok {

--- a/pkg/tuned/cmd/render/render.go
+++ b/pkg/tuned/cmd/render/render.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/operator"
@@ -184,8 +185,7 @@ func render(inputDir []string, outputDir string, mcpName string) error {
 	}
 
 	//Should run tuned
-	tunedCmd := tunedpkg.TunedCreateCmd(false)
-	err = tunedpkg.TunedRunNoDaemon(tunedCmd)
+	err = tunedpkg.TunedRunNoDaemon(0 * time.Second)
 	if err != nil {
 		klog.Errorf("Unable to run tuned error : %v", err)
 		return err

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -61,27 +61,32 @@ const (
 const (
 	operandNamespace       = "openshift-cluster-node-tuning-operator"
 	programName            = version.OperandFilename
-	tunedProfilesDirCustom = "/etc/tuned"
+	tunedEtcDir            = "/etc/tuned"
+	tunedProfilesDirCustom = ocpTunedHome + "/profiles"
 	tunedProfilesDirSystem = "/usr/lib/tuned"
 	tunedConfFile          = "tuned.conf"
-	tunedMainConfFile      = "tuned-main.conf"
-	tunedActiveProfileFile = tunedProfilesDirCustom + "/active_profile"
-	tunedRecommendDir      = tunedProfilesDirCustom + "/recommend.d"
+	tunedMainConfPath      = tunedEtcDir + "/tuned-main.conf"
+	tunedActiveProfileFile = tunedEtcDir + "/active_profile"
+	tunedRecommendDir      = tunedEtcDir + "/recommend.d"
 	tunedRecommendFile     = tunedRecommendDir + "/50-openshift.conf"
 	tunedBootcmdlineEnvVar = "TUNED_BOOT_CMDLINE"
-	tunedBootcmdlineFile   = tunedProfilesDirCustom + "/bootcmdline"
+	tunedBootcmdlineFile   = tunedEtcDir + "/bootcmdline"
 	// A couple of seconds should be more than enough for TuneD daemon to gracefully stop;
 	// be generous and give it 10s.
-	tunedGracefulExitWait  = time.Second * time.Duration(10)
-	openshiftTunedHome     = "/var/lib/ocp-tuned"
-	openshiftTunedRunDir   = "/run/" + programName
-	openshiftTunedProvider = openshiftTunedHome + "/provider"
+	tunedGracefulExitWait = time.Second * time.Duration(10)
+	ocpTunedHome          = "/var/lib/ocp-tuned"
+	ocpTunedRunDir        = "/run/" + programName
+	ocpTunedProvider      = ocpTunedHome + "/provider"
 	// With the less aggressive rate limiter, retries will happen at 100ms*2^(retry_n-1):
 	// 100ms, 200ms, 400ms, 800ms, 1.6s, 3.2s, 6.4s, 12.8s, 25.6s, 51.2s, 102.4s, 3.4m, 6.8m, 13.7m, 27.3m
 	maxRetries = 15
 	// workqueue related constants
 	wqKindDaemon  = "daemon"
 	wqKindProfile = "profile"
+
+	ocpTunedImageEnv           = ocpTunedHome + "/image.env"
+	tunedProfilesDirCustomHost = ocpTunedHome + "/profiles"
+	tunedRecommendDirHost      = ocpTunedHome + "/recommend.d"
 )
 
 // Types
@@ -308,7 +313,7 @@ func profilesEqual(profileFile string, profileData string) bool {
 	return profileData == string(content)
 }
 
-// ProfilesExtract extracts TuneD daemon profiles to the daemon configuration directory.
+// ProfilesExtract extracts TuneD daemon profiles to tunedProfilesDirCustom directory.
 // Returns:
 //   - True if the data in the to-be-extracted recommended profile or the profiles being
 //     included from the current recommended profile have changed.
@@ -325,7 +330,7 @@ func ProfilesExtract(profiles []tunedv1.TunedProfile, recommendedProfile string)
 	recommendedProfileDeps := profileDepends(recommendedProfile)
 	// Add the recommended profile itself.
 	recommendedProfileDeps[recommendedProfile] = true
-	extracted := map[string]bool{} // TuneD profile names present in TuneD CR and successfully extracted to /etc/tuned/<profile>/
+	extracted := map[string]bool{} // TuneD profile names present in TuneD CR and successfully extracted to tunedProfilesDirCustom
 
 	for index, profile := range profiles {
 		if profile.Name == nil {
@@ -339,7 +344,7 @@ func ProfilesExtract(profiles []tunedv1.TunedProfile, recommendedProfile string)
 		profileDir := fmt.Sprintf("%s/%s", tunedProfilesDirCustom, *profile.Name)
 		profileFile := fmt.Sprintf("%s/%s", profileDir, tunedConfFile)
 
-		if err := util.Mkdir(profileDir); err != nil {
+		if err := os.MkdirAll(profileDir, os.ModePerm); err != nil {
 			return change, extracted, recommendedProfileDeps, fmt.Errorf("failed to create TuneD profile directory %q: %v", profileDir, err)
 		}
 
@@ -369,7 +374,7 @@ func ProfilesExtract(profiles []tunedv1.TunedProfile, recommendedProfile string)
 }
 
 // profilesSync extracts TuneD daemon profiles to the daemon configuration directory
-// and removes any TuneD profiles from /etc/tuned/<profile>/ once the same TuneD
+// and removes any TuneD profiles from <tunedProfilesDirCustom>/<profile>/ once the same TuneD
 // <profile> is no longer defined in the 'profiles' slice.
 // Returns:
 //   - True if the data in the to-be-extracted recommended profile or the profiles being
@@ -381,53 +386,68 @@ func profilesSync(profiles []tunedv1.TunedProfile, recommendedProfile string) (b
 		return change, err
 	}
 
-	// Deal with TuneD profiles absent from Tuned CRs, but still present in /etc/tuned/<profile>/ the recommended profile depends on.
-	for profile := range recommendedProfileDeps {
-		if len(profile) == 0 {
+	dirEntries, err := os.ReadDir(tunedProfilesDirCustom)
+	if err != nil {
+		return change, err
+	}
+
+	// Deal with TuneD profiles absent from Tuned CRs, but still present in <tunedProfilesDirCustom>/<profile>/
+	for _, dirEntry := range dirEntries {
+		profile := dirEntry.Name()
+		if !dirEntry.IsDir() {
+			// There shouldn't be anything but directories in <tunedProfilesDirCustom>, but if there is, skip it.
 			continue
 		}
 
-		if !extractedNew[profile] {
-			// TuneD profile does not exist in the Tuned CR, but the recommended profile depends on it.
-			profileDir := fmt.Sprintf("%s/%s", tunedProfilesDirCustom, profile)
-			if _, err := os.Stat(profileDir); err == nil {
-				// We have a stale TuneD profile directory in /etc/tuned/<profile>/
-				// Remove it.
-				err := os.RemoveAll(profileDir)
-				if err != nil {
-					return change, fmt.Errorf("failed to remove %q: %v", profileDir, err)
-				}
-				change = true
-				klog.Infof("removed TuneD profile %q", profileDir)
-			}
+		if len(profile) == 0 {
+			// This should never happen, but if it does, do not wipe the entire tunedProfilesDirCustom directory.
+			continue
+		}
+
+		if extractedNew[profile] {
+			// Do not delete the freshly extracted profiles.  These are the profiles present in the Profile CR.
+			continue
+		}
+		// This TuneD profile does not exist in the Profile CR, delete it.
+		profileDir := fmt.Sprintf("%s/%s", tunedProfilesDirCustom, profile)
+		err := os.RemoveAll(profileDir)
+		if err != nil {
+			return change, fmt.Errorf("failed to remove %q: %v", profileDir, err)
+		}
+		klog.Infof("removed TuneD profile %q", profileDir)
+
+		if recommendedProfileDeps[profile] {
+			// This TuneD profile does not exist in the Profile CR, but the recommended profile depends on it.
+			// Trigger a change to report a configuration issue -- we depend on a profile that does not exist.
+			change = true
 		}
 	}
 
 	return change, nil
 }
 
-// providerExtract extracts Cloud Provider name into openshiftTunedProvider file.
+// providerExtract extracts Cloud Provider name into ocpTunedProvider file.
 func providerExtract(provider string) error {
-	klog.Infof("extracting cloud provider name to %v", openshiftTunedProvider)
+	klog.Infof("extracting cloud provider name to %v", ocpTunedProvider)
 
-	f, err := os.Create(openshiftTunedProvider)
+	f, err := os.Create(ocpTunedProvider)
 	if err != nil {
-		return fmt.Errorf("failed to create cloud provider name file %q: %v", openshiftTunedProvider, err)
+		return fmt.Errorf("failed to create cloud provider name file %q: %v", ocpTunedProvider, err)
 	}
 	defer f.Close()
 	if _, err = f.WriteString(provider); err != nil {
-		return fmt.Errorf("failed to write cloud provider name file %q: %v", openshiftTunedProvider, err)
+		return fmt.Errorf("failed to write cloud provider name file %q: %v", ocpTunedProvider, err)
 	}
 
 	return nil
 }
 
-// Read the Cloud Provider name from openshiftTunedProvider file and
+// Read the Cloud Provider name from ocpTunedProvider file and
 // extract/write 'provider' only if the file does not exist or it does not
 // match 'provider'.  Returns indication whether the 'provider' changed and
 // an error if any.
 func providerSync(provider string) (bool, error) {
-	providerCurrent, err := os.ReadFile(openshiftTunedProvider)
+	providerCurrent, err := os.ReadFile(ocpTunedProvider)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return len(provider) > 0, providerExtract(provider)
@@ -442,9 +462,75 @@ func providerSync(provider string) (bool, error) {
 	return true, providerExtract(provider)
 }
 
+// switchTunedHome changes "native" container's home directory as defined by the
+// Containerfile to the container's home directory on the host itself.
+func switchTunedHome() error {
+	const (
+		ocpTunedHomeHost = "/host" + ocpTunedHome
+	)
+
+	// Create the container's home directory on the host.
+	if err := os.MkdirAll(ocpTunedHomeHost, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory %q: %v", ocpTunedHomeHost, err)
+	}
+
+	// Delete the container's home directory.
+	if err := util.Delete(ocpTunedHome); err != nil {
+		return fmt.Errorf("failed to delete: %q: %v", ocpTunedHome, err)
+	}
+
+	if err := util.Symlink(ocpTunedHomeHost, ocpTunedHome); err != nil {
+		return fmt.Errorf("failed to link %q -> %q: %v", ocpTunedHome, ocpTunedHomeHost, err)
+	}
+
+	err := os.Chdir(ocpTunedHome)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func prepareOpenShiftTunedDir() error {
+	// Create the following directories unless they exist.
+	dirs := []string{
+		tunedRecommendDirHost,
+		tunedProfilesDirCustomHost,
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create directory %q: %v", d, err)
+		}
+	}
+
+	// Create the following symbolic links.
+	links := map[string]string{
+		tunedRecommendDirHost: tunedRecommendDir,
+	}
+	for target, source := range links {
+		if err := util.Symlink(target, source); err != nil {
+			return fmt.Errorf("failed to link %q -> %q: %v", source, target, err)
+		}
+	}
+
+	return nil
+}
+
+func writeOpenShiftTunedImageEnv() error {
+	klog.Infof("writing %v", ocpTunedImageEnv)
+
+	content := fmt.Sprintf("NTO_IMAGE=%s\n", os.Getenv("CLUSTER_NODE_TUNED_IMAGE"))
+	err := os.WriteFile(ocpTunedImageEnv, []byte(content), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write file %q: %v", ocpTunedImageEnv, err)
+	}
+
+	return nil
+}
+
 func TunedRecommendFileWrite(profileName string) error {
 	klog.V(2).Infof("tunedRecommendFileWrite(): %s", profileName)
-	if err := util.Mkdir(tunedRecommendDir); err != nil {
+	if err := os.MkdirAll(tunedRecommendDir, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create directory %q: %v", tunedRecommendDir, err)
 	}
 	f, err := os.Create(tunedRecommendFile)
@@ -484,7 +570,9 @@ func overridenSysctl(data string) string {
 }
 
 func (c *Controller) tunedCreateCmd() *exec.Cmd {
-	return TunedCreateCmd((c.daemon.restart & ctrlDebug) != 0)
+	command, args := TunedCreateCmdline((c.daemon.restart & ctrlDebug) != 0)
+
+	return exec.Command(command, args...)
 }
 
 func (c *Controller) tunedRun() {
@@ -746,7 +834,7 @@ func (c *Controller) changeSyncerTuneD(change Change) (synced bool, err error) {
 			if err = iniCfgSetKey(c.tunedMainCfg, "reapply_sysctl", !reapplySysctl); err != nil {
 				return false, err
 			}
-			err = iniFileSave(tunedProfilesDirCustom+"/"+tunedMainConfFile, c.tunedMainCfg)
+			err = iniFileSave(tunedMainConfPath, c.tunedMainCfg)
 			if err != nil {
 				return false, fmt.Errorf("failed to write global TuneD configuration file: %v", err)
 			}
@@ -1028,7 +1116,7 @@ func (c *Controller) informerEventHandler(workqueueKey wqKeyKube) cache.Resource
 // reentering this control loop should be made as it is an indication of an intentional
 // exit on request.
 func (c *Controller) changeWatcher() (err error) {
-	c.tunedMainCfg, err = iniFileLoad(tunedProfilesDirCustom + "/" + tunedMainConfFile)
+	c.tunedMainCfg, err = iniFileLoad(tunedMainConfPath)
 	if err != nil {
 		return fmt.Errorf("failed to load global TuneD configuration file: %v", err)
 	}
@@ -1183,14 +1271,44 @@ func retryLoop(c *Controller) (err error) {
 	}
 }
 
-func RunOperand(stopCh <-chan struct{}, version string, inCluster bool) error {
-	klog.Infof("starting %s %s; in-cluster: %v", programName, version, inCluster)
+func RunInCluster(stopCh <-chan struct{}, version string) error {
+	klog.Infof("starting in-cluster %s %s", programName, version)
 
+	if err := switchTunedHome(); err != nil {
+		return err
+	}
+
+	if err := prepareOpenShiftTunedDir(); err != nil {
+		return err
+	}
+
+	// Running in a k8s cluster pod with ocpTunedSystemdService unit present.
+	if err := writeOpenShiftTunedImageEnv(); err != nil {
+		return err
+	}
+
+	// The original way of running TuneD inside of a k8s container.
 	c, err := newController(stopCh)
 	if err != nil {
-		// This looks really bad, there was an error creating the Controller.
 		panic(err.Error())
 	}
 
 	return retryLoop(c)
+}
+
+func RunOutOfClusterOneShot(stopCh <-chan struct{}, version string) error {
+	klog.Infof("starting out-of-cluster %s %s", programName, version)
+
+	if err := prepareOpenShiftTunedDir(); err != nil {
+		return err
+	}
+
+	// Do not block the kubelet by running TuneD for longer than 60s.
+	err := TunedRunNoDaemon(60 * time.Second)
+	if err != nil {
+		// Just log this error.  We do not want to block the kubelet by failing the systemd service.
+		klog.Errorf("failed to run TuneD in one-shot mode: %v", err)
+	}
+
+	return nil
 }

--- a/pkg/util/os.go
+++ b/pkg/util/os.go
@@ -4,13 +4,23 @@ import (
 	"os"
 )
 
-// Create a directory including its parents.  Returns nil if directory already exists.
-func Mkdir(dir string) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		err = os.MkdirAll(dir, os.ModePerm)
-		if err != nil {
-			return err
+// Delete a file if it exists.  Returns nil if 'file' does not exist.
+func Delete(file string) error {
+	var err error
+	if err = os.Remove(file); os.IsNotExist(err) {
+		return nil
+	}
+
+	return err
+}
+
+// Create a symbolic link.  Returns nil if the link already exists.
+func Symlink(target, linkName string) error {
+	if _, err := os.Lstat(linkName); err != nil {
+		if os.IsNotExist(err) {
+			return os.Symlink(target, linkName)
 		}
+		return err
 	}
 
 	return nil

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -165,6 +165,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
@@ -183,6 +183,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
@@ -182,6 +182,57 @@ spec:
           WantedBy=multi-user.target
         enabled: true
         name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          # Restart=no is the default as of systemd 252, but be explicit.
+          Restart=no
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/var/lib/ocp-tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
   extensions: null
   fips: false
   kernelArguments: null


### PR DESCRIPTION
Manual backport of #1045 due to changes in Dockerfile and deprecated k8s.io/utils/pointer Go module.

Motivation.  In case of node reboots, all pods restart again in random order. Since there's no control on pod restart order, it is possible that tuned pods will start after the workload pods.  This means the workload pods can start with partial tuning which can result in degraded performance or even cause the workload pods crash.

This change is intended mostly for Telco use cases where PerformanceProfiles are used.  To minimize the risk of affecting other deployments by backporting this code, TuneD will start prior to kubelet only when PerformanceProfiles are used.

Changes:
  * Switch to /var/lib/ocp-tuned as the home directory for the operand (TuneD) pod on the host.  This directory now holds configuration for the TuneD daemon both running prior to kubelet and in the pod itself, notably TuneD daemon profiles and the recommended profile.
  * Use the new tuned-main.conf option "profile_dirs" to extract TuneD profiles to /var/lib/ocp-tuned/profiles.  This new option also allowed simplifying the algorithm for change detection in profilesSync() when extracting TuneD profiles.
  * Move a lot of the logic of creating the environment for TuneD to the operand code, so that no external script are needed for starting the operand.
  * Add ocp-tuned-one-shot.service systemd unit when using a PerformanceProfile.
  * Introduce a timeout to running TuneD in one-shot mode so that we don't block the kubelet indefinitely.
  * Shorten the constants names from openshift* to ocp*

Resolves: OCPBUGS-36868