### PR TITLE
OCPBUGS-38900: Drop sched_migration_cost_ns setting

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -64,7 +64,6 @@ runtime=0
 group.ksoftirqd=0:f:11:*:ksoftirqd.*
 group.rcuc=0:f:11:*:rcuc.*
 group.ktimers=0:f:11:*:ktimers.*
-sched_migration_cost_ns=5000000
 {{if not .GloballyDisableIrqLoadBalancing}}
 default_irq_smp_affinity = ignore
 irq_process=false

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -525,9 +525,6 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				"vm.dirty_background_ratio": "3",
 				"vm.swappiness":             "10",
 			}
-			schedulerKnobs := map[string]string{
-				"migration_cost_ns": "5000000",
-			}
 			key := types.NamespacedName{
 				Name:      components.GetComponentName(testutils.PerformanceProfileName, components.ProfileNamePerformance),
 				Namespace: components.NamespaceNodeTuningOperator,
@@ -537,7 +534,6 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator object "+components.ProfileNamePerformance)
 			validateTunedActiveProfile(context.TODO(), workerRTNodes)
 			execSysctlOnWorkers(context.TODO(), workerRTNodes, sysctlMap)
-			checkSchedKnobs(context.TODO(), workerRTNodes, schedulerKnobs)
 		})
 	})
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -23,7 +23,7 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
       = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -23,7 +23,7 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
       = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -23,7 +23,7 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
       = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -23,7 +23,7 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
       = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -23,7 +23,7 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
       = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -23,7 +23,7 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
       = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -21,7 +21,7 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
       = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -23,7 +23,7 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
       = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -21,7 +21,7 @@ spec:
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
-      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\nsched_migration_cost_ns=5000000\n\ndefault_irq_smp_affinity
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
       = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
       cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
       cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and


### PR DESCRIPTION
When using a PerformanceProfile, a TuneD scheduler was setting sched_migration_cost_ns.  This setting was previously used by throughput-performance and latency-performance profiles.  However, it was dropped from these profiles based on performance evaluation for RHEL-9 as discussed in rhbz#1957829.

Setting sched_migration_cost_ns causes issues when SecureBoot/kernel_lockdown is in effect.  Do not set this tunable when using PerformanceProfiles.

Resolves: OCPBUGS-38900