### PR TITLE
OCPBUGS-46584: Adjust Workload Hints test cases based on Intel or AMD

### DIFF
--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -366,7 +366,8 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				if isIntel {
 					Expect(cmdline).To(ContainSubstring("intel_pstate=passive"))
 					Expect(cmdline).ToNot(ContainSubstring("intel_pstate=active"))
-				} else {
+				}
+				if isAMD {
 					Expect(cmdline).To(ContainSubstring("amd_pstate=passive"))
 					Expect(cmdline).ToNot(ContainSubstring("amd_pstate=active"))
 				}

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -307,9 +307,6 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				}
 				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
 					"processor.max_cstate=1", "idle=poll"}
-				if isIntel {
-					kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0")
-				}
 				wg := sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
@@ -330,8 +327,9 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
-						kernelParameters = append(kernelParameters, utilstuned.AddPstateParameter(context.TODO(), node))
-
+						if isIntel {
+							kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0", utilstuned.AddPstateParameter(context.TODO(), node))
+						}
 						utilstuned.CheckParameters(context.TODO(), node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
 					}()
 				}
@@ -425,9 +423,6 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				}
 				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
 					"processor.max_cstate=1", "idle=poll"}
-				if isIntel {
-					kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0")
-				}
 				wg := sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
@@ -448,7 +443,9 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
-						kernelParameters = append(kernelParameters, utilstuned.AddPstateParameter(context.TODO(), node))
+						if isIntel {
+							kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0", utilstuned.AddPstateParameter(context.TODO(), node))
+						}
 						utilstuned.CheckParameters(context.TODO(), node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
 					}()
 				}
@@ -617,9 +614,6 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				kernelParameters = []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
 					"processor.max_cstate=1", "idle=poll"}
 
-				if isIntel {
-					kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0")
-				}
 				wg = sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
@@ -640,7 +634,9 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
-						kernelParameters = append(kernelParameters, utilstuned.AddPstateParameter(context.TODO(), node))
+						if isIntel {
+							kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0", utilstuned.AddPstateParameter(context.TODO(), node))
+						}
 						utilstuned.CheckParameters(context.TODO(), node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
 					}()
 				}

--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -554,7 +554,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1", "intel_pstate=passive"}
+				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1"}
 				if isIntel {
 					kernelParameters = append(kernelParameters, "intel_pstate=passive")
 				}

--- a/test/e2e/performanceprofile/functests/utils/infrastructure/cpu.go
+++ b/test/e2e/performanceprofile/functests/utils/infrastructure/cpu.go
@@ -1,0 +1,103 @@
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CpuArchitecture  struct to represent CPU Details
+type CpuArchitecture struct {
+	Lscpu []cpuField `json:"lscpu"`
+}
+type cpuField struct {
+	Field string `json:"field"`
+	Data  string `json:"data"`
+}
+
+const (
+	IntelVendorID = "GenuineIntel"
+	AMDVendorID   = "AuthenticAMD"
+)
+
+// lscpuPraser parses lscpu output and returns its fields in struct
+func lscpuPraser(ctx context.Context, node *corev1.Node) (CpuArchitecture, error) {
+	cmd := []string{"lscpu", "-J"}
+	var cpuinfo CpuArchitecture
+	out, err := nodes.ExecCommand(ctx, node, cmd)
+	if err != nil {
+		return cpuinfo, fmt.Errorf("error executing lscpu command: %v", err)
+	}
+	err = json.Unmarshal(out, &cpuinfo)
+	if err != nil {
+		return cpuinfo, fmt.Errorf("error unmarshalling cpu info: %v", err)
+	}
+	return cpuinfo, nil
+}
+
+// CPUArchitecture returns CPU Architecture from lscpu output
+func CPUArchitecture(ctx context.Context, node *corev1.Node) (string, error) {
+	cpuInfo, err := lscpuPraser(ctx, node)
+	if err != nil {
+		return "", fmt.Errorf("Unable to parse lscpu output")
+	}
+	for _, v := range cpuInfo.Lscpu {
+		if v.Field == "Architecture:" {
+			return v.Data, nil
+		}
+	}
+	return "", fmt.Errorf("could not fetch CPU architecture")
+}
+
+// CPUVendorId returns Vendor ID information from lscpu output
+func CPUVendorId(ctx context.Context, node *corev1.Node) (string, error) {
+	cpuInfo, err := lscpuPraser(ctx, node)
+	if err != nil {
+		return "", fmt.Errorf("Unable to parse lscpu output")
+	}
+	for _, v := range cpuInfo.Lscpu {
+		if v.Field == "Vendor ID:" {
+			return v.Data, nil
+		}
+	}
+	return "", fmt.Errorf("could not fetch CPU Vendor ID")
+}
+
+// IsCPUVendor checks if the CPU Vendor ID matches the given vendor string
+func IsCPUVendor(ctx context.Context, node *corev1.Node, vendor string) (bool, error) {
+	vendorData, err := CPUVendorId(ctx, node)
+	if err != nil {
+		return false, err
+	}
+	return vendorData == vendor, nil
+}
+
+// IsIntel returns if Vendor ID is GenuineIntel in lscpu output
+func IsIntel(ctx context.Context, node *corev1.Node) (bool, error) {
+	isIntel, err := IsCPUVendor(ctx, node, IntelVendorID)
+	if err != nil {
+		return false, err
+	}
+	return isIntel, nil
+}
+
+// IsAMD returns if Vendor ID is AuthenticAMD in lscpu output
+func IsAMD(ctx context.Context, node *corev1.Node) (bool, error) {
+	isAMD, err := IsCPUVendor(ctx, node, AMDVendorID)
+	if err != nil {
+		return false, err
+	}
+	return isAMD, nil
+}
+
+// IsARM returns if Architecture is aarch64
+func IsARM(ctx context.Context, node *corev1.Node) (bool, error) {
+	architectureData, err := CPUArchitecture(ctx, node)
+	if err != nil {
+		return false, err
+	}
+
+	return architectureData == "aarch64", nil
+}


### PR DESCRIPTION
This PR adds utility functions to get Cpu Vendor (intel or AMD) in case of x86_64. 
Also Adjust Workload Hints test cases  where kernel Args are adjusted based on Intel or AMD. 