### PR TITLE
NO-JIRA: e2e: common way to fetch poolName

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/memorymanager.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/memorymanager.go
@@ -16,13 +16,11 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cgroup"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/events"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/hypershift"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodepools"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/pods"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/poolname"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profilesupdate"
 	corev1 "k8s.io/api/core/v1"
@@ -67,16 +65,7 @@ var _ = Describe("[rfe_id: 43186][memorymanager] Memorymanager feature", Label(s
 			// Save the original performance profile
 			initialProfile = profile.DeepCopy()
 
-			if !hypershift.IsHypershiftCluster() {
-				poolName, err = mcps.GetByProfile(profile)
-				Expect(err).ToNot(HaveOccurred())
-			} else {
-				hostedClusterName, err := hypershift.GetHostedClusterName()
-				Expect(err).ToNot(HaveOccurred(), "unable to fetch hosted clustername")
-				np, err := nodepools.GetByClusterName(ctx, testclient.ControlPlaneClient, hostedClusterName)
-				Expect(err).ToNot(HaveOccurred())
-				poolName = client.ObjectKeyFromObject(np).String()
-			}
+			poolName = poolname.GetByProfile(ctx, profile)
 
 			for _, node := range workerRTNodes {
 				numaInfo, err := nodes.GetNumaNodes(context.TODO(), &node)
@@ -231,16 +220,7 @@ var _ = Describe("[rfe_id: 43186][memorymanager] Memorymanager feature", Label(s
 			workerRTNodes = getUpdatedNodes()
 			profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 			Expect(err).ToNot(HaveOccurred(), "unable to get performance profile")
-			if !hypershift.IsHypershiftCluster() {
-				poolName, err = mcps.GetByProfile(profile)
-				Expect(err).ToNot(HaveOccurred())
-			} else {
-				hostedClusterName, err := hypershift.GetHostedClusterName()
-				Expect(err).ToNot(HaveOccurred(), "Unable to fetch hosted cluster name")
-				np, err := nodepools.GetByClusterName(ctx, testclient.ControlPlaneClient, hostedClusterName)
-				Expect(err).ToNot(HaveOccurred())
-				poolName = client.ObjectKeyFromObject(np).String()
-			}
+			poolName = poolname.GetByProfile(ctx, profile)
 
 			for _, node := range workerRTNodes {
 				numaInfo, err := nodes.GetNumaNodes(context.TODO(), &node)
@@ -436,16 +416,7 @@ var _ = Describe("[rfe_id: 43186][memorymanager] Memorymanager feature", Label(s
 			workerRTNodes = getUpdatedNodes()
 			profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 			Expect(err).ToNot(HaveOccurred())
-			if !hypershift.IsHypershiftCluster() {
-				poolName, err = mcps.GetByProfile(profile)
-				Expect(err).ToNot(HaveOccurred())
-			} else {
-				hostedClusterName, err := hypershift.GetHostedClusterName()
-				Expect(err).ToNot(HaveOccurred(), "unable to fetch hosted clustername")
-				np, err := nodepools.GetByClusterName(ctx, testclient.ControlPlaneClient, hostedClusterName)
-				Expect(err).ToNot(HaveOccurred())
-				poolName = client.ObjectKeyFromObject(np).String()
-			}
+			poolName = poolname.GetByProfile(ctx, profile)
 			// Save the original performance profile
 			initialProfile = profile.DeepCopy()
 
@@ -555,16 +526,7 @@ var _ = Describe("[rfe_id: 43186][memorymanager] Memorymanager feature", Label(s
 			workerRTNodes = getUpdatedNodes()
 			profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 			Expect(err).ToNot(HaveOccurred(), "failed to fetch performance profile")
-			if !hypershift.IsHypershiftCluster() {
-				poolName, err = mcps.GetByProfile(profile)
-				Expect(err).ToNot(HaveOccurred())
-			} else {
-				hostedClusterName, err := hypershift.GetHostedClusterName()
-				Expect(err).ToNot(HaveOccurred(), "unable to fetch hosted clustername")
-				np, err := nodepools.GetByClusterName(ctx, testclient.ControlPlaneClient, hostedClusterName)
-				Expect(err).ToNot(HaveOccurred())
-				poolName = client.ObjectKeyFromObject(np).String()
-			}
+			poolName = poolname.GetByProfile(ctx, profile)
 			// Save the original performance profile
 			initialProfile = profile.DeepCopy()
 

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
@@ -29,14 +29,12 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cgroup"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/hypershift"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/images"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodepools"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/pods"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/poolname"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profilesupdate"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/systemd"
@@ -76,16 +74,7 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, Label(string(lab
 		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 
-		if !hypershift.IsHypershiftCluster() {
-			poolName, err = mcps.GetByProfile(profile)
-			Expect(err).ToNot(HaveOccurred())
-		} else {
-			hostedClusterName, err := hypershift.GetHostedClusterName()
-			Expect(err).ToNot(HaveOccurred(), "Unable to fetch hosted cluster name")
-			np, err := nodepools.GetByClusterName(ctx, testclient.ControlPlaneClient, hostedClusterName)
-			Expect(err).ToNot(HaveOccurred())
-			poolName = client.ObjectKeyFromObject(np).String()
-		}
+		poolName = poolname.GetByProfile(ctx, profile)
 
 		isCgroupV2, err = cgroup.IsVersion2(ctx, testclient.DataPlaneClient)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/kubelet.go
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
@@ -26,9 +25,8 @@ import (
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/hypershift"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodepools"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/poolname"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profilesupdate"
 )
@@ -55,20 +53,7 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", Ord
 		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 
-		if !hypershift.IsHypershiftCluster() {
-			poolName, err = mcps.GetByProfile(profile)
-			Expect(err).ToNot(HaveOccurred())
-			for _, mcpName := range []string{testutils.RoleWorker, poolName} {
-				mcps.WaitForCondition(mcpName, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
-			}
-		} else {
-			hostedClusterName, err := hypershift.GetHostedClusterName()
-			Expect(err).ToNot(HaveOccurred())
-			np, err := nodepools.GetByClusterName(ctx, testclient.ControlPlaneClient, hostedClusterName)
-			Expect(err).ToNot(HaveOccurred())
-			poolName = client.ObjectKeyFromObject(np).String()
-		}
-
+		poolName = poolname.GetByProfile(ctx, profile)
 		initialProfile = profile.DeepCopy()
 
 	})

--- a/test/e2e/performanceprofile/functests/utils/poolname/poolname.go
+++ b/test/e2e/performanceprofile/functests/utils/poolname/poolname.go
@@ -1,0 +1,32 @@
+package poolname
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
+	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/hypershift"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodepools"
+)
+
+// poolName can be used interchangeably for specifying MCP name or nodePool name
+// depending on the platform on which the test is running.
+
+// GetByProfile returns the poolName which is associated with the given profile
+func GetByProfile(ctx context.Context, profile *performancev2.PerformanceProfile) string {
+	GinkgoHelper()
+	if !hypershift.IsHypershiftCluster() {
+		poolName, err := mcps.GetByProfile(profile)
+		Expect(err).ToNot(HaveOccurred())
+		return poolName
+	}
+	np, err := nodepools.GetNodePool(ctx, testclient.ControlPlaneClient)
+	Expect(err).ToNot(HaveOccurred(), "failed to get node pool affected by profile: %q", profile.Name)
+	return client.ObjectKeyFromObject(np).String()
+}


### PR DESCRIPTION
On OpenShift we're looking for the MCP associated with the
nodes affected by the profile.

On HyperShift we're looking for the nodePool associated the
nodes affected by the profile.

This commit introduce a function to get the pool name
which is essentially MCP/NodePool name depending on
the platform detected at runtime.
