### PR TITLE
OCPBUGS-41487: E2E: Add hypershift support to workloadhints testsuite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ pao-functests-mixedcpus: $(BINDATA)
 pao-functests-hypershift: $(BINDATA)
 	@echo "Cluster Version"
 	hack/show-cluster-version.sh
-	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/1_performance ./test/e2e/performanceprofile/functests/3_performance_status ./test/e2e/performanceprofile/functests/6_mustgather_testing ./test/e2e/performanceprofile/functests/7_performance_kubelet_node" -p "-vv --label-filter="!openshift" -r --fail-fast --flake-attempts=2 --timeout=2h --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
+	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/1_performance ./test/e2e/performanceprofile/functests/3_performance_status ./test/e2e/performanceprofile/functests/6_mustgather_testing ./test/e2e/performanceprofile/functests/7_performance_kubelet_node ./test/e2e/performanceprofile/functests/8_performance_workloadhints/" -p "-vv --label-filter="!openshift" -r --fail-fast --flake-attempts=2 --timeout=2h --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
 
 .PHONY: cluster-clean-pao
 cluster-clean-pao:

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ pao-functests-mixedcpus: $(BINDATA)
 pao-functests-hypershift: $(BINDATA)
 	@echo "Cluster Version"
 	hack/show-cluster-version.sh
