### PR TITLE
CNF-16063: E2E: Add hypershift support to container runtime config tests

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
+++ b/pkg/performanceprofile/controller/performanceprofile/hypershift/hypershift.go
@@ -103,7 +103,8 @@ func GetObjectConfigMapDataKey(obj runtime.Object) string {
 	case *performancev2.PerformanceProfile, *performancev2.PerformanceProfileList, *tunedv1.Tuned, *tunedv1.TunedList:
 		return hypershiftconsts.TuningKey
 	case *machineconfigv1.KubeletConfig, *machineconfigv1.KubeletConfigList,
-		*machineconfigv1.MachineConfig, *machineconfigv1.MachineConfigList:
+		*machineconfigv1.MachineConfig, *machineconfigv1.MachineConfigList,
+		*machineconfigv1.ContainerRuntimeConfig, *machineconfigv1.ContainerRuntimeConfigList:
 		return hypershiftconsts.ConfigKey
 	default:
 		return ""


### PR DESCRIPTION
The container runtime configuration test was omitted during the HyperShift adjustments, as it was initially deemed unsuitable for HyperShift. This change introduces support for it.