### PR TITLE
OCPBUGS-48422: [release-4.16]  e2e: tuned degraded test fix

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -129,12 +129,16 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred(), "Failed to get the Tuned profile for node %s", node.Name)
 				degradedCondition := findCondition(tunedProfile.Status.Conditions, "Degraded")
 				Expect(degradedCondition).ToNot(BeNil(), "Degraded condition not found in Tuned profile status")
-				isNodeBasedOnVM, err := infrastructure.IsVM(&node)
+				isNodeBasedOnVM, err := infrastructure.IsVM(context.TODO(), &node)
 				Expect(err).ToNot(HaveOccurred(), "Failed to detect if the node is based on VM")
-				if isNodeBasedOnVM {
-					testlog.Warning(fmt.Sprintf("Tuned profile is degraded. A warning raised as the node is based on a VM. Error message: %s", degradedCondition.Message))
-				} else {
-					Expect(degradedCondition.Status).To(Equal(corev1.ConditionFalse), "Tuned profile is degraded. Error message: %s", degradedCondition.Message)
+
+				if degradedCondition.Status == corev1.ConditionTrue {
+					message := fmt.Sprintf("Tuned profile is degraded. Error message: %s", degradedCondition.Message)
+					if isNodeBasedOnVM {
+						testlog.Warning(fmt.Sprintf("A warning raised as the node is based on a VM. %s", message))
+					} else {
+						Fail(message)
+					}
 				}
 			}
 		})

--- a/test/e2e/performanceprofile/functests/utils/infrastructure/vm.go
+++ b/test/e2e/performanceprofile/functests/utils/infrastructure/vm.go
@@ -10,13 +10,14 @@ import (
 )
 
 // IsVM checks if a given node's underlying infrastructure is a VM
-func IsVM(node *corev1.Node) (bool, error) {
+func IsVM(ctx context.Context, node *corev1.Node) (bool, error) {
 	cmd := []string{
-		"/bin/bash",
-		"-c",
-		"systemd-detect-virt > /dev/null ; echo $?",
+		"/usr/sbin/chroot",
+		"/rootfs",
+		"/bin/bash", "-c",
+		"systemd-detect-virt > /dev/null; echo $?",
 	}
-	output, err := nodes.ExecCommandOnMachineConfigDaemon(context.TODO(), node, cmd)
+	output, err := nodes.ExecCommandOnMachineConfigDaemon(ctx, node, cmd)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This is a manual backport of #1259.
* Addressed a corner case where nodes based on VMs would always log a warning without verifying if the profile was degraded. This incorrect behavior has been fixed to properly check the profile state before logging warnings.
* Modified isVM func to execute "systemd-detect-virt" command after chroot to rootfs. This will ensures accurate virtualization detection by running the command in the host's context instead of the container.