### PR TITLE
NO-JIRA: Default to username and timestamp for custom NTO push

### DIFF
--- a/hack/deploy-custom-nto.sh
+++ b/hack/deploy-custom-nto.sh
@@ -14,8 +14,8 @@ WORKDIR=$(realpath "${0%/*}/..")
 # overriding the custom NTO image.  If you wish to upgrade your cluster,
 # do not use this script.
 
-ORG=${ORG:-openshift}	# At a minimum, you'll probably want to override this variable.
-TAG=${TAG:-$(git rev-parse --abbrev-ref HEAD)}  # You may need to override this if your git branch contains special characters
+ORG=${ORG:-$USER}	# At a minimum, you'll probably want to override this variable.
+TAG=${TAG:-$(git rev-parse --short HEAD)-$(date +%s)}  # You may need to override this if your git branch contains special characters
 IMAGE=${IMAGE:-quay.io/${ORG}/origin-cluster-node-tuning-operator:$TAG}
 
 nto_prepare_image() {


### PR DESCRIPTION
This improves the hack/deploy-custom-nto.sh script to not require the ORG variable all the time. It defaults to username which users commonly use for their quay.io as well.

The second change makes sure the newly built image has an unique tag formed of short git hash and build timestamp. This helps when systems are configured to use cached images. Each tag is unique and so the cluster will always pull the new build.