### PR TITLE
CNF-16459: Update cnf-tests image

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/images/images.go
+++ b/test/e2e/performanceprofile/functests/utils/images/images.go
@@ -13,7 +13,7 @@ func init() {
 	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
 
 	if cnfTestsImage == "" {
-		cnfTestsImage = "cnf-tests:4.14"
+		cnfTestsImage = "cnf-tests:4.19"
 	}
 
 	if registry == "" {


### PR DESCRIPTION
This PR corrects the cnf-tests image to point to the correct image version of this release.
We plan to create a corresponding PR for this down to 4.14 at least.