### PR TITLE
OCPBUGS-41995:  Fixing empty tuned submodule when using Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_o
 COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/_output/gather-sysinfo /usr/bin/
 
 ENV ASSETS_DIR=/root/assets
-COPY assets $ASSETS_DIR
+COPY --from=builder /go/src/github.com/openshift/cluster-node-tuning-operator/assets $ASSETS_DIR
 
 COPY hack/dockerfile_install_support.sh /tmp
 RUN /bin/bash /tmp/dockerfile_install_support.sh


### PR DESCRIPTION
Since we are using a multi stage builds in the Dockerfile (2 builds), and we need to use the tuned submodule also in the second layer, we must ensure we copy the directory from the builder image (where we initialize the tuned submodule), to the final image.

This PR eliminates building errors using the `make local-image` target like we had before:

```
+ cd /root/assets/tuned/tuned
+ LC_COLLATE=C
+ cat ../patches/030-no-bootloader-errors.diff
+ patch -Np1
can't find file to patch at input line 10
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|NTO currently supports the bootloader plugin only on RHCOS via the integration
|with MCO.  Disable patching of BLS entries and grub configuration files so
|that error messages from the tuned daemon are eliminated and not reported
|further on in k8s objects.
|
|diff --git a/assets/tuned/daemon/tuned/plugins/plugin_bootloader.py b/assets/tuned/daemon/tuned/plugins/plugin_bootloader.py
|index 416df7d6..b0a61905 100644
|--- a/tuned/plugins/plugin_bootloader.py
|+++ b/tuned/plugins/plugin_bootloader.py
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
3 out of 3 hunks ignored
Error: building at STEP "RUN /bin/bash /tmp/dockerfile_install_support.sh": while running runtime: exit status 1
make: *** [Makefile:175: local-image] Error 1
```