### PR TITLE
[release-4.17] OCPBUGS-43664: Add vendor and architecture specific tuning options

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -11,8 +11,8 @@ summary=Openshift node optimized for deterministic performance at the cost of in
 # This has two possible results:
 #     openshift-node,cpu-partitioning
 #     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
-include=openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Vendor ID\:\s*ARM:arm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}-{{.PerformanceProfileName}};
-  openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:}
+include=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:};
+    openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Vendor ID\:\s*ARM:arm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}-{{.PerformanceProfileName}}
 
 # Inheritance of base profiles legend:
 # cpu-partitioning -> network-latency -> latency-performance
@@ -133,6 +133,8 @@ avc_cache_threshold=8192
 {{end}}
 
 [bootloader]
+# !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86
+
 # set empty values to disable RHEL initrd setting in cpu-partitioning
 initrd_remove_dir=
 initrd_dst_img=
@@ -151,7 +153,9 @@ cmdline_isolation=+isolcpus=managed_irq,${isolated_cores}
 {{end}}
 
 {{if .RealTimeHint}}
-cmdline_realtime=+nohz_full=${isolated_cores} nosoftlockup skew_tick=1 rcutree.kthread_prio=11
+cmdline_realtime_nohzfull=+nohz_full=${isolated_cores}
+cmdline_realtime_nosoftlookup=+nosoftlockup
+cmdline_realtime_common=+skew_tick=1 rcutree.kthread_prio=11
 {{end}}
 
 {{if .HighPowerConsumption}}

--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -1,12 +1,18 @@
 [main]
 summary=Openshift node optimized for deterministic performance at the cost of increased power consumption, focused on low latency network performance. Based on Tuned 2.11 and Cluster node tuning (oc 4.5)
 
-# In case real time kernel is enabled the following include section will be evaluated as:
-# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
-# Otherwise:
-# include=openshift-node,cpu-partitioning
-include=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:}
-
+# The final result of the include depends on cpu vendor, cpu architecture, and whether the real time kernel is enabled
+# The first line will be evaluated based on the CPU vendor and architecture
+# This has three possible results:
+#   include=openshift-node-performance-amd-x86;
+#   include=openshift-node-performance-arm-aarch64;
+#   include=openshift-node-performance-intel-x86;
+# The second line will be evaluated based on whether the real time kernel is enabled
+# This has two possible results:
+#     openshift-node,cpu-partitioning
+#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
+include=openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Vendor ID\:\s*ARM:arm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}-{{.PerformanceProfileName}};
+  openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:}
 
 # Inheritance of base profiles legend:
 # cpu-partitioning -> network-latency -> latency-performance
@@ -24,7 +30,6 @@ isolated_cores={{.IsolatedCpus}}
 {{end}}
 
 not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
-automatic_pstate=${f:intel_recommended_pstate}
 
 {{if .PerPodPowerManagement}}
 [cpu]
@@ -134,7 +139,10 @@ initrd_dst_img=
 initrd_add_dir=
 
 # overrides cpu-partitioning cmdline
-cmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded} intel_iommu=on iommu=pt
+cmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+
+# No default value but will be composed conditionally based on platform
+cmdline_iommu=
 
 {{if .StaticIsolation}}
 cmdline_isolation=+isolcpus=domain,managed_irq,${isolated_cores}
@@ -143,30 +151,24 @@ cmdline_isolation=+isolcpus=managed_irq,${isolated_cores}
 {{end}}
 
 {{if .RealTimeHint}}
-cmdline_realtime=+nohz_full=${isolated_cores} tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11
+cmdline_realtime=+nohz_full=${isolated_cores} nosoftlockup skew_tick=1 rcutree.kthread_prio=11
 {{end}}
 
 {{if .HighPowerConsumption}}
-cmdline_power_performance=+processor.max_cstate=1 intel_idle.max_cstate=0
+# No default value but will be composed conditionally based on platform
+cmdline_power_performance=
 {{end}}
 
 {{if and .HighPowerConsumption .RealTimeHint}}
-cmdline_idle_poll=+idle=poll
+# No default value but will be composed conditionally based on platform
+cmdline_idle_poll=
 {{end}}
 
 {{if .DefaultHugepagesSize}}
 cmdline_hugepages=+ default_hugepagesz={{.DefaultHugepagesSize}} {{end}} {{if .Hugepages}} {{.Hugepages}} {{end}}
 
 {{if .AdditionalArgs}}
