### PR TITLE
OCPBUGS-39333:  E2E: Add support for hypershift to  ovs dynamic pinning and kubelet.experimental annotation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ pao-functests-mixedcpus: $(BINDATA)
 pao-functests-hypershift: $(BINDATA)
 	@echo "Cluster Version"
 	hack/show-cluster-version.sh
-	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/1_performance ./test/e2e/performanceprofile/functests/3_performance_status ./test/e2e/performanceprofile/functests/6_mustgather_testing" -p "-vv --label-filter="!openshift" -r --fail-fast --flake-attempts=2 --timeout=2h --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
+	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/1_performance ./test/e2e/performanceprofile/functests/3_performance_status ./test/e2e/performanceprofile/functests/6_mustgather_testing ./test/e2e/performanceprofile/functests/7_performance_kubelet_node" -p "-vv --label-filter="!openshift" -r --fail-fast --flake-attempts=2 --timeout=2h --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
 
 .PHONY: cluster-clean-pao
 cluster-clean-pao:

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
@@ -173,7 +173,7 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, Label(string(lab
 				profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 				By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-				profilesupdate.PostUpdateSync(ctx, profile)
+				profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 				By("Checking Activation file")
 				cmd := []string{"ls", activation_file}
@@ -197,7 +197,7 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, Label(string(lab
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 				}
 			})
 		})
@@ -507,7 +507,7 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, Label(string(lab
 				profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 				By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-				profilesupdate.PostUpdateSync(ctx, profile)
+				profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 				// After reboot we want the deployment to be ready before moving forward
 				desiredStatus := appsv1.DeploymentStatus{
@@ -695,7 +695,7 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, Label(string(lab
 					profilesupdate.WaitForTuningUpdating(ctx, initialProfile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, initialProfile)
+					profilesupdate.WaitForTuningUpdated(ctx, initialProfile)
 				}
 			})
 		})

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
@@ -80,7 +80,7 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 			profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 			By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-			profilesupdate.PostUpdateSync(ctx, profile)
+			profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 			for _, node := range workerRTNodes {
 				kubeletConfig, err := nodes.GetKubeletConfig(context.TODO(), &node)
@@ -110,7 +110,7 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 				profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 				By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-				profilesupdate.PostUpdateSync(ctx, profile)
+				profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 				for _, node := range workerRTNodes {
 					kubeletConfig, err := nodes.GetKubeletConfig(context.TODO(), &node)
@@ -134,7 +134,7 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 			profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 			By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-			profilesupdate.PostUpdateSync(ctx, profile)
+			profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 			var kubeletConfig machineconfigv1.KubeletConfig
 
@@ -192,7 +192,7 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 				profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 				By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-				profilesupdate.PostUpdateSync(ctx, profile)
+				profilesupdate.WaitForTuningUpdated(ctx, profile)
 			}
 			for _, node := range workerRTNodes {
 				kubeletConfig, err := nodes.GetKubeletConfig(context.TODO(), &node)
@@ -235,7 +235,7 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 				profilesupdate.WaitForTuningUpdating(ctx, initialProfile)
 
 				By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-				profilesupdate.PostUpdateSync(ctx, initialProfile)
+				profilesupdate.WaitForTuningUpdated(ctx, initialProfile)
 
 			}
 		})

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/test_suite_performance_kubelet_node_test.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/test_suite_performance_kubelet_node_test.go
@@ -31,7 +31,7 @@ import (
 var _ = BeforeSuite(func() {
 	Expect(testclient.ClientsEnabled).To(BeTrue())
 	// create test namespace
-	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
+	err := testclient.ControlPlaneClient.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {
 		testlog.Warning("test namespace already exists, that is unexpected")
 		return
@@ -40,7 +40,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	err := testclient.Client.Delete(context.TODO(), namespaces.TestingNamespace)
+	err := testclient.ControlPlaneClient.Delete(context.TODO(), namespaces.TestingNamespace)
 	Expect(err).ToNot(HaveOccurred())
 	err = namespaces.WaitForDeletion(testutils.NamespaceTesting, 5*time.Minute)
 	nodeinspector.Delete(context.TODO())

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/test_suite_performance_kubelet_node_test.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/test_suite_performance_kubelet_node_test.go
@@ -31,7 +31,7 @@ import (
 var _ = BeforeSuite(func() {
 	Expect(testclient.ClientsEnabled).To(BeTrue())
 	// create test namespace
-	err := testclient.ControlPlaneClient.Create(context.TODO(), namespaces.TestingNamespace)
+	err := testclient.DataPlaneClient.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {
 		testlog.Warning("test namespace already exists, that is unexpected")
 		return
@@ -40,7 +40,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	err := testclient.ControlPlaneClient.Delete(context.TODO(), namespaces.TestingNamespace)
+	err := testclient.DataPlaneClient.Delete(context.TODO(), namespaces.TestingNamespace)
 	Expect(err).ToNot(HaveOccurred())
 	err = namespaces.WaitForDeletion(testutils.NamespaceTesting, 5*time.Minute)
 	nodeinspector.Delete(context.TODO())


### PR DESCRIPTION
- use appropriate resource pool  nodepools for hypershift and mcp for regular cluster 
-  replace dataplane test client instead of generic testclient.Client