### PR TITLE
CNF-13014:  Add a specific error message for when the TuneD submodule folder is not initialized

### DIFF
--- a/hack/dockerfile_install_support.sh
+++ b/hack/dockerfile_install_support.sh
@@ -9,6 +9,12 @@ INSTALL_PKGS="nmap-ncat procps-ng pciutils"
 cp -r /root/assets/bin/* /usr/local/bin
 mkdir -p /etc/grub.d/ /boot /run/ocp-tuned
 
+# Verify TuneD submodule is not empty
+if [[ -z $(ls /root/assets/tuned/tuned) ]]; then
+    echo "TuneD submodule is an empty folder. Consider initializing the module: 'git submodule update --init --recursive'"
+    exit 1
+fi
+
 source /etc/os-release
 if [[ "${ID}" == "centos" ]]; then
 


### PR DESCRIPTION
- If you did not checkout the git repo using `--recursive` then the tuned submodule folder will be empty
- Without a specific error message it would instead return a vague error that a patch failed to be applied
- Instead we will check explicitly if the folder is empty and return a more helpful error message in these cases
