### PR TITLE
OCPBUGS-28647: tuned: distinguish deferred updates

### DIFF
--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -645,7 +645,7 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 			}
 
 			klog.V(2).Infof("syncProfile(): Profile %s not found, creating one [%s]", profileMf.Name, computed.TunedProfileName)
-			profileMf.Annotations = util.ToggleDeferredUpdateAnnotation(profileMf.Annotations, computed.Deferred)
+			profileMf.Annotations = updateDeferredAnnotation(profileMf.Annotations, computed.Deferred)
 			profileMf.Spec.Config.TunedProfile = computed.TunedProfileName
 			profileMf.Spec.Config.Debug = computed.Operand.Debug
 			profileMf.Spec.Config.TuneDConfig = computed.Operand.TuneDConfig
@@ -706,14 +706,14 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 		}
 	}
 
-	anns := util.ToggleDeferredUpdateAnnotation(profile.Annotations, computed.Deferred)
+	anns := updateDeferredAnnotation(profile.Annotations, computed.Deferred)
 
 	// Minimize updates
 	if profile.Spec.Config.TunedProfile == computed.TunedProfileName &&
 		profile.Spec.Config.Debug == computed.Operand.Debug &&
 		reflect.DeepEqual(profile.Spec.Config.TuneDConfig, computed.Operand.TuneDConfig) &&
 		reflect.DeepEqual(profile.Spec.Profile, computed.AllProfiles) &&