-	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/1_performance ./test/e2e/performanceprofile/functests/3_performance_status ./test/e2e/performanceprofile/functests/6_mustgather_testing ./test/e2e/performanceprofile/functests/7_performance_kubelet_node ./test/e2e/performanceprofile/functests/8_performance_workloadhints/" -p "-vv --label-filter="!openshift" -r --fail-fast --flake-attempts=2 --timeout=2h --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
+	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/1_performance ./test/e2e/performanceprofile/functests/3_performance_status ./test/e2e/performanceprofile/functests/6_mustgather_testing ./test/e2e/performanceprofile/functests/7_performance_kubelet_node ./test/e2e/performanceprofile/functests/8_performance_workloadhints/" -p "-vv -r --label-filter=!(openshift||slow) --fail-fast --flake-attempts=2 --timeout=4h --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
 
 .PHONY: cluster-clean-pao
 cluster-clean-pao:

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/test_suite_performance_workloadhints_test.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/test_suite_performance_workloadhints_test.go
@@ -30,7 +30,7 @@ import (
 
 var _ = BeforeSuite(func() {
 	// create test namespace
-	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
+	err := testclient.DataPlaneClient.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {
 		testlog.Warning("test namespace already exists, that is unexpected")
 		return
@@ -39,7 +39,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	err := testclient.Client.Delete(context.TODO(), namespaces.TestingNamespace)
+	err := testclient.DataPlaneClient.Delete(context.TODO(), namespaces.TestingNamespace)
 	Expect(err).ToNot(HaveOccurred())
 	err = namespaces.WaitForDeletion(testutils.NamespaceTesting, 5*time.Minute)
 	nodeinspector.Delete(context.TODO())

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -90,22 +90,24 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 		})
 		When("workloadHint RealTime is disabled", func() {
 			It("should update kernel arguments and tuned accordingly to realTime Hint enabled by default", func() {
+				currentWorkloadHints := profile.Spec.WorkloadHints
 				By("Modifying profile")
 				profile.Spec.WorkloadHints = nil
 
 				profile.Spec.RealTimeKernel = &performancev2.RealTimeKernel{
 					Enabled: pointer.Bool(false),
 				}
+				// If current workload hints already contains the changes skip updating
+				if !(cmp.Equal(currentWorkloadHints, profile.Spec.WorkloadHints)) {
+					By("Updating the performance profile")
+					profiles.UpdateWithRetry(profile)
 
-				By("Updating the performance profile")
-				profiles.UpdateWithRetry(profile)
+					testlog.Infof("Applying changes in performance profile and waiting until %s will start updating", resourcePool)
+					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
-				testlog.Infof("Applying changes in performance profile and waiting until %s will start updating", resourcePool)
-				profilesupdate.WaitForTuningUpdating(ctx, profile)
-
-				testlog.Infof("Waiting when %s finishes updates", resourcePool)
-				profilesupdate.PostUpdateSync(ctx, profile)
-
+					testlog.Infof("Waiting when %s finishes updates", resourcePool)
+					profilesupdate.PostUpdateSync(ctx, profile)
+				}
 				stalldEnabled, rtKernel := true, false
 				noHzParam := fmt.Sprintf("nohz_full=%s", *profile.Spec.CPU.Isolated)
 				sysctlMap := map[string]string{
@@ -145,6 +147,8 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 
 		When("RealTime Workload with RealTime Kernel set to false", func() {
 			It("[test_id:50991][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", func() {
+
+				currentWorkloadHints := profile.Spec.WorkloadHints
 				By("Modifying profile")
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
 					HighPowerConsumption: pointer.Bool(false),
@@ -154,15 +158,17 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					Enabled: pointer.Bool(false),
 				}
 
-				By("Updating the performance profile")
-				profiles.UpdateWithRetry(profile)
+				// If current workload hints already contains the changes skip updating
+				if !(cmp.Equal(currentWorkloadHints, profile.Spec.WorkloadHints)) {
+					By("Updating the performance profile")
+					profiles.UpdateWithRetry(profile)
 
-				testlog.Infof("Applying changes in performance profile and waiting until %s will start updating", resourcePool)
-				profilesupdate.WaitForTuningUpdating(ctx, profile)
+					testlog.Infof("Applying changes in performance profile and waiting until %s will start updating", resourcePool)
+					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
-				testlog.Infof("Waiting when %s finishes updates", resourcePool)
-				profilesupdate.WaitForTuningUpdated(ctx, profile)
-
+					testlog.Infof("Waiting when %s finishes updates", resourcePool)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
+				}
 				stalldEnabled, rtKernel := true, false
 				noHzParam := fmt.Sprintf("nohz_full=%s", *profile.Spec.CPU.Isolated)
 				sysctlMap := map[string]string{
@@ -201,6 +207,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 		})
 		When("HighPower Consumption workload enabled", func() {
 			It("[test_id:50992][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", func() {
+				currentWorkloadHints := profile.Spec.WorkloadHints
 				By("Modifying profile")
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
 					HighPowerConsumption: pointer.Bool(true),
@@ -211,15 +218,17 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					Enabled: pointer.Bool(false),
 				}
 
-				By("Updating the performance profile")
-				profiles.UpdateWithRetry(profile)
+				// If current workload hints already contains the changes skip updating
+				if !(cmp.Equal(currentWorkloadHints, profile.Spec.WorkloadHints)) {
+					By("Updating the performance profile")
+					profiles.UpdateWithRetry(profile)
 
-				testlog.Infof("Applying changes in performance profile and waiting until %s will start updating", resourcePool)
-				profilesupdate.WaitForTuningUpdating(ctx, profile)
+					testlog.Infof("Applying changes in performance profile and waiting until %s will start updating", resourcePool)
+					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
-				testlog.Infof("Waiting when %s finishes updates", resourcePool)
-				profilesupdate.WaitForTuningUpdated(ctx, profile)
-
+					testlog.Infof("Waiting when %s finishes updates", resourcePool)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
+				}
 				stalldEnabled, rtKernel := false, false
 				sysctlMap := map[string]string{
 					"kernel.hung_task_timeout_secs": "600",

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -107,7 +107,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 				}
 				stalldEnabled, rtKernel := true, false
 				noHzParam := fmt.Sprintf("nohz_full=%s", *profile.Spec.CPU.Isolated)
@@ -168,7 +168,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 				}
 				stalldEnabled, rtKernel := true, false
 				noHzParam := fmt.Sprintf("nohz_full=%s", *profile.Spec.CPU.Isolated)
@@ -228,7 +228,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 				}
 				stalldEnabled, rtKernel := false, false
 				sysctlMap := map[string]string{
@@ -284,7 +284,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 				}
 				stalldEnabled, rtKernel := true, true
@@ -342,7 +342,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 				}
 
@@ -392,7 +392,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 				}
 				stalldEnabled, rtKernel := true, true
@@ -451,7 +451,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 				By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-				profilesupdate.PostUpdateSync(ctx, profile)
+				profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 				stalldEnabled, rtKernel = true, true
 				noHzParam = fmt.Sprintf("nohz_full=%s", *profile.Spec.CPU.Isolated)
@@ -515,7 +515,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 				}
 				stalldEnabled, rtKernel := true, true
 				noHzParam := fmt.Sprintf("nohz_full=%s", *profile.Spec.CPU.Isolated)
@@ -570,7 +570,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 				By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-				profilesupdate.PostUpdateSync(ctx, profile)
+				profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 				stalldEnabled, rtKernel = true, true
 				noHzParam = fmt.Sprintf("nohz_full=%s", *profile.Spec.CPU.Isolated)
@@ -647,7 +647,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 				}
 
@@ -751,7 +751,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					profilesupdate.WaitForTuningUpdating(ctx, profile)
 
 					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.PostUpdateSync(ctx, profile)
+					profilesupdate.WaitForTuningUpdated(ctx, profile)
 				}
 				annotations := map[string]string{
 					"cpu-load-balancing.crio.io": "disable",
@@ -847,7 +847,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 			profilesupdate.WaitForTuningUpdating(ctx, initialProfile)
 
 			By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-			profilesupdate.PostUpdateSync(ctx, profile)
+			profilesupdate.WaitForTuningUpdated(ctx, profile)
 
 		})
 	})

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -617,7 +617,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					RealTime:              pointer.Bool(true),
 				}
 				EventuallyWithOffset(1, func() string {
-					err := testclient.DataPlaneClient.Update(context.TODO(), profile)
+					err := testclient.ControlPlaneClient.Update(context.TODO(), profile)
 					if err != nil {
 						statusErr, _ := err.(*errors.StatusError)
 						return statusErr.Status().Message

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -90,7 +90,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 			initialProfile = profile.DeepCopy()
 		})
 		When("workloadHint RealTime is disabled", func() {
-			It("should update kernel arguments and tuned accordingly to realTime Hint enabled by default", func() {
+			It("should update kernel arguments and tuned accordingly to realTime Hint enabled by default", Label(string(label.Slow)), func() {
 				currentWorkloadHints := profile.Spec.WorkloadHints
 				By("Modifying profile")
 				profile.Spec.WorkloadHints = nil
@@ -147,7 +147,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 		})
 
 		When("RealTime Workload with RealTime Kernel set to false", func() {
-			It("[test_id:50991][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", func() {
+			It("[test_id:50991][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", Label(string(label.Slow)), func() {
 
 				currentWorkloadHints := profile.Spec.WorkloadHints
 				By("Modifying profile")
@@ -207,7 +207,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 			})
 		})
 		When("HighPower Consumption workload enabled", func() {
-			It("[test_id:50992][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", func() {
+			It("[test_id:50992][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", Label(string(label.Slow)), func() {
 				currentWorkloadHints := profile.Spec.WorkloadHints
 				By("Modifying profile")
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
@@ -267,7 +267,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 		})
 
 		When("realtime and high power consumption enabled", func() {
-			It("[test_id:50993][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", func() {
+			It("[test_id:50993][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", Label(string(label.Slow)), func() {
 				currentWorkloadHints := profile.Spec.WorkloadHints
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
 					HighPowerConsumption:  pointer.Bool(true),
@@ -327,7 +327,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 		})
 
 		When("perPodPowerManagent enabled", func() {
-			It("[test_id:54177]should update kernel arguments and tuned accordingly", func() {
+			It("[test_id:54177]should update kernel arguments and tuned accordingly", Label(string(label.Slow)), func() {
 				currentWorkloadHints := profile.Spec.WorkloadHints
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
 					PerPodPowerManagement: pointer.Bool(true),
@@ -366,7 +366,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				Expect(cpuSection.Key("enabled").String()).To(Equal("false"))
 			})
 
-			It("[test_id:54178]Verify System is tuned when updating from HighPowerConsumption to PerPodPowermanagment", func() {
+			It("[test_id:54178]Verify System is tuned when updating from HighPowerConsumption to PerPodPowermanagment", Label(string(label.Slow)), func() {
 
 				// This test requires real hardware with powermanagement settings done on BIOS
 				// Using numa nodes to check if we are running on real hardware.
@@ -489,7 +489,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				wg.Wait()
 			})
 
-			It("[test_id:54179]Verify System is tuned when reverting from PerPodPowerManagement to HighPowerConsumption", func() {
+			It("[test_id:54179]Verify System is tuned when reverting from PerPodPowerManagement to HighPowerConsumption", Label(string(label.Slow)), func() {
 
 				// This test requires real hardware with powermanagement settings done on BIOS
 				// Using numa nodes to check if we are running on real hardware.
@@ -610,7 +610,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				wg.Wait()
 			})
 
-			It("[test_id:54184]Verify enabling both HighPowerConsumption and PerPodPowerManagment fails", func() {
+			It("[test_id:54184]Verify enabling both HighPowerConsumption and PerPodPowerManagment fails", Label(string(label.Tier0)), func() {
 
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
 					PerPodPowerManagement: pointer.Bool(true),
@@ -627,7 +627,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				}, time.Minute, 5*time.Second).Should(ContainSubstring("HighPowerConsumption and PerPodPowerManagement can not be both enabled"))
 			})
 
-			It("[test_id:54185] Verify sysfs parameters of guaranteed pod with powersave annotations", func() {
+			It("[test_id:54185] Verify sysfs parameters of guaranteed pod with powersave annotations", Label(string(label.Slow)), func() {
 				var fullPath string
 				var err error
 				// This test requires real hardware with powermanagement settings done on BIOS
@@ -731,7 +731,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:54186] Verify sysfs parameters of guaranteed pod with performance annotiations", func() {
+			It("[test_id:54186] Verify sysfs parameters of guaranteed pod with performance annotiations", Label(string(label.Slow)), func() {
 
 				// This test requires real hardware with powermanagement settings done on BIOS
 				// Using numa nodes to check if we are running on real hardware

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -146,7 +146,6 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 		When("RealTime Workload with RealTime Kernel set to false", func() {
 			It("[test_id:50991][crit:high][vendor:cnf-qe@redhat.com][level:acceptance]should update kernel arguments and tuned accordingly", func() {
 				By("Modifying profile")
-
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
 					HighPowerConsumption: pointer.Bool(false),
 					RealTime:             pointer.Bool(true),
@@ -816,7 +815,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 
 		AfterEach(func() {
 			currentProfile := &performancev2.PerformanceProfile{}
-			if err := testclient.DataPlaneClient.Get(context.TODO(), client.ObjectKeyFromObject(initialProfile), currentProfile); err != nil {
+			if err := testclient.ControlPlaneClient.Get(context.TODO(), client.ObjectKeyFromObject(initialProfile), currentProfile); err != nil {
 				klog.Errorf("failed to get performance profile %q", initialProfile.Name)
 				return
 			}

--- a/test/e2e/performanceprofile/functests/utils/nodepools/nodepools.go
+++ b/test/e2e/performanceprofile/functests/utils/nodepools/nodepools.go
@@ -47,6 +47,22 @@ func waitForCondition(ctx context.Context, c client.Client, NpName, namespace st
 	})
 }
 
+func NodePoolStatusMessages(ctx context.Context, c client.Client, NpName, namespace string, conditionReason string) ([]string, error) {
+	var messages []string
+	condFunc := func(conds []hypershiftv1beta1.NodePoolCondition) bool {
+		for _, cond := range conds {
+			if cond.Reason == conditionReason {
+				messages = append(messages, cond.Message)
+			}
+		}
+		return len(messages) > 0
+	}
+	if err := waitForCondition(ctx, c, NpName, namespace, condFunc); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
 func GetByClusterName(ctx context.Context, c client.Client, hostedClusterName string) (*hypershiftv1beta1.NodePool, error) {
 	npList := &hypershiftv1beta1.NodePoolList{}
 	if err := c.List(ctx, npList); err != nil {


### PR DESCRIPTION
- Changes primarily done to check nodepools instead of mcp for hypershift.
- replace dataplane test client instead of generic testclient.Client