### PR TITLE
OCPBUGS-45346: performanceprofile cpuset input validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,11 @@ endif
 vet: $(BINDATA)
 	$(GO) vet ./...
 
-test-unit: $(BINDATA)
+test-unit: $(BINDATA) test-fuzz
 	$(GO) test ./cmd/... ./pkg/... -coverprofile cover.out
+
+test-fuzz:
+	$(GO) test ./pkg/apis/performanceprofile/v2 -fuzz=FuzzValidateCPUs -fuzztime=10s 
 
 clean:
 	$(GO) clean $(PACKAGE_MAIN)

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -179,6 +179,8 @@ func (r *PerformanceProfile) validateCPUs() field.ErrorList {
 			cpuLists, err := components.NewCPULists(string(*cpus.Reserved), string(*cpus.Isolated), offlined, shared)
 			if err != nil {
 				allErrs = append(allErrs, field.InternalError(field.NewPath("spec.cpu"), err))
+				// If err != nil then the cpuList is nil and we can't continue with the function logic
+				return allErrs
 			}
 
 			if cpuLists.GetReserved().IsEmpty() {

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -151,6 +152,33 @@ func NewPerformanceProfile(name string) *PerformanceProfile {
 			},
 		},
 	}
+}
+
+// Fuzz test for ValidateCPUs to ensure it handles invalid inputs and does not panic.
+func FuzzValidateCPUs(f *testing.F) {
+	seeds := []string{"garbage", "a,b,c", "0-1"}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		cpuFields := map[string]func(*PerformanceProfile, CPUSet){
+			"reserved": func(p *PerformanceProfile, input CPUSet) { p.Spec.CPU.Reserved = &input },
+			"isolated": func(p *PerformanceProfile, input CPUSet) { p.Spec.CPU.Isolated = &input },
+			"shared":   func(p *PerformanceProfile, input CPUSet) { p.Spec.CPU.Shared = &input },
+			"offline":  func(p *PerformanceProfile, input CPUSet) { p.Spec.CPU.Offlined = &input },
+		}
+
+		for fieldName, setField := range cpuFields {
+			t.Run(fieldName, func(t *testing.T) {
+				cpuSet := CPUSet(input)
+				profile := NewPerformanceProfile("test")
+
+				setField(profile, cpuSet)
+				// We don't care for the errors we got, only care about panics, which will cause a failure if they occur.
+				_ = profile.validateCPUs()
+			})
+		}
+	})
 }
 
 var _ = Describe("PerformanceProfile", func() {


### PR DESCRIPTION
This fix ensures that the input for any CPU set field is valid. If an invalid string that does not represent a valid CPU set is provided, the admission webhook will return an appropriate error, such as:
 `spec.cpu: Internal error: strconv.Atoi: parsing "garbage": invalid syntax`

This replaces the previous behavior where the server would return an error like: 
`Error from server: error when creating "pp.yaml": admission webhook "vwb.performance.openshift.io" denied the request: panic: runtime error: invalid memory address or nil pointer dereference [recovered].`

Moreover, fuzz tests have been added to ensure we exercise all errors when executing the validation function on valid and invalid inputs, ensuring no panic occurs during execution. 