### PR TITLE
OCPBUGS-43944: E2E: fix modify node selector to use lowercase

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -842,7 +842,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 
 				profile.Name = "without-numa"
 				profile.ResourceVersion = ""
-				profile.Spec.NodeSelector = map[string]string{"withoutNUMA/withoutNUMA": "withoutNUMA"}
+				profile.Spec.NodeSelector = map[string]string{"withoutnuma/withoutnuma": "withoutnuma"}
 				profile.Spec.NUMA = nil
 				profile.Spec.MachineConfigPoolSelector = nil
 				profile.Spec.MachineConfigLabel = nil


### PR DESCRIPTION
When using uppercase characters in node selector field of Performance profile causes validator to
complain about RFC-1123 compliance

Change to lower case characters for node selector map