### PR TITLE
OCPBUGS-44372: cmd: PPC: support tolerating heterogeneous core IDs

### DIFF
--- a/pkg/performanceprofile/profilecreator/helper.go
+++ b/pkg/performanceprofile/profilecreator/helper.go
@@ -4,6 +4,32 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+const (
+	EnableHardwareTuning  = "enableHardwareTuning"
+	HardwareTuningMessage = `# HardwareTuning is an advanced feature, and only intended to be used if 
+# user is aware of the vendor recommendation on maximum cpu frequency.
+# The structure must follow
+#
+# hardwareTuning:
+#   isolatedCpuFreq: <Maximum frequency for applications running on isolated cpus>
+#   reservedCpuFreq: <Maximum frequency for platform software running on reserved cpus>
+`
+
+	DifferentCoreIDs        = "differentCoreIDs"
+	DifferentCoreIDsMessage = `# PPC tolerates having different core IDs for the same logical processors on 
+# the same NUMA cell compared with other nodes that belong to the stated pool.
+# While core IDs numbering may differ between two systems, it still can be considered 
+# that NUMA and HW topologies are similar; However this depends on the combination 
+# setting of the hardware, software and firmware as that may affect the mapping pattern. 
+# While the performance profile controller depends on the logical processors per NUMA, 
+# having different IDs may affect your system's performance optimization where the cores
+# location matters, thus use the generated profile with caution.
+`
+)
+
+// TolerationSet records the data to be tolerated or warned about based on the tool handling
+type TolerationSet map[string]bool
+
 // This is a linter false positive, this function is used in unit tests.
 //
 //nolint:unused

--- a/pkg/performanceprofile/profilecreator/profilecreator.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator.go
@@ -677,8 +677,9 @@ func contains(s []string, str string) bool {
 	return false
 }
 
-// EnsureNodesHaveTheSameHardware returns an error if all the input nodes do not have the same hardware configuration
-func EnsureNodesHaveTheSameHardware(nodeHandlers []*GHWHandler) error {
+// EnsureNodesHaveTheSameHardware returns an error if all the input nodes do not have the same hardware configuration and
+// updates the toleration set to consider as warnings/comments when publishing the generated profile
+func EnsureNodesHaveTheSameHardware(nodeHandlers []*GHWHandler, tolerations TolerationSet) error {
 	if len(nodeHandlers) < 1 {
 		return fmt.Errorf("no suitable nodes to compare")
 	}
@@ -688,18 +689,12 @@ func EnsureNodesHaveTheSameHardware(nodeHandlers []*GHWHandler) error {
 	if err != nil {
 		return fmt.Errorf("can't obtain Topology info from GHW snapshot for %s: %v", firstHandle.Node.GetName(), err)
 	}
-
 	for _, handle := range nodeHandlers[1:] {
-		if err != nil {
-			return fmt.Errorf("can't obtain GHW snapshot handle for %s: %v", handle.Node.GetName(), err)
-		}
-
 		topology, err := handle.SortedTopology()
 		if err != nil {
 			return fmt.Errorf("can't obtain Topology info from GHW snapshot for %s: %v", handle.Node.GetName(), err)
 		}
-		err = ensureSameTopology(firstTopology, topology)
-		if err != nil {
+		if err := ensureSameTopology(firstTopology, topology, tolerations); err != nil {
 			return fmt.Errorf("nodes %s and %s have different topology: %v", firstHandle.Node.GetName(), handle.Node.GetName(), err)
 		}
 	}
@@ -707,7 +702,7 @@ func EnsureNodesHaveTheSameHardware(nodeHandlers []*GHWHandler) error {
 	return nil
 }
 
-func ensureSameTopology(topology1, topology2 *topology.Info) error {
+func ensureSameTopology(topology1, topology2 *topology.Info, tolerations TolerationSet) error {
 	// the assumption here is that both topologies are deep sorted (e.g. slices of numa nodes, cores, processors ..);
 	// see handle.SortedTopology()
 	if topology1.Architecture != topology2.Architecture {
@@ -735,7 +730,17 @@ func ensureSameTopology(topology1, topology2 *topology.Info) error {
 			// skip comparing index because it's fine if they deffer; see https://github.com/jaypipes/ghw/issues/345#issuecomment-1620274077
 			// ghw.ProcessorCore.Index is completely removed starting v0.11.0
 			if core1.ID != cores2[j].ID {
-				return fmt.Errorf("the CPU core ids in NUMA node %d differ: %d vs %d", node1.ID, core1.ID, cores2[j].ID)
+				// it was learned that core numbering can have different schemes even with
+				// a system from the same vendor. One case was observed on Intel Xeon Gold 6438N with 0-127
+				// online CPUs distributed across 2 sockets, 32 cores per socket and 2 threads per core.
+				// The numbering pattern depends on the settings of the hardware, the software and the
+				// firmware (BIOS).While core IDs may vary nodes can still be considered having same NUMA
+				// topology taking into account that core scope is on the single NUMA. In other words, as long
+				// as the NUMA cells have same logical processors' count and IDs and same threads' number,
+				// core ID equality is treated as best effort. That is because when scheduling workloads,
+				// we care about the logical processors ids and their location on the NUMAs.
+				log.Warnf("the CPU core ids in NUMA node %d differ: %d vs %d", node1.ID, core1.ID, cores2[j].ID)
+				tolerations[DifferentCoreIDs] = true
 			}
 			if core1.NumThreads != cores2[j].NumThreads {
 				return fmt.Errorf("number of threads for CPU %d in NUMA node %d differs: %d vs %d", core1.ID, node1.ID, core1.NumThreads, cores2[j].NumThreads)
@@ -745,7 +750,6 @@ func ensureSameTopology(topology1, topology2 *topology.Info) error {
 			}
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Problem: In a system with a specific number of cores per socket the host gives each core a number. So far PPC would generate performance profile only after verifying that the nodes pointed to by the specified node pool are all of the same hardware and topology. That is because the performance profile will apply the same configuration on all these nodes and it is most important that they have same structure, CPUs distribution across NUMAs and CPUs availability. This by default includes having same core IDs for each CPU in the same NUMA cells for all the compute nodes. for instance:

Worker-0 has NUMA-0 on which the CPUs siblings [2,66] is coupled in one core numbered 18`.
All other workers should have this info true for them, otherwise the tool would fail.

It was observed (for example on Intel Xeon GoldGold 6438N with 0-127 online CPUs distributed across 2 sockets, 32 cores per socket and 2 threads per core) that core numbering can have different schemes even with a system from the same vendor, which causes the tool to fail to generate a profile.

Suggested solution:
With further investigation, The numbering the pattern depends on the settings of the hardware, the software and the firmware (BIOS).While core IDs may vary nodes can still be considered having same NUMA topology taking into account that core scope is on the single NUMA. However, core IDs can be important in optimizing the system's performance and managing isolation of tasks, meaning if the performance of worker-0 is not comparable to that of worker-1 before having performance-profile applied on both, having an improved performance on both after applying PP is not guaranteed.

In this PR, we loosen the hard requirment of having same core numbering on same NUMA cells on different systems into a warning will be logged out as well as a comment on the generated CSV file. So as long as the NUMA cells have same logical processors' count and IDs and same threads' number, core ID equality is treated as best effort. That is because when scheduling workloads, we care about the logical processors ids and their location on the NUMAs.

Disclaimer: We support this option to unblock business matters and is recommended to use the generated PP with cautiono.