### PR TITLE
NO-JIRA: logs: avoid spamming when PerformanceProfile is missing

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -328,7 +328,7 @@ func (r *PerformanceProfileReconciler) tunedProfileToPerformanceProfileForHypers
 		return nil
 	}
 	if len(cmList.Items) == 0 {
-		klog.Errorf("no performance profile ConfigMap found that matches label %s", hypershiftconsts.NodePoolNameLabel)
+		klog.V(4).InfoS("no performance profile ConfigMap found that matches label", "label", hypershiftconsts.NodePoolNameLabel)
 		return nil
 	}
 	if len(cmList.Items) > 1 {


### PR DESCRIPTION
A case when tuned profile exists, but there's no performance profile, is completely valid state.

We should not log error in that case.
This casues spamming NTO pod's logs.