### PR TITLE
NO-JIRA: Add a script to test internal TuneD FDP releases

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -54,10 +54,21 @@ We recommend running some e2e tests to verify the custom image works as expected
 
 By default the build will compile using the architecture the system is currently using.
 
-You can specify a cross compiling architecture by setting `GOARCH` in your environment:
+You can specify a cross compiling architecture by setting `GOARCH` in your environment.
+
+For example, to cross-compile for the aarch64 architecture, use the following:
 
 ```bash
-GOARCH='arm64' make build
+GOARCH=arm64 make build
+```
+
+For QEMU user mode emulation, make sure you have the appropriate static binaries installed.  For aarch64 builds above
+on Fedora, the package is qemu-user-static-aarch64.
+
+To cross-compile for x86_64 architecture (e.g. from Apple's M hardware), use the following:
+
+```bash
+GOARCH=amd64 make build
 ```
 
 # Local build failed with error 125: invalid reference format

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ REGISTRY?=quay.io
 ORG?=openshift
 TAG?=$(shell git rev-parse --abbrev-ref HEAD)
 IMAGE?=$(REGISTRY)/$(ORG)/origin-cluster-node-tuning-operator:$(TAG)
+IMAGE_BUILD_EXTRA_OPTS?=
 
 # PAO variables
 CLUSTER ?= "ci"

--- a/hack/deploy-custom-nto.sh
+++ b/hack/deploy-custom-nto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-WORKDIR=$(dirname "$(realpath "$0")")/..
+WORKDIR=$(realpath "${0%/*}/..")
 
 # Example invocation
 # ~~~~~~~~~~~~~~~~~~
@@ -16,7 +16,7 @@ WORKDIR=$(dirname "$(realpath "$0")")/..
 
 ORG=${ORG:-openshift}	# At a minimum, you'll probably want to override this variable.
 TAG=${TAG:-$(git rev-parse --abbrev-ref HEAD)}  # You may need to override this if your git branch contains special characters
-IMAGE=quay.io/${ORG}/origin-cluster-node-tuning-operator:$TAG
+IMAGE=${IMAGE:-quay.io/${ORG}/origin-cluster-node-tuning-operator:$TAG}
 
 nto_prepare_image() {
   make -C $WORKDIR update-tuned-submodule TUNED_COMMIT=${TUNED_COMMIT:-HEAD}

--- a/hack/test-tuned-fdp.sh
+++ b/hack/test-tuned-fdp.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -e
+
+# Example invocation
+# ~~~~~~~~~~~~~~~~~~
+# ORG=quay-user FDP_REPO_BASEURL=fdp-repo-baseurl ./test-tuned-fdp.sh
+#
+# This script assumes a deployed OpenShift cluster and an environment 
+# configured to write the locally built IMAGE to an image repository.
+#
+# Also note the deploy-custom-nto.sh scales down CVO replica to 0 to
+# prevent it from overriding the custom NTO image.  If you wish to
+# upgrade your cluster, do not use this script or revert the change
+# after using it.
+#
+# If you are using this script on a different architecture than x86_64,
+# make sure you target x86_64 architecture by "export GOARCH=amd64"
+# prior to running this script.
+
+WORKDIR=$(realpath "${0%/*}/..")
+CURRENT_SCRIPT=${0##*/}
+REPO_DIR=$(mktemp -d -t "${CURRENT_SCRIPT}XXXX")
+FDP_REPO_BASEURL=${FDP_REPO_BASEURL:-https://brew-task-repos.engineering.redhat.com/repos/official/tuned/2.24.0/1.2.20240819gitc082797f.el9fdp/noarch/}
+RHEL_REPO_COMPOSE=${RHEL_REPO_COMPOSE:-http://download-01.eng.brq.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.4/compose/}
+
+trap cleanup INT TERM EXIT
+
+cleanup()
+{
+  test -d "$REPO_DIR" && rm -rf "$REPO_DIR"
+}
+
+prepare_repo_files() {
+  cat >$REPO_DIR/tuned-fdp.repo<<EOF
+[tuned-fdp]
+name=TuneD FDP repository
+enabled=1
+gpgcheck=0
+baseurl=$FDP_REPO_BASEURL
+module_hotfixes=1
+sslverify=0
+EOF
+
+  # An alternative approach would be to use subscription-manager with either real or testing subscription server.
+  # However, this script is meant for internal use only and using subscription-manager would make things more complicated.
+  cat >$REPO_DIR/rhel-baseos-appstream.repo<<EOF
+[rhel-9-baseos]
+name=rhel-9-baseos
+baseurl=$RHEL_REPO_COMPOSE/BaseOS/\$basearch/os/
+enabled=1
+gpgcheck=0
+
+[rhel-9-appstream]
+name=rhel-9-appstream
+baseurl=$RHEL_REPO_COMPOSE/AppStream/\$basearch/os/
+enabled=1
+gpgcheck=0
+EOF
+}
+
+deploy_custom_nto() {
+  # Prepare Makefile and deploy-custom-nto.sh variables
+  export IMAGE_BUILD_EXTRA_OPTS="-v=$REPO_DIR:/etc/yum.repos.d:z"
+  export DOCKERFILE=Dockerfile.rhel9	# Do not build TuneD from source, use pre-built TuneD RPMs.  These RPMs might contain extra patches which do not ship ustream.
+  export ORG
+
+  $WORKDIR/hack/deploy-custom-nto.sh
+}
+
+nto_run_tuned_tests() {
+  # test-e2e usually take 30min
+  echo "Starting test-e2e"
+  make -C $WORKDIR test-e2e
+
+  CLUSTER=mcp-only make -C $WORKDIR cluster-deploy-pao
+  # e2e-gcp-pao	usually take 40min
+  echo "Starting pao-functests"
+  make -C $WORKDIR pao-functests
+
+  # e2e-gcp-pao-updating-profile usually take 4-5h
+  # echo "Starting e2e-gcp-pao-updating-profile"
+  # make -C $WORKDIR pao-functests-updating-profile
+}
+
+prepare_repo_files
+deploy_custom_nto
+nto_run_tuned_tests

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -652,8 +652,9 @@ func switchTunedHome() error {
 		return fmt.Errorf("failed to create directory %q: %v", ocpTunedHomeHost, err)
 	}
 
-	// Delete the container's home directory.
-	if err := util.Delete(ocpTunedHome); err != nil {
+	// Delete the container's home directory.  We need a recursive delete, because some cross-compiling environments
+	// populate the directory with hidden cache directories.
+	if err := os.RemoveAll(ocpTunedHome); err != nil {
 		return fmt.Errorf("failed to delete: %q: %v", ocpTunedHome, err)
 	}
 


### PR DESCRIPTION
This change adds a script to test internal TuneD FDP releases
`hack/test-tuned-fdp.sh`.  The script builds on top of
`hack/deploy-custom-nto.sh` script, but it makes use of `Dockerfile.rhel9`
versus the default upstream `Dockerfile`.

For detail on how to use it, refer to "Example invocation" section within
the script.  At a minimum, you'll typically want to supply your quay.io
username and baseurl to the TuneD FDP repository.
