### PR TITLE
[release-4.18]: machineconfig: add support for various hugepage sizes.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/coreos/ignition v0.35.0
 	github.com/coreos/ignition/v2 v2.18.0
+	github.com/docker/go-units v0.5.0
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.6.0
 	github.com/jaypipes/ghw v0.8.1-0.20210605191321-eb162add542b
@@ -69,7 +70,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.5.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect


### PR DESCRIPTION
This is a backport of #1295.

* Generalized GetHugepagesSizeKilobytes function to handle various inputs. This allows us to use more possible hugepages size (e.g 512M on ARM). Pleas note we expect the validation to ensure the node arch + hugepage size combination is valid. Therefore, this function assumes a valid input, so it can safely convert it to bytes.