### PR TITLE
OCPBUGS-34917: Operator: do not use /tmp

### DIFF
--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -15,7 +15,6 @@ import (
 
 	"k8s.io/klog/v2"
 
-	ntoconfig "github.com/openshift/cluster-node-tuning-operator/pkg/config"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/fsnotify.v1"
 )
@@ -25,36 +24,34 @@ const (
 	tlsCert      = tlsSecretDir + "/tls.crt"
 	tlsKey       = tlsSecretDir + "/tls.key"
 
-	authCADir                = "/tmp/metrics-client-ca"
-	authCAFile               = authCADir + "/ca.crt"
 	AuthConfigMapNamespace   = "kube-system"
 	AuthConfigMapName        = "extension-apiserver-authentication"
 	AuthConfigMapClientCAKey = "client-ca-file"
 )
 
 type Server struct {
+	caBundle   string
+	caBundleCh chan string
 }
 
-// DumpCA writes the root certificate bundle which is used to verify client certificates
-// on incoming requests to 'authCAFile' file.
-func DumpCA(ca string) error {
-	if err := os.MkdirAll(authCADir, os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create directory %q: %v", authCADir, err)
-	}
+var (
+	server Server
+)
 
-	f, err := os.Create(authCAFile)
-	if err != nil {
-		return fmt.Errorf("failed to create file %q: %v", authCAFile, err)
-	}
-	defer f.Close()
-	if _, err = f.WriteString(ca); err != nil {
-		return fmt.Errorf("failed to write file %q: %v", authCAFile, err)
-	}
-
-	return nil
+func init() {
+	server = Server{caBundleCh: make(chan string)}
 }
 
-func buildServer(port int) *http.Server {
+// DumpCA stores the root certificate bundle which is used to verify metric server
+// client certificates.  It uses an unbuffered channel to store the data and it
+// it does so only if the CA bundle changed from the current CA bundle on record.
+func DumpCA(caBundle string) {
+	if caBundle != server.caBundle {
+		server.caBundleCh <- caBundle
+	}
+}
+
+func buildServer(port int, caBundle string) *http.Server {
 	if port <= 0 {
 		klog.Error("invalid port for metric server")
 		return nil
@@ -68,29 +65,24 @@ func buildServer(port int) *http.Server {
 	)
 
 	tlsConfig := &tls.Config{}
-	caCert, err := os.ReadFile(authCAFile)
-	if err == nil {
-		caCertPool := x509.NewCertPool()
-		if caCertPool.AppendCertsFromPEM(caCert) {
-			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-			tlsConfig.ClientCAs = caCertPool
-			// Default minimum version is TLS 1.2, previous versions are insecure and deprecated.
-			tlsConfig.MinVersion = tls.VersionTLS12
-			tlsConfig.CipherSuites = []uint16{
-				// Drop
-				// - 64-bit block cipher 3DES as it is vulnerable to SWEET32 attack.
-				// - CBC encryption method.
-				// - RSA key exchange.
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			}
-			tlsConfig.NextProtos = []string{"http/1.1"} // CVE-2023-44487
-		} else {
-			klog.Errorf("failed to parse %q", authCAFile)
+	caCertPool := x509.NewCertPool()
+	if caCertPool.AppendCertsFromPEM([]byte(caBundle)) {
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsConfig.ClientCAs = caCertPool
+		// Default minimum version is TLS 1.2, previous versions are insecure and deprecated.
+		tlsConfig.MinVersion = tls.VersionTLS12
+		tlsConfig.CipherSuites = []uint16{
+			// Drop
+			// - 64-bit block cipher 3DES as it is vulnerable to SWEET32 attack.
+			// - CBC encryption method.
+			// - RSA key exchange.
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		}
+		tlsConfig.NextProtos = []string{"http/1.1"} // CVE-2023-44487
 	} else {
-		klog.Errorf("failed to read %q: %v", authCAFile, err)
+		klog.Errorf("failed to parse root certificate bundle of the metrics server, client authentication will be disabled")
 	}
 	if tlsConfig.ClientCAs == nil {
 		klog.Infof("continuing without client authentication")
@@ -128,8 +120,8 @@ func (Server) Start(ctx context.Context) error {
 	return RunServer(MetricsPort, ctx)
 }
 
-// RunServer starts the server, and watches the tlsCert, tlsKey and authCAFile for changes.
-// If a change happens to both tlsCert and tlsKey or authCAFile, the metrics server is rebuilt
+// RunServer starts the server, and watches the tlsCert and tlsKey for changes.
+// If a change happens to both tlsCert and tlsKey, the metrics server is rebuilt
 // and restarted with the current files.  Every non-nil return from this function is fatal
 // and will restart the whole operator.
 func RunServer(port int, ctx context.Context) error {
@@ -140,44 +132,16 @@ func RunServer(port int, ctx context.Context) error {
 	} else {
 		defer watcher.Close()
 
-		// In HyperShift the CA is mounted in
-		if !ntoconfig.InHyperShift() {
-			if err := os.MkdirAll(authCADir, os.ModePerm); err != nil {
-				return fmt.Errorf("failed to create directory %q: %v", authCADir, err)
-			}
-		}
-
-		if err = watcher.Add(authCADir); err != nil {
-			klog.Errorf("failed to add %v to watcher, CA client authentication and rotation will be disabled: %v", authCADir, err)
-		} else {
-			if ok, _ := fileExistsAndNotEmpty(authCAFile); !ok {
-				// authCAFile does not exist (or is empty); wait for it to be created.
-				select {
-				case <-ctx.Done():
-					return nil
-				case event := <-watcher.Events:
-					klog.V(2).Infof("event from filewatcher on file: %v, event: %v", event.Name, event.Op)
-
-					if event.Name == authCAFile {
-						//nolint:staticcheck
-						if ok, _ := fileExistsAndNotEmpty(authCAFile); ok {
-							// authCAFile is now created and is not empty.
-							break
-						}
-					}
-
-				case err = <-watcher.Errors:
-					klog.Warningf("error from metrics server CA client authentication file watcher: %v", err)
-				}
-			}
-		}
-
 		if err = watcher.Add(tlsSecretDir); err != nil {
 			klog.Errorf("failed to add %v to watcher, cert/key rotation will be disabled: %v", tlsSecretDir, err)
 		}
+
+		// Wait for the root certificate bundle of the metrics server for client authentication.
+		// The bundle is sent from a ConfigMap via a channel by the operator.
+		server.caBundle = <-server.caBundleCh
 	}
 
-	srv := buildServer(port)
+	srv := buildServer(port, server.caBundle)
 	if srv == nil {
 		return fmt.Errorf("failed to build server with port %d", port)
 	}
@@ -186,13 +150,15 @@ func RunServer(port int, ctx context.Context) error {
 
 	origCertChecksum := checksumFile(tlsCert)
 	origKeyChecksum := checksumFile(tlsKey)
-	origAuthCAChecksum := checksumFile(authCAFile)
 
 	for {
+		restartServer := false
 		select {
 		case <-ctx.Done():
 			stopServer(srv)
 			return nil
+		case server.caBundle = <-server.caBundleCh:
+			restartServer = true
 		case event := <-watcher.Events:
 			klog.V(2).Infof("event from filewatcher on file: %v, event: %v", event.Name, event.Op)
 
@@ -200,28 +166,30 @@ func RunServer(port int, ctx context.Context) error {
 				continue
 			}
 
-			if certsChanged(origCertChecksum, origKeyChecksum, origAuthCAChecksum) {
+			if certsChanged(origCertChecksum, origKeyChecksum) {
 				// Update file checksums with latest files.
 				origCertChecksum = checksumFile(tlsCert)
 				origKeyChecksum = checksumFile(tlsKey)
-				origAuthCAChecksum = checksumFile(authCAFile)
-
-				// restart server
-				klog.Infof("restarting metrics server to rotate certificates")
-				stopServer(srv)
-				srv = buildServer(port)
-				go startServer(srv)
+				restartServer = true
 			}
 		case err = <-watcher.Errors:
 			klog.Warningf("error from metrics server certificate file watcher: %v", err)
 		}
+
+		if restartServer {
+			// Restart the metrics server.
+			klog.Infof("restarting metrics server to rotate certificates")
+			stopServer(srv)
+			srv = buildServer(port, server.caBundle)
+			go startServer(srv)
+		}
 	}
 }
 
-// Determine if both the server certificate/key or auth CA have changed and need to be updated.
-// Given the server certificate/key and auth CA exist and are non-empty, returns true if
-// both server certificate and key have changed or if auth CA have changed.
-func certsChanged(origCertChecksum []byte, origKeyChecksum []byte, origAuthCAChecksum []byte) bool {
+// Determine if both the server certificate/key have changed and need to be updated.
+// Given the server certificate/key exist and are non-empty, returns true if
+// both server certificate and key have changed.
+func certsChanged(origCertChecksum, origKeyChecksum []byte) bool {
 	// Check if all files exist.
 	certNotEmpty, err := fileExistsAndNotEmpty(tlsCert)
 	if err != nil {
@@ -233,27 +201,20 @@ func certsChanged(origCertChecksum []byte, origKeyChecksum []byte, origAuthCAChe
 		klog.Warningf("error checking if changed TLS key file empty/exists: %v", err)
 		return false
 	}
-	caNotEmpty, err := fileExistsAndNotEmpty(authCAFile)
-	if err != nil {
-		klog.Warningf("error checking if changed auth CA file empty/exists: %v", err)
-		return false
-	}
 
-	if !certNotEmpty || !keyNotEmpty || !caNotEmpty {
+	if !certNotEmpty || !keyNotEmpty {
 		// One of the files is missing despite some file event.
-		klog.V(1).Infof("certificate, key or auth CA is missing or empty, certificates will not be rotated")
+		klog.V(1).Infof("certificate or key is missing or empty, certificates will not be rotated")
 		return false
 	}
 	currentCertChecksum := checksumFile(tlsCert)
 	currentKeyChecksum := checksumFile(tlsKey)
-	currentAuthCAChecksum := checksumFile(authCAFile)
 
-	klog.V(2).Infof("certificate checksums before: %x, %x, %x. checksums after: %x, %x, %x",
-		origCertChecksum, origKeyChecksum, origAuthCAChecksum, currentCertChecksum, currentKeyChecksum, currentAuthCAChecksum)
-	// Check if the non-empty certificate/key or auth CA files have actually changed.
-	if !bytes.Equal(origCertChecksum, currentCertChecksum) && !bytes.Equal(origKeyChecksum, currentKeyChecksum) ||
-		!bytes.Equal(origAuthCAChecksum, currentAuthCAChecksum) {
-		klog.Infof("cert and key or auth CA changed, need to restart the metrics server")
+	klog.V(2).Infof("certificate checksums before: %x, %x. checksums after: %x, %x",
+		origCertChecksum, origKeyChecksum, currentCertChecksum, currentKeyChecksum)
+	// Check if the non-empty certificate/key files have actually changed.
+	if !bytes.Equal(origCertChecksum, currentCertChecksum) && !bytes.Equal(origKeyChecksum, currentKeyChecksum) {
+		klog.Infof("cert and key changed, need to restart the metrics server")
 		return true
 	}
 

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -320,7 +320,8 @@ func (c *Controller) sync(key wqKey) error {
 			return fmt.Errorf("failed to find key %s in ConfigMap %s/%s", metrics.AuthConfigMapClientCAKey, metrics.AuthConfigMapNamespace, metrics.AuthConfigMapName)
 		}
 
-		return metrics.DumpCA(ca)
+		metrics.DumpCA(ca)
+		return nil
 
 	case key.kind == wqKindConfigMap:
 		// This should only happen in HyperShift


### PR DESCRIPTION
Stop writing root certificate bundle of the metrics server for client authentication to /tmp.  There are two reasons for this.  Firstly, it is racy and it could cause the operator to temporarily start without client authentication.  Secondly, it prevents us from making the operator more secure by setting its container securityContext.readOnlyRootFilesystem=true.

Resolves: OCPBUGS-34917