### PR TITLE
OCPBUGS-48213: [release-4.17][manual] Adjust Workload Hints test cases based on Intel or AMD

### DIFF
--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -318,7 +318,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
 						if isIntel {
-							kernelParameters = append(kernelParameters, "intel_idle.max.cstate=0", utilstuned.AddPstateParameter(context.TODO(), node))
+							kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0", utilstuned.AddPstateParameter(context.TODO(), node))
 						}
 						utilstuned.CheckParameters(context.TODO(), node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
 					}()

--- a/test/e2e/performanceprofile/functests/utils/infrastructure/cpu.go
+++ b/test/e2e/performanceprofile/functests/utils/infrastructure/cpu.go
@@ -1,0 +1,103 @@
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CpuArchitecture  struct to represent CPU Details
+type CpuArchitecture struct {
+	Lscpu []cpuField `json:"lscpu"`
+}
+type cpuField struct {
+	Field string `json:"field"`
+	Data  string `json:"data"`
+}
+
+const (
+	IntelVendorID = "GenuineIntel"
+	AMDVendorID   = "AuthenticAMD"
+)
+
+// lscpuPraser parses lscpu output and returns its fields in struct
+func lscpuPraser(ctx context.Context, node *corev1.Node) (CpuArchitecture, error) {
+	cmd := []string{"lscpu", "-J"}
+	var cpuinfo CpuArchitecture
+	out, err := nodes.ExecCommand(ctx, node, cmd)
+	if err != nil {
+		return cpuinfo, fmt.Errorf("error executing lscpu command: %v", err)
+	}
+	err = json.Unmarshal(out, &cpuinfo)
+	if err != nil {
+		return cpuinfo, fmt.Errorf("error unmarshalling cpu info: %v", err)
+	}
+	return cpuinfo, nil
+}
+
+// CPUArchitecture returns CPU Architecture from lscpu output
+func CPUArchitecture(ctx context.Context, node *corev1.Node) (string, error) {
+	cpuInfo, err := lscpuPraser(ctx, node)
+	if err != nil {
+		return "", fmt.Errorf("Unable to parse lscpu output")
+	}
+	for _, v := range cpuInfo.Lscpu {
+		if v.Field == "Architecture:" {
+			return v.Data, nil
+		}
+	}
+	return "", fmt.Errorf("could not fetch CPU architecture")
+}
+
+// CPUVendorId returns Vendor ID information from lscpu output
+func CPUVendorId(ctx context.Context, node *corev1.Node) (string, error) {
+	cpuInfo, err := lscpuPraser(ctx, node)
+	if err != nil {
+		return "", fmt.Errorf("Unable to parse lscpu output")
+	}
+	for _, v := range cpuInfo.Lscpu {
+		if v.Field == "Vendor ID:" {
+			return v.Data, nil
+		}
+	}
+	return "", fmt.Errorf("could not fetch CPU Vendor ID")
+}
+
+// IsCPUVendor checks if the CPU Vendor ID matches the given vendor string
+func IsCPUVendor(ctx context.Context, node *corev1.Node, vendor string) (bool, error) {
+	vendorData, err := CPUVendorId(ctx, node)
+	if err != nil {
+		return false, err
+	}
+	return vendorData == vendor, nil
+}
+
+// IsIntel returns if Vendor ID is GenuineIntel in lscpu output
+func IsIntel(ctx context.Context, node *corev1.Node) (bool, error) {
+	isIntel, err := IsCPUVendor(ctx, node, IntelVendorID)
+	if err != nil {
+		return false, err
+	}
+	return isIntel, nil
+}
+
+// IsAMD returns if Vendor ID is AuthenticAMD in lscpu output
+func IsAMD(ctx context.Context, node *corev1.Node) (bool, error) {
+	isAMD, err := IsCPUVendor(ctx, node, AMDVendorID)
+	if err != nil {
+		return false, err
+	}
+	return isAMD, nil
+}
+
+// IsARM returns if Architecture is aarch64
+func IsARM(ctx context.Context, node *corev1.Node) (bool, error) {
+	architectureData, err := CPUArchitecture(ctx, node)
+	if err != nil {
+		return false, err
+	}
+
+	return architectureData == "aarch64", nil
+}


### PR DESCRIPTION
* Add utility function to check cpu vendor We use lscpu output and check Vendor ID to determine if the system is AMD or Intel.

* Workload Hints E2E: Modify kernel args based on Vendor Adjust Workload Hints E2E test cases to verify kernel parameters depending on the Vendor in the case of x86_64 where kernel args are changed based on Intel or AMD.

* Remove duplicate intel related kernel args Remove duplicate intel_pstate=passive from kernelParameters string slice as it's already added if system is intel

* Add a single condition to add all kernel parameters related to intel