-cmdline_additionalArg=+{{.AdditionalArgs}} 
-{{end}}
-
-{{if .PerPodPowerManagement}}
-cmdline_pstate=+intel_pstate=passive
-{{else if .HardwareTuning}}
-cmdline_pstate=+intel_pstate=active
-{{else}}
-cmdline_pstate=+intel_pstate=${automatic_pstate}
+cmdline_additionalArg=+{{.AdditionalArgs}}
 {{end}}
 
 [rtentsk]

--- a/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
@@ -1,0 +1,25 @@
+[main]
+summary=Platform specific tuning for AMD x86
+
+[bootloader]
+cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+{{if .PerPodPowerManagement}}
+cmdline_pstate=amd_pstate=passive
+{{else if .HardwareTuning}}
+cmdline_pstate=amd_pstate=active
+{{else}}
+cmdline_pstate=amd_pstate=guided
+{{end}}
+
+{{if .RealTimeHint}}
+cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+{{end}}
+
+{{if .HighPowerConsumption}}
+cmdline_power_performance_amd=processor.max_cstate=1
+{{end}}
+
+{{if and .HighPowerConsumption .RealTimeHint}}
+cmdline_idle_poll_amd=idle=poll
+{{end}}

--- a/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
@@ -2,7 +2,7 @@
 summary=Platform specific tuning for AMD x86
 
 [bootloader]
-cmdline_iommu_amd=amd_iommu=on iommu=pt
+cmdline_iommu_amd=iommu=pt
 
 {{if .PerPodPowerManagement}}
 cmdline_pstate=amd_pstate=passive

--- a/assets/performanceprofile/tuned/openshift-node-performance-arm-aarch64
+++ b/assets/performanceprofile/tuned/openshift-node-performance-arm-aarch64
@@ -1,0 +1,9 @@
+[main]
+summary=Platform specific tuning for aarch64
+
+[bootloader]
+# No cstate for ARM
+# No pstate args for ARM
+
+# aarch64 specific tuning options
+cmdline_iommu_arm=iommu.passthrough=1

--- a/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
@@ -1,0 +1,25 @@
+[main]
+summary=Platform specific tuning for Intel x86
+
+[bootloader]
+cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+{{if .PerPodPowerManagement}}
+cmdline_pstate=intel_pstate=passive
+{{else if .HardwareTuning}}
+cmdline_pstate=intel_pstate=active
+{{else}}
+cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+{{end}}
+
+{{if .RealTimeHint}}
+cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+{{end}}
+
+{{if .HighPowerConsumption}}
+cmdline_power_performance_intel=processor.max_cstate=1 intel_idle.max_cstate=0
+{{end}}
+
+{{if and .HighPowerConsumption .RealTimeHint}}
+cmdline_idle_poll_intel=idle=poll
+{{end}}

--- a/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
@@ -2,18 +2,32 @@
 summary=Platform specific tuning for Intel x86
 
 [bootloader]
+# DO NOT REMOVE THIS BLOCK
+# It makes sure the kernel arguments for Intel are applied
+# in the order compatible with OCP 4.17 which is important
+# for preventing an extra reboot during upgrade
+cmdline_cpu_part=
+cmdline_iommu_intel=
+cmdline_isolation=
+cmdline_realtime_nohzfull=
+cmdline_realtime_intel=
+cmdline_realtime_nosoftlookup=
+cmdline_realtime_intel_nmi=
+cmdline_realtime_common=
+cmdline_power_performance=
+cmdline_power_performance_intel=
+cmdline_idle_poll=
+cmdline_idle_poll_intel=
+cmdline_hugepages=
+cmdline_pstate=
+
+# Here comes the Intel specific tuning
+
 cmdline_iommu_intel=intel_iommu=on iommu=pt
 
-{{if .PerPodPowerManagement}}
-cmdline_pstate=intel_pstate=passive
-{{else if .HardwareTuning}}
-cmdline_pstate=intel_pstate=active
-{{else}}
-cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-{{end}}
-
 {{if .RealTimeHint}}
-cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+cmdline_realtime_intel=tsc=reliable
+cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
 {{end}}
 
 {{if .HighPowerConsumption}}
@@ -23,3 +37,12 @@ cmdline_power_performance_intel=processor.max_cstate=1 intel_idle.max_cstate=0
 {{if and .HighPowerConsumption .RealTimeHint}}
 cmdline_idle_poll_intel=idle=poll
 {{end}}
