### PR TITLE
PPC: verify core with the same ID always has same sibling list and add missing test

### DIFF
--- a/pkg/performanceprofile/profilecreator/profilecreator.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator.go
@@ -688,6 +688,21 @@ func EnsureNodesHaveTheSameHardware(nodeHandlers []*GHWHandler) error {
 	if err != nil {
 		return fmt.Errorf("can't obtain Topology info from GHW snapshot for %s: %v", firstHandle.Node.GetName(), err)
 	}
+	if len(nodeHandlers) == 1 {
+		for _, node := range firstTopology.Nodes {
+			lpListByCoreID := make(map[int][]int)
+			for _, core := range node.Cores {
+				val, ok := lpListByCoreID[core.ID]
+				if ok {
+					if !reflect.DeepEqual(val, core.LogicalProcessors) {
+						return fmt.Errorf("found different list of logical processors for CPU %d in the same NUMA node %d: %d vs %d", core.ID, node.ID, val, core.LogicalProcessors)
+					}
+				}
+				lpListByCoreID[core.ID] = val
+			}
+		}
+
+	}
 
 	for _, handle := range nodeHandlers[1:] {
 		if err != nil {
@@ -731,6 +746,8 @@ func ensureSameTopology(topology1, topology2 *topology.Info) error {
 				node1.ID, len(topology1.Nodes), len(topology2.Nodes))
 		}
 
+		lpListByCoreID1 := make(map[int][]int)
+		lpListByCoreID2 := make(map[int][]int)
 		for j, core1 := range cores1 {
 			// skip comparing index because it's fine if they deffer; see https://github.com/jaypipes/ghw/issues/345#issuecomment-1620274077
 			// ghw.ProcessorCore.Index is completely removed starting v0.11.0
@@ -743,6 +760,23 @@ func ensureSameTopology(topology1, topology2 *topology.Info) error {
 			if !reflect.DeepEqual(core1.LogicalProcessors, cores2[j].LogicalProcessors) {
 				return fmt.Errorf("logical processors for CPU %d in NUMA node %d differs: %d vs %d", core1.ID, node1.ID, core1.LogicalProcessors, cores2[j].LogicalProcessors)
 			}
+
+			// in addition to verifying logical processors list between the two NUMAs we want to verify that siblings are under the same core ID in NUMA level of the same node
+			val, ok := lpListByCoreID1[core1.ID]
+			if ok {
+				if !reflect.DeepEqual(val, core1.LogicalProcessors) {
+					return fmt.Errorf("found different list of logical processors for CPU %d in the same NUMA node %d: %d vs %d", core1.ID, node1.ID, val, core1.LogicalProcessors)
+				}
+			}
+			lpListByCoreID1[core1.ID] = core1.LogicalProcessors
+
+			val, ok = lpListByCoreID2[cores2[j].ID]
+			if ok {
+				if !reflect.DeepEqual(val, cores2[j].LogicalProcessors) {
+					return fmt.Errorf("found different list of logical processors for CPU %d in the same NUMA node %d: %d vs %d", cores2[j].ID, node1.ID, val, cores2[j].LogicalProcessors)
+				}
+			}
+			lpListByCoreID2[cores2[j].ID] = cores2[j].LogicalProcessors
 		}
 	}
 

--- a/pkg/performanceprofile/profilecreator/profilecreator_test.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator_test.go
@@ -1483,6 +1483,63 @@ var _ = Describe("PerformanceProfileCreator: Test Helper Function ensureSameTopo
 			err := ensureSameTopology(&originTopology, &mutatedTopology)
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("should fail when core id on same numa is associated with different siblings list", func() {
+			nodes3 := []*topology.Node{
+				{
+					ID: 0,
+					Cores: []*cpu.ProcessorCore{
+						{ID: 0, Index: 0, NumThreads: 2, LogicalProcessors: []int{0, 4}}, // Cores must be sorted by logical processors before passing them to ensureSameTopology
+						{ID: 2, Index: 3, NumThreads: 2, LogicalProcessors: []int{0, 4}},
+						{ID: 2, Index: 2, NumThreads: 2, LogicalProcessors: []int{2, 6}},
+						{ID: 0, Index: 1, NumThreads: 2, LogicalProcessors: []int{2, 6}},
+					},
+				},
+				{
+					ID: 1,
+					Cores: []*cpu.ProcessorCore{
+						{ID: 0, Index: 2, NumThreads: 2, LogicalProcessors: []int{1, 3}},
+						{ID: 0, Index: 2, NumThreads: 2, LogicalProcessors: []int{1, 3}},
+						{ID: 1, Index: 3, NumThreads: 2, LogicalProcessors: []int{5, 7}},
+						{ID: 1, Index: 3, NumThreads: 2, LogicalProcessors: []int{5, 7}},
+					},
+				},
+			}
+
+			t3 := topology.Info{
+				Architecture: topology.ARCHITECTURE_NUMA,
+				Nodes:        nodes3,
+			}
+
+			nodes4 := []*topology.Node{
+				{
+					ID: 0,
+					Cores: []*cpu.ProcessorCore{
+						{ID: 0, Index: 0, NumThreads: 2, LogicalProcessors: []int{0, 4}},
+						{ID: 2, Index: 3, NumThreads: 2, LogicalProcessors: []int{0, 4}},
+						{ID: 2, Index: 2, NumThreads: 2, LogicalProcessors: []int{2, 6}},
+						{ID: 0, Index: 1, NumThreads: 2, LogicalProcessors: []int{2, 6}},
+					},
+				},
+				{
+					ID: 1,
+					Cores: []*cpu.ProcessorCore{
+						{ID: 0, Index: 2, NumThreads: 2, LogicalProcessors: []int{1, 3}},
+						{ID: 0, Index: 2, NumThreads: 2, LogicalProcessors: []int{1, 3}},
+						{ID: 1, Index: 3, NumThreads: 2, LogicalProcessors: []int{5, 7}},
+						{ID: 1, Index: 3, NumThreads: 2, LogicalProcessors: []int{5, 7}},
+					},
+				},
+			}
+
+			t4 := topology.Info{
+				Architecture: topology.ARCHITECTURE_NUMA,
+				Nodes:        nodes4,
+			}
+			err := ensureSameTopology(&t3, &t4)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("found different list of logical processors for CPU"))
+		})
+
 	})
 })
 


### PR DESCRIPTION
In other words, verify that siblings CPUs are associated with same
core id on NUMA level.

Core ID (from `/sys/devices/system/node/nodeX/cpuY/topology/core_id`) is
important especially for the specific NUMA, and CPUs siblings are
featured by that they have same core id. Although this rarely happens in
real computers, PPC tool depends on the data reported by the
must-gather, so we need to verify that what's received is still
preserving the accepted configuration for generating a
performance-profile. Additionally add unit tests to cover this behavior.