### PR TITLE
OCPBUGS-43992: e2e: wait for node inspector deletion

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/node_inspector/inspector.go
+++ b/test/e2e/performanceprofile/functests/utils/node_inspector/inspector.go
@@ -3,6 +3,7 @@ package node_inspector
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -101,6 +102,9 @@ func Delete(ctx context.Context) error {
 		} else {
 			return fmt.Errorf("failed to delete namespace: %v", err)
 		}
+	}
+	if err := namespaces.WaitForDeletion(testutils.NodeInspectorNamespace, 5*time.Minute); err != nil {
+		return fmt.Errorf("timed out waiting for deletion of namespace %s: %v", testutils.NodeInspectorNamespace, err)
 	}
 
 	cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", nodeInspectorName, clusterRoleSuffix)}}


### PR DESCRIPTION
We need to ensure the node inspector is fully deleted when a suite ends; otherwise, the subsequent suite may encounter an error if it attempts to create the namespace while it's still in the termination process.