### PR TITLE
OCPBUGS-48207:[release-4.15][manual]e2e:performance: decode to valid kubeletconfig object

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/utils/cpuset"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +24,7 @@ import (
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/utils/schedstat"
+	manifestsutil "github.com/openshift/cluster-node-tuning-operator/pkg/util"
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cluster"
@@ -111,8 +113,11 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			cmd = []string{"cat", "/rootfs/etc/kubernetes/kubelet.conf"}
 			conf, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
 			Expect(err).ToNot(HaveOccurred(), "failed to cat kubelet.conf")
-			// kubelet.conf changed formatting, there is a space after colons atm. Let's deal with both cases with a regex
-			Expect(conf).To(MatchRegexp(fmt.Sprintf(`"reservedSystemCPUs": ?"%s"`, reservedCPU)))
+			obj, err := manifestsutil.DeserializeObjectFromData([]byte(conf), kubeletconfigv1beta1.AddToScheme)
+			Expect(err).ToNot(HaveOccurred())
+			kc, ok := obj.(*kubeletconfigv1beta1.KubeletConfiguration)
+			Expect(ok).To(BeTrue(), "wrong type %T", obj)
+			Expect(kc.ReservedSystemCPUs).To(Equal(reservedCPU))
 
 			By("checking CPU affinity mask for kernel scheduler")
 			cmd = []string{"/bin/bash", "-c", "taskset -pc 1"}

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/utils/cpuset"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,6 +26,7 @@ import (
 	performancev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	"github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components"
 	profilecomponent "github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/controller/performanceprofile/components/profile"
+	manifestsutil "github.com/openshift/cluster-node-tuning-operator/pkg/util"
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
@@ -293,9 +295,21 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			Entry("[test_id:28025] verify that cpu affinity mask was updated", chkCmdLineFn, []string{"tuned.non_isolcpus=.*9"}, true, true),
 			Entry("[test_id:28071] verify that cpu balancer disabled", chkCmdLineFn, []string{"isolcpus=domain,managed_irq,1-2"}, true, false),
 			Entry("[test_id:28071] verify that cpu balancer disabled", chkCmdLineFn, []string{"systemd.cpu_affinity=0,3"}, true, false),
-			// kubelet.conf changed formatting, there is a space after colons atm. Let's deal with both cases with a regex
-			Entry("[test_id:28935] verify that reservedSystemCPUs was updated", chkKubeletConfigFn, []string{`"reservedSystemCPUs": ?"0,3"`}, true, true),
-			Entry("[test_id:28760] verify that topologyManager was updated", chkKubeletConfigFn, []string{`"topologyManagerPolicy": ?"best-effort"`}, true, true),
+		)
+
+		DescribeTable("Verify that kubelet parameters were updated", func(ctx context.Context, cmdFn checkFunction, getterFn func(kubeletCfg *kubeletconfigv1beta1.KubeletConfiguration) string, wantedValue string) {
+			for _, node := range workerRTNodes {
+				result, err := cmdFn(&node)
+				obj, err := manifestsutil.DeserializeObjectFromData([]byte(result), kubeletconfigv1beta1.AddToScheme)
+				Expect(err).ToNot(HaveOccurred())
+
+				kc, ok := obj.(*kubeletconfigv1beta1.KubeletConfiguration)
+				Expect(ok).To(BeTrue(), "wrong type %T", obj)
+				Expect(getterFn(kc)).To(Equal(wantedValue))
+			}
+		},
+			Entry("[test_id:28935] verify that reservedSystemCPUs was updated", chkKubeletConfigFn, func(k *kubeletconfigv1beta1.KubeletConfiguration) string { return k.ReservedSystemCPUs }, "0,3"),
+			Entry("[test_id:28760] verify that topologyManager was updated", chkKubeletConfigFn, func(k *kubeletconfigv1beta1.KubeletConfiguration) string { return k.TopologyManagerPolicy }, "best-effort"),
 		)
 
 		It("[test_id:27738] should succeed to disable the RT kernel", func() {


### PR DESCRIPTION
manual cherry-pick of: https://github.com/openshift/cluster-node-tuning-operator/pull/1273
we need this one to be backport up until 4.14 because we're facing the similar issue in [cnf-feature-deploy ci](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-kni_cnf-features-deploy/2135/pull-ci-openshift-kni-cnf-features-deploy-release-4.14-e2e-aws-ci-tests/1875935067373572096)

```
  [FAILED] Expected
      <string>: {
        "kind": "KubeletConfiguration",
        "apiVersion": "kubelet.config.k8s.io/v1beta1",
        "staticPodPath": "/etc/kubernetes/manifests",
        "syncFrequency": "0s",
        "fileCheckFrequency": "0s",
        "httpCheckFrequency": "0s",
        "tlsCipherSuites": [
          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
  to match regular expression
      <string>: "reservedSystemCPUs": ?"0"
```