### PR TITLE
Revert "[release-4.17] OCPBUGS-39124: Add cluster-wide proxy env file"

### DIFF
--- a/assets/performanceprofile/configs/ocp-tuned-one-shot.service
+++ b/assets/performanceprofile/configs/ocp-tuned-one-shot.service
@@ -39,7 +39,6 @@ ExecStart=/usr/bin/podman run \
     --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
     $NTO_IMAGE
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=/etc/mco/proxy.env
 EnvironmentFile=-/var/lib/ocp-tuned/image.env
 ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
 ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
@@ -207,7 +207,6 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
-          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
@@ -207,7 +207,6 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
-          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -207,7 +207,6 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
-          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -207,7 +207,6 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
-          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -207,7 +207,6 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
-          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -207,7 +207,6 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
-          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
@@ -209,7 +209,6 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
-          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
@@ -225,7 +225,6 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
-          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
@@ -224,7 +224,6 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
-          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned


### PR DESCRIPTION
Reverts openshift/cluster-node-tuning-operator#1145

/hold

we're testing whether this makes a difference in https://issues.redhat.com/browse/OCPBUGS-42083