### PR TITLE
NO-JIRA:e2e:daemonset: pod phase and events

### DIFF
--- a/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/test/e2e/performanceprofile/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 		testlog.Errorf("cannot create the namespace: %v", err)
 	}
 
-	ds, err := images.PrePull(testclient.Client, images.Test(), prePullNamespace.Name, "cnf-tests")
+	ds, err := images.PrePull(context.TODO(), testclient.Client, images.Test(), prePullNamespace.Name, "cnf-tests")
 	if err != nil {
 		data, _ := json.Marshal(ds) // we can safely skip errors
 		testlog.Infof("DaemonSet %s/%s image=%q status:\n%s", ds.Namespace, ds.Name, images.Test(), string(data))

--- a/test/e2e/performanceprofile/functests/utils/daemonset/daemonset.go
+++ b/test/e2e/performanceprofile/functests/utils/daemonset/daemonset.go
@@ -44,5 +44,5 @@ func IsRunning(ctx context.Context, cli client.Client, namespace, name string) (
 		return false, err
 	}
 	testlog.Infof("daemonset %q %q desired %d scheduled %d ready %d", namespace, name, ds.Status.DesiredNumberScheduled, ds.Status.CurrentNumberScheduled, ds.Status.NumberReady)
-	return (ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady), nil
+	return ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady, nil
 }

--- a/test/e2e/performanceprofile/functests/utils/daemonset/daemonset.go
+++ b/test/e2e/performanceprofile/functests/utils/daemonset/daemonset.go
@@ -13,29 +13,29 @@ import (
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 )
 
-func WaitToBeRunning(cli client.Client, namespace, name string) error {
-	return WaitToBeRunningWithTimeout(cli, namespace, name, 5*time.Minute)
+func WaitToBeRunning(ctx context.Context, cli client.Client, namespace, name string) error {
+	return WaitToBeRunningWithTimeout(ctx, cli, namespace, name, 5*time.Minute)
 }
 
-func WaitToBeRunningWithTimeout(cli client.Client, namespace, name string, timeout time.Duration) error {
+func WaitToBeRunningWithTimeout(ctx context.Context, cli client.Client, namespace, name string, timeout time.Duration) error {
 	testlog.Infof("wait for the daemonset %q %q to be running", namespace, name)
-	return wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		return IsRunning(cli, namespace, name)
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx2 context.Context) (bool, error) {
+		return IsRunning(ctx2, cli, namespace, name)
 	})
 }
 
-func GetByName(cli client.Client, namespace, name string) (*appsv1.DaemonSet, error) {
+func GetByName(ctx context.Context, cli client.Client, namespace, name string) (*appsv1.DaemonSet, error) {
 	key := client.ObjectKey{
 		Namespace: namespace,
 		Name:      name,
 	}
 	var ds appsv1.DaemonSet
-	err := cli.Get(context.TODO(), key, &ds)
+	err := cli.Get(ctx, key, &ds)
 	return &ds, err
 }
 
-func IsRunning(cli client.Client, namespace, name string) (bool, error) {
-	ds, err := GetByName(cli, namespace, name)
+func IsRunning(ctx context.Context, cli client.Client, namespace, name string) (bool, error) {
+	ds, err := GetByName(ctx, cli, namespace, name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			testlog.Warningf("daemonset %q %q not found - retrying", namespace, name)

--- a/test/e2e/performanceprofile/functests/utils/daemonset/daemonset.go
+++ b/test/e2e/performanceprofile/functests/utils/daemonset/daemonset.go
@@ -2,14 +2,18 @@ package daemonset
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/events"
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 )
 
@@ -43,6 +47,33 @@ func IsRunning(ctx context.Context, cli client.Client, namespace, name string) (
 		}
 		return false, err
 	}
-	testlog.Infof("daemonset %q %q desired %d scheduled %d ready %d", namespace, name, ds.Status.DesiredNumberScheduled, ds.Status.CurrentNumberScheduled, ds.Status.NumberReady)
-	return ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady, nil
+	if isRunning := ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady; !isRunning {
+		return false, logEventsAndPhase(ctx, cli, ds)
+	}
+	return true, nil
+}
+
+func logEventsAndPhase(ctx context.Context, cli client.Client, ds *appsv1.DaemonSet) error {
+	podList := &corev1.PodList{}
+	err := cli.List(ctx, podList, &client.ListOptions{
+		Namespace:     ds.Namespace,
+		LabelSelector: labels.SelectorFromSet(ds.Spec.Selector.MatchLabels),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list pods for DaemonSet %s; %w", client.ObjectKeyFromObject(ds).String(), err)
+	}
+	for _, pod := range podList.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			podKey := client.ObjectKeyFromObject(&pod).String()
+			testlog.Warningf("daemonset %s pod %s is not running, expected status %s got %s", ds.Name, podKey, corev1.PodRunning, pod.Status.Phase)
+			podEvents, err := events.GetEventsForObject(cli, pod.Namespace, pod.Name, string(pod.UID))
+			if err != nil {
+				return fmt.Errorf("failed to list events for Pod %s; %w", podKey, err)
+			}
+			for _, event := range podEvents.Items {
+				testlog.Warningf("-> %s %s %s", event.Action, event.Reason, event.Message)
+			}
+		}
+	}
+	return nil
 }

