### PR TITLE
NO-JIRA: hypershift:handler: add KubeletConfig unique label

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
@@ -143,7 +143,7 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 	}
 
 	if mcMutated != nil {
-		cm, err := EncapsulateObjInConfigMap(h.scheme, instance, mfs.MachineConfig, profile.Name, hypershiftconsts.ConfigKey, hypershiftconsts.NTOGeneratedMachineConfigLabel)
+		cm, err := EncapsulateObjInConfigMap(h.scheme, instance, mfs.MachineConfig, profile.Name, hypershiftconsts.ConfigKey, map[string]string{hypershiftconsts.NTOGeneratedMachineConfigLabel: "true"})
 		if err != nil {
 			return err
 		}
@@ -154,7 +154,7 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 	}
 
 	if kcMutated != nil {
-		cm, err := EncapsulateObjInConfigMap(h.scheme, instance, mfs.KubeletConfig, profile.Name, hypershiftconsts.ConfigKey, hypershiftconsts.NTOGeneratedMachineConfigLabel)
+		cm, err := EncapsulateObjInConfigMap(h.scheme, instance, mfs.KubeletConfig, profile.Name, hypershiftconsts.ConfigKey, map[string]string{hypershiftconsts.NTOGeneratedMachineConfigLabel: "true"})
 		if err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 	}
 
 	if performanceTunedMutated != nil {
-		cm, err := EncapsulateObjInConfigMap(h.scheme, instance, mfs.Tuned, profile.Name, hypershiftconsts.TuningKey, hypershiftconsts.ControllerGeneratedTunedConfigMapLabel)
+		cm, err := EncapsulateObjInConfigMap(h.scheme, instance, mfs.Tuned, profile.Name, hypershiftconsts.TuningKey, map[string]string{hypershiftconsts.ControllerGeneratedTunedConfigMapLabel: "true"})
 		if err != nil {
 			return err
 		}
@@ -231,7 +231,7 @@ func (h *handler) getContainerRuntimeName(ctx context.Context, profile *performa
 	return ctrcfgs[0].Spec.ContainerRuntimeConfig.DefaultRuntime, nil
 }
 
-func EncapsulateObjInConfigMap(scheme *runtime.Scheme, instance *corev1.ConfigMap, object client.Object, profileName, dataKey, objectLabel string) (*corev1.ConfigMap, error) {
+func EncapsulateObjInConfigMap(scheme *runtime.Scheme, instance *corev1.ConfigMap, object client.Object, profileName, dataKey string, objectLabels map[string]string) (*corev1.ConfigMap, error) {
 	encodedObj, err := hypershift.EncodeManifest(object, scheme)
 	if err != nil {
 		return nil, err
@@ -247,7 +247,9 @@ func EncapsulateObjInConfigMap(scheme *runtime.Scheme, instance *corev1.ConfigMa
 	if err != nil {
 		return nil, err
 	}
-	cm.Labels[objectLabel] = "true"
+	for v, k := range objectLabels {
+		cm.Labels[v] = k
+	}
 	cm.Data = map[string]string{
 		dataKey: string(encodedObj),
 	}

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler.go
@@ -154,7 +154,10 @@ func (h *handler) Apply(ctx context.Context, obj client.Object, recorder record.
 	}
 
 	if kcMutated != nil {
-		cm, err := EncapsulateObjInConfigMap(h.scheme, instance, mfs.KubeletConfig, profile.Name, hypershiftconsts.ConfigKey, map[string]string{hypershiftconsts.NTOGeneratedMachineConfigLabel: "true"})
+		cm, err := EncapsulateObjInConfigMap(h.scheme, instance, mfs.KubeletConfig, profile.Name, hypershiftconsts.ConfigKey, map[string]string{
+			hypershiftconsts.NTOGeneratedMachineConfigLabel: "true",
+			hypershiftconsts.KubeletConfigConfigMapLabel:    "true",
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/components/handler_test.go
@@ -1,0 +1,94 @@
+package components
+
+import (
+	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	hypershiftconsts "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/hypershift/consts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+func TestEncapsulateObjInConfigMap(t *testing.T) {
+	tests := []struct {
+		name            string
+		profileName     string
+		ppConfigMap     *corev1.ConfigMap
+		encapsulatedObj client.Object
+		dataKey         string
+		objectLabels    map[string]string
+	}{
+		{
+			name:        "MachineConfigObject",
+			profileName: "test-1",
+			ppConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pp-test-1",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						hypershiftconsts.NodePoolNameLabel: "np-test-1",
+					},
+				},
+			},
+			encapsulatedObj: &machineconfigv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mc-test-1",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						hypershiftconsts.NodePoolNameLabel: "np-test-1",
+					},
+				},
+			},
+			dataKey: hypershiftconsts.ConfigKey,
+			objectLabels: map[string]string{
+				hypershiftconsts.NTOGeneratedMachineConfigLabel: "true",
+			},
+		},
+		{
+			name:        "KubeletConfigObject",
+			profileName: "test-1",
+			ppConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pp-test-1",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						hypershiftconsts.NodePoolNameLabel: "np-test-1",
+					},
+				},
+			},
+			encapsulatedObj: &machineconfigv1.KubeletConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kc-test-1",
+					Namespace: "test-ns",
+				},
+			},
+			dataKey: hypershiftconsts.ConfigKey,
+			objectLabels: map[string]string{
+				hypershiftconsts.NTOGeneratedMachineConfigLabel: "true",
+				hypershiftconsts.KubeletConfigConfigMapLabel:    "",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Encapsulation of %s", tt.name), func(t *testing.T) {
+			configMap, err := EncapsulateObjInConfigMap(scheme, tt.ppConfigMap, tt.encapsulatedObj, tt.profileName, tt.dataKey, tt.objectLabels)
+			if err != nil {
+				t.Errorf("EncapsulateObjInConfigMap() error = %v", err)
+			}
+			for k := range tt.objectLabels {
+				if _, ok := configMap.Labels[k]; !ok {
+					t.Errorf("EncapsulateObjInConfigMap() missing label %s", k)
+				}
+			}
+		})
+	}
+}

