### PR TITLE
OCPBUGS-36431: Fix generated cpu mask for 512+ cpus

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/utils.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/utils.go
@@ -47,7 +47,7 @@ func CPUListToHexMask(cpulist string) (hexMask string, err error) {
 		x := new(big.Int).Lsh(big.NewInt(1), uint(cpu))
 		currMask.Or(currMask, x)
 	}
-	return fmt.Sprintf("%064x", currMask), nil
+	return fmt.Sprintf("%0x", currMask), nil
 }
 
 // CPUListToMaskList converts a list of cpus into a cpu mask represented
@@ -57,6 +57,14 @@ func CPUListToMaskList(cpulist string) (hexMask string, err error) {
 	if err != nil {
 		return "", nil
 	}
+
+	// Make sure the raw mask can be processed in 8 character chunks
+	padding_needed := len(maskStr) % 8
+	if padding_needed != 0 {
+		padding_needed = 8 - padding_needed
+		maskStr = strings.Repeat("0", padding_needed) + maskStr
+	}
+
 	index := 0
 	for index < (len(maskStr) - 8) {
 		if maskStr[index:index+8] != "00000000" {

--- a/pkg/performanceprofile/controller/performanceprofile/components/utils_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/utils_test.go
@@ -19,6 +19,17 @@ var cpuListToMask = []listToMask{
 	{"1,3-7", "000000fa"},
 	{"0-127", "ffffffff,ffffffff,ffffffff,ffffffff"},
 	{"0-255", "ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff,ffffffff"},
+	{"0,1,256,257", "00000003,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000003"},
+}
+
+var cpuListToHexMask = []listToMask{
+	{"0", "1"},
+	{"2-3", "c"},
+	{"3,4,53-55,61-63", "e0e0000000000018"},
+	{"1,3-7", "fa"},
+	{"0-127", "ffffffffffffffffffffffffffffffff"},
+	{"0-255", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
+	{"0,1,256,257", "30000000000000000000000000000000000000000000000000000000000000003"},
 }
 
 func intersectHelper(cpuListA, cpuListB string) ([]int, error) {
@@ -31,6 +42,14 @@ func intersectHelper(cpuListA, cpuListB string) ([]int, error) {
 
 var _ = Describe("Components utils", func() {
 	Context("Convert CPU list to CPU mask", func() {
+		It("should generate a valid hex CPU mask from CPU list", func() {
+			for _, cpuEntry := range cpuListToHexMask {
+				cpuMask, err := CPUListToHexMask(cpuEntry.cpuList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cpuMask).Should(Equal(cpuEntry.cpuMask))
+			}
+		})
+
 		It("should generate a valid CPU mask from CPU list", func() {
 			for _, cpuEntry := range cpuListToMask {
 				cpuMask, err := CPUListToMaskList(cpuEntry.cpuList)


### PR DESCRIPTION
The padding size was hardcoded to support max 64 nibbles which is equivalent to 256 cpus (%064x). Any mask bigger than this that was not itself 32 cpu aligned broke the chunking algorithm.