### PR TITLE
NO-JIRA: Fix context deadlines in ExecCommandOnPod()

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -3,7 +3,6 @@ package __performance
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -198,22 +197,6 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 				workqueueWritebackMask := getTrimmedMaskFromData("workqueue", workqueueWritebackMaskData)
 				expectMasksEqual(nonIsolcpusMaskNoDelimiters, workqueueWritebackMask)
-			}
-		})
-
-		It("[test_id:32375][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] initramfs should not have injected configuration", func() {
-			for _, node := range workerRTNodes {
-				// updating the field to 4 as the latest proc/cmdline has been updated to
-				// BOOT_IMAGE=(hd0,gpt3)/boot/ostree/rhcos-<imageid> instead of BOOT_IMAGE=(hd1,gpt3)/ostree/rhcos-<imageId>
-				// TODO: Modify the awk script to be resilent to these changes or check if we can remove it completely
-				rhcosId, err := nodes.ExecCommand(context.TODO(), &node, []string{"awk", "-F", "/", "{printf $4}", "/rootfs/proc/cmdline"})
-				Expect(err).ToNot(HaveOccurred())
-				initramfsImagesPath, err := nodes.ExecCommand(context.TODO(), &node, []string{"find", filepath.Join("/rootfs/boot/ostree", string(rhcosId)), "-name", "*.img"})
-				Expect(err).ToNot(HaveOccurred())
-				modifiedImagePath := strings.TrimPrefix(strings.TrimSpace(string(initramfsImagesPath)), "/rootfs")
-				initrd, err := nodes.ExecCommand(context.TODO(), &node, []string{"chroot", "/rootfs", "lsinitrd", modifiedImagePath})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(initrd)).ShouldNot(ContainSubstring("'/etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf'"))
 			}
 		})
 

--- a/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
+++ b/test/e2e/performanceprofile/functests/utils/nodes/nodes.go
@@ -514,7 +514,7 @@ func ContainerPid(ctx context.Context, node *corev1.Node, containerId string) (s
 	var criInfo CrictlInfo
 	var cridata = []byte{}
 	Eventually(func() []byte {
-		cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs crictl inspect %s", containerId)}
+		cmd := []string{"/usr/sbin/chroot", "/rootfs", "crictl", "inspect", containerId}
 		cridata, err = ExecCommand(ctx, node, cmd)
 		Expect(err).ToNot(HaveOccurred(), "failed to run %s cmd", cmd)
 		return cridata
@@ -530,7 +530,7 @@ func ContainerPid(ctx context.Context, node *corev1.Node, containerId string) (s
 func CpuManagerCpuSet(ctx context.Context, node *corev1.Node) (cpuset.CPUSet, error) {
 	stateFilePath := "/var/lib/kubelet/cpu_manager_state"
 	var stateData CpuManagerStateInfo
-	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs cat %s", stateFilePath)}
+	cmd := []string{"/usr/sbin/chroot", "/rootfs", "cat", stateFilePath}
 	data, err := ExecCommand(ctx, node, cmd)
 	err = json.Unmarshal(data, &stateData)
 	if err != nil {

--- a/test/e2e/performanceprofile/functests/utils/pods/pods.go
+++ b/test/e2e/performanceprofile/functests/utils/pods/pods.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -146,7 +145,7 @@ func ExecCommandOnPod(c *kubernetes.Clientset, pod *corev1.Pod, containerName st
 		VersionedParams(&corev1.PodExecOptions{
 			Container: containerName,
 			Command:   command,
-			Stdin:     true,
+			Stdin:     false,
 			Stdout:    true,
 			Stderr:    true,
 			TTY:       true,
@@ -163,7 +162,6 @@ func ExecCommandOnPod(c *kubernetes.Clientset, pod *corev1.Pod, containerName st
 	}
 
 	err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
-		Stdin:  os.Stdin,
 		Stdout: &outputBuf,
 		Stderr: &errorBuf,
 		Tty:    true,


### PR DESCRIPTION
During testing on x86_64 cluster from an arm64 host, I've
observed strange context deadlines when enabling stdin in
ExecCommandOnPod() function.

Disable stdin as it is not needed during non-interactive tests.

Other changes:
  * Drop obsolete test "test_id:32375".
  * Drop unnecessary "/bin/bash -c" in some tests.
    Further cleanup possible, but it could make code
    slightly less readable, so avoiding it for now.
