### PR TITLE
CNF-13014: Add cross compiling support to Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
+
+ARG GOARCH
+
 RUN make update-tuned-submodule
 RUN make build
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -54,7 +54,7 @@ We recommend running some e2e tests to verify the custom image works as expected
 
 By default the build will compile using the architecture the system is currently using.
 
-You can specifying a cross compiling architecture by setting `GOARCH` in your environment:
+You can specify a cross compiling architecture by setting `GOARCH` in your environment:
 
 ```bash
 GOARCH='arm64' make build

--- a/HACKING.md
+++ b/HACKING.md
@@ -49,3 +49,13 @@ can automate this for you:
 It is also possible to opt for a specific revision of [TuneD](https://github.com/redhat-performance/tuned) by specifying: `TUNED_COMMIT=commit-hash`
 
 We recommend running some e2e tests to verify the custom image works as expected.
+
+# Cross Compiling
+
+By default the build will compile using the architecture the system is currently using.
+
+You can specifying a cross compiling architecture by setting `GOARCH` in your environment:
+
+```bash
+GOARCH='arm64' make build
+```

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,20 @@ PACKAGE_MAIN=$(PACKAGE)/cmd/$(PACKAGE_BIN)
 
 # By default we build the same architecture we are running
 # Override this by specifying a different GOARCH in your environment
-GOARCH?=$(shell /bin/bash -c "podman version --format '{{ .Client.OsArch }}' | grep -o '[^/]*$$'")
+HOST_ARCH ?= $(shell uname -m)
+
+# Convert from uname format to GOARCH format
+ifeq ($(HOST_ARCH),aarch64)
+	HOST_ARCH=arm64
+endif
+ifeq ($(HOST_ARCH),x86_64)
+	HOST_ARCH=amd64
+endif
+
+# Define GOARCH as HOST_ARCH if not otherwise defined
+ifndef GOARCH
+	GOARCH=$(HOST_ARCH)
+endif
 
 # Build-specific variables
 OUT_DIR=_output
@@ -28,7 +41,7 @@ API_GO_HEADER_FILE:=$(API_TYPES_DIR)/header.go.txt
 CONTROLLER_GEN_VERSION :=v0.6.0
 
 # Container image-related variables
-IMAGE_BUILD_CMD?=podman build --no-cache --arch=$(GOARCH)
+IMAGE_BUILD_CMD?=podman build --no-cache --arch=$(GOARCH) --build-arg GOARCH=$(GOARCH)
 IMAGE_PUSH_CMD=podman push
 DOCKERFILE?=Dockerfile
 REGISTRY?=quay.io


### PR DESCRIPTION
- Makefile will now use the value from GOARCH to set the target architecture
- If not specified then it will use the architecture of the running system
- Add relevant documentation to HACKING