### PR TITLE
OCPBUGS-49823: machineconfig: add support for various hugepage sizes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/coreos/ignition v0.35.0
 	github.com/coreos/ignition/v2 v2.18.0
+	github.com/docker/go-units v0.5.0
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.6.0
 	github.com/jaypipes/ghw v0.8.1-0.20210605191321-eb162add542b
@@ -69,7 +70,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.5.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"strconv"
 	"text/template"
 
 	assets "github.com/openshift/cluster-node-tuning-operator/assets/performanceprofile"
 
 	"github.com/coreos/go-systemd/unit"
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/docker/go-units"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/cpuset"
@@ -427,19 +429,15 @@ func getSystemdContent(options []*unit.UnitOption) (string, error) {
 }
 
 // GetHugepagesSizeKilobytes retruns hugepages size in kilobytes
+// Validation ensures that hugepagesSize is compatible with the platform architecture,
+// so encountering an error here is unexpected.
 func GetHugepagesSizeKilobytes(hugepagesSize performancev2.HugePageSize) (string, error) {
-	switch hugepagesSize {
-	case "2M":
-		return "2048", nil
-	case "32M":
-		return "32768", nil
-	case "512M":
-		return "524288", nil
-	case "1G":
-		return "1048576", nil
-	default:
-		return "", fmt.Errorf("can not convert size %q to kilobytes", hugepagesSize)
+	size, err := units.RAMInBytes(string(hugepagesSize))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse hugepages size: %w", err)
 	}
+
+	return strconv.FormatInt(size/1024, 10), nil
 }
 
 func getTemplatedOvsFile(fsys fs.FS, templateName string, name string) ([]byte, error) {


### PR DESCRIPTION
* Generalized GetHugepagesSizeKilobytes function to handle various inputs. This allows us to use more possible hugepages size (e.g 512M on ARM). Pleas note we expect the validation to ensure the node arch + hugepage size combination is valid. Therefore, this function assumes a valid input, so it can safely convert it to bytes.
* This is done by using the `github.com/docker/go-units` which we should vet.