### PR TITLE
OCPBUGS-44477: Fix nil pointer dereference caused by external calling of validation function

### DIFF
--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -583,6 +583,14 @@ func (r *PerformanceProfile) getNodesList() (corev1.NodeList, error) {
 	// Get the nodes from the client using the node selector in the profile
 	nodes := &corev1.NodeList{}
 
+    // The validatorClient is initialized via a webhook but not all external callers use a webhook
+    // The external callers that attempt validation would otherwise crash here with a nil pointer dereference
+    // See OCPBUGS-44477 for more information
+    if validatorClient == nil {
+        klog.Warningf("Attempted to fetch node list with a nil validatorClient, returning empty list instead of crashing from a nil pointer dereference")
+        return corev1.NodeList{}, nil
+    }
+
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: r.Spec.NodeSelector,
 	})

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -583,13 +583,13 @@ func (r *PerformanceProfile) getNodesList() (corev1.NodeList, error) {
 	// Get the nodes from the client using the node selector in the profile
 	nodes := &corev1.NodeList{}
 
-    // The validatorClient is initialized via a webhook but not all external callers use a webhook
-    // The external callers that attempt validation would otherwise crash here with a nil pointer dereference
-    // See OCPBUGS-44477 for more information
-    if validatorClient == nil {
-        klog.Warningf("Attempted to fetch node list with a nil validatorClient, returning empty list instead of crashing from a nil pointer dereference")
-        return corev1.NodeList{}, nil
-    }
+	// The validatorClient is initialized via a webhook but not all external callers use a webhook
+	// The external callers that attempt validation would otherwise crash here with a nil pointer dereference
+	// See OCPBUGS-44477 for more information
+	if validatorClient == nil {
+		klog.Warningf("Attempted to fetch node list with a nil validatorClient, returning empty list instead of crashing from a nil pointer dereference")
+		return corev1.NodeList{}, nil
+	}
 
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: r.Spec.NodeSelector,

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -388,7 +388,16 @@ var _ = Describe("PerformanceProfile", func() {
 			nodeSpecs := []NodeSpecifications{}
 			validatorClient = GetFakeValidatorClient(nodeSpecs)
 
-			// There should be an empty node list and error present
+			// There should be an empty node list and no error present
+			nodes, err := profile.getNodesList()
+			Expect(err).To(BeNil())
+			Expect(nodes.Items).To(BeEmpty())
+		})
+		It("should not crash when validator client is nil", func() {
+			// Some external callers do not have a validator client present
+			// See OCPBUGS-44477 for more information
+
+			// There should be an empty node list and no error
 			nodes, err := profile.getNodesList()
 			Expect(err).To(BeNil())
 			Expect(nodes.Items).To(BeEmpty())


### PR DESCRIPTION
- Attempting to validate the performance profile's fields in an external context without a validatorClient was causing a nil pointer dereference
- If the validatorClient is not present then skip the validation that would required it and log a warning message (CPU arch, CPU capacity)