### PR TITLE
NO-JIRA: deferred updates: fix in-place update handling on reboot

### DIFF
--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -357,6 +357,8 @@ func (c *Controller) sync(key wqKeyKube) error {
 		err = util.SetLogLevel(profile.Spec.Config.Verbosity)
 		if err != nil {
 			klog.Errorf("failed to set log level %d: %v", profile.Spec.Config.Verbosity, err)
+		} else {
+			klog.Infof("set log level %d", profile.Spec.Config.Verbosity)
 		}
 		change.reapplySysctl = true
 		if profile.Spec.Config.TuneDConfig.ReapplySysctl != nil {
@@ -1727,7 +1729,7 @@ func RunInCluster(stopCh <-chan struct{}, version string) error {
 	c.daemon.profileFingerprintUnpacked = profileFP
 	// We should *never* recover `c.daemon.recommendedProfile`.
 	// NTO operand supervises the TuneD daemon, so we must trigger
-	// a TuneD restart. Currently, the main trigger for the tuned
+	// a TuneD restart. Currently, the main reason to trigger a tuned
 	// reload to be triggered is when the current recommended profile
 	// is different from the change.recommended profile (see changeSyncerTuneD).
 	// Hence, we MUST NOT recover the recommended profile name

--- a/test/e2e/deferred/non_regression.go
+++ b/test/e2e/deferred/non_regression.go
@@ -51,6 +51,8 @@ var _ = ginkgo.Describe("Profile non-deferred", ginkgo.Label("deferred", "non-re
 				ginkgo.By(fmt.Sprintf("cluster changes rollback: %q", createdTuned))
 				util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", createdTuned)
 			}
+
+			checkWorkerNodeIsDefaultState(context.Background(), targetNode)
 		})
 
 		ginkgo.It("should trigger changes", func(ctx context.Context) {

--- a/test/e2e/deferred/updates.go
+++ b/test/e2e/deferred/updates.go
@@ -74,6 +74,8 @@ var _ = ginkgo.Describe("Profile deferred", ginkgo.Label("deferred", "inplace-up
 				ginkgo.By(fmt.Sprintf("cluster changes rollback: %q", createdTuned))
 				util.ExecAndLogCommand("oc", "delete", "-n", ntoconfig.WatchNamespace(), "-f", createdTuned)
 			}
+
+			checkWorkerNodeIsDefaultState(context.Background(), targetNode)
 		})
 
 		ginkgo.It("should trigger changes when applied fist, then deferred when edited", func(ctx context.Context) {

--- a/test/e2e/testing_manifests/deferred/tuned-basic-00.yaml
+++ b/test/e2e/testing_manifests/deferred/tuned-basic-00.yaml
@@ -20,3 +20,5 @@ spec:
     - label: node-role.kubernetes.io/worker
     priority: 20
     profile: test-shmmni
+    operand:
+      verbosity: 4

--- a/test/e2e/testing_manifests/deferred/tuned-basic-10.yaml
+++ b/test/e2e/testing_manifests/deferred/tuned-basic-10.yaml
@@ -22,3 +22,5 @@ spec:
     - label: node-role.kubernetes.io/worker
     priority: 15
     profile: test-cpu-energy
+    operand:
+      verbosity: 4

--- a/test/e2e/testing_manifests/deferred/tuned-basic-20.yaml
+++ b/test/e2e/testing_manifests/deferred/tuned-basic-20.yaml
@@ -23,3 +23,5 @@ spec:
     - label: node-role.kubernetes.io/worker
     priority: 15
     profile: test-vm-latency
+    operand:
+      verbosity: 4

--- a/test/e2e/testing_manifests/deferred/tuned-basic-updates-00.yaml
+++ b/test/e2e/testing_manifests/deferred/tuned-basic-updates-00.yaml
@@ -21,3 +21,5 @@ spec:
     - label: node-role.kubernetes.io/worker
     priority: 15
     profile: test-vmlat-inplace
+    operand:
+      verbosity: 4

--- a/test/e2e/testing_manifests/deferred/tuned-basic-updates-10.yaml
+++ b/test/e2e/testing_manifests/deferred/tuned-basic-updates-10.yaml
@@ -21,3 +21,5 @@ spec:
     - label: node-role.kubernetes.io/worker
     priority: 15
     profile: test-vmlat-inplace
+    operand:
+      verbosity: 4


### PR DESCRIPTION
There are conditions on which we should not set the reload flag. This avoid regression in the test
"Profile deferred when applied should trigger changes when applied fist, then deferred when edited, if tuned restart should be kept deferred"