### PR TITLE
OCPBUGS-43666: Fix kernel arguments ordering on Intel

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -11,8 +11,8 @@ summary=Openshift node optimized for deterministic performance at the cost of in
 # This has two possible results:
 #     openshift-node,cpu-partitioning
 #     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
-include=openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Vendor ID\:\s*ARM:arm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}-{{.PerformanceProfileName}};
-  openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:}
+include=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:};
+    openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Vendor ID\:\s*ARM:arm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}-{{.PerformanceProfileName}}
 
 # Inheritance of base profiles legend:
 # cpu-partitioning -> network-latency -> latency-performance
@@ -133,6 +133,8 @@ avc_cache_threshold=8192
 {{end}}
 
 [bootloader]
+# !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86
+
 # set empty values to disable RHEL initrd setting in cpu-partitioning
 initrd_remove_dir=
 initrd_dst_img=
@@ -151,7 +153,9 @@ cmdline_isolation=+isolcpus=managed_irq,${isolated_cores}
 {{end}}
 
 {{if .RealTimeHint}}
-cmdline_realtime=+nohz_full=${isolated_cores} nosoftlockup skew_tick=1 rcutree.kthread_prio=11
+cmdline_realtime_nohzfull=+nohz_full=${isolated_cores}
+cmdline_realtime_nosoftlookup=+nosoftlockup
+cmdline_realtime_common=+skew_tick=1 rcutree.kthread_prio=11
 {{end}}
 
 {{if .HighPowerConsumption}}

--- a/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
@@ -2,18 +2,32 @@
 summary=Platform specific tuning for Intel x86
 
 [bootloader]
+# DO NOT REMOVE THIS BLOCK
+# It makes sure the kernel arguments for Intel are applied
+# in the order compatible with OCP 4.17 which is important
+# for preventing an extra reboot during upgrade
+cmdline_cpu_part=
+cmdline_iommu_intel=
+cmdline_isolation=
+cmdline_realtime_nohzfull=
+cmdline_realtime_intel=
+cmdline_realtime_nosoftlookup=
+cmdline_realtime_intel_nmi=
+cmdline_realtime_common=
+cmdline_power_performance=
+cmdline_power_performance_intel=
+cmdline_idle_poll=
+cmdline_idle_poll_intel=
+cmdline_hugepages=
+cmdline_pstate=
+
+# Here comes the Intel specific tuning
+
 cmdline_iommu_intel=intel_iommu=on iommu=pt
 
-{{if .PerPodPowerManagement}}
-cmdline_pstate=intel_pstate=passive
-{{else if .HardwareTuning}}
-cmdline_pstate=intel_pstate=active
-{{else}}
-cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-{{end}}
-
 {{if .RealTimeHint}}
-cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
+cmdline_realtime_intel=tsc=reliable
+cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
 {{end}}
 
 {{if .HighPowerConsumption}}
@@ -23,3 +37,12 @@ cmdline_power_performance_intel=processor.max_cstate=1 intel_idle.max_cstate=0
 {{if and .HighPowerConsumption .RealTimeHint}}
 cmdline_idle_poll_intel=idle=poll
 {{end}}
+
+{{if .PerPodPowerManagement}}
+cmdline_pstate=intel_pstate=passive
+{{else if .HardwareTuning}}
+cmdline_pstate=intel_pstate=active
+{{else}}
+cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+{{end}}
+

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -37,7 +37,9 @@ var (
 	cmdlineIntelPstateAutomatic      = "intel_pstate=${f:intel_recommended_pstate}"
 	cmdlineIntelPstatePassive        = "intel_pstate=passive"
 	cmdlineMultipleHugePages         = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=128"
-	cmdlineRealtime                  = "+nohz_full=${isolated_cores} nosoftlockup skew_tick=1 rcutree.kthread_prio=11"
+	cmdlineRealtimeNoHZFull          = "+nohz_full=${isolated_cores}"
+	cmdlineRealtimeNosoftlookup      = "+nosoftlockup"
+	cmdlineRealtimeCommon            = "+skew_tick=1 rcutree.kthread_prio=11"
 	cmdlineWithoutStaticIsolation    = "+isolcpus=managed_irq,${isolated_cores}"
 	cmdlineWithStaticIsolation       = "+isolcpus=domain,managed_irq,${isolated_cores}"
 )
@@ -122,7 +124,9 @@ var _ = Describe("Tuned", func() {
 			Expect(bootLoaderSection.Key("cmdline_isolation").String()).To(Equal(cmdlineWithoutStaticIsolation))
 			Expect(bootLoaderSection.Key("cmdline_hugepages").String()).To(Equal(cmdlineHugepages))
 			Expect(bootLoaderSection.Key("cmdline_additionalArg").String()).To(Equal(cmdlineAdditionalArgs))
-			Expect(bootLoaderSection.Key("cmdline_realtime").String()).To(Equal(cmdlineRealtime))
+			Expect(bootLoaderSection.Key("cmdline_realtime_nohzfull").String()).To(Equal(cmdlineRealtimeNoHZFull))
+			Expect(bootLoaderSection.Key("cmdline_realtime_nosoftlookup").String()).To(Equal(cmdlineRealtimeNosoftlookup))
+			Expect(bootLoaderSection.Key("cmdline_realtime_common").String()).To(Equal(cmdlineRealtimeCommon))
 		})
 
 		Context("default profile default tuned", func() {
@@ -134,6 +138,20 @@ var _ = Describe("Tuned", func() {
 				Expect((cpuSection.Key("governor").String())).To(Equal("performance"))
 				Expect((cpuSection.Key("energy_perf_bias").String())).To(Equal("performance"))
 				Expect((cpuSection.Key("min_perf_pct").String())).To(Equal("100"))
+			})
+
+			It("should have mandatory bootloader keys in tuned", func() {
+				tunedData := getTunedStructuredData(profile, components.ProfileNameIntelX86)
+				bootloader, err := tunedData.GetSection("bootloader")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bootloader.HasKey("cmdline_cpu_part")).To(BeTrue())
+				Expect(bootloader.HasKey("cmdline_isolation")).To(BeTrue())
+				Expect(bootloader.HasKey("cmdline_realtime_nohzfull")).To(BeTrue())
+				Expect(bootloader.HasKey("cmdline_realtime_nosoftlookup")).To(BeTrue())
+				Expect(bootloader.HasKey("cmdline_realtime_common")).To(BeTrue())
+				Expect(bootloader.HasKey("cmdline_idle_poll")).To(BeTrue())
+				Expect(bootloader.HasKey("cmdline_hugepages")).To(BeTrue())
+				Expect(bootloader.HasKey("cmdline_pstate")).To(BeTrue())
 			})
 		})
 
