### PR TITLE
NO-JIRA: Fix hack/test-tuned-fdp.sh

### DIFF
--- a/hack/test-tuned-fdp.sh
+++ b/hack/test-tuned-fdp.sh
@@ -61,7 +61,7 @@ EOF
 
 deploy_custom_nto() {
   # Prepare Makefile and deploy-custom-nto.sh variables
-  export IMAGE_BUILD_EXTRA_OPTS="-v=$REPO_DIR:/etc/yum.repos.d:z"
+  export IMAGE_BUILD_EXTRA_OPTS="-v=$REPO_DIR:/etc/yum.repos.d:z --env=ART_DNF_WRAPPER_POLICY=append"
   export DOCKERFILE=Dockerfile.rhel9	# Do not build TuneD from source, use pre-built TuneD RPMs.  These RPMs might contain extra patches which do not ship ustream.
   export ORG
 


### PR DESCRIPTION
When testing new TuneD releases, we use the official `Dockerfile.rhel9`. The official Containerfile uses
`registry.ci.openshift.org/ocp/<OCP-VERSION>:base-rhel<RHEL-VERSION>` images.  These images use a wrapper for dnf/yum commands.  The purpose of that wrapper to wrap yum/dnf invocations that are issued by CI workloads or local docker builds of OCP components.

While the wrapper is useful to build an image identical or close to identical to the actual ART releases, it will ignore any custom repositories supplied to it via the "podman build" process and volume mounting `/etc/yum.repos.d`.

The behaviour of the wrapper dnf/yum script can be modified by supplying it `ART_DNF_WRAPPER_POLICY` variable.  Setting the value "append" to this variable does exactly what we need -- do not remove base image .repo files from dnf runs - only add ART repos based on invocation context.