### PR TITLE
OCPBUGS-44644: [release-4.17] PPC: correct EnableHardwareTuning flag value

### DIFF
--- a/cmd/performance-profile-creator/cmd/root.go
+++ b/cmd/performance-profile-creator/cmd/root.go
@@ -175,7 +175,7 @@ func NewRootCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to make profile data from node handler: %w", err)
 			}
-			tolerations[profilecreator.EnableHardwareTuning] = true
+			tolerations[profilecreator.EnableHardwareTuning] = profileData.enableHardwareTuning
 			profile, err := makePerformanceProfileFrom(*profileData)
 			if err != nil {
 				return err


### PR DESCRIPTION
By mistake this was overridden to always `true` in this PR: #1236 Correct this by setting the value equal to the passed value from the parsed data.

Signed-off-by: Shereen Haj <shajmakh@redhat.com>
(cherry picked from commit 827db751f72744e72c8d04458eca5985f9096391) (cherry picked from commit fc95cb0cca16e6f8bd76c1f19229ef5e227e8843)