### PR TITLE
CNF-14557:hypershift: make target for perf profile update suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,12 @@ pao-functests-update-only: $(BINDATA)
 	hack/show-cluster-version.sh
 	hack/run-test.sh -t "test/e2e/performanceprofile/functests/0_config test/e2e/performanceprofile/functests/2_performance_update test/e2e/performanceprofile/functests/3_performance_status test/e2e/performanceprofile/functests/7_performance_kubelet_node test/e2e/performanceprofile/functests/9_reboot" -p "-v -r --fail-fast --flake-attempts=2 --timeout=5h --junit-report=report.xml" -m "Running Functional Tests"
 
+.PHONY: pao-functests-update-only-hypershift
+pao-functests-update-only-hypershift: $(BINDATA)
+	@echo "Cluster Version"
+	hack/show-cluster-version.sh
+	hack/run-test.sh -t "test/e2e/performanceprofile/functests/0_config" -p "-v -r --fail-fast --flake-attempts=2 --timeout=5h --junit-report=report.xml" -m "Running Functional Tests"
+
 .PHONY: pao-functests-performance-workloadhints
 pao-functests-performance-workloadhints: cluster-label-worker-cnf pao-functests-performance-workloadhints-only
 


### PR DESCRIPTION
This infrastructure is required to run the performance profile update suite on the U/S CI Hypershift lane. Currently, the test execution has been commented out until full support is available.

Needed for: https://github.com/openshift/release/pull/56871