### PR TITLE
OCPBUGS-48317: PPC_Test_fix: use ROLE_WORKER_CNF environment variable to determine mcp name

### DIFF
--- a/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go
+++ b/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go
@@ -63,6 +63,7 @@ func PPCTestCreateUtil() *PPCTestIntegration {
 
 var _ = Describe("[rfe_id: 38968] PerformanceProfile setup helper and platform awareness", Label(string(label.PerformanceProfileCreator)), func() {
 	mustgatherDir := testutils.MustGatherDir
+	mcpName := testutils.RoleWorkerCNF
 	ntoImage := testutils.NTOImage
 	Context("PPC Sanity Tests", Label(string(label.Tier0)), func() {
 		ppcIntgTest := PPCTestCreateUtil()
@@ -79,7 +80,7 @@ var _ = Describe("[rfe_id: 38968] PerformanceProfile setup helper and platform a
 			cmdArgs := []string{
 				fmt.Sprintf("%s:%s:z", mustgatherDir, mustgatherDir),
 				ntoImage,
-				"--mcp-name=worker",
+				fmt.Sprintf("--mcp-name=%s", mcpName),
 				fmt.Sprintf("--reserved-cpu-count=%d", reservedCpuCount),
 				fmt.Sprintf("--rt-kernel=%t", true),
 				fmt.Sprintf("--power-consumption-mode=%s", "low-latency"),
@@ -111,7 +112,7 @@ var _ = Describe("[rfe_id: 38968] PerformanceProfile setup helper and platform a
 			cmdArgs := []string{
 				fmt.Sprintf("%s:%s:z", mustgatherDir, mustgatherDir),
 				ntoImage,
-				"--mcp-name=worker",
+				fmt.Sprintf("--mcp-name=%s", mcpName),
 				fmt.Sprintf("--reserved-cpu-count=%d", 2),
 				fmt.Sprintf("--rt-kernel=%t", true),
 				fmt.Sprintf("--power-consumption-mode=%s", "low-latency"),
@@ -142,7 +143,7 @@ var _ = Describe("[rfe_id: 38968] PerformanceProfile setup helper and platform a
 			cmdArgs := []string{
 				fmt.Sprintf("%s:%s:z", mustgatherDir, mustgatherDir),
 				ntoImage,
-				"--mcp-name=worker",
+				fmt.Sprintf("--mcp-name=%s", mcpName),
 				fmt.Sprintf("--reserved-cpu-count=%d", 2),
 				fmt.Sprintf("--rt-kernel=%t", true),
 				fmt.Sprintf("--power-consumption-mode=%s", "low-latency"),
@@ -172,7 +173,7 @@ var _ = Describe("[rfe_id: 38968] PerformanceProfile setup helper and platform a
 			cmdArgs := []string{
 				fmt.Sprintf("%s:%s:z", mustgatherDir, mustgatherDir),
 				ntoImage,
-				"--mcp-name=worker",
+				fmt.Sprintf("--mcp-name=%s", mcpName),
 				fmt.Sprintf("--reserved-cpu-count=%d", 100),
 				fmt.Sprintf("--rt-kernel=%t", true),
 				fmt.Sprintf("--power-consumption-mode=%s", "low-latency"),


### PR DESCRIPTION
In the current ppc tests, we are using mcp-name as worker. Instead of using hardcoded value of worker, use the mcp name from ROLE_WORKER_CNF environment variable