### PR TITLE
OCPBUGS-48357: [release-4.16] [manual] Adjust Workload Hints test cases based on Intel or AMD 

### DIFF
--- a/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
+++ b/test/e2e/performanceprofile/functests/8_performance_workloadhints/workloadhints.go
@@ -32,6 +32,8 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cgroup"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/infrastructure"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
@@ -45,14 +47,16 @@ const (
 	cgroupRoot = "/rootfs/sys/fs/cgroup"
 )
 
-var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific PerformanceProfile API", func() {
-	var workerRTNodes []corev1.Node
-	var profile, initialProfile *performancev2.PerformanceProfile
-	var performanceMCP string
-	var err error
-
+var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific PerformanceProfile API", Label(string(label.WorkloadHints)), func() {
+	var (
+		workerRTNodes           []corev1.Node
+		profile, initialProfile *performancev2.PerformanceProfile
+		performanceMCP          string
+		err                     error
+		ctx                     context.Context = context.Background()
+		isIntel, isAMD          bool
+	)
 	nodeLabel := testutils.NodeSelectorLabels
-
 	BeforeEach(func() {
 		if discovery.Enabled() && testutils.ProfileNotFound {
 			Skip("Discovery mode enabled, performance profile not found")
@@ -65,6 +69,11 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 		performanceMCP, err = mcps.GetByProfile(profile)
 		Expect(err).ToNot(HaveOccurred())
 		klog.Infof("using performanceMCP: %q", performanceMCP)
+		// Check if one of the nodes is intel or AMD using Vendor ID
+		isIntel, err = infrastructure.IsIntel(ctx, &workerRTNodes[0])
+		Expect(err).ToNot(HaveOccurred(), "Unable to fetch Vendor ID")
+		isAMD, err = infrastructure.IsAMD(ctx, &workerRTNodes[0])
+		Expect(err).ToNot(HaveOccurred(), "Unable to fetch Vendor ID")
 
 		// Verify that worker and performance MCP have updated state equals to true
 		for _, mcpName := range []string{testutils.RoleWorker, performanceMCP} {
@@ -218,8 +227,10 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "950000",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{"processor.max_cstate=1", "intel_idle.max_cstate=0"}
-
+				kernelParameters := []string{"processor.max_cstate=1"}
+				if isIntel {
+					kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0")
+				}
 				wg := sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
@@ -284,8 +295,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"vm.stat_interval":              "10",
 				}
 				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
-					"processor.max_cstate=1", "intel_idle.max_cstate=0", "idle=poll"}
-
+					"processor.max_cstate=1", "idle=poll"}
 				wg := sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
@@ -306,7 +316,9 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
-						kernelParameters = append(kernelParameters, utilstuned.AddPstateParameter(context.TODO(), node))
+						if isIntel {
+							kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0", utilstuned.AddPstateParameter(context.TODO(), node))
+						}
 						utilstuned.CheckParameters(context.TODO(), node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
 					}()
 				}
@@ -343,9 +355,15 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				By("Verifying node kernel arguments")
 				cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), &workerRTNodes[0], []string{"cat", "/proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cmdline).To(ContainSubstring("intel_pstate=passive"))
-				Expect(cmdline).ToNot(ContainSubstring("intel_pstate=active"))
+				if isIntel {
+					Expect(cmdline).To(ContainSubstring("intel_pstate=passive"))
+					Expect(cmdline).ToNot(ContainSubstring("intel_pstate=active"))
+				}
 
+				if isAMD {
+					Expect(cmdline).To(ContainSubstring("amd_pstate=passive"))
+					Expect(cmdline).ToNot(ContainSubstring("amd_pstate=active"))
+				}
 				By("Verifying tuned profile")
 				key := types.NamespacedName{
 					Name:      components.GetComponentName(profile.Name, components.ProfileNamePerformance),
@@ -405,7 +423,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"vm.stat_interval":              "10",
 				}
 				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
-					"processor.max_cstate=1", "intel_idle.max_cstate=0", "idle=poll"}
+					"processor.max_cstate=1", "idle=poll"}
 
 				wg := sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
