### PR TITLE
CNF-13014: Allow specifying $TAG separately from the full image path

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -59,3 +59,11 @@ You can specify a cross compiling architecture by setting `GOARCH` in your envir
 ```bash
 GOARCH='arm64' make build
 ```
+
+# Local build failed with error 125: invalid reference format
+
+By default the image tag is generated using the name of the local git branch. This behaviour will cause error 125 if you have a special character in your local git branch name. You should specify a tag manually instead:
+
+```bash
+TAG=my-custom-tag make local-image
+```

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ IMAGE_PUSH_CMD=podman push
 DOCKERFILE?=Dockerfile
 REGISTRY?=quay.io
 ORG?=openshift
-TAG=$(shell git rev-parse --abbrev-ref HEAD)
+TAG?=$(shell git rev-parse --abbrev-ref HEAD)
 IMAGE?=$(REGISTRY)/$(ORG)/origin-cluster-node-tuning-operator:$(TAG)
 
 # PAO variables

--- a/hack/deploy-custom-nto.sh
+++ b/hack/deploy-custom-nto.sh
@@ -15,7 +15,7 @@ WORKDIR=$(dirname "$(realpath "$0")")/..
 # do not use this script.
 
 ORG=${ORG:-openshift}	# At a minimum, you'll probably want to override this variable.
-TAG=$(git rev-parse --abbrev-ref HEAD)
+TAG=${TAG:-$(git rev-parse --abbrev-ref HEAD)}  # You may need to override this if your git branch contains special characters
 IMAGE=quay.io/${ORG}/origin-cluster-node-tuning-operator:$TAG
 
 nto_prepare_image() {


### PR DESCRIPTION
- Since $TAG by default is using the local git branch name, this can cause problems if special characters (notably '/') are used
- Add section to HACKING.md about the potential error