### PR TITLE
OCPBUGS-42492: Make ocp-tuned-one-shot.service restart on-failure

### DIFF
--- a/assets/performanceprofile/configs/ocp-tuned-one-shot.service
+++ b/assets/performanceprofile/configs/ocp-tuned-one-shot.service
@@ -12,8 +12,9 @@ ConditionPathExists=/var/lib/ocp-tuned/image.env
 # is strongly discouraged by "man systemd.service" and results in
 # failed dependency for the kubelet service.
 Type=oneshot
-# Restart=no is the default as of systemd 252, but be explicit.
-Restart=no
+Restart=on-failure
+# Time to wait between restart attempts.
+RestartSec=5s
 ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
 ExecStartPre=/bin/bash -c " \
   mkdir -p /run/tuned "

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_machineconfig.yaml
@@ -180,8 +180,9 @@ spec:
           # is strongly discouraged by "man systemd.service" and results in
           # failed dependency for the kubelet service.
           Type=oneshot
-          # Restart=no is the default as of systemd 252, but be explicit.
-          Restart=no
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
           ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
           ExecStartPre=/bin/bash -c " \
             mkdir -p /run/tuned "

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_machineconfig.yaml
@@ -180,8 +180,9 @@ spec:
           # is strongly discouraged by "man systemd.service" and results in
           # failed dependency for the kubelet service.
           Type=oneshot
-          # Restart=no is the default as of systemd 252, but be explicit.
-          Restart=no
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
           ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
           ExecStartPre=/bin/bash -c " \
             mkdir -p /run/tuned "

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -180,8 +180,9 @@ spec:
           # is strongly discouraged by "man systemd.service" and results in
           # failed dependency for the kubelet service.
           Type=oneshot
-          # Restart=no is the default as of systemd 252, but be explicit.
-          Restart=no
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
           ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
           ExecStartPre=/bin/bash -c " \
             mkdir -p /run/tuned "

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -180,8 +180,9 @@ spec:
           # is strongly discouraged by "man systemd.service" and results in
           # failed dependency for the kubelet service.
           Type=oneshot
-          # Restart=no is the default as of systemd 252, but be explicit.
-          Restart=no
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
           ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
           ExecStartPre=/bin/bash -c " \
             mkdir -p /run/tuned "

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -180,8 +180,9 @@ spec:
           # is strongly discouraged by "man systemd.service" and results in
           # failed dependency for the kubelet service.
           Type=oneshot
-          # Restart=no is the default as of systemd 252, but be explicit.
-          Restart=no
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
           ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
           ExecStartPre=/bin/bash -c " \
             mkdir -p /run/tuned "

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -180,8 +180,9 @@ spec:
           # is strongly discouraged by "man systemd.service" and results in
           # failed dependency for the kubelet service.
           Type=oneshot
-          # Restart=no is the default as of systemd 252, but be explicit.
-          Restart=no
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
           ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
           ExecStartPre=/bin/bash -c " \
             mkdir -p /run/tuned "

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
@@ -182,8 +182,9 @@ spec:
           # is strongly discouraged by "man systemd.service" and results in
           # failed dependency for the kubelet service.
           Type=oneshot
-          # Restart=no is the default as of systemd 252, but be explicit.
-          Restart=no
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
           ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
           ExecStartPre=/bin/bash -c " \
             mkdir -p /run/tuned "

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
@@ -198,8 +198,9 @@ spec:
           # is strongly discouraged by "man systemd.service" and results in
           # failed dependency for the kubelet service.
           Type=oneshot
-          # Restart=no is the default as of systemd 252, but be explicit.
-          Restart=no
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
           ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
           ExecStartPre=/bin/bash -c " \
             mkdir -p /run/tuned "

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
@@ -197,8 +197,9 @@ spec:
           # is strongly discouraged by "man systemd.service" and results in
           # failed dependency for the kubelet service.
           Type=oneshot
-          # Restart=no is the default as of systemd 252, but be explicit.
-          Restart=no
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
           ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
           ExecStartPre=/bin/bash -c " \
             mkdir -p /run/tuned "


### PR DESCRIPTION
There are known podman [issues/races](https://github.com/containers/podman/pull/23524), which may cause "podman run" failures (e.g. OCPBUGS-42492).  While the correct approach is to fix podman and its configuration, this does not prevent against unknown/future podman issues which can easily be resolved by retries.

Add restart on failure for ocp-tuned-one-shot.service and a 5s wait between retries.

Resolves: OCPBUGS-42492