### PR TITLE
OCPBUGS-44372: PPC: skip comparing ProcessorCore.Index between NUMA cores 

### DIFF
--- a/pkg/performanceprofile/profilecreator/profilecreator_test.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator_test.go
@@ -1474,6 +1474,12 @@ var _ = Describe("PerformanceProfileCreator: Test Helper Function ensureSameTopo
 			err := ensureSameTopology(&topology1, &topology2)
 			Expect(err).To(HaveOccurred())
 		})
+		It("same cores with different indices should still considered equivalent", func() {
+			topology2.Nodes[0].Cores[0].Index = 1
+			topology2.Nodes[0].Cores[1].Index = 0
+			err := ensureSameTopology(&topology1, &topology2)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })
 


### PR DESCRIPTION
ProcessorCore.Index indicates the zero-based index of the core in the
Cores slice. While core might be shown in a different order, they can still
be equivalent. See: jaypipes/ghw#346.

Adjust the equality check to skip this field to fix this:

```
  Error: targeted nodes differ: nodes host1.development.lab and host2.development.lab have different topology: the CPU cores differ: processor core #20 (2 threads), logical processors [2 66] vs processor core #20 (2 threads), logical processors [2 66]
```

And add a unit test to cover this scenario and the sortTopology function. 

Signed-off-by: Shereen Haj <shajmakh@redhat.com>