### PR TITLE
OCPBUGS-48144:[release-4.16][manual]:e2e:performance: decode to valid kubeletconfig object

### DIFF
--- a/pkg/util/manifests.go
+++ b/pkg/util/manifests.go
@@ -24,10 +24,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes/scheme"
+
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 type manifest struct {
@@ -167,4 +170,18 @@ func AppendMissingDefaultMCPManifests(currentMCPs []*mcfgv1.MachineConfigPool) [
 	}
 
 	return append(finalMCPList, currentMCPs...)
+}
+
+func DeserializeObjectFromData(data []byte, addToSchemeFn ...func(scheme2 *runtime.Scheme) error) (runtime.Object, error) {
+	for _, fn := range addToSchemeFn {
+		if err := fn(scheme.Scheme); err != nil {
+			return nil, err
+		}
+	}
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, _, err := decode(data, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
 }


### PR DESCRIPTION
manual cherry-pick of: https://github.com/openshift/cluster-node-tuning-operator/pull/1091
we need this one to be backport up until 4.14 because we're facing the similar issue in [cnf-feature-deploy ci](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-kni_cnf-features-deploy/2135/pull-ci-openshift-kni-cnf-features-deploy-release-4.14-e2e-aws-ci-tests/1875935067373572096 )


```
  [FAILED] Expected
      <string>: {
        "kind": "KubeletConfiguration",
        "apiVersion": "kubelet.config.k8s.io/v1beta1",
        "staticPodPath": "/etc/kubernetes/manifests",
        "syncFrequency": "0s",
        "fileCheckFrequency": "0s",
        "httpCheckFrequency": "0s",
        "tlsCipherSuites": [
          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
  to match regular expression
      <string>: "reservedSystemCPUs": ?"0"
```