### PR TITLE
NO-JIRA: nodeInspector: do not reuse namespace

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
+++ b/test/e2e/performanceprofile/functests/utils/namespaces/namespaces.go
@@ -42,13 +42,6 @@ var TestingNamespace = &corev1.Namespace{
 	},
 }
 
-// NodeInspectorNamespace is the namespace used for deploying a daemonset that will be used to executing commands on nodes.
-var NodeInspectorNamespace = &corev1.Namespace{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: testutils.NodeInspectorNamespace,
-	},
-}
-
 // WaitForDeletion waits until the namespace will be removed from the cluster
 func WaitForDeletion(name string, timeout time.Duration) error {
 	key := types.NamespacedName{

--- a/test/e2e/performanceprofile/functests/utils/node_inspector/inspector.go
+++ b/test/e2e/performanceprofile/functests/utils/node_inspector/inspector.go
@@ -39,8 +39,14 @@ func initialize(ctx context.Context) error {
 	if initialized {
 		return nil
 	}
-	// Create the test namespace
-	err := testclient.DataPlaneClient.Create(ctx, namespace)
+	// NodeInspectorNamespace is the namespace
+	// used for deploying a DaemonSet that will be used to executing commands on nodes.
+	nodeInspectorNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testutils.NodeInspectorNamespace,
+		},
+	}
+	err := testclient.DataPlaneClient.Create(ctx, nodeInspectorNamespace)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create namespace: %v", err)
 	}
@@ -50,7 +56,6 @@ func initialize(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create Node Inspector resources: %v", err)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Using the global namespace object leads to an error
when trying to recreate the namespace againg.

This is becuase when the first `Create` call return
the object is fullfiled with some metadata from the API server
like `resourceVersion`.

This in turn leads to error when trying to reuse the object for creation
becuase the API doesn't expect the `resourceVersion` to be set.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>