### PR TITLE
cmd: PPC: support tolerating heterogeneous core IDs

### DIFF
--- a/cmd/performance-profile-creator/cmd/root.go
+++ b/cmd/performance-profile-creator/cmd/root.go
@@ -168,7 +168,7 @@ func NewRootCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := profilecreator.EnsureNodesHaveTheSameHardware(nodesHandlers); err != nil {
+			if err := profilecreator.EnsureNodesHaveTheSameHardware(nodesHandlers, pcArgs.TolerateCoreIDsDiff); err != nil {
 				return fmt.Errorf("targeted nodes differ: %w", err)
 			}
 			// We make sure that the matched Nodes are the same
@@ -412,6 +412,7 @@ type ProfileCreatorArgs struct {
 	TMPolicy                    string `json:"topology-manager-policy"`
 	PerPodPowerManagement       *bool  `json:"per-pod-power-management,omitempty"`
 	EnableHardwareTuning        bool   `json:"enable-hardware-tuning,omitempty"`
+	TolerateCoreIDsDiff         bool   `json:"tolerate-core-ids-diff,omitempty"`
 	// internal only this argument not passed by the user
 	// but detected automatically
 	createForHypershift bool
@@ -432,6 +433,7 @@ func (pca *ProfileCreatorArgs) AddFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(pca.PerPodPowerManagement, "per-pod-power-management", false, "Enable Per Pod Power Management")
 	flags.BoolVar(&pca.EnableHardwareTuning, "enable-hardware-tuning", false, "Enable setting maximum cpu frequencies")
 	flags.StringVar(&pca.NodePoolName, "node-pool-name", "", "Node pool name corresponding to the target machines (HyperShift only)")
+	flags.BoolVar(&pca.TolerateCoreIDsDiff, "tolerate-core-ids-diff", false, "[EXPERIMENTAL] If set to true PPC tolerates having different core IDs for the same logical processors on the same NUMA cell compared with other nodes that belong to the stated pool. While core IDs numbering may differ between two systems, it still can be considered that NUMA and HW topologies are similar; However this depends on the combination setting of the hardware, software and firmware as that may affect the mapping pattern. While the performance profile controller depends on the logical processors per NUMA, having different IDs may affect your system's performance optimization where the cores location matters, thus use this flag with caution.")
 }
 
 func makePerformanceProfileFrom(profileData ProfileData) (runtime.Object, error) {

--- a/pkg/performanceprofile/profilecreator/profilecreator.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator.go
@@ -688,6 +688,21 @@ func EnsureNodesHaveTheSameHardware(nodeHandlers []*GHWHandler) error {
 	if err != nil {
 		return fmt.Errorf("can't obtain Topology info from GHW snapshot for %s: %v", firstHandle.Node.GetName(), err)
 	}
+	if len(nodeHandlers) == 1 {
+		for _, node := range firstTopology.Nodes {
+			lpListByCoreID := make(map[int][]int)
+			for _, core := range node.Cores {
+				val, ok := lpListByCoreID[core.ID]
+				if ok {
+					if !reflect.DeepEqual(val, core.LogicalProcessors) {
+						return fmt.Errorf("found different list of logical processors for CPU %d in the same NUMA node %d: %d vs %d", core.ID, node.ID, val, core.LogicalProcessors)
+					}
+				}
+				lpListByCoreID[core.ID] = val
+			}
+		}
+
+	}
 
 	for _, handle := range nodeHandlers[1:] {
 		if err != nil {
@@ -731,6 +746,8 @@ func ensureSameTopology(topology1, topology2 *topology.Info) error {
 				node1.ID, len(topology1.Nodes), len(topology2.Nodes))
 		}
 
+		lpListByCoreID1 := make(map[int][]int)
+		lpListByCoreID2 := make(map[int][]int)
 		for j, core1 := range cores1 {
 			// skip comparing index because it's fine if they deffer; see https://github.com/jaypipes/ghw/issues/345#issuecomment-1620274077
 			// ghw.ProcessorCore.Index is completely removed starting v0.11.0
@@ -743,6 +760,23 @@ func ensureSameTopology(topology1, topology2 *topology.Info) error {
 			if !reflect.DeepEqual(core1.LogicalProcessors, cores2[j].LogicalProcessors) {
 				return fmt.Errorf("logical processors for CPU %d in NUMA node %d differs: %d vs %d", core1.ID, node1.ID, core1.LogicalProcessors, cores2[j].LogicalProcessors)
 			}
+
+			// in addition to verifying logical processors list between the two NUMAs we want to verify that siblings are under the same core ID in NUMA level of the same node
+			val, ok := lpListByCoreID1[core1.ID]
+			if ok {
+				if !reflect.DeepEqual(val, core1.LogicalProcessors) {
+					return fmt.Errorf("found different list of logical processors for CPU %d in the same NUMA node %d: %d vs %d", core1.ID, node1.ID, val, core1.LogicalProcessors)
+				}
+			}
+			lpListByCoreID1[core1.ID] = core1.LogicalProcessors
+
+			val, ok = lpListByCoreID2[cores2[j].ID]
+			if ok {
+				if !reflect.DeepEqual(val, cores2[j].LogicalProcessors) {
+					return fmt.Errorf("found different list of logical processors for CPU %d in the same NUMA node %d: %d vs %d", cores2[j].ID, node1.ID, val, cores2[j].LogicalProcessors)
+				}
+			}
+			lpListByCoreID2[cores2[j].ID] = cores2[j].LogicalProcessors
 		}
 	}
 

--- a/pkg/performanceprofile/profilecreator/profilecreator_test.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator_test.go
@@ -1483,6 +1483,63 @@ var _ = Describe("PerformanceProfileCreator: Test Helper Function ensureSameTopo
 			err := ensureSameTopology(&originTopology, &mutatedTopology)
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("should fail when core id on same numa is associated with different siblings list", func() {
+			nodes3 := []*topology.Node{
+				{
+					ID: 0,
+					Cores: []*cpu.ProcessorCore{
+						{ID: 0, Index: 0, NumThreads: 2, LogicalProcessors: []int{0, 4}}, // Cores must be sorted by logical processors before passing them to ensureSameTopology
+						{ID: 2, Index: 3, NumThreads: 2, LogicalProcessors: []int{0, 4}},
+						{ID: 2, Index: 2, NumThreads: 2, LogicalProcessors: []int{2, 6}},
+						{ID: 0, Index: 1, NumThreads: 2, LogicalProcessors: []int{2, 6}},
+					},
+				},
+				{
+					ID: 1,
+					Cores: []*cpu.ProcessorCore{
+						{ID: 0, Index: 2, NumThreads: 2, LogicalProcessors: []int{1, 3}},
+						{ID: 0, Index: 2, NumThreads: 2, LogicalProcessors: []int{1, 3}},
+						{ID: 1, Index: 3, NumThreads: 2, LogicalProcessors: []int{5, 7}},
+						{ID: 1, Index: 3, NumThreads: 2, LogicalProcessors: []int{5, 7}},
+					},
+				},
+			}
+
+			t3 := topology.Info{
+				Architecture: topology.ARCHITECTURE_NUMA,
+				Nodes:        nodes3,
+			}
+
+			nodes4 := []*topology.Node{
+				{
+					ID: 0,
+					Cores: []*cpu.ProcessorCore{
+						{ID: 0, Index: 0, NumThreads: 2, LogicalProcessors: []int{0, 4}},
+						{ID: 2, Index: 3, NumThreads: 2, LogicalProcessors: []int{0, 4}},
+						{ID: 2, Index: 2, NumThreads: 2, LogicalProcessors: []int{2, 6}},
+						{ID: 0, Index: 1, NumThreads: 2, LogicalProcessors: []int{2, 6}},
+					},
+				},
+				{
+					ID: 1,
+					Cores: []*cpu.ProcessorCore{
+						{ID: 0, Index: 2, NumThreads: 2, LogicalProcessors: []int{1, 3}},
+						{ID: 0, Index: 2, NumThreads: 2, LogicalProcessors: []int{1, 3}},
+						{ID: 1, Index: 3, NumThreads: 2, LogicalProcessors: []int{5, 7}},
+						{ID: 1, Index: 3, NumThreads: 2, LogicalProcessors: []int{5, 7}},
+					},
+				},
+			}
+
+			t4 := topology.Info{
+				Architecture: topology.ARCHITECTURE_NUMA,
+				Nodes:        nodes4,
+			}
+			err := ensureSameTopology(&t3, &t4)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("found different list of logical processors for CPU"))
+		})
+
 	})
 })
 


