### PR TITLE
perf-prof: latency: fix calculating isolated CPUs size

### DIFF
--- a/test/e2e/performanceprofile/functests/4_latency/latency.go
+++ b/test/e2e/performanceprofile/functests/4_latency/latency.go
@@ -482,8 +482,7 @@ func isOddCpuNumber(cpusNum int, profile *performancev2.PerformanceProfile) bool
 	if cpusNum == defaultTestCpus {
 		isolatedCpus, err := cpuset.Parse(string(*profile.Spec.CPU.Isolated))
 		Expect(err).ToNot(HaveOccurred(), "failed to parse cpus %q", string(*profile.Spec.CPU.Isolated))
-		isolatedCpusNum := isolatedCpus.Size() - 1
-		return isolatedCpusNum%2 != 0
+		return isolatedCpus.Size()%2 != 0
 	}
 	return cpusNum%2 != 0
 }

--- a/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -58,7 +58,7 @@ var _ = BeforeSuite(func() {
 	initialIsolated := profile.Spec.CPU.Isolated
 	initialReserved := profile.Spec.CPU.Reserved
 	//updated both sets to ensure there is no overlap
-	latencyIsolatedSet := performancev2.CPUSet("1-9")
+	latencyIsolatedSet := performancev2.CPUSet("1-8")
 	latencyReservedSet := performancev2.CPUSet("0")
 	testlog.Infof("current isolated cpus: %s, desired is %s", string(*initialIsolated), latencyIsolatedSet)
 	isolated, err := cpuset.Parse(string(latencyIsolatedSet))


### PR DESCRIPTION
Calculating the size of the isolated CPUs set from the performance profile was reducing 1 which is incorrect. Remove the reduction line and fix the corresponding setup of the test suite.