### PR TITLE
CNF-16742: kernelPageSize + hugepages combinations validation

### DIFF
--- a/docs/performanceprofile/performance_profile.md
+++ b/docs/performanceprofile/performance_profile.md
@@ -72,7 +72,12 @@ HugePage defines the number of allocated huge pages of the specific size.
 
 ## HugePageSize
 
-HugePageSize defines size of huge pages, can be 2M or 1G.
+HugePageSize defines the size of huge pages, which depends on the CPU architecture:
+
+- **For x86/amd64**, the valid values are **2M** and **1G**.
+- **For aarch64**, the valid values depend on the kernel page size:
+  - With **[kernelPageSize](#kernelpagesize) set to 4k**: **64k, 2M, 32M, 1G**
+  - With **[kernelPageSize](#kernelpagesize) set to 64k**: **2M, 512M, 16G**
 
 HugePageSize is of type `string`.
 

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -143,8 +143,12 @@ type KernelPageSize string
 
 // HugePageSize defines size of huge pages
 // The allowed values for this depend on CPU architecture
-// For x86/amd64, the valid values are 2M and 1G
-// For aarch64, the valid values are 2M, 32M, and 512M
+// For x86/amd64, the valid values are 2M and 1G.
+// For aarch64, the valid huge page sizes depend on the kernel page size:
+// - With a 4k kernel page size: 64k, 2M, 32M, 1G
+// - With a 64k kernel page size: 2M, 512M, 16G
+//
+// Reference: https://docs.kernel.org/mm/vmemmap_dedup.html
 type HugePageSize string
 
 // HugePages defines a set of huge pages that we want to allocate at boot.


### PR DESCRIPTION
This PR includes these changes:

* Corrected valid huge page sizes for ARM.
* Improved huge pages validation to depend on the configured kernelPageSize.
* Added unit tests to validate all `kernelPageSize` and `hugepages` combinations, covering both valid and invalid cases.

This improves validation coverage and prevents misconfiguration.

The validation for this work can be found in the Jira ticket.