### PR TITLE
OCPBUGS-45048: Move reboot tests to appropriate make target for hypershift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ pao-functests-update-only: $(BINDATA)
 pao-functests-update-only-hypershift: $(BINDATA)
 	@echo "Cluster Version"
 	hack/show-cluster-version.sh
-	hack/run-test.sh -t "test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/2_performance_update" -p "-v -r --label-filter="!openshift" --fail-fast --flake-attempts=2 --timeout=5h --junit-report=report.xml" -m "Running Functional Tests"
+	hack/run-test.sh -t "test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/2_performance_update ./test/e2e/performanceprofile/functests/7_performance_kubelet_node ./test/e2e/performanceprofile/functests/8_performance_workloadhints ./test/e2e/performanceprofile/functests/12_hypershift" -p "-v -r --label-filter=!(openshift||slow) --fail-fast --flake-attempts=2 --timeout=5h --junit-report=report.xml" -m "Running Functional Tests"
 
 .PHONY: pao-functests-performance-workloadhints
 pao-functests-performance-workloadhints: cluster-label-worker-cnf pao-functests-performance-workloadhints-only
@@ -250,7 +250,7 @@ pao-functests-mixedcpus: $(BINDATA)
 pao-functests-hypershift: $(BINDATA)
 	@echo "Cluster Version"
 	hack/show-cluster-version.sh
-	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/1_performance ./test/e2e/performanceprofile/functests/2_performance_update ./test/e2e/performanceprofile/functests/3_performance_status ./test/e2e/performanceprofile/functests/6_mustgather_testing ./test/e2e/performanceprofile/functests/7_performance_kubelet_node ./test/e2e/performanceprofile/functests/8_performance_workloadhints ./test/e2e/performanceprofile/functests/12_hypershift" -p "-vv -r --label-filter=!(openshift||slow) --fail-fast --flake-attempts=2 --timeout=4h --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
+	hack/run-test.sh -t "./test/e2e/performanceprofile/functests/0_config ./test/e2e/performanceprofile/functests/1_performance ./test/e2e/performanceprofile/functests/3_performance_status ./test/e2e/performanceprofile/functests/6_mustgather_testing" -p "-vv -r --label-filter="!openshift" --fail-fast --flake-attempts=2 --timeout=4h --junit-report=report.xml" -m "Running Functional Tests over Hypershift"
 
 .PHONY: cluster-clean-pao
 cluster-clean-pao:


### PR DESCRIPTION
Move all test which reboot nodes to pao-functests-update-only-hypershift

- Use pao-functests-hypershift for tests which do not update profile 
- Use pao-functests-update-only-hypershift for tests which update Performance profile and reboot the nodes