### PR TITLE
NO-JIRA: Fix failing pao-functests after a MCO change

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -31,7 +31,6 @@ import (
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/machineconfig"
-	componentprofile "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
 	profileutil "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cgroup"
@@ -578,7 +577,13 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				},
 			}
 
-			machineConfigSelector := componentprofile.GetMachineConfigLabel(secondProfile)
+			// Create LabelSelectorRequirement
+			req := metav1.LabelSelectorRequirement{
+				Key:      components.MachineConfigRoleLabelKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"worker", newRole},
+			}
+
 			secondMCP = &mcov1.MachineConfigPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "second-mcp",
@@ -588,7 +593,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				},
 				Spec: mcov1.MachineConfigPoolSpec{
 					MachineConfigSelector: &metav1.LabelSelector{
-						MatchLabels: machineConfigSelector,
+						MatchExpressions: []metav1.LabelSelectorRequirement{req},
 					},
 					NodeSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{


### PR DESCRIPTION
Recent MCO change https://github.com/openshift/machine-config-operator/pull/4557 enforced custom MCP to have worker label.  This caused an issue with "Create second performance profiles on a cluster" pao-functest. Adjust the tests's MachineConfigPool Spec to use MatchExpressions instead of MatchLabels, so that the new MCO requirement "All custom MachineConfigPools must inherit from the worker pool and must have a machineConfigSelector that matches for a
'machineconfiguration.openshift.io/role: worker' label" is met.