### PR TITLE
OCPBUGS-43665: Drop amd_iommu=on from amd tuning

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-amd-x86
@@ -2,7 +2,7 @@
 summary=Platform specific tuning for AMD x86
 
 [bootloader]
-cmdline_iommu_amd=amd_iommu=on iommu=pt
+cmdline_iommu_amd=iommu=pt
 
 {{if .PerPodPowerManagement}}
 cmdline_pstate=amd_pstate=passive

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-master_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-ctrcfg/openshift-bootstrap-worker_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -69,7 +69,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=active

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -70,7 +70,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -68,7 +68,7 @@ spec:
       summary=Platform specific tuning for AMD x86
 
       [bootloader]
-      cmdline_iommu_amd=amd_iommu=on iommu=pt
+      cmdline_iommu_amd=iommu=pt
 
 
       cmdline_pstate=amd_pstate=guided


### PR DESCRIPTION
- "=on" is not a valid value for amd_iommu
- amd_iommu is enabled by default unless you specify "amd_iommu=off", unlike intel
- See kernel docs for more information (https://docs.kernel.org/admin-guide/kernel-parameters.html)