### PR TITLE
Inherit container runtime configuration

### DIFF
--- a/assets/performanceprofile/configs/99-runtimes.conf
+++ b/assets/performanceprofile/configs/99-runtimes.conf
@@ -18,4 +18,5 @@ runtime_root = "/run/runc"
 runtime_path = "{{.RuntimePath}}"
 runtime_type = "oci"
 runtime_root = "{{.RuntimeRoot}}"
+inherit_default_runtime = true
 allowed_annotations = ["cpu-load-balancing.crio.io", "cpu-quota.crio.io", "irq-load-balancing.crio.io", "cpu-c-states.crio.io", "cpu-freq-governor.crio.io"{{ if .CrioSharedCPUsAnnotation }}{{ printf ", %q" .CrioSharedCPUsAnnotation}}{{end}}]


### PR DESCRIPTION
A new patch has been introduced for CRI-O, allowing the container runtime for the high-performance runtime class to be inherited from the system instead of being detected and explicitly set. https://github.com/cri-o/cri-o/issues/8753

A follow-up PR will be filed to remove all the unnecessary logic of the runtime detection from containerRuntimeConfig and further adjustments

/hold
Until the [crio patch](https://github.com/cri-o/cri-o/pull/8754) will be backported down to release 1.31