### PR TITLE
NO-JIRA: Fix upstream and OKD builds

### DIFF
--- a/hack/dockerfile_install_support.sh
+++ b/hack/dockerfile_install_support.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 set -o xtrace
 
-INSTALL_PKGS="nmap-ncat procps-ng pciutils"
+INSTALL_PKGS="nmap-ncat procps-ng pciutils rsync"
 
 # TuneD pre-installation steps
 cp -r /root/assets/bin/* /usr/local/bin


### PR DESCRIPTION
PR #1099 broke upstream and OKD builds as it added a dependency on rsync.  quay.io/centos/centos:stream9 image does not ship rsync by default.

Once we can use the new golang's recursive copy (CopyFS) functionality in go 1.23 (https://github.com/golang/go/issues/62484), use it and remove the dependency on rsync.