### PR TITLE
OCPBUGS-47683: [release-4.15][manual]: Fix context deadlines in ExecCommandOnPod()

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/pods/pods.go
+++ b/test/e2e/performanceprofile/functests/utils/pods/pods.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -145,7 +144,7 @@ func ExecCommandOnPod(c *kubernetes.Clientset, pod *corev1.Pod, containerName st
 		VersionedParams(&corev1.PodExecOptions{
 			Container: containerName,
 			Command:   command,
-			Stdin:     true,
+			Stdin:     false,
 			Stdout:    true,
 			Stderr:    true,
 			TTY:       true,
@@ -162,7 +161,6 @@ func ExecCommandOnPod(c *kubernetes.Clientset, pod *corev1.Pod, containerName st
 	}
 
 	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:  os.Stdin,
 		Stdout: &outputBuf,
 		Stderr: &errorBuf,
 		Tty:    true,


### PR DESCRIPTION
Manual and partial backport of https://github.com/openshift/cluster-node-tuning-operator/pull/1263