### PR TITLE
NO-JIRA: PPC: unit: test sortTopology for expected output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp
 /*.sh
 /TODO
 pkg/manifests/bindata.go
+cover.out

--- a/pkg/performanceprofile/profilecreator/profilecreator.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator.go
@@ -270,6 +270,11 @@ func (ghwHandler GHWHandler) SortedTopology() (*topology.Info, error) {
 	if err != nil {
 		return nil, fmt.Errorf("can't obtain topology info from GHW snapshot: %v", err)
 	}
+	sortTopology(topologyInfo)
+	return topologyInfo, nil
+}
+
+func sortTopology(topologyInfo *topology.Info) {
 	sort.Slice(topologyInfo.Nodes, func(x, y int) bool {
 		return topologyInfo.Nodes[x].ID < topologyInfo.Nodes[y].ID
 	})
@@ -283,7 +288,6 @@ func (ghwHandler GHWHandler) SortedTopology() (*topology.Info, error) {
 			return node.Cores[i].LogicalProcessors[0] < node.Cores[j].LogicalProcessors[0]
 		})
 	}
-	return topologyInfo, nil
 }
 
 // topologyHTDisabled returns topologyinfo in case Hyperthreading needs to be disabled.

--- a/pkg/performanceprofile/profilecreator/profilecreator_test.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator_test.go
@@ -3,6 +3,7 @@ package profilecreator
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sort"
 
@@ -1774,6 +1775,106 @@ var _ = Describe("PerformanceProfileCreator: Test Helper Function ensureSameTopo
 			Expect(val).To(BeTrue())
 
 		})
+	})
+})
+
+var _ = Describe("PerformanceProfileCreator: Test Helper Function sortTopology", func() {
+	It("should sort node topologies as expected", func() {
+		unsorted := topology.Info{
+			Nodes: []*topology.Node{
+				{
+					ID: 1,
+					Cores: []*cpu.ProcessorCore{
+						{
+							ID:                5,
+							LogicalProcessors: []int{5, 7},
+						},
+						{
+							ID:                4,
+							LogicalProcessors: []int{4, 6},
+						},
+						{
+							ID:                7,
+							LogicalProcessors: []int{5, 7},
+						},
+						{
+							ID:                6,
+							LogicalProcessors: []int{6, 4},
+						},
+					},
+				},
+				{
+					ID: 0,
+					Cores: []*cpu.ProcessorCore{
+						{
+							ID:                0,
+							LogicalProcessors: []int{2, 0},
+						},
+						{
+							ID:                1,
+							LogicalProcessors: []int{1, 3},
+						},
+						{
+							ID:                2,
+							LogicalProcessors: []int{0, 2},
+						},
+						{
+							ID:                3,
+							LogicalProcessors: []int{3, 1},
+						},
+					},
+				},
+			},
+		}
+		expectedSorted := topology.Info{
+			Nodes: []*topology.Node{
+				{
+					ID: 0,
+					Cores: []*cpu.ProcessorCore{
+						{
+							ID:                0,
+							LogicalProcessors: []int{0, 2},
+						},
+						{
+							ID:                2,
+							LogicalProcessors: []int{0, 2},
+						},
+						{
+							ID:                1,
+							LogicalProcessors: []int{1, 3},
+						},
+						{
+							ID:                3,
+							LogicalProcessors: []int{1, 3},
+						},
+					},
+				},
+				{
+					ID: 1,
+					Cores: []*cpu.ProcessorCore{
+						{
+							ID:                4,
+							LogicalProcessors: []int{4, 6},
+						},
+						{
+							ID:                6,
+							LogicalProcessors: []int{4, 6},
+						},
+						{
+							ID:                5,
+							LogicalProcessors: []int{5, 7},
+						},
+						{
+							ID:                7,
+							LogicalProcessors: []int{5, 7},
+						},
+					},
+				},
+			},
+		}
+
+		sortTopology(&unsorted)
+		Expect(reflect.DeepEqual(unsorted, expectedSorted)).To(BeTrue(), "expected %+v, got %+v", expectedSorted, unsorted)
 	})
 })
 


### PR DESCRIPTION
The node topology contains several slices that later on are sorted and used to determine whether two nodes are equal. Add a unit test to verify this sorting is done as expected.