--- a/test/e2e/performanceprofile/functests/utils/daemonset/daemonset.go
+++ b/test/e2e/performanceprofile/functests/utils/daemonset/daemonset.go
@@ -19,8 +19,8 @@ func WaitToBeRunning(ctx context.Context, cli client.Client, namespace, name str
 
 func WaitToBeRunningWithTimeout(ctx context.Context, cli client.Client, namespace, name string, timeout time.Duration) error {
 	testlog.Infof("wait for the daemonset %q %q to be running", namespace, name)
-	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx2 context.Context) (bool, error) {
-		return IsRunning(ctx2, cli, namespace, name)
+	return wait.PollUntilContextTimeout(ctx, 30*time.Second, timeout, true, func(derivedCtx context.Context) (bool, error) {
+		return IsRunning(derivedCtx, cli, namespace, name)
 	})
 }
 

--- a/test/e2e/performanceprofile/functests/utils/images/prepull.go
+++ b/test/e2e/performanceprofile/functests/utils/images/prepull.go
@@ -34,7 +34,7 @@ func GetPullTimeout() (time.Duration, error) {
 }
 
 // PrePull makes sure the image is pre-pulled on the relevant nodes.
-func PrePull(cli client.Client, pullSpec, namespace, tag string) (*appsv1.DaemonSet, error) {
+func PrePull(ctx context.Context, cli client.Client, pullSpec, namespace, tag string) (*appsv1.DaemonSet, error) {
 	name := PrePullPrefix + tag
 	ds := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -82,10 +82,10 @@ func PrePull(cli client.Client, pullSpec, namespace, tag string) (*appsv1.Daemon
 	data, _ := json.Marshal(ds)
 	testlog.Infof("created daemonset %s/%s to prepull %q:\n%s", namespace, name, pullSpec, string(data))
 
-	err = testds.WaitToBeRunningWithTimeout(testclient.Client, ds.Namespace, ds.Name, prePullTimeout)
+	err = testds.WaitToBeRunningWithTimeout(ctx, testclient.Client, ds.Namespace, ds.Name, prePullTimeout)
 	if err != nil {
 		// if this fails, no big deal, we are just trying to make the troubleshooting easier
-		updatedDs, _ := testds.GetByName(testclient.Client, ds.Namespace, ds.Name)
+		updatedDs, _ := testds.GetByName(ctx, testclient.Client, ds.Namespace, ds.Name)
 		return updatedDs, err
 	}
 	testlog.Infof("prepulled %q in %v", pullSpec, time.Since(ts))

--- a/test/e2e/performanceprofile/functests/utils/node_inspector/inspector.go
+++ b/test/e2e/performanceprofile/functests/utils/node_inspector/inspector.go
@@ -89,7 +89,7 @@ func create(ctx context.Context) error {
 		}
 		testlog.Warningf("Node Inspector Daemonset %s already exists, this is not expected.", testutils.NodeInspectorName)
 	}
-	if err := daemonset.WaitToBeRunning(testclient.DataPlaneClient, testutils.NodeInspectorNamespace, testutils.NodeInspectorName); err != nil {
+	if err := daemonset.WaitToBeRunning(ctx, testclient.DataPlaneClient, testutils.NodeInspectorNamespace, testutils.NodeInspectorName); err != nil {
 		return err
 	}
 	initialized = true
@@ -128,7 +128,7 @@ func isRunning(ctx context.Context) (bool, error) {
 		}
 		return true, nil
 	}
-	return daemonset.IsRunning(testclient.DataPlaneClient, testutils.NodeInspectorNamespace, testutils.NodeInspectorName)
+	return daemonset.IsRunning(ctx, testclient.DataPlaneClient, testutils.NodeInspectorNamespace, testutils.NodeInspectorName)
 }
 
 // getDaemonPodByNode returns the daemon pod that runs on the specified node


### PR DESCRIPTION
In case the DaemonSet's pods are not running for some reason,
we want to log the pod's phase and event for
better observability.

This could help us with finding the root cause
for the reason the pod didn't start.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>