### PR TITLE
[release-4.17] OCPBUGS-45263: Invalid cpuset validation fix 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,11 @@ endif
 vet: $(BINDATA)
 	$(GO) vet ./...
 
-test-unit: $(BINDATA)
+test-unit: $(BINDATA) test-fuzz
 	$(GO) test ./cmd/... ./pkg/... -coverprofile cover.out
+
+test-fuzz:
+	$(GO) test ./pkg/apis/performanceprofile/v2 -fuzz=FuzzValidateCPUs -fuzztime=10s 
 
 clean:
 	$(GO) clean $(PACKAGE_MAIN)

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation.go
@@ -142,6 +142,8 @@ func (r *PerformanceProfile) validateCPUs() field.ErrorList {
 			cpuLists, err := components.NewCPULists(string(*cpus.Reserved), string(*cpus.Isolated), offlined, shared)
 			if err != nil {
 				allErrs = append(allErrs, field.InternalError(field.NewPath("spec.cpu"), err))
+				// If err != nil then the cpuList is nil and we can't continue with the function logic
+				return allErrs
 			}
 
 			if cpuLists.GetReserved().IsEmpty() {

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -217,6 +217,19 @@ var _ = Describe("PerformanceProfile", func() {
 			Expect(errors).NotTo(BeEmpty(), "should have validation error when isolated and shared CPUs have overlap")
 			Expect(errors[0].Error()).To(Or(ContainSubstring("isolated and shared cpus overlap"), ContainSubstring("shared and isolated cpus overlap")))
 		})
+		DescribeTable("should reject invalid input that does not represent CPU sets",
+			func(fieldSetter func(*PerformanceProfile, CPUSet), cpusField string) {
+				garbageInput := CPUSet("garbage")
+				fieldSetter(profile, garbageInput)
+				errors := profile.validateCPUs()
+				Expect(errors).NotTo(BeEmpty(), "should have error when "+cpusField+" is filled with garbage input")
+				Expect(errors[0].Error()).To(Or(ContainSubstring("Internal error: strconv.Atoi: parsing")))
+			},
+			Entry("reserved CPUs", func(p *PerformanceProfile, input CPUSet) { p.Spec.CPU.Reserved = &input }, "reserved CPUs"),
+			Entry("isolated CPUs", func(p *PerformanceProfile, input CPUSet) { p.Spec.CPU.Isolated = &input }, "isolated CPUs"),
+			Entry("shared CPUs", func(p *PerformanceProfile, input CPUSet) { p.Spec.CPU.Shared = &input }, "shared CPUs"),
+			Entry("offline CPUs", func(p *PerformanceProfile, input CPUSet) { p.Spec.CPU.Offlined = &input }, "offline CPUs"),
+		)
 	})
 
 	Describe("CPU Frequency validation", func() {


### PR DESCRIPTION
This fix ensures that the input for any CPU set field is valid. If an invalid string that does not represent a valid CPU set is provided, the admission webhook will return an appropriate error, such as:
spec.cpu: Internal error: strconv.Atoi: parsing "garbage": invalid syntax

This replaces the previous behavior, where the server would accept the performance profile and create it with invalid values, which would, in turn, break the cluster.

Moreover, fuzz tests have been added to ensure we exercise all errors when executing the validation function on valid and invalid inputs, ensuring no panic occurs during execution.