### PR TITLE
CNF-12525: Switch builder image to multi-arch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-node-tuning-operator
 COPY . .
 


### PR DESCRIPTION
This change is necessary to enable building images for architectures like ARM. This is already been done in production Dockerfile.rhel9. The current Dockerfile does not support multi-architecture builds.