### PR TITLE
PSAP-1428: Read-only filesystem for the operator

### DIFF
--- a/manifests/50-operator-ibm-cloud-managed.yaml
+++ b/manifests/50-operator-ibm-cloud-managed.yaml
@@ -51,6 +51,8 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/secrets

--- a/manifests/50-operator.yaml
+++ b/manifests/50-operator.yaml
@@ -71,6 +71,8 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            readOnlyRootFilesystem: true
           volumeMounts:
             # Certificates and keys for node-tuning-operator.openshift-cluster-node-tuning-operator.svc
             - name: node-tuning-operator-tls


### PR DESCRIPTION
This change switches the operator's `securityContext.readOnlyRootFilesystem` to `true`.  This is in line with the OCP's Control Plane required privileges policy,