### PR DESCRIPTION
**Problem**: In a system with a specific number of cores per socket
the host gives each core a number. So far PPC would generate
performance profile only after verifying that the nodes pointed to by
the specified node pool are all of the same hardware and topology. That
is because the performance profile will apply the same configuration on all
these nodes and it is most important that they have same structure, CPUs
distribution across NUMAs and CPUs availability. This by default
includes having same core IDs for each CPU in the same NUMA cells for
all the compute nodes. for instance:

Worker-0 has NUMA-0 on which the CPUs siblings [2,66] is coupled in
one core numbered 18`.
All other workers should have this info true for them, otherwise the
tool would fail.

**Suggested solution:**
With further investigation, it was learned that core numbering can have
different schemes even with a system from the same vendor. The numbering
the pattern depends on the settings of the hardware, the software and the
firmware (BIOS).While core IDs may vary nodes can still be considered
having same NUMA topology taking into account that core scope is on the
single NUMA. However, core IDs can be important in optimizing the
system's performance and managing isolation of tasks, meaning if the
performance of worker-0 is not comparable to that of worker-1 before
having performance-profile applied on both, having an improved
performance on both after applying PP is not guaranteed.

In this PR, we introduce an experimental flag to be added to the PPC
tool called `tolerate-core-ids-diff` and is `false` by default; if set
to true then the check to ensure same topologies between nodes will
ignore having different core IDs for the same CPUs in the same NUMA
cells.

Disclaimer: We support this option to unblock business matters and is recommended
to use it with caution only if the default value is not providing the
desired results; and only if the user is willing to take on the
responsibility of troubleshooting the settings on their environment which not all
are reflected in the must-gather collection.

Signed-off-by: Shereen Haj <shajmakh@redhat.com>
@shajmakh
