### PR TITLE
OCPBUGS-44283: right-hand-side profile_dirs take precedence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN INSTALL_PKGS=" \
     find /root/rpms -name \*.rpm -exec basename {} .rpm \; | xargs rpm -e --justdb && \
     rm -rf /etc/tuned/recommend.d && \
     echo auto > /etc/tuned/profile_mode && \
-    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' \
+    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /usr/lib/tuned,/var/lib/ocp-tuned/profiles|' \
       /etc/tuned/tuned-main.conf && \
     touch /etc/sysctl.conf && \
     dnf clean all && \

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -23,7 +23,7 @@ RUN INSTALL_PKGS=" \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rm -rf /etc/tuned/recommend.d && \
     echo auto > /etc/tuned/profile_mode && \
-    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' \
+    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /usr/lib/tuned,/var/lib/ocp-tuned/profiles|' \
       /etc/tuned/tuned-main.conf && \
     touch /etc/sysctl.conf && \
     dnf clean all && \

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -23,7 +23,7 @@ RUN INSTALL_PKGS=" \
     dnf install --setopt=tsflags=nodocs -y $INSTALL_PKGS && \
     rm -rf /etc/tuned/recommend.d && \
     echo auto > /etc/tuned/profile_mode && \
-    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /var/lib/ocp-tuned/profiles,/usr/lib/tuned|' \
+    sed -Ei 's|^#?\s*enable_unix_socket\s*=.*$|enable_unix_socket = 1|;s|^#?\s*rollback\s*=.*$|rollback = not_on_exit|;s|^#?\s*profile_dirs\s*=.*$|profile_dirs = /usr/lib/tuned,/var/lib/ocp-tuned/profiles|' \
       /etc/tuned/tuned-main.conf && \
     touch /etc/sysctl.conf && \
     dnf clean all && \


### PR DESCRIPTION
This is a manual backport of #1061.

The new TuneD option profile_dirs defines custom TuneD directories. Fix the order of the directories so that the system TuneD directory (/usr/lib/tuned) is the first one (searched last), and the custom TuneD directory (/var/lib/ocp-tuned/profiles) is the last one (searched first).

Resolves: OCPBUGS-44283