+
+{{if .PerPodPowerManagement}}
+cmdline_pstate=intel_pstate=passive
+{{else if .HardwareTuning}}
+cmdline_pstate=intel_pstate=active
+{{else}}
+cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+{{end}}
+

--- a/pkg/performanceprofile/controller/performanceprofile/components/consts.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/consts.go
@@ -23,6 +23,12 @@ const (
 	ProfileNamePerformance = "openshift-node-performance"
 	// ProfileNamePerformanceRT defines the performance real time tuned profile name
 	ProfileNamePerformanceRT = "openshift-node-performance-rt"
+	// ProfileNameAmdX86 defines the AMD X86 specific tuning parameters
+	ProfileNameAmdX86 = "openshift-node-performance-amd-x86"
+	// ProfileNameArmAarch64 defines the ARM Aarch64 specific tuning parameters
+	ProfileNameArmAarch64 = "openshift-node-performance-arm-aarch64"
+	// ProfileNameIntelX86 defines the Intel X86 specific tuning parameters
+	ProfileNameIntelX86 = "openshift-node-performance-intel-x86"
 )
 
 const (

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
@@ -214,13 +214,32 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 	if err != nil {
 		return nil, err
 	}
+	name := components.GetComponentName(profile.Name, components.ProfileNamePerformance)
 
 	RealTimeKernelProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNamePerformanceRT), templateArgs)
 	if err != nil {
 		return nil, err
 	}
-	name := components.GetComponentName(profile.Name, components.ProfileNamePerformance)
 	RealTimeKernelProfileName := components.GetComponentName(profile.Name, components.ProfileNamePerformanceRT)
