### PR TITLE
CNF-13014: Align dockerfile ocp version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 


### PR DESCRIPTION
- Since master branch is used for 4.18, we should be using the 4.18 OCP image here like we do in Dockerfile.rhel9 and .ci-operator.yaml