### PR TITLE
WIP: One shot tuning must start after irqbalance cleanup

### DIFF
--- a/assets/performanceprofile/configs/ocp-tuned-one-shot.service
+++ b/assets/performanceprofile/configs/ocp-tuned-one-shot.service
@@ -4,6 +4,7 @@ After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.ser
 # Requires is necessary to start this unit before kubelet-dependencies.target
 Requires=kubelet-dependencies.target
 Before=kubelet-dependencies.target
+After=clear-irqbalance-banned-cpus.service
 ConditionPathExists=/var/lib/ocp-tuned/image.env
 
 [Service]


### PR DESCRIPTION
This fixes a potential race condition between the two early services:

- clear-irqbalance-banned-cpus.service
- ocp-tuned-one-shot.service