@@ -156,7 +174,9 @@ var _ = Describe("Tuned", func() {
 
 				bootLoaderSection, err := tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bootLoaderSection.Key("cmdline_realtime").String()).ToNot(Equal(cmdlineRealtime))
+				Expect(bootLoaderSection.Key("cmdline_realtime_nohzfull").String()).ToNot(Equal(cmdlineRealtimeNoHZFull))
+				Expect(bootLoaderSection.Key("cmdline_realtime_nosoftlookup").String()).ToNot(Equal(cmdlineRealtimeNosoftlookup))
+				Expect(bootLoaderSection.Key("cmdline_realtime_common").String()).ToNot(Equal(cmdlineRealtimeCommon))
 			})
 		})
 
@@ -173,7 +193,9 @@ var _ = Describe("Tuned", func() {
 				Expect(sysctl.Key("kernel.sched_rt_runtime_us").String()).To(Equal("-1"))
 				bootLoader, err := tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bootLoader.Key("cmdline_realtime").String()).To(Equal(cmdlineRealtime))
+				Expect(bootLoader.Key("cmdline_realtime_nohzfull").String()).To(Equal(cmdlineRealtimeNoHZFull))
+				Expect(bootLoader.Key("cmdline_realtime_nosoftlookup").String()).To(Equal(cmdlineRealtimeNosoftlookup))
+				Expect(bootLoader.Key("cmdline_realtime_common").String()).To(Equal(cmdlineRealtimeCommon))
 			})
 		})
 
@@ -285,14 +307,22 @@ var _ = Describe("Tuned", func() {
 		})
 
 		It("should not allocate hugepages on the specific NUMA node via kernel arguments", func() {
-			manifest := getTunedManifest(profile)
+			tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
+			bootloader, err := tunedData.GetSection("bootloader")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bootloader.HasKey("cmdline_hugepages")).To(BeTrue())
+			manifest := bootloader.Key("cmdline_hugepages").String()
 			Expect(strings.Count(manifest, "hugepagesz=")).To(BeNumerically("==", 2))
-			Expect(strings.Count(manifest, "hugepages=")).To(BeNumerically("==", 3))
+			Expect(strings.Count(manifest, "hugepages=")).To(BeNumerically("==", 1))
 
 			profile.Spec.HugePages.Pages[0].Node = pointer.Int32(1)
-			manifest = getTunedManifest(profile)
+
+			tunedData = getTunedStructuredData(profile, components.ProfileNamePerformance)
+			bootloader, err = tunedData.GetSection("bootloader")
+			Expect(err).ToNot(HaveOccurred())
+			manifest = bootloader.Key("cmdline_hugepages").String()
 			Expect(strings.Count(manifest, "hugepagesz=")).To(BeNumerically("==", 1))
-			Expect(strings.Count(manifest, "hugepages=")).To(BeNumerically("==", 2))
+			Expect(strings.Count(manifest, "hugepages=")).To(BeNumerically("==", 0))
 		})
 
 		Context("with 1G default huge pages", func() {

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-master

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,11 +53,12 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-openshift-bootstrap-worker

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -15,9 +15,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -51,13 +51,14 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n[sysfs]\n#
-      sets provided frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
+      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n[sysfs]\n# sets provided
+      frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,17 +100,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=active
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-manual

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -17,9 +17,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -53,12 +53,13 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
+      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -100,17 +101,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-manual

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -15,9 +15,9 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual;\n
-      \ openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:}\n\n#
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
@@ -51,12 +51,13 @@ spec:
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
       \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
       Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime=+nohz_full=${isolated_cores}
-      nosoftlockup skew_tick=1 rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
-      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
+      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -98,17 +99,40 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
-
-
-
-      cmdline_realtime_intel=tsc=reliable nmi_watchdog=0 mce=off
-
-
-
 
 
     name: openshift-node-performance-intel-x86-manual


### PR DESCRIPTION
An upgrade from previous version causes one extra reboot due to differently ordered kernel arguments. This is a side effect of platform specific tuned profile split we merged in https://github.com/openshift/cluster-node-tuning-operator/pull/1083

This fix updates the Intel specific tuned profile to follow the same ordering that was used in the past.

It does so by exploiting a specific tuned behavior of the bootloader plugin. It orders the kernel argument cmdline_suffix keys based on the order of first appearance. Any additional appearance just changes the value, but not the ordering.

The change is only needed for Intel, because we have never supported other platforms before and so upgrade is not an issue.