@@ -427,7 +445,9 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
-						kernelParameters = append(kernelParameters, utilstuned.AddPstateParameter(context.TODO(), node))
+						if isIntel {
+							kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0", utilstuned.AddPstateParameter(context.TODO(), node))
+						}
 						utilstuned.CheckParameters(context.TODO(), node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
 					}()
 				}
@@ -470,8 +490,14 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters = []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1", "intel_pstate=passive"}
+				kernelParameters = []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1"}
+				if isIntel {
+					kernelParameters = append(kernelParameters, "intel_pstate=passive")
+				}
 
+				if isAMD {
+					kernelParameters = append(kernelParameters, "amd_pstate=passive")
+				}
 				wg = sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
 				for i := 0; i < len(workerRTNodes); i++ {
@@ -542,7 +568,13 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"kernel.sched_rt_runtime_us":    "-1",
 					"vm.stat_interval":              "10",
 				}
-				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1", "intel_pstate=passive"}
+				kernelParameters := []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1"}
+				if isIntel {
+					kernelParameters = append(kernelParameters, "intel_pstate=passive")
+				}
+				if isAMD {
+					kernelParameters = append(kernelParameters, "amd_pstate=passive")
+				}
 
 				wg := sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
@@ -607,7 +639,7 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 					"vm.stat_interval":              "10",
 				}
 				kernelParameters = []string{noHzParam, "tsc=reliable", "nosoftlockup", "nmi_watchdog=0", "mce=off", "skew_tick=1",
-					"processor.max_cstate=1", "intel_idle.max_cstate=0", "idle=poll"}
+					"processor.max_cstate=1", "idle=poll"}
 
 				wg = sync.WaitGroup{}
 				By("Waiting for TuneD to start on nodes")
@@ -629,7 +661,9 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 							fmt.Sprintf("stalld is not running on %q when it should", node.Name))
 
 						By(fmt.Sprintf("Checking TuneD parameters on %q", node.Name))
-						kernelParameters = append(kernelParameters, utilstuned.AddPstateParameter(context.TODO(), node))
+						if isIntel {
+							kernelParameters = append(kernelParameters, "intel_idle.max_cstate=0", utilstuned.AddPstateParameter(context.TODO(), node))
+						}
 						utilstuned.CheckParameters(context.TODO(), node, sysctlMap, kernelParameters, stalldEnabled, rtKernel)
 					}()
 				}
@@ -658,6 +692,10 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				var fullPath string = ""
 				// This test requires real hardware with powermanagement settings done on BIOS
 				// Using numa nodes to check if we are running on real hardware.
+
+				if isAMD {
+					Skip("Crio Powersave annotations test can only be run on Intel systems")
+				}
 				checkHardwareCapability(context.TODO(), workerRTNodes)
 				currentWorkloadHints := profile.Spec.WorkloadHints
 				profile.Spec.WorkloadHints = &performancev2.WorkloadHints{
@@ -756,10 +794,13 @@ var _ = Describe("[rfe_id:49062][workloadHints] Telco friendly workload specific
 				err = checkCpuGovernorsAndResumeLatency(context.TODO(), targetCpus, &workerRTNodes[0], "0", "performance")
 			})
 
