### PR TITLE
OCPBUGS-42365: E2E: Adjusted mixed_cpus suite for hypershift

### DIFF
--- a/test/e2e/performanceprofile/functests/11_mixedcpus/11_mixedcpus_suite_test.go
+++ b/test/e2e/performanceprofile/functests/11_mixedcpus/11_mixedcpus_suite_test.go
@@ -2,14 +2,20 @@ package __mixedcpus_test
 
 import (
 	"context"
+	"log"
+	"os"
 	"testing"
 
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	nodeinspector "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/node_inspector"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestMixedCPUs(t *testing.T) {
+	ctrllog.SetLogger(stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)))
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Performance Profile Mixed Cpus")
 }


### PR DESCRIPTION
- Performance Profile applying is made consistent with mcp and nodepool based environments
- Removed deprecated API client.
- Added test suite run in makefile