### PR TITLE
WIP: Use the new IRQBALANCE_BANNED_CPULIST variable

### DIFF
--- a/assets/performanceprofile/scripts/clear-irqbalance-banned-cpus.sh
+++ b/assets/performanceprofile/scripts/clear-irqbalance-banned-cpus.sh
@@ -7,15 +7,17 @@ SED="/usr/bin/sed"
 # tunable - overridable for testing purposes
 IRQBALANCE_CONF="${1:-/etc/sysconfig/irqbalance}"
 CRIO_ORIG_BANNED_CPUS="${2:-/etc/sysconfig/orig_irq_banned_cpus}"
-NONE=0
+NONE=""
 
 [ ! -f "${IRQBALANCE_CONF}" ] && exit 0
 
 ${SED} -i '/^\s*IRQBALANCE_BANNED_CPUS\b/d' "${IRQBALANCE_CONF}" || exit 0
+${SED} -i '/^\s*IRQBALANCE_BANNED_CPULIST\b/d' "${IRQBALANCE_CONF}" || exit 0
+
 # CPU numbers which have their corresponding bits set to one in this mask
 # will not have any irq's assigned to them on rebalance.
 # so zero means all cpus are participating in load balancing.
-echo "IRQBALANCE_BANNED_CPUS=${NONE}" >> "${IRQBALANCE_CONF}"
+echo "IRQBALANCE_BANNED_CPULIST=${NONE}" >> "${IRQBALANCE_CONF}"
 
 # we now own this configuration. But CRI-O has code to restore the configuration,
 # and until it gains the option to disable this restore flow, we need to make


### PR DESCRIPTION
Use the new IRQBALANCE_BANNED_CPULIST variable

The IRQBALANCE_BANNED_CPUS variable is deprecated and will not
be used anymore in the near future.
    
The newer IRQBALANCE_BANNED_CPULIST variable is already supported
by irqbalanced (https://github.com/Irqbalance/irqbalance/blob/v1.9.0/cputree.c#L135)
and should be used.

This must be merged together with https://github.com/cri-o/cri-o/pull/8783