-			It("[test_id:54186] Verify sysfs paramters of guaranteed pod with performance annotiations", func() {
+			It("[test_id:54186] Verify sysfs parameters of guaranteed pod with performance annotiations", func() {
 
 				// This test requires real hardware with powermanagement settings done on BIOS
 				// Using numa nodes to check if we are running on real hardware
+				if isAMD {
+					Skip("Crio Powersave annotations test can only be run on Intel systems")
+				}
 				var containerCgroup, fullPath string
 				checkHardwareCapability(context.TODO(), workerRTNodes)
 				currentWorkloadHints := profile.Spec.WorkloadHints

--- a/test/e2e/performanceprofile/functests/utils/infrastructure/cpu.go
+++ b/test/e2e/performanceprofile/functests/utils/infrastructure/cpu.go
@@ -1,0 +1,103 @@
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CpuArchitecture  struct to represent CPU Details
+type CpuArchitecture struct {
+	Lscpu []cpuField `json:"lscpu"`
+}
+type cpuField struct {
+	Field string `json:"field"`
+	Data  string `json:"data"`
+}
+
+const (
+	IntelVendorID = "GenuineIntel"
+	AMDVendorID   = "AuthenticAMD"
+)
+
+// lscpuPraser parses lscpu output and returns its fields in struct
+func lscpuPraser(ctx context.Context, node *corev1.Node) (CpuArchitecture, error) {
+	cmd := []string{"lscpu", "-J"}
+	var cpuinfo CpuArchitecture
+	out, err := nodes.ExecCommandOnNode(ctx, cmd, node)
+	if err != nil {
+		return cpuinfo, fmt.Errorf("error executing lscpu command: %v", err)
+	}
+	err = json.Unmarshal([]byte(out), &cpuinfo)
+	if err != nil {
+		return cpuinfo, fmt.Errorf("error unmarshalling cpu info: %v", err)
+	}
+	return cpuinfo, nil
+}
+
+// CPUArchitecture returns CPU Architecture from lscpu output
+func CPUArchitecture(ctx context.Context, node *corev1.Node) (string, error) {
+	cpuInfo, err := lscpuPraser(ctx, node)
+	if err != nil {
+		return "", fmt.Errorf("Unable to parse lscpu output")
+	}
+	for _, v := range cpuInfo.Lscpu {
+		if v.Field == "Architecture:" {
+			return v.Data, nil
+		}
+	}
+	return "", fmt.Errorf("could not fetch CPU architecture")
+}
+
+// CPUVendorId returns Vendor ID information from lscpu output
+func CPUVendorId(ctx context.Context, node *corev1.Node) (string, error) {
+	cpuInfo, err := lscpuPraser(ctx, node)
+	if err != nil {
+		return "", fmt.Errorf("Unable to parse lscpu output")
+	}
+	for _, v := range cpuInfo.Lscpu {
+		if v.Field == "Vendor ID:" {
+			return v.Data, nil
+		}
+	}
+	return "", fmt.Errorf("could not fetch CPU Vendor ID")
+}
+
+// IsCPUVendor checks if the CPU Vendor ID matches the given vendor string
+func IsCPUVendor(ctx context.Context, node *corev1.Node, vendor string) (bool, error) {
+	vendorData, err := CPUVendorId(ctx, node)
+	if err != nil {
+		return false, err
+	}
+	return vendorData == vendor, nil
+}
+
+// IsIntel returns if Vendor ID is GenuineIntel in lscpu output
+func IsIntel(ctx context.Context, node *corev1.Node) (bool, error) {
+	isIntel, err := IsCPUVendor(ctx, node, IntelVendorID)
+	if err != nil {
+		return false, err
+	}
+	return isIntel, nil
+}
+
+// IsAMD returns if Vendor ID is AuthenticAMD in lscpu output
+func IsAMD(ctx context.Context, node *corev1.Node) (bool, error) {
+	isAMD, err := IsCPUVendor(ctx, node, AMDVendorID)
+	if err != nil {
+		return false, err
+	}
+	return isAMD, nil
+}
+
+// IsARM returns if Architecture is aarch64
+func IsARM(ctx context.Context, node *corev1.Node) (bool, error) {
+	architectureData, err := CPUArchitecture(ctx, node)
+	if err != nil {
+		return false, err
+	}
+
+	return architectureData == "aarch64", nil
+}


### PR DESCRIPTION
Manual Backport of  #1277 

* Adjust Workload Hints test cases based on Intel or AMD

* Add utility function to check cpu vendor We use lscpu output and check Vendor ID to determine if the system is AMD or Intel.

* Workload Hints E2E: Modify kernel args based on Vendor Adjust Workload Hints E2E test cases to verify kernel parameters depending on the Vendor in the case of x86_64 where kernel args are changed based on Intel or AMD.

* Remove duplicate intel related kernel args Remove duplicate intel_pstate=passive from kernelParameters string slice as it's already added if system is intel

* Add a single condition to add all kernel parameters related to intel