-		util.HasDeferredUpdateAnnotation(profile.Annotations) == util.HasDeferredUpdateAnnotation(anns) &&
+		util.GetDeferredUpdateAnnotation(profile.Annotations) == util.GetDeferredUpdateAnnotation(anns) &&
 		profile.Spec.Config.ProviderName == providerName {
 		klog.V(2).Infof("syncProfile(): no need to update Profile %s", nodeName)
 		return nil
@@ -732,9 +732,16 @@ func (c *Controller) syncProfile(tuned *tunedv1.Tuned, nodeName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to update Profile %s: %v", profile.Name, err)
 	}
-	klog.Infof("updated profile %s [%s] (deferred=%v)", profile.Name, computed.TunedProfileName, util.HasDeferredUpdateAnnotation(profile.Annotations))
+	klog.Infof("updated profile %s [%s] (deferred=%v)", profile.Name, computed.TunedProfileName, util.GetDeferredUpdateAnnotation(profile.Annotations))
 
 	return nil
+}
+
+func updateDeferredAnnotation(anns map[string]string, mode util.DeferMode) map[string]string {
+	if util.IsDeferredUpdate(mode) {
+		return util.SetDeferredUpdateAnnotation(anns, mode)
+	}
+	return util.DeleteDeferredUpdateAnnotation(anns)
 }
 
 func (c *Controller) getProviderName(nodeName string) (string, error) {

--- a/pkg/operator/profilecalculator.go
+++ b/pkg/operator/profilecalculator.go
@@ -153,7 +153,7 @@ func (pc *ProfileCalculator) nodeChangeHandler(nodeName string) (bool, error) {
 type ComputedProfile struct {
 	TunedProfileName string
 	AllProfiles      []tunedv1.TunedProfile
-	Deferred         bool
+	Deferred         util.DeferMode
 	MCLabels         map[string]string
 	NodePoolName     string
 	Operand          tunedv1.OperandConfig
@@ -161,7 +161,7 @@ type ComputedProfile struct {
 
 type RecommendedProfile struct {
 	TunedProfileName string
-	Deferred         bool
+	Deferred         util.DeferMode
 	Labels           map[string]string
 	Config           tunedv1.OperandConfig
 }
@@ -302,7 +302,7 @@ func (pc *ProfileCalculator) calculateProfile(nodeName string) (ComputedProfile,
 
 type HypershiftRecommendedProfile struct {
 	TunedProfileName string
-	Deferred         bool
+	Deferred         util.DeferMode
 	NodePoolName     string
 	Config           tunedv1.OperandConfig
 }
@@ -732,7 +732,7 @@ func tunedProfiles(tunedSlice []*tunedv1.Tuned) []tunedv1.TunedProfile {
 
 type TunedRecommendInfo struct {
 	tunedv1.TunedRecommend
-	Deferred bool
+	Deferred util.DeferMode
 }
 
 // TunedRecommend returns a priority-sorted TunedRecommend slice out of
@@ -752,7 +752,7 @@ func TunedRecommend(tunedSlice []*tunedv1.Tuned) []TunedRecommendInfo {
 		for _, recommend := range tuned.Spec.Recommend {
 			recommendAll = append(recommendAll, TunedRecommendInfo{
 				TunedRecommend: recommend,
-				Deferred:       util.HasDeferredUpdateAnnotation(tuned.Annotations),
+				Deferred:       util.GetDeferredUpdateAnnotation(tuned.Annotations),
 			})
 		}
 	}

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -124,6 +124,9 @@ type Daemon struct {
 	// profileFingerprintEffective is the fingerprint of the profile effective on the node.
 	// Relevant in the startup flow with deferred updates.
 	profileFingerprintEffective string
+	// recoveredRecommendedProfile is the TuneD profile which we detected to be in effect.
+	// Relevant in the deferred updates flow.
+	recoveredRecommendedProfile string
 }
 
 type Change struct {
@@ -148,8 +151,9 @@ type Change struct {
 	// The current recommended profile as calculated by the operator.
 	recommendedProfile string
 
-	// Is the current Change triggered by an object with the deferred annotation?
-	deferred bool
+	// Mode of the deferred update. deferredMode == util.DeferNever if this is a change
+	// triggered by an object without deferred annotation, which is the default.
+	deferredMode util.DeferMode
 	// Text to convey in status message, if present.
 	message string
 }
@@ -180,8 +184,8 @@ func (ch Change) String() string {
 	if ch.recommendedProfile != "" {
 		items = append(items, fmt.Sprintf("recommendedProfile:%q", ch.recommendedProfile))
 	}
-	if ch.deferred {
-		items = append(items, "deferred:true")
+	if ch.deferredMode != "" {
+		items = append(items, fmt.Sprintf("deferredMode:%q", string(ch.deferredMode)))
 	}
 	if ch.message != "" {
 		items = append(items, fmt.Sprintf("message:%q", ch.message))
@@ -354,7 +358,7 @@ func (c *Controller) sync(key wqKeyKube) error {
 		if profile.Spec.Config.TuneDConfig.ReapplySysctl != nil {
 			change.reapplySysctl = *profile.Spec.Config.TuneDConfig.ReapplySysctl
 		}
-		change.deferred = util.HasDeferredUpdateAnnotation(profile.Annotations)
+		change.deferredMode = util.GetDeferredUpdateAnnotation(profile.Annotations)
 		// Notify the event processor that the Profile k8s object containing information about which TuneD profile to apply changed.
 		c.wqTuneD.Add(wqKeyTuned{kind: wqKindDaemon, change: change})
 
@@ -987,6 +991,7 @@ func (c *Controller) changeSyncerProfileStatus(change Change) (synced bool) {
 func (c *Controller) changeSyncerTuneD(change Change) (synced bool, err error) {
 	var restart bool
 	var reload bool
+	var inplaceUpdate bool // updating a profile already recommended
 	var cfgUpdated bool
 	var changeRecommend bool
 
@@ -1010,15 +1015,26 @@ func (c *Controller) changeSyncerTuneD(change Change) (synced bool, err error) {
 		}
 		reload = reload || changeProvider
 
-		if (c.daemon.recommendedProfile != change.recommendedProfile) || change.nodeRestart {
+		inplaceUpdate = (c.daemon.recommendedProfile == change.recommendedProfile)
+		if !inplaceUpdate || change.nodeRestart {
 			if err = TunedRecommendFileWrite(change.recommendedProfile); err != nil {
 				return false, err
 			}
-			klog.V(1).Infof("recommended TuneD profile changed from %q to %q [deferred=%v nodeRestart=%v]", c.daemon.recommendedProfile, change.recommendedProfile, change.deferred, change.nodeRestart)
+
+			prevRecommended := c.daemon.recommendedProfile
 			// Cache the value written to tunedRecommendFile.
 			c.daemon.recommendedProfile = change.recommendedProfile
-			reload = true
-		} else if !change.deferred && (c.daemon.status&scDeferred != 0) {
+			klog.V(1).Infof("recommended TuneD profile updated from %q to %q [inplaceUpdate=%v nodeRestart=%v]", prevRecommended, change.recommendedProfile, inplaceUpdate, change.nodeRestart)
+
+			if change.deferredMode == util.DeferUpdate && !inplaceUpdate && c.daemon.recoveredRecommendedProfile == change.recommendedProfile {
+				klog.V(1).Infof("recommended TuneD profile changed; skip TuneD reload [deferred=%v recoveredRecommended=%v]", change.deferredMode, c.daemon.recoveredRecommendedProfile)
+				// Reset because we need only once the first time we process the TuneD k8s object. Let's avoid stale data.
+				c.daemon.recoveredRecommendedProfile = ""
+			} else {
+				klog.V(1).Infof("recommended TuneD profile changed; trigger TuneD reload [deferred=%v]", change.deferredMode)
+				reload = true
+			}
+		} else if util.IsImmediateUpdate(change.deferredMode) && (c.daemon.status&scDeferred != 0) {
 			klog.V(1).Infof("detected deferred update changed to immediate after object update")
 			reload = true
 		} else {
@@ -1077,7 +1093,7 @@ func (c *Controller) changeSyncerTuneD(change Change) (synced bool, err error) {
 	}
 
 	// failures pertaining to deferred updates are not critical
-	_ = c.handleDaemonReloadRestartRequest(change, reload, restart)
+	_ = c.handleDaemonReloadRestartRequest(change, reload, restart, inplaceUpdate)
 
 	cfgUpdated, err = c.changeSyncerRestartOrReloadTuneD()
 	klog.V(2).Infof("changeSyncerTuneD() configuration updated: %v", cfgUpdated)
@@ -1088,19 +1104,39 @@ func (c *Controller) changeSyncerTuneD(change Change) (synced bool, err error) {
 	return err == nil, err
 }
 
-func (c *Controller) handleDaemonReloadRestartRequest(change Change, reload, restart bool) error {
+// treatAsImmediate determines if a Change should be treated as immediate update or as a deferred update.
+// This function is necessary because the treatment of a change doesn't depend only on the value of the
+// `deferredMode` field, because there are known cases on which a Change whose `deferredMode` is not `Never`
+// should be treated as immediate, for example when processing a deferred change after a node restart.
+// Returns a boolean to signal if the change should be treated as immediate, and a human-friendly string
+// to document the reason. If the change should be deferred (returns false), the reason is always ""
+func treatAsImmediate(change Change, inplaceUpdate bool) (bool, string) {
+	if change.nodeRestart {
+		return true, "node restart"
+	}
+	// An immediate update detected. Either no deferred annotation was set or it was set to util.DeferNever.
+	if util.IsImmediateUpdate(change.deferredMode) {
+		return true, "immediate update"
+	}
+	if !inplaceUpdate && change.deferredMode == util.DeferUpdate {
+		return true, "recommended profile change with deferredMode=" + util.DeferUpdate.String()
+	}
+	return false, ""
+}
+
+func (c *Controller) handleDaemonReloadRestartRequest(change Change, reload, restart, inplaceUpdate bool) error {
 	if !reload && !restart {
 		// nothing to do
 		return nil
 	}
 
-	if !change.deferred || change.nodeRestart {
+	if ok, reason := treatAsImmediate(change, inplaceUpdate); ok {
 		if reload {
-			klog.V(2).Infof("immediate update, setting reload flag")
+			klog.V(2).Infof("%s: setting reload flag", reason)
 			c.daemon.restart |= ctrlReload
 		}
 		if restart {
-			klog.V(2).Infof("immediate update, setting restart flag")
+			klog.V(2).Infof("%s: setting restart flag", reason)
 			c.daemon.restart |= ctrlRestart
 		}
 		return nil
@@ -1321,7 +1357,7 @@ func (c *Controller) updateTunedProfileStatus(ctx context.Context, change Change
 	}
 
 	var message string
-	wantsDeferred := util.HasDeferredUpdateAnnotation(profile.Annotations)
+	wantsDeferred := util.IsDeferredUpdate(util.GetDeferredUpdateAnnotation(profile.Annotations))
 	isApplied := (c.daemon.profileFingerprintUnpacked == c.daemon.profileFingerprintEffective)
 	daemonStatus := c.daemon.status
 
@@ -1684,7 +1720,18 @@ func RunInCluster(stopCh <-chan struct{}, version string) error {
 
 	profileFP := profilesFingerprint(profiles, recommended)
 	c.daemon.profileFingerprintUnpacked = profileFP
-	klog.Infof("starting: profile fingerprint unpacked %q", profileFP)
+	// We should *never* recover `c.daemon.recommendedProfile`.
+	// NTO operand supervises the TuneD daemon, so we must trigger
+	// a TuneD restart. Currently, the main trigger for the tuned
+	// reload to be triggered is when the current recommended profile
+	// is different from the change.recommended profile (see changeSyncerTuneD).
+	// Hence, we MUST NOT recover the recommended profile name
+	// and set the internal state with this info. Leaving the internal
+	// field unset will trigger (albeit by side effect) the reload.
+	// note: this core logic predates the `deferred updates`;
+	// xref: https://github.com/openshift/cluster-node-tuning-operator/pull/1129#issuecomment-2283437075
+	c.daemon.recoveredRecommendedProfile = recommended
+	klog.Infof("starting: profile unpacked is %q fingerprint %q", recommended, profileFP)
 
 	deferredFP, isNodeReboot, err := c.recoverAndClearDeferredUpdate()
 	if err != nil {
@@ -1694,7 +1741,7 @@ func RunInCluster(stopCh <-chan struct{}, version string) error {
 	} else if deferredFP == "" {
 		klog.Infof("starting: node reboot, but no pending deferred update")
 	} else {
-		klog.Infof("starting: recovered and cleared pending deferred update %q (fingerprint=%q)", recommended, deferredFP)
+		klog.Infof("starting: recovered and cleared pending deferred update %q for %s (fingerprint=%q)", recommended, restartReason(isNodeReboot), deferredFP)
 		c.pendingChange = &Change{
 			profile:            true,
 			nodeRestart:        true,
@@ -1704,6 +1751,13 @@ func RunInCluster(stopCh <-chan struct{}, version string) error {
 	}
 
 	return retryLoop(c)
+}
+
+func restartReason(isNodeReboot bool) string {
+	if isNodeReboot {
+		return "node reboot"
+	}
+	return "daemon restart"
 }
 
 func RunOutOfClusterOneShot(stopCh <-chan struct{}, version string) error {

--- a/pkg/tuned/controller_test.go
+++ b/pkg/tuned/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	"github.com/openshift/cluster-node-tuning-operator/pkg/util"
 )
 
 func TestRecommendFileRoundTrip(t *testing.T) {
@@ -295,7 +296,7 @@ func fullChange() Change {
 		provider:           "test-provider",
 		reapplySysctl:      true,
 		recommendedProfile: "test-profile",
-		deferred:           true,
+		deferredMode:       util.DeferAlways,
 		message:            "test-message",
 	}
 }

--- a/pkg/util/annotations.go
+++ b/pkg/util/annotations.go
@@ -4,28 +4,59 @@ import (
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 )
 
-func HasDeferredUpdateAnnotation(anns map[string]string) bool {
-	if anns == nil {
-		return false
-	}
-	_, ok := anns[tunedv1.TunedDeferredUpdate]
-	return ok
+// DeferMode controls the deferred feature. Default is "never", which is the value
+// assumed when no annotation is set, and which cause all objects to be processed
+// immediately (never deferred)
+type DeferMode string
+
+const (
+	// DeferNever means deferred mode is disabled; treat as immediate update, like the annotation is not present.
+	DeferNever DeferMode = "never"
+	// DeferAlways means the changes carried will be deferred until the next node restart: both for the first application and for profile changes.
+	DeferAlways DeferMode = "always"
+	// DeferUpdate means in-place updates/changes to only the contents of the currently used profile. Switches to different TuneD profiles are processed immediately without the need to reboot.
+	DeferUpdate DeferMode = "update"
+)
+
+func (dm DeferMode) String() string {
+	return string(dm)
 }
 
-func SetDeferredUpdateAnnotation(anns map[string]string, tuned *tunedv1.Tuned) map[string]string {
-	if anns == nil {
-		anns = make(map[string]string)
-	}
-	return ToggleDeferredUpdateAnnotation(anns, HasDeferredUpdateAnnotation(tuned.Annotations))
+func IsImmediateUpdate(value DeferMode) bool {
+	return value == DeferNever
 }
 
-func ToggleDeferredUpdateAnnotation(anns map[string]string, toggle bool) map[string]string {
+func IsDeferredUpdate(value DeferMode) bool {
+	return value == DeferAlways || value == DeferUpdate
+}
+
+func GetDeferredUpdateAnnotation(anns map[string]string) DeferMode {
+	if anns == nil {
+		return DeferNever
+	}
+	val, ok := anns[tunedv1.TunedDeferredUpdate]
+	if !ok {
+		return DeferNever
+	}
+	value := DeferMode(val)
+	if !IsDeferredUpdate(value) {
+		return DeferNever
+	}
+	return value
+}
+
+func SetDeferredUpdateAnnotation(anns map[string]string, value DeferMode) map[string]string {
 	ret := cloneMapStringString(anns)
-	if toggle {
-		ret[tunedv1.TunedDeferredUpdate] = ""
-	} else {
-		delete(ret, tunedv1.TunedDeferredUpdate)
+	if value == DeferNever {
+		return ret
 	}
+	ret[tunedv1.TunedDeferredUpdate] = string(value)
+	return ret
+}
+
+func DeleteDeferredUpdateAnnotation(anns map[string]string) map[string]string {
+	ret := cloneMapStringString(anns)
+	delete(ret, tunedv1.TunedDeferredUpdate)
 	return ret
 }
 

--- a/test/e2e/deferred/basic.go
+++ b/test/e2e/deferred/basic.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
 
-var _ = ginkgo.Describe("[deferred][profile-status] Profile deferred", ginkgo.Label("deferred", "profile-status"), func() {
+var _ = ginkgo.Describe("Profile deferred", ginkgo.Label("deferred", "profile-status"), func() {
 	ginkgo.Context("when applied", func() {
 		var (
 			createdTuneds     []string

--- a/test/e2e/deferred/basic.go
+++ b/test/e2e/deferred/basic.go
@@ -85,8 +85,8 @@ var _ = ginkgo.Describe("[deferred][profile-status] Profile deferred", ginkgo.La
 			verifData := util.MustExtractVerificationOutputAndCommand(cs, targetNode, tuned)
 			gomega.Expect(verifData.OutputCurrent).ToNot(gomega.Equal(verifData.OutputExpected), "current output %q already matches expected %q", verifData.OutputCurrent, verifData.OutputExpected)
 
-			tunedMutated := setDeferred(tuned.DeepCopy())
-			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.HasDeferredUpdateAnnotation(tunedMutated.Annotations)))
+			tunedMutated := setDeferred(tuned.DeepCopy(), ntoutil.DeferAlways)
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.GetDeferredUpdateAnnotation(tunedMutated.Annotations)))
 
 			_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedMutated, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -138,10 +138,10 @@ var _ = ginkgo.Describe("[deferred][profile-status] Profile deferred", ginkgo.La
 				}
 				for _, condition := range curProf.Status.Conditions {
 					if condition.Type == tunedv1.TunedProfileApplied && condition.Status != corev1.ConditionFalse && condition.Reason != "Deferred" {
-						return fmt.Errorf("Profile deferred=%v %s applied", ntoutil.HasDeferredUpdateAnnotation(curProf.Annotations), curProf.Name)
+						return fmt.Errorf("Profile deferred=%v %s applied", ntoutil.GetDeferredUpdateAnnotation(curProf.Annotations), curProf.Name)
 					}
 					if condition.Type == tunedv1.TunedDegraded && condition.Status != corev1.ConditionTrue && condition.Reason != "TunedDeferredUpdate" {
-						return fmt.Errorf("Profile deferred=%v %s not degraded", ntoutil.HasDeferredUpdateAnnotation(curProf.Annotations), curProf.Name)
+						return fmt.Errorf("Profile deferred=%v %s not degraded", ntoutil.GetDeferredUpdateAnnotation(curProf.Annotations), curProf.Name)
 					}
 				}
 				ginkgo.By(fmt.Sprintf("checking real node conditions for profile %q are not changed from pristine state", curProf.Name))
@@ -174,8 +174,8 @@ var _ = ginkgo.Describe("[deferred][profile-status] Profile deferred", ginkgo.La
 			verifData := util.MustExtractVerificationOutputAndCommand(cs, targetNode, tuned)
 			gomega.Expect(verifData.OutputCurrent).ToNot(gomega.Equal(verifData.OutputExpected), "current output %q already matches expected %q", verifData.OutputCurrent, verifData.OutputExpected)
 
-			tunedMutated := setDeferred(tuned.DeepCopy())
-			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.HasDeferredUpdateAnnotation(tunedMutated.Annotations)))
+			tunedMutated := setDeferred(tuned.DeepCopy(), ntoutil.DeferAlways)
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.GetDeferredUpdateAnnotation(tunedMutated.Annotations)))
 
 			_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedMutated, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -266,8 +266,8 @@ var _ = ginkgo.Describe("[deferred][profile-status] Profile deferred", ginkgo.La
 			tunedDeferred, err := util.LoadTuned(tunedPathSHMMNI)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-			tunedMutated := setDeferred(tunedDeferred.DeepCopy())
-			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.HasDeferredUpdateAnnotation(tunedMutated.Annotations)))
+			tunedMutated := setDeferred(tunedDeferred.DeepCopy(), ntoutil.DeferAlways)
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.GetDeferredUpdateAnnotation(tunedMutated.Annotations)))
 
 			_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedMutated, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -316,8 +316,8 @@ var _ = ginkgo.Describe("[deferred][profile-status] Profile deferred", ginkgo.La
 			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
 
 			tunedDeferred2 := tunedObjVMLatency
-			tunedMutated2 := setDeferred(tunedDeferred2.DeepCopy())
-			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated2.Name, ntoutil.HasDeferredUpdateAnnotation(tunedMutated2.Annotations)))
+			tunedMutated2 := setDeferred(tunedDeferred2.DeepCopy(), ntoutil.DeferAlways)
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated2.Name, ntoutil.GetDeferredUpdateAnnotation(tunedMutated2.Annotations)))
 
 			_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedMutated2, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -362,8 +362,8 @@ var _ = ginkgo.Describe("[deferred][profile-status] Profile deferred", ginkgo.La
 
 		ginkgo.It("should be overridden by a immediate update by edit", func(ctx context.Context) {
 			tunedImmediate := tunedObjVMLatency
-			tunedMutated := setDeferred(tunedImmediate.DeepCopy())
-			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.HasDeferredUpdateAnnotation(tunedMutated.Annotations)))
+			tunedMutated := setDeferred(tunedImmediate.DeepCopy(), ntoutil.DeferAlways)
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.GetDeferredUpdateAnnotation(tunedMutated.Annotations)))
 
 			_, err := cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedMutated, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -416,7 +416,7 @@ var _ = ginkgo.Describe("[deferred][profile-status] Profile deferred", ginkgo.La
 				curTuned = curTuned.DeepCopy()
 
 				ginkgo.By(fmt.Sprintf("removing the deferred annotation from Tuned %q", tunedImmediate.Name))
-				curTuned.Annotations = ntoutil.ToggleDeferredUpdateAnnotation(curTuned.Annotations, false)
+				curTuned.Annotations = ntoutil.DeleteDeferredUpdateAnnotation(curTuned.Annotations)
 
 				_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Update(ctx, curTuned, metav1.UpdateOptions{})
 				return err

--- a/test/e2e/deferred/non_regression.go
+++ b/test/e2e/deferred/non_regression.go
@@ -56,7 +56,7 @@ var _ = ginkgo.Describe("[deferred][non-regression] Profile non-deferred", ginkg
 		ginkgo.It("should trigger changes", func(ctx context.Context) {
 			tuned, err := util.LoadTuned(tunedPathVMLatency)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tuned.Name, ntoutil.HasDeferredUpdateAnnotation(tuned.Annotations)))
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tuned.Name, ntoutil.GetDeferredUpdateAnnotation(tuned.Annotations)))
 
 			verifications := extractVerifications(tuned)
 			gomega.Expect(len(verifications)).To(gomega.Equal(1), "unexpected verification count, check annotations")

--- a/test/e2e/deferred/non_regression.go
+++ b/test/e2e/deferred/non_regression.go
@@ -18,7 +18,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 )
 
-var _ = ginkgo.Describe("[deferred][non-regression] Profile non-deferred", ginkgo.Label("deferred", "non-regression"), func() {
+var _ = ginkgo.Describe("Profile non-deferred", ginkgo.Label("deferred", "non-regression"), func() {
 	ginkgo.Context("when applied", func() {
 		var (
 			createdTuneds []string

--- a/test/e2e/deferred/operator_test.go
+++ b/test/e2e/deferred/operator_test.go
@@ -195,7 +195,7 @@ func checkAppliedConditionStaysOKForNode(ctx context.Context, nodeName, expected
 	}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
 }
 
-func checkNontargetWorkerNodesAreUnaffected(ctx context.Context, workerNodes []corev1.Node, targetNodeName string) {
+func checkNonTargetWorkerNodesAreUnaffected(ctx context.Context, workerNodes []corev1.Node, targetNodeName string) {
 	ginkgo.GinkgoHelper()
 
 	// all the other nodes should be fine as well. For them the state should be settled now, so we just check once

--- a/test/e2e/deferred/operator_test.go
+++ b/test/e2e/deferred/operator_test.go
@@ -23,6 +23,10 @@ import (
 )
 
 const (
+	defaultWorkerProfile = "openshift-node"
+)
+
+const (
 	verifyCommandAnnotation = "verificationCommand"
 	verifyOutputAnnotation  = "verificationOutput"
 
@@ -34,6 +38,9 @@ const (
 	tunedSHMMNI    = "../testing_manifests/deferred/tuned-basic-00.yaml"
 	tunedCPUEnergy = "../testing_manifests/deferred/tuned-basic-10.yaml"
 	tunedVMLatency = "../testing_manifests/deferred/tuned-basic-20.yaml"
+
+	tunedVMLatInplaceBootstrap = "../testing_manifests/deferred/tuned-basic-updates-00.yaml"
+	tunedVMLatInplaceUpdate    = "../testing_manifests/deferred/tuned-basic-updates-10.yaml"
 )
 
 var (
@@ -118,14 +125,14 @@ func prepend(strs []string, s string) []string {
 	return append([]string{s}, strs...)
 }
 
-func setDeferred(obj *tunedv1.Tuned) *tunedv1.Tuned {
+func setDeferred(obj *tunedv1.Tuned, mode ntoutil.DeferMode) *tunedv1.Tuned {
 	if obj == nil {
 		return obj
 	}
 	if obj.Annotations == nil {
 		obj.Annotations = make(map[string]string)
 	}
-	obj.Annotations = ntoutil.ToggleDeferredUpdateAnnotation(obj.Annotations, true)
+	obj.Annotations = ntoutil.SetDeferredUpdateAnnotation(obj.Annotations, mode)
 	return obj
 }
 
@@ -186,4 +193,41 @@ func checkAppliedConditionStaysOKForNode(ctx context.Context, nodeName, expected
 		}
 		return err
 	}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+}
+
+func checkNontargetWorkerNodesAreUnaffected(ctx context.Context, workerNodes []corev1.Node, targetNodeName string) {
+	ginkgo.GinkgoHelper()
+
+	// all the other nodes should be fine as well. For them the state should be settled now, so we just check once
+	// why: because of bugs, we had once allegedly unaffected nodes stuck in deferred updates (obvious bug), let's
+	// be prudent and add a check this never happens again. Has sky fell yet?
+	for _, workerNode := range workerNodes {
+		if workerNode.Name == targetNodeName {
+			continue // checked previously, if we got this far it's OK
+		}
+
+		ginkgo.By(fmt.Sprintf("checking non-target worker node after rollback: %q", workerNode.Name))
+
+		gomega.Eventually(func() error {
+			wrkNodeProf, err := cs.Profiles(ntoconfig.WatchNamespace()).Get(ctx, workerNode.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			ginkgo.By(fmt.Sprintf("checking profile for target node %q matches expectations about %q", wrkNodeProf.Name, defaultWorkerProfile))
+			if wrkNodeProf.Spec.Config.TunedProfile != defaultWorkerProfile {
+				return fmt.Errorf("checking profile for worker node %q matches expectations %q", wrkNodeProf.Name, defaultWorkerProfile)
+			}
+
+			ginkgo.By(fmt.Sprintf("checking condition for target node %q matches expectations about %q", wrkNodeProf.Name, defaultWorkerProfile))
+			if len(wrkNodeProf.Status.Conditions) == 0 {
+				return fmt.Errorf("missing status conditions")
+			}
+			cond := findCondition(wrkNodeProf.Status.Conditions, tunedv1.TunedProfileApplied)
+			if cond == nil {
+				return fmt.Errorf("missing status applied condition")
+			}
+			return checkAppliedConditionOK(cond)
+		}).WithPolling(10. * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+	}
 }

--- a/test/e2e/deferred/restart.go
+++ b/test/e2e/deferred/restart.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util/wait"
 )
 
-var _ = ginkgo.Describe("[deferred][slow][disruptive][flaky] Profile deferred", ginkgo.Label("deferred", "slow", "disruptive", "flaky"), func() {
+var _ = ginkgo.Describe("Profile deferred", ginkgo.Label("deferred", "slow", "disruptive", "flaky"), func() {
 	ginkgo.Context("when restarting", func() {
 		var (
 			createdTuneds []string
@@ -67,11 +67,11 @@ var _ = ginkgo.Describe("[deferred][slow][disruptive][flaky] Profile deferred", 
 			if len(createdTuneds) == 0 {
 				return
 			}
-			checkNontargetWorkerNodesAreUnaffected(context.TODO(), workerNodes, targetNode.Name)
+			checkNonTargetWorkerNodesAreUnaffected(context.TODO(), workerNodes, targetNode.Name)
 		})
 
-		ginkgo.Context("[slow][pod]the tuned daemon", func() {
-			ginkgo.It("[reload] should not be applied", ginkgo.Label("reload"), func(ctx context.Context) {
+		ginkgo.Context("the tuned daemon", ginkgo.Label("slow", "pod"), func() {
+			ginkgo.It("should not be applied", ginkgo.Label("reload"), func(ctx context.Context) {
 				ginkgo.By(fmt.Sprintf("getting the tuned pod running on %q", targetNode.Name))
 				targetTunedPod, err := util.GetTunedForNode(cs, targetNode)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -191,8 +191,8 @@ var _ = ginkgo.Describe("[deferred][slow][disruptive][flaky] Profile deferred", 
 			})
 		})
 
-		ginkgo.Context("[slow][disruptive][node] the worker node", func() {
-			ginkgo.It("[restart] should be applied", ginkgo.Label("restart"), func(ctx context.Context) {
+		ginkgo.Context("the worker node", ginkgo.Label("slow", "disruptive", "node"), func() {
+			ginkgo.It("should be applied", ginkgo.Label("restart"), func(ctx context.Context) {
 				tunedImmediate := tunedObjVMLatency
 
 				verifications := extractVerifications(tunedImmediate)
@@ -290,7 +290,7 @@ var _ = ginkgo.Describe("[deferred][slow][disruptive][flaky] Profile deferred", 
 				}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
 			})
 
-			ginkgo.It("[restart][revert] should be reverted once applied and the node state should be restored", ginkgo.Label("restart", "revert"), func(ctx context.Context) {
+			ginkgo.It("should be reverted once applied and the node state should be restored", ginkgo.Label("restart", "revert"), func(ctx context.Context) {
 				tunedImmediate := tunedObjSHMMNI
 
 				verifications := extractVerifications(tunedImmediate)
@@ -428,7 +428,7 @@ var _ = ginkgo.Describe("[deferred][slow][disruptive][flaky] Profile deferred", 
 					return nil
 				}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
 
-				checkNontargetWorkerNodesAreUnaffected(ctx, workerNodes, targetNode.Name)
+				checkNonTargetWorkerNodesAreUnaffected(ctx, workerNodes, targetNode.Name)
 			})
 		})
 	})

--- a/test/e2e/deferred/restart.go
+++ b/test/e2e/deferred/restart.go
@@ -20,11 +20,12 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util/wait"
 )
 
-var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile deferred", ginkgo.Label("deferred", "restart", "slow", "disruptive", "flaky"), func() {
+var _ = ginkgo.Describe("[deferred][slow][disruptive][flaky] Profile deferred", ginkgo.Label("deferred", "slow", "disruptive", "flaky"), func() {
 	ginkgo.Context("when restarting", func() {
 		var (
 			createdTuneds []string
 			targetNode    *corev1.Node
+			workerNodes   []corev1.Node
 
 			dirPath            string
 			tunedPathSHMMNI    string
@@ -34,12 +35,13 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 		)
 
 		ginkgo.BeforeEach(func() {
+			var err error
 			ginkgo.By("getting a list of worker nodes")
-			nodes, err := util.GetNodesByRole(cs, "worker")
+			workerNodes, err = util.GetNodesByRole(cs, "worker")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(len(nodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
+			gomega.Expect(workerNodes).ToNot(gomega.BeEmpty(), "number of worker nodes is 0")
 
-			targetNode = &nodes[0]
+			targetNode = &workerNodes[0]
 			ginkgo.By(fmt.Sprintf("using node %q as reference", targetNode.Name))
 
 			createdTuneds = []string{}
@@ -61,10 +63,15 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 				ginkgo.By(fmt.Sprintf("cluster changes rollback: %q", createdTuned))
 				util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", createdTuned)
 			}
+
+			if len(createdTuneds) == 0 {
+				return
+			}
+			checkNontargetWorkerNodesAreUnaffected(context.TODO(), workerNodes, targetNode.Name)
 		})
 
 		ginkgo.Context("[slow][pod]the tuned daemon", func() {
-			ginkgo.It("should not be applied", func(ctx context.Context) {
+			ginkgo.It("[reload] should not be applied", ginkgo.Label("reload"), func(ctx context.Context) {
 				ginkgo.By(fmt.Sprintf("getting the tuned pod running on %q", targetNode.Name))
 				targetTunedPod, err := util.GetTunedForNode(cs, targetNode)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -75,8 +82,8 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 				verifData := util.MustExtractVerificationOutputAndCommand(cs, targetNode, tunedImmediate)
 				gomega.Expect(verifData.OutputCurrent).ToNot(gomega.Equal(verifData.OutputExpected), "current output %q already matches expected %q", verifData.OutputCurrent, verifData.OutputExpected)
 
-				tunedMutated := setDeferred(tunedImmediate.DeepCopy())
-				ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.HasDeferredUpdateAnnotation(tunedMutated.Annotations)))
+				tunedMutated := setDeferred(tunedImmediate.DeepCopy(), ntoutil.DeferAlways)
+				ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.GetDeferredUpdateAnnotation(tunedMutated.Annotations)))
 
 				_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedMutated, metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -163,10 +170,10 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 					}
 					for _, condition := range curProf.Status.Conditions {
 						if condition.Type == tunedv1.TunedProfileApplied && condition.Status != corev1.ConditionFalse && condition.Reason != "Deferred" {
-							return fmt.Errorf("Profile deferred=%v %s applied", ntoutil.HasDeferredUpdateAnnotation(curProf.Annotations), curProf.Name)
+							return fmt.Errorf("Profile deferred=%v %s applied", ntoutil.GetDeferredUpdateAnnotation(curProf.Annotations), curProf.Name)
 						}
 						if condition.Type == tunedv1.TunedDegraded && condition.Status != corev1.ConditionTrue && condition.Reason != "TunedDeferredUpdate" {
-							return fmt.Errorf("Profile deferred=%v %s not degraded", ntoutil.HasDeferredUpdateAnnotation(curProf.Annotations), curProf.Name)
+							return fmt.Errorf("Profile deferred=%v %s not degraded", ntoutil.GetDeferredUpdateAnnotation(curProf.Annotations), curProf.Name)
 						}
 					}
 
@@ -185,7 +192,7 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 		})
 
 		ginkgo.Context("[slow][disruptive][node] the worker node", func() {
-			ginkgo.It("should be applied", func(ctx context.Context) {
+			ginkgo.It("[restart] should be applied", ginkgo.Label("restart"), func(ctx context.Context) {
 				tunedImmediate := tunedObjVMLatency
 
 				verifications := extractVerifications(tunedImmediate)
@@ -196,8 +203,8 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				ginkgo.By(fmt.Sprintf("got the tuned pod running on %q: %s/%s %s", targetNode.Name, targetTunedPod.Namespace, targetTunedPod.Name, targetTunedPod.UID))
 
-				tunedMutated := setDeferred(tunedImmediate.DeepCopy())
-				ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.HasDeferredUpdateAnnotation(tunedMutated.Annotations)))
+				tunedMutated := setDeferred(tunedImmediate.DeepCopy(), ntoutil.DeferAlways)
+				ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.GetDeferredUpdateAnnotation(tunedMutated.Annotations)))
 
 				_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedMutated, metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -283,7 +290,7 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 				}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
 			})
 
-			ginkgo.It("should be reverted once applied and the node state should be restored", func(ctx context.Context) {
+			ginkgo.It("[restart][revert] should be reverted once applied and the node state should be restored", ginkgo.Label("restart", "revert"), func(ctx context.Context) {
 				tunedImmediate := tunedObjSHMMNI
 
 				verifications := extractVerifications(tunedImmediate)
@@ -297,8 +304,8 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 				verifData := util.MustExtractVerificationOutputAndCommand(cs, targetNode, tunedImmediate)
 				gomega.Expect(verifData.OutputCurrent).ToNot(gomega.Equal(verifData.OutputExpected), "verification output current %q matches expected %q", verifData.OutputCurrent, verifData.OutputExpected)
 
-				tunedMutated := setDeferred(tunedImmediate.DeepCopy())
-				ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.HasDeferredUpdateAnnotation(tunedMutated.Annotations)))
+				tunedMutated := setDeferred(tunedImmediate.DeepCopy(), ntoutil.DeferAlways)
+				ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedMutated.Name, ntoutil.GetDeferredUpdateAnnotation(tunedMutated.Annotations)))
 
 				_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedMutated, metav1.CreateOptions{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
@@ -383,10 +390,11 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 					return nil
 				}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
 
-				ginkgo.By(fmt.Sprintf("cluster changes rollback: %q", tunedPathSHMMNI))
+				ginkgo.By(fmt.Sprintf("doing cluster changes rollback: %q", tunedPathSHMMNI))
 				_, _, err = util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", tunedPathSHMMNI)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
+				ginkgo.By(fmt.Sprintf("checking target node after rollback: %q", targetNode.Name))
 				_, createdTuneds, _ = popleft(createdTuneds)
 				gomega.Eventually(func() error {
 					curProf, err := cs.Profiles(ntoconfig.WatchNamespace()).Get(ctx, targetNode.Name, metav1.GetOptions{})
@@ -394,6 +402,7 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 						return err
 					}
 					ginkgo.By(fmt.Sprintf("checking profile for target node %q matches expectations about %q", curProf.Name, expectedProfile))
+					gomega.Expect(curProf.Name).To(gomega.Equal(expectedProfile), "checking profile for worker node %q matches expectations %q", curProf.Name, expectedProfile)
 
 					if len(curProf.Status.Conditions) == 0 {
 						return fmt.Errorf("missing status conditions")
@@ -418,6 +427,8 @@ var _ = ginkgo.Describe("[deferred][restart][slow][disruptive][flaky] Profile de
 					}
 					return nil
 				}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+				checkNontargetWorkerNodesAreUnaffected(ctx, workerNodes, targetNode.Name)
 			})
 		})
 	})

--- a/test/e2e/deferred/updates.go
+++ b/test/e2e/deferred/updates.go
@@ -1,0 +1,439 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
+	ntoutil "github.com/openshift/cluster-node-tuning-operator/pkg/util"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util/wait"
+)
+
+/*
+ * notes about manifests to be used in this test:
+ * - manifests are already annotated natively (no need to call setDeferred)
+ * - we need fresh manifests never seen before in the node; this is why we also
+ *   set the annoation natively. This restriction many be lifted in the future.
+ */
+var _ = ginkgo.Describe("[deferred][inplace-update] Profile deferred", ginkgo.Label("deferred", "inplace-update"), func() {
+	ginkgo.Context("when applied", func() {
+		var (
+			createdTuneds     []string
+			referenceNode     *corev1.Node // control plane
+			targetNode        *corev1.Node
+			referenceTunedPod *corev1.Pod // control plane
+			referenceProfile  string
+
+			dirPath string
+		)
+
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("getting a list of worker nodes")
+			workerNodes, err := util.GetNodesByRole(cs, "worker")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(workerNodes)).NotTo(gomega.BeZero(), "number of worker nodes is 0")
+
+			targetNode = &workerNodes[0]
+			ginkgo.By(fmt.Sprintf("using node %q as target for workers", targetNode.Name))
+
+			ginkgo.By("getting a list of control-plane nodes")
+			controlPlaneNodes, err := util.GetNodesByRole(cs, "control-plane")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(len(controlPlaneNodes)).NotTo(gomega.BeZero(), "number of control plane nodes is 0")
+
+			referenceNode = &controlPlaneNodes[0]
+			ginkgo.By(fmt.Sprintf("using node %q as reference control plane", referenceNode.Name))
+
+			referenceTunedPod, err = util.GetTunedForNode(cs, referenceNode)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(referenceTunedPod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
+
+			referenceProfile, err = getRecommendedProfile(referenceTunedPod)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("using profile %q as reference control plane", referenceProfile))
+
+			createdTuneds = []string{}
+
+			dirPath, err = util.GetCurrentDirPath()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.AfterEach(func() {
+			for _, createdTuned := range createdTuneds {
+				ginkgo.By(fmt.Sprintf("cluster changes rollback: %q", createdTuned))
+				util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", createdTuned)
+			}
+		})
+
+		ginkgo.It("should trigger changes when applied fist, then deferred when edited", func(ctx context.Context) {
+			tunedPathBootstrap := filepath.Join(dirPath, tunedVMLatInplaceBootstrap)
+			ginkgo.By(fmt.Sprintf("loading tuned data from %s (basepath=%s)", tunedPathBootstrap, dirPath))
+			tunedPathUpdate := filepath.Join(dirPath, tunedVMLatInplaceUpdate)
+			ginkgo.By(fmt.Sprintf("loading tuned data from %s (basepath=%s)", tunedPathUpdate, dirPath))
+
+			tunedBootstrap, err := util.LoadTuned(tunedPathBootstrap)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+
+			tunedUpdate, err := util.LoadTuned(tunedPathUpdate)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedUpdate.Name, ntoutil.GetDeferredUpdateAnnotation(tunedUpdate.Annotations)))
+
+			verifDataBootstrap := util.MustExtractVerificationOutputAndCommand(cs, targetNode, tunedBootstrap)
+			gomega.Expect(verifDataBootstrap.OutputCurrent).ToNot(gomega.Equal(verifDataBootstrap.OutputExpected), "current output %q already matches expected %q", verifDataBootstrap.OutputCurrent, verifDataBootstrap.OutputExpected)
+
+			_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedBootstrap, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			createdTuneds = prepend(createdTuneds, tunedPathBootstrap) // we need the path, not the name
+			ginkgo.By(fmt.Sprintf("create tuneds: %v", createdTuneds))
+
+			gomega.Expect(tunedBootstrap.Spec.Recommend).ToNot(gomega.BeEmpty(), "tuned %q has empty recommendations", tunedBootstrap.Name)
+			gomega.Expect(tunedBootstrap.Spec.Recommend[0].Profile).ToNot(gomega.BeNil(), "tuned %q has empty recommended tuned profile", tunedBootstrap.Name)
+			expectedProfile := *tunedBootstrap.Spec.Recommend[0].Profile
+			ginkgo.By(fmt.Sprintf("expecting Tuned Profile %q to be picked up", expectedProfile))
+
+			curProfName := ""
+			ginkgo.By(fmt.Sprintf("waiting for tuned object %s deferred=%v to be in effect", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Eventually(func() error {
+				curProf, err := cs.Profiles(ntoconfig.WatchNamespace()).Get(ctx, targetNode.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				ginkgo.By(fmt.Sprintf("checking profile for target node %q matches expectations about %q", curProf.Name, expectedProfile))
+
+				if len(curProf.Status.Conditions) == 0 {
+					return fmt.Errorf("missing status conditions")
+				}
+				cond := findCondition(curProf.Status.Conditions, tunedv1.TunedProfileApplied)
+				if cond == nil {
+					return fmt.Errorf("missing status applied condition")
+				}
+				err = checkAppliedConditionOK(cond)
+				if err != nil {
+					util.Logf("profile for target node %q does not match expectations about %q: %v", curProf.Name, expectedProfile, err)
+				}
+				recommended, err := getRecommendedProfile(verifDataBootstrap.TargetTunedPod)
+				if err != nil {
+					return err
+				}
+				if recommended != expectedProfile {
+					return fmt.Errorf("recommended profile is %q expected %q", recommended, expectedProfile)
+				}
+				curProfName = recommended
+				return err
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("ensuring tuned object %s deferred=%v are applied", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Eventually(func() error {
+				ginkgo.By(fmt.Sprintf("checking real node conditions for profile %q are changed as expected [command=%v]", curProfName, verifDataBootstrap.CommandArgs))
+				out, err := util.ExecCmdInPod(verifDataBootstrap.TargetTunedPod, verifDataBootstrap.CommandArgs...)
+				if err != nil {
+					return err
+				}
+				out = strings.TrimSpace(out)
+				if out != verifDataBootstrap.OutputExpected {
+					return fmt.Errorf("got: %s; expected: %s", out, verifDataBootstrap.OutputExpected)
+				}
+				return nil
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("ensuring tuned object %s deferred=%v changes stay applied", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Consistently(func() error {
+				ginkgo.By(fmt.Sprintf("checking real node conditions for profile %q are changed as expected [command=%v]", curProfName, verifDataBootstrap.CommandArgs))
+				out, err := util.ExecCmdInPod(verifDataBootstrap.TargetTunedPod, verifDataBootstrap.CommandArgs...)
+				if err != nil {
+					return err
+				}
+				out = strings.TrimSpace(out)
+				if out != verifDataBootstrap.OutputExpected {
+					return fmt.Errorf("got: %s; expected: %s", out, verifDataBootstrap.OutputExpected)
+				}
+				return nil
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("updating tuned object %s deferred=%v in place", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Eventually(func() error {
+				curTuned, err := cs.Tuneds(ntoconfig.WatchNamespace()).Get(ctx, tunedBootstrap.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				curTuned = curTuned.DeepCopy()
+				curTuned.Spec = tunedUpdate.Spec
+				_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Update(ctx, curTuned, metav1.UpdateOptions{})
+				return err
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("ensuring tuned object %s deferred=%v is now NOT picked up and stays deferred, being in-place update", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Eventually(func() error {
+				curProf, err := cs.Profiles(ntoconfig.WatchNamespace()).Get(ctx, targetNode.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				ginkgo.By(fmt.Sprintf("checking profile for target node %q matches expectations about %q", curProf.Name, expectedProfile))
+
+				if len(curProf.Status.Conditions) == 0 {
+					return fmt.Errorf("missing status conditions")
+				}
+				ginkgo.By(fmt.Sprintf("checking UPDATED conditions for profile %q: %#v", curProf.Name, curProf.Status.Conditions))
+
+				cond := findCondition(curProf.Status.Conditions, tunedv1.TunedProfileApplied)
+				if cond == nil {
+					return fmt.Errorf("missing status applied condition")
+				}
+
+				ginkgo.By(fmt.Sprintf("checking UPDATED condition is DEFERRED: %#v", cond))
+				err = checkAppliedConditionDeferred(cond, expectedProfile)
+				if err != nil {
+					util.Logf("profile for target node %q does not match expectations about %q: %v", curProf.Name, expectedProfile, err)
+					return err
+				}
+				recommended, err := getRecommendedProfile(verifDataBootstrap.TargetTunedPod)
+				if err != nil {
+					return err
+				}
+				if recommended != expectedProfile {
+					return fmt.Errorf("recommended profile is %q expected %q", recommended, expectedProfile)
+				}
+				return err
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("ensuring tuned object %s deferred=%v INITIAL changes stay applied", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Consistently(func() error {
+				ginkgo.By(fmt.Sprintf("checking real node conditions for profile %q are changed as expected [command=%v]", curProfName, verifDataBootstrap.CommandArgs))
+				out, err := util.ExecCmdInPod(verifDataBootstrap.TargetTunedPod, verifDataBootstrap.CommandArgs...)
+				if err != nil {
+					return err
+				}
+				out = strings.TrimSpace(out)
+				if out != verifDataBootstrap.OutputExpected {
+					return fmt.Errorf("got: %s; expected: %s", out, verifDataBootstrap.OutputExpected)
+				}
+				return nil
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			// on non-targeted nodes, like control plane, nothing should have changed
+			checkAppliedConditionStaysOKForNode(ctx, referenceNode.Name, referenceProfile)
+		})
+
+		ginkgo.It("[reload] should trigger changes when applied fist, then deferred when edited, if tuned restart should be kept deferred", ginkgo.Label("reload"), func(ctx context.Context) {
+			tunedPathBootstrap := filepath.Join(dirPath, tunedVMLatInplaceBootstrap)
+			ginkgo.By(fmt.Sprintf("loading tuned data from %s (basepath=%s)", tunedPathBootstrap, dirPath))
+			tunedPathUpdate := filepath.Join(dirPath, tunedVMLatInplaceUpdate)
+			ginkgo.By(fmt.Sprintf("loading tuned data from %s (basepath=%s)", tunedPathUpdate, dirPath))
+
+			tunedBootstrap, err := util.LoadTuned(tunedPathBootstrap)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+
+			tunedUpdate, err := util.LoadTuned(tunedPathUpdate)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			ginkgo.By(fmt.Sprintf("creating tuned object %s deferred=%v", tunedUpdate.Name, ntoutil.GetDeferredUpdateAnnotation(tunedUpdate.Annotations)))
+
+			verifDataBootstrap := util.MustExtractVerificationOutputAndCommand(cs, targetNode, tunedBootstrap)
+			gomega.Expect(verifDataBootstrap.OutputCurrent).ToNot(gomega.Equal(verifDataBootstrap.OutputExpected), "current output %q already matches expected %q", verifDataBootstrap.OutputCurrent, verifDataBootstrap.OutputExpected)
+
+			_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Create(ctx, tunedBootstrap, metav1.CreateOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			createdTuneds = prepend(createdTuneds, tunedPathBootstrap) // we need the path, not the name
+			ginkgo.By(fmt.Sprintf("create tuneds: %v", createdTuneds))
+
+			gomega.Expect(tunedBootstrap.Spec.Recommend).ToNot(gomega.BeEmpty(), "tuned %q has empty recommendations", tunedBootstrap.Name)
+			gomega.Expect(tunedBootstrap.Spec.Recommend[0].Profile).ToNot(gomega.BeNil(), "tuned %q has empty recommended tuned profile", tunedBootstrap.Name)
+			expectedProfile := *tunedBootstrap.Spec.Recommend[0].Profile
+			ginkgo.By(fmt.Sprintf("expecting Tuned Profile %q to be picked up", expectedProfile))
+
+			curProfName := ""
+			ginkgo.By(fmt.Sprintf("waiting for tuned object %s deferred=%v to be in effect", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Eventually(func() error {
+				curProf, err := cs.Profiles(ntoconfig.WatchNamespace()).Get(ctx, targetNode.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				ginkgo.By(fmt.Sprintf("checking profile for target node %q matches expectations about %q", curProf.Name, expectedProfile))
+
+				if len(curProf.Status.Conditions) == 0 {
+					return fmt.Errorf("missing status conditions")
+				}
+				cond := findCondition(curProf.Status.Conditions, tunedv1.TunedProfileApplied)
+				if cond == nil {
+					return fmt.Errorf("missing status applied condition")
+				}
+				err = checkAppliedConditionOK(cond)
+				if err != nil {
+					util.Logf("profile for target node %q does not match expectations about %q: %v", curProf.Name, expectedProfile, err)
+				}
+				recommended, err := getRecommendedProfile(verifDataBootstrap.TargetTunedPod)
+				if err != nil {
+					return err
+				}
+				if recommended != expectedProfile {
+					return fmt.Errorf("recommended profile is %q expected %q", recommended, expectedProfile)
+				}
+				curProfName = recommended
+				return err
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("ensuring tuned object %s deferred=%v are applied", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Eventually(func() error {
+				ginkgo.By(fmt.Sprintf("checking real node conditions for profile %q are changed as expected [command=%v]", curProfName, verifDataBootstrap.CommandArgs))
+				out, err := util.ExecCmdInPod(verifDataBootstrap.TargetTunedPod, verifDataBootstrap.CommandArgs...)
+				if err != nil {
+					return err
+				}
+				out = strings.TrimSpace(out)
+				if out != verifDataBootstrap.OutputExpected {
+					return fmt.Errorf("got: %s; expected: %s", out, verifDataBootstrap.OutputExpected)
+				}
+				return nil
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("updating tuned object %s deferred=%v in place", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Eventually(func() error {
+				curTuned, err := cs.Tuneds(ntoconfig.WatchNamespace()).Get(ctx, tunedBootstrap.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				curTuned = curTuned.DeepCopy()
+				curTuned.Spec = tunedUpdate.Spec
+				_, err = cs.Tuneds(ntoconfig.WatchNamespace()).Update(ctx, curTuned, metav1.UpdateOptions{})
+				return err
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("ensuring tuned object %s deferred=%v is now NOT picked up and stays deferred, being in-place update", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Eventually(func() error {
+				curProf, err := cs.Profiles(ntoconfig.WatchNamespace()).Get(ctx, targetNode.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				ginkgo.By(fmt.Sprintf("checking profile for target node %q matches expectations about %q", curProf.Name, expectedProfile))
+
+				if len(curProf.Status.Conditions) == 0 {
+					return fmt.Errorf("missing status conditions")
+				}
+				ginkgo.By(fmt.Sprintf("checking UPDATED conditions for profile %q: %#v", curProf.Name, curProf.Status.Conditions))
+
+				cond := findCondition(curProf.Status.Conditions, tunedv1.TunedProfileApplied)
+				if cond == nil {
+					return fmt.Errorf("missing status applied condition")
+				}
+
+				ginkgo.By(fmt.Sprintf("checking UPDATED condition is DEFERRED: %#v", cond))
+				err = checkAppliedConditionDeferred(cond, expectedProfile)
+				if err != nil {
+					util.Logf("profile for target node %q does not match expectations about %q: %v", curProf.Name, expectedProfile, err)
+					return err
+				}
+				recommended, err := getRecommendedProfile(verifDataBootstrap.TargetTunedPod)
+				if err != nil {
+					return err
+				}
+				if recommended != expectedProfile {
+					return fmt.Errorf("recommended profile is %q expected %q", recommended, expectedProfile)
+				}
+				return err
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("ensuring tuned object %s deferred=%v INITIAL changes stay applied", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Consistently(func() error {
+				ginkgo.By(fmt.Sprintf("checking real node conditions for profile %q are changed as expected [command=%v]", curProfName, verifDataBootstrap.CommandArgs))
+				out, err := util.ExecCmdInPod(verifDataBootstrap.TargetTunedPod, verifDataBootstrap.CommandArgs...)
+				if err != nil {
+					return err
+				}
+				out = strings.TrimSpace(out)
+				if out != verifDataBootstrap.OutputExpected {
+					return fmt.Errorf("got: %s; expected: %s", out, verifDataBootstrap.OutputExpected)
+				}
+				return nil
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			oldTunedPodUID := verifDataBootstrap.TargetTunedPod.UID
+			ginkgo.By(fmt.Sprintf("killing the tuned pod running on %q", targetNode.Name))
+			gomega.Expect(cs.Pods(verifDataBootstrap.TargetTunedPod.Namespace).Delete(ctx, verifDataBootstrap.TargetTunedPod.Name, metav1.DeleteOptions{})).To(gomega.Succeed())
+			// wait for the tuned pod to be found again
+
+			var targetTunedPod *corev1.Pod
+			ginkgo.By(fmt.Sprintf("getting again the tuned pod running on %q", targetNode.Name))
+			gomega.Eventually(func() error {
+				targetTunedPod, err = util.GetTunedForNode(cs, targetNode)
+				if err != nil {
+					return err
+				}
+				if targetTunedPod.UID == oldTunedPodUID {
+					return fmt.Errorf("pod %s/%s not refreshed old UID %q current UID %q", targetTunedPod.Namespace, targetTunedPod.Name, oldTunedPodUID, targetTunedPod.UID)
+				}
+				if !wait.PodReady(*targetTunedPod) {
+					return fmt.Errorf("pod %s/%s (%s) not ready", targetTunedPod.Namespace, targetTunedPod.Name, targetTunedPod.UID)
+				}
+				return nil
+			}).WithPolling(2 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+			ginkgo.By(fmt.Sprintf("got again the tuned pod running on %q: %s/%s %s", targetNode.Name, targetTunedPod.Namespace, targetTunedPod.Name, targetTunedPod.UID))
+
+			verifDataBootstrap.TargetTunedPod = targetTunedPod
+
+			ginkgo.By(fmt.Sprintf("ensuring tuned object %s deferred=%v is again NOT picked up and stays deferred, being in-place update", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Eventually(func() error {
+				curProf, err := cs.Profiles(ntoconfig.WatchNamespace()).Get(ctx, targetNode.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				ginkgo.By(fmt.Sprintf("checking profile for target node %q matches expectations about %q", curProf.Name, expectedProfile))
+
+				if len(curProf.Status.Conditions) == 0 {
+					return fmt.Errorf("missing status conditions")
+				}
+				ginkgo.By(fmt.Sprintf("checking UPDATED conditions for profile %q: %#v", curProf.Name, curProf.Status.Conditions))
+
+				cond := findCondition(curProf.Status.Conditions, tunedv1.TunedProfileApplied)
+				if cond == nil {
+					return fmt.Errorf("missing status applied condition")
+				}
+
+				ginkgo.By(fmt.Sprintf("checking UPDATED condition is DEFERRED: %#v", cond))
+				err = checkAppliedConditionDeferred(cond, expectedProfile)
+				if err != nil {
+					util.Logf("profile for target node %q does not match expectations about %q: %v", curProf.Name, expectedProfile, err)
+					return err
+				}
+				recommended, err := getRecommendedProfile(verifDataBootstrap.TargetTunedPod)
+				if err != nil {
+					return err
+				}
+				if recommended != expectedProfile {
+					return fmt.Errorf("recommended profile is %q expected %q", recommended, expectedProfile)
+				}
+				return err
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("ensuring tuned object %s deferred=%v INITIAL changes are still applied", tunedBootstrap.Name, ntoutil.GetDeferredUpdateAnnotation(tunedBootstrap.Annotations)))
+			gomega.Consistently(func() error {
+				ginkgo.By(fmt.Sprintf("checking real node conditions for profile %q are changed as expected [command=%v]", curProfName, verifDataBootstrap.CommandArgs))
+				out, err := util.ExecCmdInPod(verifDataBootstrap.TargetTunedPod, verifDataBootstrap.CommandArgs...)
+				if err != nil {
+					return err
+				}
+				out = strings.TrimSpace(out)
+				if out != verifDataBootstrap.OutputExpected {
+					return fmt.Errorf("got: %s; expected: %s", out, verifDataBootstrap.OutputExpected)
+				}
+				return nil
+			}).WithPolling(10 * time.Second).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
+			// on non-targeted nodes, like control plane, nothing should have changed
+			checkAppliedConditionStaysOKForNode(ctx, referenceNode.Name, referenceProfile)
+		})
+	})
+})

--- a/test/e2e/deferred/updates.go
+++ b/test/e2e/deferred/updates.go
@@ -26,7 +26,7 @@ import (
  * - we need fresh manifests never seen before in the node; this is why we also
  *   set the annoation natively. This restriction many be lifted in the future.
  */
-var _ = ginkgo.Describe("[deferred][inplace-update] Profile deferred", ginkgo.Label("deferred", "inplace-update"), func() {
+var _ = ginkgo.Describe("Profile deferred", ginkgo.Label("deferred", "inplace-update"), func() {
 	ginkgo.Context("when applied", func() {
 		var (
 			createdTuneds     []string
@@ -227,7 +227,7 @@ var _ = ginkgo.Describe("[deferred][inplace-update] Profile deferred", ginkgo.La
 			checkAppliedConditionStaysOKForNode(ctx, referenceNode.Name, referenceProfile)
 		})
 
-		ginkgo.It("[reload] should trigger changes when applied fist, then deferred when edited, if tuned restart should be kept deferred", ginkgo.Label("reload"), func(ctx context.Context) {
+		ginkgo.It("should trigger changes when applied fist, then deferred when edited, if tuned restart should be kept deferred", ginkgo.Label("reload", "flaky"), func(ctx context.Context) {
 			tunedPathBootstrap := filepath.Join(dirPath, tunedVMLatInplaceBootstrap)
 			ginkgo.By(fmt.Sprintf("loading tuned data from %s (basepath=%s)", tunedPathBootstrap, dirPath))
 			tunedPathUpdate := filepath.Join(dirPath, tunedVMLatInplaceUpdate)

--- a/test/e2e/testing_manifests/deferred/tuned-basic-updates-00.yaml
+++ b/test/e2e/testing_manifests/deferred/tuned-basic-updates-00.yaml
@@ -1,0 +1,23 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: ocp-prof-deferred-updates-00
+  namespace: openshift-cluster-node-tuning-operator
+  annotations:
+    tuned.openshift.io/deferred: "update"
+    verificationCommand: "[\"/usr/sbin/sysctl\", \"-n\", \"vm.swappiness\"]"
+    verificationOutput: "17"
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift profile
+      include=openshift-node
+      [sysctl]
+      vm.swappiness=17
+    name: test-vmlat-inplace
+  recommend:
+  - match:
+    - label: node-role.kubernetes.io/worker
+    priority: 15
+    profile: test-vmlat-inplace

--- a/test/e2e/testing_manifests/deferred/tuned-basic-updates-10.yaml
+++ b/test/e2e/testing_manifests/deferred/tuned-basic-updates-10.yaml
@@ -1,0 +1,23 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: ocp-prof-deferred-updates-00
+  namespace: openshift-cluster-node-tuning-operator
+  annotations:
+    tuned.openshift.io/deferred: "update"
+    verificationCommand: "[\"/usr/sbin/sysctl\", \"-n\", \"vm.swappiness\"]"
+    verificationOutput: "41"
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift profile
+      include=openshift-node
+      [sysctl]
+      vm.swappiness=41
+    name: test-vmlat-inplace
+  recommend:
+  - match:
+    - label: node-role.kubernetes.io/worker
+    priority: 15
+    profile: test-vmlat-inplace


### PR DESCRIPTION
To fully support the usecase described in OCPBUGS-28647 and fix
the issue, we need to further distinguish between first-time
profile change and (in-place) profile change. This is required to
better support a GitOps flow.

The key distinction is if the recommended profile changes or not,
and there's a desire to defer application of changes only when a
profile is updated (e.g. sysctl modified), not the first time it
is applied.

Thus:
- first-time profile change is a change which triggers a change of the recommended profile.
- (in-place) profile update is a change which does NOT cause a switch to a different TuneD profile. This usually, but not exclusively, involve changes of the sysctls.

We change the way the annotation is used. We now require a value,
which can be either
- always: every Tuned object annotated this way will have its application deferred
- update: every Tuned object annotated this way will be processed as usual (and as it wasn't annotated) if it's a first-time profile change, but its (in-place) updates will be deferred.
- a new internal value "never" is also added to be used internally to mean the deferred feature is disabled entirely. User can use this value but it will explicitly disable the feature (which is disabled already by default), thus is redundant and not recommended.