--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/consts/consts.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/consts/consts.go
@@ -24,6 +24,10 @@ const (
 	//to label a ConfigMap that holds encoded performance-profile status object
 	NTOGeneratedPerformanceProfileStatusConfigMapLabel = "hypershift.openshift.io/nto-generated-performance-profile-status"
 
+	// KubeletConfigConfigMapLabel uses
+	// to label a ConfigMap that holds a KubeletConfig object
+	KubeletConfigConfigMapLabel = "hypershift.openshift.io/kubeletconfig-config"
+
 	// TuningKey is the key under ConfigMap.Data on which encoded
 	// tuned and performance-profile objects are stored.
 	TuningKey = "tuning"

--- a/pkg/performanceprofile/controller/performanceprofile_controller_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/tuned"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/hypershift"
 	hcpcomponents "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/hypershift/components"
+	hypershiftconsts "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/hypershift/consts"
 	hcpstatus "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/hypershift/status"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/status"
 	testutils "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/utils/testing"
@@ -1211,13 +1212,13 @@ func adaptObjectsForHypershift(instance client.Object, initObjects ...runtime.Ob
 	for _, obj := range initObjects {
 		switch obj.(type) {
 		case *tunedv1.Tuned:
-			cm, err := hcpcomponents.EncapsulateObjInConfigMap(scheme.Scheme, profileCM, obj.(client.Object), performanceProfileName, "tuning", "hypershift.openshift.io/tuned-config")
+			cm, err := hcpcomponents.EncapsulateObjInConfigMap(scheme.Scheme, profileCM, obj.(client.Object), performanceProfileName, hypershiftconsts.TuningKey, map[string]string{hypershiftconsts.ControllerGeneratedTunedConfigMapLabel: "true"})
 			if err != nil {
 				klog.Fatal(err)
 			}
 			mngClusterObjects = append(mngClusterObjects, cm)
 		case *mcov1.MachineConfig, *mcov1.KubeletConfig:
-			cm, err := hcpcomponents.EncapsulateObjInConfigMap(scheme.Scheme, profileCM, obj.(client.Object), performanceProfileName, "config", "hypershift.openshift.io/nto-generated-machine-config")
+			cm, err := hcpcomponents.EncapsulateObjInConfigMap(scheme.Scheme, profileCM, obj.(client.Object), performanceProfileName, hypershiftconsts.ConfigKey, map[string]string{hypershiftconsts.NTOGeneratedMachineConfigLabel: "true"})
 			if err != nil {
 				klog.Fatal(err)
 			}


### PR DESCRIPTION
According to https://github.com/openshift/enhancements/pull/1671
HyperShift operator will mirror KubeletConfig's ConfigMap to the hosted clusters.

In order to identify the desired ConfigMaps in efficient way,
HyperShift operator lists the ConfigMaps by this unique label.

KubeletConfig's ConfigMap which is generated by NTO should be mirror as well
hence the reason for adding the label.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>