+
+	AmdX86ProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNameAmdX86), templateArgs)
+	if err != nil {
+		return nil, err
+	}
+	AmdX86ProfileName := components.GetComponentName(profile.Name, components.ProfileNameAmdX86)
+
+	ArmAarch64ProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNameArmAarch64), templateArgs)
+	if err != nil {
+		return nil, err
+	}
+	ArmAarch64ProfileName := components.GetComponentName(profile.Name, components.ProfileNameArmAarch64)
+
+	IntelX86ProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNameIntelX86), templateArgs)
+	if err != nil {
+		return nil, err
+	}
+	IntelX86ProfileName := components.GetComponentName(profile.Name, components.ProfileNameIntelX86)
+
 	profiles := []tunedv1.TunedProfile{
 		{
 			Name: &name,
@@ -229,6 +248,18 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 		{
 			Name: &RealTimeKernelProfileName,
 			Data: &RealTimeKernelProfileData,
+		},
+		{
+			Name: &AmdX86ProfileName,
+			Data: &AmdX86ProfileData,
+		},
+		{
+			Name: &ArmAarch64ProfileName,
+			Data: &ArmAarch64ProfileData,
+		},
+		{
+			Name: &IntelX86ProfileName,
+			Data: &IntelX86ProfileData,
 		},
 	}
 

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -23,18 +23,23 @@ const expectedMatchSelector = `
 `
 
 var (
-	cmdlineCPUsPartitioning          = "+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded} intel_iommu=on iommu=pt"
-	cmdlineWithStaticIsolation       = "+isolcpus=domain,managed_irq,${isolated_cores}"
-	cmdlineWithoutStaticIsolation    = "+isolcpus=managed_irq,${isolated_cores}"
-	cmdlineRealtime                  = "+nohz_full=${isolated_cores} tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11"
-	cmdlineHighPowerConsumption      = "+processor.max_cstate=1 intel_idle.max_cstate=0"
-	cmdlineIdlePoll                  = "+idle=poll"
-	cmdlineHugepages                 = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4"
 	cmdlineAdditionalArgs            = "+audit=0 processor.max_cstate=1 idle=poll intel_idle.max_cstate=0"
+	cmdlineAmdHighPowerConsumption   = "processor.max_cstate=1"
+	cmdlineAmdPstateActive           = "amd_pstate=active"
+	cmdlineAmdPstateAutomatic        = "amd_pstate=guided"
+	cmdlineAmdPstatePassive          = "amd_pstate=passive"
+	cmdlineCPUsPartitioning          = "+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}"
 	cmdlineDummy2MHugePages          = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=0"
+	cmdlineHugepages                 = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4"
+	cmdlineIdlePoll                  = "idle=poll"
+	cmdlineIntelHighPowerConsumption = "processor.max_cstate=1 intel_idle.max_cstate=0"
+	cmdlineIntelPstateActive         = "intel_pstate=active"
+	cmdlineIntelPstateAutomatic      = "intel_pstate=${f:intel_recommended_pstate}"
+	cmdlineIntelPstatePassive        = "intel_pstate=passive"
 	cmdlineMultipleHugePages         = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=128"
-	cmdlinePerPodPowerManagementHint = "+intel_pstate=passive"
-	cmdlineAutomaticPstate           = "+intel_pstate=${automatic_pstate}"
+	cmdlineRealtime                  = "+nohz_full=${isolated_cores} nosoftlockup skew_tick=1 rcutree.kthread_prio=11"
+	cmdlineWithoutStaticIsolation    = "+isolcpus=managed_irq,${isolated_cores}"
+	cmdlineWithStaticIsolation       = "+isolcpus=domain,managed_irq,${isolated_cores}"
 )
 
 var _ = Describe("Tuned", func() {
@@ -52,11 +57,29 @@ var _ = Describe("Tuned", func() {
 		return string(y)
 	}
 
-	getTunedStructuredData := func(profile *performancev2.PerformanceProfile) *ini.File {
+	getTunedStructuredData := func(profile *performancev2.PerformanceProfile, profileName string) *ini.File {
 		tuned, err := NewNodePerformance(profile)
 		Expect(err).ToNot(HaveOccurred())
-		tunedData := []byte(*tuned.Spec.Profile[0].Data)
+		var profileIndex int
+		// The index order here should match how they are defined in tuned.go
+		switch profileName {
+		case components.ProfileNamePerformance:
+			profileIndex = 0
+		case components.ProfileNamePerformanceRT:
+			profileIndex = 1
+		case components.ProfileNameAmdX86:
+			profileIndex = 2
+		case components.ProfileNameArmAarch64:
+			profileIndex = 3
+		case components.ProfileNameIntelX86:
+			profileIndex = 4
+		default:
+			profileIndex = 0
+		}
+		tunedData := []byte(*tuned.Spec.Profile[profileIndex].Data)
 		cfg, err := ini.Load(tunedData)
+		print(cfg)
+		print(err)
 		Expect(err).ToNot(HaveOccurred())
 		return cfg
 	}
@@ -64,7 +87,7 @@ var _ = Describe("Tuned", func() {
 	Context("with worker performance profile", func() {
 		It("should generate yaml with expected parameters", func() {
 			manifest := getTunedManifest(profile)
-			tunedData := getTunedStructuredData(profile)
+			tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 			isolated, err := tunedData.GetSection("variables")
 			Expect(err).ToNot(HaveOccurred())
 
@@ -110,7 +133,7 @@ var _ = Describe("Tuned", func() {
 			test_profile.Spec.CPU.Isolated = &isolated_cpus
 			test_profile.Spec.CPU.Reserved = &reserved_cpus
 
-			tunedData := getTunedStructuredData(test_profile)
+			tunedData := getTunedStructuredData(test_profile, components.ProfileNamePerformance)
 			isolated, err := tunedData.GetSection("variables")
 			Expect(err).ToNot(HaveOccurred())
 
@@ -119,7 +142,7 @@ var _ = Describe("Tuned", func() {
 
 		Context("default profile default tuned", func() {
 			It("should [cpu] section in tuned", func() {
-				tunedData := getTunedStructuredData(profile)
+				tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 				cpuSection, err := tunedData.GetSection("cpu")
 				Expect(err).ToNot(HaveOccurred())
 				Expect((cpuSection.Key("force_latency").String())).To(Equal("cstate.id:1|3"))
@@ -132,7 +155,7 @@ var _ = Describe("Tuned", func() {
 		When("realtime hint disabled", func() {
 			It("should not contain realtime related parameters", func() {
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{RealTime: pointer.Bool(false)}
-				tunedData := getTunedStructuredData(profile)
+				tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 				service, err := tunedData.GetSection("service")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(service.Key("service.stalld").String()).To(Equal("stop,disable"))
@@ -155,7 +178,7 @@ var _ = Describe("Tuned", func() {
 		When("realtime hint enabled", func() {
 			It("should contain realtime related parameters", func() {
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{RealTime: pointer.Bool(true)}
-				tunedData := getTunedStructuredData(profile)
+				tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 				service, err := tunedData.GetSection("service")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(service.Key("service.stalld").String()).To(Equal("start,enable"))
@@ -171,13 +194,12 @@ var _ = Describe("Tuned", func() {
 
 		Context("high power consumption hint enabled", func() {
 			When("default realtime workload settings", func() {
-				It("should contain high power consumption related parameters", func() {
+				It("should not contain high power consumption related parameters", func() {
 					profile.Spec.WorkloadHints = &performancev2.WorkloadHints{HighPowerConsumption: pointer.Bool(true)}
-					tunedData := getTunedStructuredData(profile)
+					tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 					bootLoader, err := tunedData.GetSection("bootloader")
 					Expect(err).ToNot(HaveOccurred())
-					Expect(bootLoader.Key("cmdline_power_performance").String()).To(Equal(cmdlineHighPowerConsumption))
-					Expect(bootLoader.Key("cmdline_pstate").String()).To(Equal(cmdlineAutomaticPstate))
+					Expect(bootLoader.Key("cmdline_power_performance").String()).To(Equal(""))
 				})
 			})
 
@@ -187,23 +209,10 @@ var _ = Describe("Tuned", func() {
 						HighPowerConsumption: pointer.Bool(true),
 						RealTime:             pointer.Bool(true),
 					}
-					tunedData := getTunedStructuredData(profile)
+					tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 					bootLoader, err := tunedData.GetSection("bootloader")
 					Expect(err).ToNot(HaveOccurred())
-					Expect(bootLoader.Key("cmdline_idle_poll").String()).To(Equal(cmdlineIdlePoll))
-				})
-			})
-
-			When("realtime workload disabled", func() {
-				It("should contain idle=poll cmdline", func() {
-					profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
-						HighPowerConsumption: pointer.Bool(true),
-						RealTime:             pointer.Bool(false),
-					}
-					tunedData := getTunedStructuredData(profile)
-					bootLoader, err := tunedData.GetSection("bootloader")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(bootLoader.Key("cmdline_idle_poll").String()).ToNot(Equal(cmdlineIdlePoll))
+					Expect(bootLoader.Key("cmdline_idle_poll").String()).To(Equal(""))
 				})
 			})
 
@@ -223,50 +232,43 @@ var _ = Describe("Tuned", func() {
 			It("should not contain perPodPowerManagement related parameters", func() {
 				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(false)
 				profile.Spec.WorkloadHints.RealTime = pointer.Bool(false)
-				tunedData := getTunedStructuredData(profile)
+				tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 				cpuSection, err := tunedData.GetSection("cpu")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cpuSection.Key("enabled").String()).ToNot(Equal("false"))
-				bootLoaderSection, err := tunedData.GetSection("bootloader")
+				_, err = tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bootLoaderSection.Key("cmdline_pstate").String()).ToNot(Equal(cmdlinePerPodPowerManagementHint))
-				Expect(bootLoaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineAutomaticPstate))
-
 			})
 		})
 
 		When("perPodPowerManagement Hint is false realTime Hint true", func() {
-			It("should not contain perPodPowerManagement related parameters but intel_pstate to automatic mode", func() {
+			It("should not contain perPodPowerManagement related parameters", func() {
 				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(false)
 				profile.Spec.WorkloadHints.RealTime = pointer.Bool(true)
-				tunedData := getTunedStructuredData(profile)
+				tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 				cpuSection, err := tunedData.GetSection("cpu")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cpuSection.Key("enabled").String()).ToNot(Equal("false"))
-				bootLoaderSection, err := tunedData.GetSection("bootloader")
+				_, err = tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bootLoaderSection.Key("cmdline_pstate").String()).ToNot(Equal(cmdlinePerPodPowerManagementHint))
-				Expect(bootLoaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineAutomaticPstate))
 			})
 		})
 
 		When("perPodPowerManagement Hint to true", func() {
 			It("should contain perPodPowerManagement related parameters", func() {
 				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(true)
-				tunedData := getTunedStructuredData(profile)
+				tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 				cpuSection, err := tunedData.GetSection("cpu")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cpuSection.Key("enabled").String()).To(Equal("false"))
-				bootLoader, err := tunedData.GetSection("bootloader")
+				_, err = tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bootLoader.Key("cmdline_pstate").String()).To(Equal(cmdlinePerPodPowerManagementHint))
-				Expect(bootLoader.Key("cmdline_pstate").String()).ToNot(Equal(cmdlineAutomaticPstate))
 			})
 		})
 
 		It("should generate yaml with expected parameters for Isolated balancing disabled", func() {
 			profile.Spec.CPU.BalanceIsolated = pointer.Bool(false)
-			tunedData := getTunedStructuredData(profile)
+			tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 			bootLoader, err := tunedData.GetSection("bootloader")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bootLoader.Key("cmdline_isolation").String()).To(Equal(cmdlineWithStaticIsolation))
@@ -274,7 +276,7 @@ var _ = Describe("Tuned", func() {
 
 		It("should generate yaml with expected parameters for Isolated balancing enabled", func() {
 			profile.Spec.CPU.BalanceIsolated = pointer.Bool(true)
-			tunedData := getTunedStructuredData(profile)
+			tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 			bootLoader, err := tunedData.GetSection("bootloader")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bootLoader.Key("cmdline_isolation").String()).To(Equal(cmdlineWithoutStaticIsolation))
@@ -283,7 +285,7 @@ var _ = Describe("Tuned", func() {
 		// This tests checking Additional arguments is an example of how additional kernel args could look like
 		// they have been selected randomly with no concrete purpose
 		It("should contain additional additional parameters", func() {
-			tunedData := getTunedStructuredData(profile)
+			tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 			bootLoader, err := tunedData.GetSection("bootloader")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bootLoader.Key("cmdline_additionalArg").String()).To(Equal(cmdlineAdditionalArgs))
@@ -291,7 +293,7 @@ var _ = Describe("Tuned", func() {
 
 		It("should not contain additional additional parameters", func() {
 			profile.Spec.AdditionalKernelArgs = nil
-			tunedData := getTunedStructuredData(profile)
+			tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 			bootLoader, err := tunedData.GetSection("bootloader")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(bootLoader.Key("cmdline_additionalArg").String()).ToNot(Equal(cmdlineAdditionalArgs))
@@ -317,7 +319,7 @@ var _ = Describe("Tuned", func() {
 						Node:  pointer.Int32(0),
 					})
 
-					tunedData := getTunedStructuredData(profile)
+					tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 					bootLoader, err := tunedData.GetSection("bootloader")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(bootLoader.Key("cmdline_hugepages").String()).To(Equal(cmdlineDummy2MHugePages))
@@ -331,7 +333,7 @@ var _ = Describe("Tuned", func() {
 						Count: 128,
 					})
 
-					tunedData := getTunedStructuredData(profile)
+					tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 					bootLoader, err := tunedData.GetSection("bootloader")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(bootLoader.Key("cmdline_hugepages").String()).ToNot(Equal(cmdlineDummy2MHugePages))
@@ -341,7 +343,7 @@ var _ = Describe("Tuned", func() {
 
 			Context("without requested 2M hugepages", func() {
 				It("should not append dummy 2M huge pages kernel arguments", func() {
-					tunedData := getTunedStructuredData(profile)
+					tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 					bootLoader, err := tunedData.GetSection("bootloader")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(bootLoader.Key("cmdline_hugepages").String()).ToNot(Equal(cmdlineDummy2MHugePages))
@@ -360,7 +362,7 @@ var _ = Describe("Tuned", func() {
 						Count: 128,
 					})
 
-					tunedData := getTunedStructuredData(profile)
+					tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 					bootLoader, err := tunedData.GetSection("bootloader")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(bootLoader.Key("cmdline_hugepages").String()).ToNot(Equal(cmdlineDummy2MHugePages))
@@ -380,7 +382,7 @@ var _ = Describe("Tuned", func() {
 						Node:  pointer.Int32(0),
 					})
 
-					tunedData := getTunedStructuredData(profile)
+					tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 					bootLoader, err := tunedData.GetSection("bootloader")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(bootLoader.Key("cmdline_hugepages").String()).ToNot(Equal(cmdlineDummy2MHugePages))
@@ -539,6 +541,151 @@ var _ = Describe("Tuned", func() {
 					manifest := getTunedManifest(profile)
 					Expect(len(manifest)).ToNot(Equal(0))
 				})
+			})
+		})
+	})
+
+	Context("with amd x86 performance profile", func() {
+		When("perPodPowerManagement Hint is false and realTime hint is false", func() {
+			It("should contain amd_pstate set to automatic", func() {
+				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(false)
+				tunedData := getTunedStructuredData(profile, components.ProfileNameAmdX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineAmdPstateAutomatic))
+			})
+		})
+		When("perPodPowerManagement Hint is false and realTime hint is true", func() {
+			It("should contain amd_pstate set to automatic", func() {
+				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(false)
+				profile.Spec.WorkloadHints.RealTime = pointer.Bool(true)
+				tunedData := getTunedStructuredData(profile, components.ProfileNameAmdX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineAmdPstateAutomatic))
+			})
+		})
+		When("perPodPowerManagement Hint is true", func() {
+			It("should contain amd_pstate set to passive", func() {
+				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(true)
+				tunedData := getTunedStructuredData(profile, components.ProfileNameAmdX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineAmdPstatePassive))
+			})
+		})
+		When("realtime workload enabled and high power consumption is enabled", func() {
+			It("should contain idle=poll cmdline", func() {
+				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
+					HighPowerConsumption: pointer.Bool(true),
+					RealTime:             pointer.Bool(true),
+				}
+				tunedData := getTunedStructuredData(profile, components.ProfileNameAmdX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_idle_poll_amd").String()).To(Equal(cmdlineIdlePoll))
+			})
+		})
+		When("realtime workload disabled and high power consumption is disabled", func() {
+			It("should not contain idle=poll cmdline", func() {
+				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
+					HighPowerConsumption: pointer.Bool(true),
+					RealTime:             pointer.Bool(false),
+				}
+				tunedData := getTunedStructuredData(profile, components.ProfileNameAmdX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_idle_poll_amd").String()).To(Equal(""))
+			})
+		})
+		When("high power consumption is enabled", func() {
+			It("should contain high power consumption related parameters", func() {
+				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{HighPowerConsumption: pointer.Bool(true)}
+				tunedData := getTunedStructuredData(profile, components.ProfileNameAmdX86)
+				bootLoader, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootLoader.Key("cmdline_power_performance_amd").String()).To(Equal(cmdlineAmdHighPowerConsumption))
+			})
+		})
+	})
+
+	Context("with arm aarch64 performance profile", func() {
+		When("regardless of perPodPowerManagement hint", func() {
+			It("should not set pstate", func() {
+				tunedData := getTunedStructuredData(profile, components.ProfileNameArmAarch64)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(""))
+			})
+			It("should set iommu passthrough", func() {
+				tunedData := getTunedStructuredData(profile, components.ProfileNameArmAarch64)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_iommu_arm").String()).To(Equal("iommu.passthrough=1"))
+			})
+		})
+	})
+
+	Context("with intel x86 performance profile", func() {
+		When("perPodPowerManagement Hint is false and realTime hint is false", func() {
+			It("should contain intel_pstate set to automatic", func() {
+				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(false)
+				tunedData := getTunedStructuredData(profile, components.ProfileNameIntelX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineIntelPstateAutomatic))
+			})
+		})
+		When("perPodPowerManagement Hint is false and realTime hint is true", func() {
+			It("should contain intel_pstate set to automatic", func() {
+				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(false)
+				profile.Spec.WorkloadHints.RealTime = pointer.Bool(true)
+				tunedData := getTunedStructuredData(profile, components.ProfileNameIntelX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineIntelPstateAutomatic))
+			})
+		})
+		When("perPodPowerManagement Hint is true", func() {
+			It("should contain intel_pstate set to passive", func() {
+				profile.Spec.WorkloadHints.PerPodPowerManagement = pointer.Bool(true)
+				tunedData := getTunedStructuredData(profile, components.ProfileNameIntelX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_pstate").String()).To(Equal(cmdlineIntelPstatePassive))
+			})
+		})
+		When("realtime workload enabled and high power consumption is enabled", func() {
+			It("should contain idle=poll cmdline", func() {
+				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
+					HighPowerConsumption: pointer.Bool(true),
+					RealTime:             pointer.Bool(true),
+				}
+				tunedData := getTunedStructuredData(profile, components.ProfileNameIntelX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_idle_poll_intel").String()).To(Equal(cmdlineIdlePoll))
+			})
+		})
+		When("realtime workload disabled and high power consumption is disabled", func() {
+			It("should not contain idle=poll cmdline", func() {
+				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
+					HighPowerConsumption: pointer.Bool(true),
+					RealTime:             pointer.Bool(false),
+				}
+				tunedData := getTunedStructuredData(profile, components.ProfileNameIntelX86)
+				bootloaderSection, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloaderSection.Key("cmdline_idle_poll_intel").String()).To(Equal(""))
+			})
+		})
+		When("high power consumption is enabled", func() {
+			It("should contain high power consumption related parameters", func() {
+				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{HighPowerConsumption: pointer.Bool(true)}
+				tunedData := getTunedStructuredData(profile, components.ProfileNameIntelX86)
+				bootLoader, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootLoader.Key("cmdline_power_performance_intel").String()).To(Equal(cmdlineIntelHighPowerConsumption))
 			})
 		})
 	})

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,64 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-master
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,64 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-worker
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,64 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-master
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,64 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-worker
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,64 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-master
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-master
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-master
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,64 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n
-      \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-openshift-bootstrap-worker
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-worker
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-intel-x86-openshift-bootstrap-worker
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -15,9 +15,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -51,13 +51,14 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n[sysfs]\n#
-      sets provided frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
+      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n[sysfs]\n# sets provided
+      frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=active
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-manual

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -8,16 +8,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=2-3\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=2-3\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -46,10 +53,10 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=active\n\n\n[rtentsk]\n\n\n[sysfs]\n#
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n[sysfs]\n#
       sets provided frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
@@ -57,6 +64,55 @@ spec:
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=active
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-manual
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=active
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-intel-x86-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=active

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -70,7 +70,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,12 +53,13 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
+      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -100,17 +101,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-manual

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -10,16 +10,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -48,16 +55,65 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-manual
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-intel-x86-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -68,7 +68,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -15,9 +15,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -51,12 +51,13 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
+      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -98,17 +99,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-manual

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -8,16 +8,23 @@ spec:
   profile:
   - data: "[main]\nsummary=Openshift node optimized for deterministic performance
       at the cost of increased power consumption, focused on low latency network performance.
-      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# In case real time
-      kernel is enabled the following include section will be evaluated as:\n# include=openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\n# Otherwise:\n# include=openshift-node,cpu-partitioning\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n\n#
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
+      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\nautomatic_pstate=${f:intel_recommended_pstate}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -46,16 +53,65 @@ spec:
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
-      intel_iommu=on iommu=pt\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n\ncmdline_pstate=+intel_pstate=${automatic_pstate}\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
+      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
     name: openshift-node-performance-rt-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=amd_iommu=on iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-manual
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+
+      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-intel-x86-manual
   recommend:
   - machineConfigLabels:
       machineconfiguration.openshift.io/role: worker-cnf


### PR DESCRIPTION
* [CNF-14090](https://issues.redhat.com//browse/CNF-14090): Add vendor and architecture specific tuning options
- Performance tuning support for 3 platforms (amd/x86,arm/aarch64,intel/x86) is added in this change
- When a valid platform is detected the additional platform specific tuning will be imported alongside the default tuning
- This makes use of a new helper function added to tuned to detect the system name and architecture
- Update unit tests to account for the various changes
- Add new unit tests to cover the platform specific tuning

* [CNF-14090](https://issues.redhat.com//browse/CNF-14090): Re-sync e2e test yaml for tuning changes

* [CNF-14090](https://issues.redhat.com//browse/CNF-14090): Use variable composition for idle_poll
- idle=poll is only supported on x86
- Update tests to account for changes
- Add explaination comments to empty values in openshift-node-performance

* [CNF-14090](https://issues.redhat.com//browse/CNF-14090): Re-sync e2e test yaml for tuning changes

* [CNF-14090](https://issues.redhat.com//browse/CNF-14090): Fix active/passive pstates

* [CNF-14090](https://issues.redhat.com//browse/CNF-14090): Re-sync e2e test yaml for tuning changes

* OCPBUGS-43665: Drop amd_iommu=on from amd tuning
- "=on" is not a valid value for amd_iommu
- amd_iommu is enabled by default unless you specify "amd_iommu=off", unlike intel
- See kernel docs for more information (https://docs.kernel.org/admin-guide/kernel-parameters.html)

OCPBUGS-43666: Fix kernel arguments ordering on Intel

An upgrade from previous version causes one extra reboot
due to differently ordered kernel arguments. This is
a side effect of platform specific tuned profile split
we merged in https://github.com/openshift/cluster-node-tuning-operator/pull/1083

This fix updates the Intel specific tuned profile to
follow the same ordering that was used in the past.

It does so by exploiting a specific tuned behavior
of the bootloader plugin. It orders the kernel argument
cmdline_suffix keys based on the order of first appearance.
Any additional appearance just changes the value, but
not the ordering.

The change is only needed for Intel, because we have
never supported other platforms before and so upgrade
is not an issue.