### PR TITLE
[release-4.17] OCPBUGS-45627: Normalize cpu sets when rendering to Tuned profiles

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -102,6 +102,21 @@ var _ = Describe("Tuned", func() {
 			Expect(bootLoaderSection.Key("cmdline_realtime").String()).To(Equal(cmdlineRealtime))
 		})
 
+		It("should normalize cpusets", func() {
+			test_profile := testutils.NewPerformanceProfile("test")
+			isolated_cpus := performancev2.CPUSet("10,9,8,7,6,5,4,3,2,1,21,22,23,24,25,26,27,28")
+			reserved_cpus := performancev2.CPUSet("11-15,19,18,17,16")
+
+			test_profile.Spec.CPU.Isolated = &isolated_cpus
+			test_profile.Spec.CPU.Reserved = &reserved_cpus
+
+			tunedData := getTunedStructuredData(test_profile)
+			isolated, err := tunedData.GetSection("variables")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(isolated.Key("isolated_cores").String()).To(Equal("1-10,21-28"))
+		})
+
 		Context("default profile default tuned", func() {
 			It("should [cpu] section in tuned", func() {
 				tunedData := getTunedStructuredData(profile)


### PR DESCRIPTION
Previously the isolated cpu list was passed verbatim as the user entered it. This could have resulted in very long kernel command line.

Example: 10,9,8,7,6,5,4,3,2,1 (imagine 500+ cpus)

This change consolidates the parsing logic in the Tuned templating and generates simply the following in such case.

Example: 1-10