### PR TITLE
OCPBUGS-42284: Add cluster-wide proxy env file

### DIFF
--- a/assets/performanceprofile/configs/ocp-tuned-one-shot.service
+++ b/assets/performanceprofile/configs/ocp-tuned-one-shot.service
@@ -39,6 +39,7 @@ ExecStart=/usr/bin/podman run \
     --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
     $NTO_IMAGE
 Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=/etc/mco/proxy.env
 EnvironmentFile=-/var/lib/ocp-tuned/image.env
 ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
 ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
@@ -207,6 +207,7 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
@@ -207,6 +207,7 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -207,6 +207,7 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -207,6 +207,7 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -207,6 +207,7 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -207,6 +207,7 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
@@ -225,6 +225,7 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
@@ -224,6 +224,7 @@ spec:
               --entrypoint '["/usr/bin/cluster-node-tuning-operator","openshift-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
               $NTO_IMAGE
           Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
           EnvironmentFile=-/var/lib/ocp-tuned/image.env
           ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
           ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned


### PR DESCRIPTION
This is a manual backport of https://github.com/openshift/cluster-node-tuning-operator/pull/1166

Add cluster-wide proxy environment file `/etc/mco/proxy.env` to `ocp-tuned-one-shot.service` file.  This allows podman to pull NTO image in environments which need to use http(s) proxy for out-of-cluster connections.

Resolves: OCPBUGS-42284