### PR TITLE
CNF-16638: Reduce code duplication of RPS enabled checks

### DIFF
--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -39,8 +39,9 @@ function rendersync() {
 }
 
 rendersync manual-cluster/performance base/performance default
+rendersync manual-cluster/performance-norps base/performance default/pp-norps
 rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap/no-mcp
 rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap-cluster/extra-mcp bootstrap/extra-mcp
-rendersync --owner-ref none -- base/performance manual-cluster/performance no-ref 
-rendersync --owner-ref none -- base/performance manual-cluster/cpuFrequency default/cpuFrequency 
+rendersync --owner-ref none -- base/performance manual-cluster/performance no-ref
+rendersync --owner-ref none -- base/performance manual-cluster/cpuFrequency default/cpuFrequency
 rendersync --owner-ref none -- base/performance manual-cluster/arm default/arm

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -182,8 +182,7 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, opts *componen
 	}
 
 	// add script files under the node /usr/local/bin directory
-	if profileutil.IsRpsEnabled(profile) || profile.Spec.WorkloadHints == nil ||
-		profile.Spec.WorkloadHints.RealTime == nil || *profile.Spec.WorkloadHints.RealTime {
+	if profileutil.IsRpsEnabled(profile) {
 		scripts = []string{hugepagesAllocation, setRPSMask, setCPUsOffline, clearIRQBalanceBannedCPUs}
 	} else {
 		// realtime is explicitly disabled by workload hint
@@ -209,8 +208,7 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, opts *componen
 	addContent(ignitionConfig, crioConfigSnippetContent, crioConfSnippetDst, &crioConfdRuntimesMode)
 
 	// do not add RPS handling when realtime is explicitly disabled by workload hint
-	if profileutil.IsRpsEnabled(profile) || profile.Spec.WorkloadHints == nil ||
-		profile.Spec.WorkloadHints.RealTime == nil || *profile.Spec.WorkloadHints.RealTime {
+	if profileutil.IsRpsEnabled(profile) {
 		// configure default rps mask applied to all network devices
 		sysctlConfContent, err := renderSysctlConf(profile, filepath.Join("configs", defaultRPSMaskConfig))
 		if err != nil {

--- a/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
@@ -71,15 +71,19 @@ func IsPhysicalRpsEnabled(profile *performancev2.PerformanceProfile) bool {
 
 // IsRpsEnabled checks if all RPS should be applied
 func IsRpsEnabled(profile *performancev2.PerformanceProfile) bool {
-	if profile.Annotations == nil {
-		return false
-	}
-	isRpsEnabled, ok := profile.Annotations[performancev2.PerformanceProfileEnableRpsAnnotation]
-	if ok && isRpsEnabled == "true" {
-		return true
+	if profile.Annotations != nil {
+		// First check overrides
+		isRpsEnabled, ok := profile.Annotations[performancev2.PerformanceProfileEnableRpsAnnotation]
+		if ok && isRpsEnabled == "true" {
+			return true
+		} else if ok && isRpsEnabled == "false" {
+			return false
+		}
 	}
 
-	return false
+	// The default behavior enables RPS for real time workloads
+	return profile.Spec.WorkloadHints == nil ||
+		profile.Spec.WorkloadHints.RealTime == nil || *profile.Spec.WorkloadHints.RealTime
 }
 
 func IsMixedCPUsEnabled(profile *performancev2.PerformanceProfile) bool {

--- a/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance-norps/kustomization.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance-norps/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base/performance
+
+resources:
+  - performance_profile.yaml

--- a/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance-norps/performance_profile.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/manual-cluster/performance-norps/performance_profile.yaml
@@ -1,0 +1,29 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: manual
+  annotations:
+    performance.openshift.io/enable-rps: "false"
+spec:
+  cpu:
+    isolated: "1"
+    reserved: "0"
+    offlined: "2,3"
+  hugepages:
+    defaultHugepagesSize: "1G"
+    pages:
+      - size: "1G"
+        count: 1
+        node: 0
+      - size: "2M"
+        count: 128
+  realTimeKernel:
+    enabled: true
+  numa:
+    topologyPolicy: "single-numa-node"
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  workloadHints:
+    highPowerConsumption: false
+    realTime: true
+    perPodPowerManagement: false

--- a/test/e2e/performanceprofile/functests-render-command/1_render_command/render_test.go
+++ b/test/e2e/performanceprofile/functests-render-command/1_render_command/render_test.go
@@ -19,12 +19,14 @@ const (
 	noRefExpectedDir        = "no-ref"
 	cpuFrequencyExpectedDir = defaultExpectedDir + "/" + "cpuFrequency"
 	armExpectedDir          = defaultExpectedDir + "/" + "arm"
+	ppNoRPSExpectedDir      = defaultExpectedDir + "/" + "pp-norps"
 )
 
 var (
 	assetsOutDir                                            string
+	assetsInDir                                             string
 	assetsInDirs, assetsCpuFrequencyInDirs, assetsARMInDirs []string
-	ppDir                                                   string
+	ppDir, ppDirNoRPS                                       string
 	ppCpuFrequencyDir                                       string
 	armDir                                                  string
 	testDataPath                                            string
@@ -38,10 +40,11 @@ var _ = Describe("render command e2e test", func() {
 
 	BeforeEach(func() {
 		assetsOutDir = createTempAssetsDir()
-		assetsInDir := filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "base", "performance")
+		assetsInDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "base", "performance")
 		bootstrapPPDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "bootstrap-cluster", "performance")
 		extraMCPDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "bootstrap-cluster", "extra-mcp")
 		ppDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "manual-cluster", "performance")
+		ppDirNoRPS = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "manual-cluster", "performance-norps")
 		ppCpuFrequencyDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "manual-cluster", "cpuFrequency")
 		armDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "manual-cluster", "arm")
 		defaultPinnedDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "pinned-cluster", "default")
@@ -142,6 +145,19 @@ var _ = Describe("render command e2e test", func() {
 
 			cmd := exec.Command(cmdline[0], cmdline[1:]...)
 			runAndCompare(cmd, armExpectedDir)
+		})
+
+		It("should not render RPS when disabled", func() {
+			cmdline := []string{
+				filepath.Join(binPath, "cluster-node-tuning-operator"),
+				"render",
+				"--asset-input-dir", assetsInDir + "," + ppDirNoRPS,
+				"--asset-output-dir", assetsOutDir,
+			}
+			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			runAndCompare(cmd, ppNoRPSExpectedDir)
 		})
 	})
 

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -375,8 +375,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			}
 		})
 		It("[test_id: 59572] Check RPS Mask is applied to at least one single rx queue on all veth interface", func() {
-			if profile.Spec.WorkloadHints != nil && profile.Spec.WorkloadHints.RealTime != nil &&
-				!*profile.Spec.WorkloadHints.RealTime && !profileutil.IsRpsEnabled(profile) {
+			if !profileutil.IsRpsEnabled(profile) {
 				Skip("realTime Workload Hints is not enabled")
 			}
 			count := 0
@@ -415,8 +414,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			}
 		})
 		It("[test_id:55012] Should have the correct RPS configuration", func() {
-			if profile.Spec.WorkloadHints != nil && profile.Spec.WorkloadHints.RealTime != nil &&
-				!*profile.Spec.WorkloadHints.RealTime && !profileutil.IsRpsEnabled(profile) {
+			if !profileutil.IsRpsEnabled(profile) {
 				Skip("realTime Workload Hints is not enabled")
 			}
 
@@ -491,8 +489,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			}
 		})
 		It("[test_id:54190] Should not have RPS configuration set when realtime workload hint is explicitly set", func() {
-			if profile.Spec.WorkloadHints != nil && profile.Spec.WorkloadHints.RealTime != nil &&
-				!*profile.Spec.WorkloadHints.RealTime && !profileutil.IsRpsEnabled(profile) {
+			if !profileutil.IsRpsEnabled(profile) {
 				for _, node := range workerRTNodes {
 					// Verify the systemd RPS services were not created
 					cmd := []string{"ls", "/rootfs/etc/systemd/system/update-rps@.service"}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_kubeletconfig.yaml
@@ -1,0 +1,68 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: performance-manual
+spec:
+  kubeletConfig:
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous: {}
+      webhook:
+        cacheTTL: 0s
+      x509: {}
+    authorization:
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    containerRuntimeEndpoint: ""
+    cpuManagerPolicy: static
+    cpuManagerPolicyOptions:
+      full-pcpus-only: "true"
+    cpuManagerReconcilePeriod: 5s
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 0s
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMaximumGCAge: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      memory: 500Mi
+    logging:
+      flushFrequency: 0
+      options:
+        json:
+          infoBufferSize: "0"
+        text:
+          infoBufferSize: "0"
+      verbosity: 0
+    memoryManagerPolicy: Static
+    memorySwap: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    reservedMemory:
+    - limits:
+        memory: 1100Mi
+      numaNode: 0
+    reservedSystemCPUs: "0"
+    runtimeRequestTimeout: 0s
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      memory: 500Mi
+    topologyManagerPolicy: single-numa-node
+    volumeStatsAggPeriod: 0s
+  machineConfigPoolSelector:
+    matchLabels:
+      machineconfiguration.openshift.io/role: worker-cnf
+status:
+  conditions: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_machineconfig.yaml
@@ -1,0 +1,215 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: 50-performance-manual
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCm5vZGVzX3BhdGg9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vbm9kZSIKaHVnZXBhZ2VzX2ZpbGU9IiR7bm9kZXNfcGF0aH0vbm9kZSR7TlVNQV9OT0RFfS9odWdlcGFnZXMvaHVnZXBhZ2VzLSR7SFVHRVBBR0VTX1NJWkV9a0IvbnJfaHVnZXBhZ2VzIgoKaWYgWyAhIC1mICIke2h1Z2VwYWdlc19maWxlfSIgXTsgdGhlbgogIGVjaG8gIkVSUk9SOiAke2h1Z2VwYWdlc19maWxlfSBkb2VzIG5vdCBleGlzdCIKICBleGl0IDEKZmkKCnRpbWVvdXQ9NjAKc2FtcGxlPTEKY3VycmVudF90aW1lPTAKd2hpbGUgWyAiJChjYXQgIiR7aHVnZXBhZ2VzX2ZpbGV9IikiIC1uZSAiJHtIVUdFUEFHRVNfQ09VTlR9IiBdOyBkbwogIGVjaG8gIiR7SFVHRVBBR0VTX0NPVU5UfSIgPiIke2h1Z2VwYWdlc19maWxlfSIKCiAgY3VycmVudF90aW1lPSQoKGN1cnJlbnRfdGltZSArIHNhbXBsZSkpCiAgaWYgWyAkY3VycmVudF90aW1lIC1ndCAkdGltZW91dCBdOyB0aGVuCiAgICBlY2hvICJFUlJPUjogJHtodWdlcGFnZXNfZmlsZX0gZG9lcyBub3QgaGF2ZSB0aGUgZXhwZWN0ZWQgbnVtYmVyIG9mIGh1Z2VwYWdlcyAke0hVR0VQQUdFU19DT1VOVH0iCiAgICBleGl0IDEKICBmaQoKICBzbGVlcCAkc2FtcGxlCmRvbmUK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/hugepages-allocation.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9iYXNoCgpzZXQgLWV1byBwaXBlZmFpbAoKZm9yIGNwdSBpbiAke09GRkxJTkVfQ1BVUy8vLC8gfTsKICBkbwogICAgb25saW5lX2NwdV9maWxlPSIvc3lzL2RldmljZXMvc3lzdGVtL2NwdS9jcHUkY3B1L29ubGluZSIKICAgIGlmIFsgISAtZiAiJHtvbmxpbmVfY3B1X2ZpbGV9IiBdOyB0aGVuCiAgICAgIGVjaG8gIkVSUk9SOiAke29ubGluZV9jcHVfZmlsZX0gZG9lcyBub3QgZXhpc3QsIGFib3J0IHNjcmlwdCBleGVjdXRpb24iCiAgICAgIGV4aXQgMQogICAgZmkKICBkb25lCgplY2hvICJBbGwgY3B1cyBvZmZsaW5lZCBleGlzdHMsIHNldCB0aGVtIG9mZmxpbmUiCgpmb3IgY3B1IGluICR7T0ZGTElORV9DUFVTLy8sLyB9OwogIGRvCiAgICBvbmxpbmVfY3B1X2ZpbGU9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vY3B1L2NwdSRjcHUvb25saW5lIgogICAgZWNobyAwID4gIiR7b25saW5lX2NwdV9maWxlfSIKICAgIGVjaG8gIm9mZmxpbmUgY3B1IG51bSAkY3B1IgogIGRvbmUKCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-cpus-offline.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLWV1byBwaXBlZmFpbApzZXQgLXgKCiMgY29uc3QKU0VEPSIvdXNyL2Jpbi9zZWQiCiMgdHVuYWJsZSAtIG92ZXJyaWRhYmxlIGZvciB0ZXN0aW5nIHB1cnBvc2VzCklSUUJBTEFOQ0VfQ09ORj0iJHsxOi0vZXRjL3N5c2NvbmZpZy9pcnFiYWxhbmNlfSIKQ1JJT19PUklHX0JBTk5FRF9DUFVTPSIkezI6LS9ldGMvc3lzY29uZmlnL29yaWdfaXJxX2Jhbm5lZF9jcHVzfSIKTk9ORT0wCgpbICEgLWYgIiR7SVJRQkFMQU5DRV9DT05GfSIgXSAmJiBleGl0IDAKCiR7U0VEfSAtaSAnL15ccypJUlFCQUxBTkNFX0JBTk5FRF9DUFVTXGIvZCcgIiR7SVJRQkFMQU5DRV9DT05GfSIgfHwgZXhpdCAwCiMgQ1BVIG51bWJlcnMgd2hpY2ggaGF2ZSB0aGVpciBjb3JyZXNwb25kaW5nIGJpdHMgc2V0IHRvIG9uZSBpbiB0aGlzIG1hc2sKIyB3aWxsIG5vdCBoYXZlIGFueSBpcnEncyBhc3NpZ25lZCB0byB0aGVtIG9uIHJlYmFsYW5jZS4KIyBzbyB6ZXJvIG1lYW5zIGFsbCBjcHVzIGFyZSBwYXJ0aWNpcGF0aW5nIGluIGxvYWQgYmFsYW5jaW5nLgplY2hvICJJUlFCQUxBTkNFX0JBTk5FRF9DUFVTPSR7Tk9ORX0iID4+ICIke0lSUUJBTEFOQ0VfQ09ORn0iCgojIHdlIG5vdyBvd24gdGhpcyBjb25maWd1cmF0aW9uLiBCdXQgQ1JJLU8gaGFzIGNvZGUgdG8gcmVzdG9yZSB0aGUgY29uZmlndXJhdGlvbiwKIyBhbmQgdW50aWwgaXQgZ2FpbnMgdGhlIG9wdGlvbiB0byBkaXNhYmxlIHRoaXMgcmVzdG9yZSBmbG93LCB3ZSBuZWVkIHRvIG1ha2UKIyB0aGUgY29uZmlndXJhdGlvbiBjb25zaXN0ZW50IHN1Y2ggYXMgdGhlIENSSS1PIHJlc3RvcmUgd2lsbCBkbyBub3RoaW5nLgppZiBbIC1uICIke0NSSU9fT1JJR19CQU5ORURfQ1BVU30iIF0gJiYgWyAtZiAiJHtDUklPX09SSUdfQkFOTkVEX0NQVVN9IiBdOyB0aGVuCgllY2hvICIke05PTkV9IiA+ICIke0NSSU9fT1JJR19CQU5ORURfQ1BVU30iCmZpCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/clear-irqbalance-banned-cpus.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMCIKCgoKCiMgVGhlIENSSS1PIHdpbGwgY2hlY2sgdGhlIGFsbG93ZWRfYW5ub3RhdGlvbnMgdW5kZXIgdGhlIHJ1bnRpbWUgaGFuZGxlciBhbmQgYXBwbHkgaGlnaC1wZXJmb3JtYW5jZSBob29rcyB3aGVuIG9uZSBvZgojIGhpZ2gtcGVyZm9ybWFuY2UgYW5ub3RhdGlvbnMgcHJlc2VudHMgdW5kZXIgaXQuCiMgV2Ugc2hvdWxkIHByb3ZpZGUgdGhlIHJ1bnRpbWVfcGF0aCBiZWNhdXNlIHdlIG5lZWQgdG8gaW5mb3JtIHRoYXQgd2Ugd2FudCB0byByZS11c2UgcnVuYyBiaW5hcnkgYW5kIHdlCiMgZG8gbm90IGhhdmUgaGlnaC1wZXJmb3JtYW5jZSBiaW5hcnkgdW5kZXIgdGhlICRQQVRIIHRoYXQgd2lsbCBwb2ludCB0byBpdC4KW2NyaW8ucnVudGltZS5ydW50aW1lcy5oaWdoLXBlcmZvcm1hbmNlXQppbmhlcml0X2RlZmF1bHRfcnVudGltZSA9IHRydWUKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LWMtc3RhdGVzLmNyaW8uaW8iLCAiY3B1LWZyZXEtZ292ZXJub3IuY3Jpby5pbyJdCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-runtimes.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCiMgY3B1c2V0LWNvbmZpZ3VyZS5zaCBjb25maWd1cmVzIHRocmVlIGNwdXNldHMgaW4gcHJlcGFyYXRpb24gZm9yIGFsbG93aW5nIGNvbnRhaW5lcnMgdG8gaGF2ZSBjcHUgbG9hZCBiYWxhbmNpbmcgZGlzYWJsZWQuCiMgVG8gY29uZmlndXJlIGEgY3B1c2V0IHRvIGhhdmUgbG9hZCBiYWxhbmNlIGRpc2FibGVkIChvbiBjZ3JvdXAgdjEpLCBhIGNwdXNldCBjZ3JvdXAgbXVzdCBoYXZlIGBjcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlYAojIHNldCB0byAwIChkaXNhYmxlKSwgYW5kIGFueSBjcHVzZXQgdGhhdCBjb250YWlucyB0aGUgc2FtZSBzZXQgYXMgYGNwdXNldC5jcHVzYCBtdXN0IGFsc28gaGF2ZSBgY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZWAgc2V0IHRvIGRpc2FibGVkLgoKc2V0IC1ldW8gcGlwZWZhaWwKCmlmIHRlc3QgIiQoc3RhdCAtZiAtYyVUIC9zeXMvZnMvY2dyb3VwKSIgPSAiY2dyb3VwMmZzIjsgdGhlbgoJZWNobyAiTm9kZSBpcyB1c2luZyBjZ3JvdXAgdjIsIG5vIGNvbmZpZ3VyYXRpb24gbmVlZGVkIgoJZXhpdCAwCmZpCgpyb290PS9zeXMvZnMvY2dyb3VwL2NwdXNldApzeXN0ZW09IiRyb290Ii9zeXN0ZW0uc2xpY2UKbWFjaGluZT0iJHJvb3QiL21hY2hpbmUuc2xpY2UKCm92c3NsaWNlPSIke3Jvb3R9L292cy5zbGljZSIKb3Zzc2xpY2Vfc3lzdGVtZD0iL3N5cy9mcy9jZ3JvdXAvcGlkcy9vdnMuc2xpY2UiCgojIEFzIHN1Y2gsIHRoZSByb290IGNncm91cCBuZWVkcyB0byBoYXZlIGNwdXNldC5zY2hlZF9sb2FkX2JhbGFuY2U9MC4gCmVjaG8gMCA+ICIkcm9vdCIvY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZQoKIyBIb3dldmVyLCB0aGlzIHdvdWxkIHByZXNlbnQgYSBwcm9ibGVtIGZvciBzeXN0ZW0gZGFlbW9ucywgd2hpY2ggc2hvdWxkIGhhdmUgbG9hZCBiYWxhbmNpbmcgZW5hYmxlZC4KIyBBcyBzdWNoLCBhIHNlY29uZCBjcHVzZXQgbXVzdCBiZSBjcmVhdGVkLCBoZXJlIGR1YmJlZCBgc3lzdGVtYCwgd2hpY2ggd2lsbCB0YWtlIGFsbCBzeXN0ZW0gZGFlbW9ucy4KIyBTaW5jZSBzeXN0ZW1kIHN0YXJ0cyBpdHMgY2hpbGRyZW4gd2l0aCB0aGUgY3B1c2V0IGl0IGlzIGluLCBtb3Zpbmcgc3lzdGVtZCB3aWxsIGVuc3VyZSBhbGwgcHJvY2Vzc2VzIHN5c3RlbWQgYmVnaW5zIHdpbGwgYmUgaW4gdGhlIGNvcnJlY3QgY2dyb3VwLgpta2RpciAtcCAiJHN5c3RlbSIKIyBjcHVzZXQubWVtcyBtdXN0IGJlIGluaXRpYWxpemVkIG9yIHByb2Nlc3NlcyB3aWxsIGZhaWwgdG8gYmUgbW92ZWQgaW50byBpdC4KY2F0ICIkcm9vdC9jcHVzZXQubWVtcyIgPiAiJHN5c3RlbSIvY3B1c2V0Lm1lbXMKIyBSZXRyaWV2ZSB0aGUgY3B1c2V0IG9mIHN5c3RlbWQsIGFuZCB3cml0ZSBpdCB0byBjcHVzZXQuY3B1cyBvZiB0aGUgc3lzdGVtIGNncm91cC4KcmVzZXJ2ZWRfc2V0PSQodGFza3NldCAtY3AgIDEgIHwgYXdrICdORnsgcHJpbnQgJE5GIH0nKQplY2hvICIkcmVzZXJ2ZWRfc2V0IiA+ICIkc3lzdGVtIi9jcHVzZXQuY3B1cwoKIyBBbmQgbW92ZSB0aGUgc3lzdGVtIHByb2Nlc3NlcyBpbnRvIGl0LgojIE5vdGUsIHNvbWUga2VybmVsIHRocmVhZHMgd2lsbCBmYWlsIHRvIGJlIG1vdmVkIHdpdGggIkludmFsaWQgQXJndW1lbnQiLiBUaGlzIHNob3VsZCBiZSBpZ25vcmVkLgpmb3IgcHJvY2VzcyBpbiAkKGNhdCAiJHJvb3QiL2Nncm91cC5wcm9jcyB8IHNvcnQgLXIpOyBkbwoJZWNobyAkcHJvY2VzcyA+ICIkc3lzdGVtIi9jZ3JvdXAucHJvY3MgMj4mMSB8IGdyZXAgLXYgIkludmFsaWQgQXJndW1lbnQiIHx8IHRydWU7CmRvbmUKCiMgRmluYWxseSwgYSB0aGUgYG1hY2hpbmUuc2xpY2VgIGNncm91cCBtdXN0IGJlIHByZWNvbmZpZ3VyZWQuIFBvZG1hbiB3aWxsIGNyZWF0ZSBjb250YWluZXJzIGFuZCBtb3ZlIHRoZW0gaW50byB0aGUgYG1hY2hpbmUuc2xpY2VgLCBidXQgdGhlcmUncwojIG5vIHdheSB0byB0ZWxsIHBvZG1hbiB0byB1cGRhdGUgbWFjaGluZS5zbGljZSB0byBub3QgaGF2ZSB0aGUgZnVsbCBzZXQgb2YgY3B1cy4gSW5zdGVhZCBvZiBkaXNhYmxpbmcgbG9hZCBiYWxhbmNpbmcgaW4gaXQsIHdlIGNhbiBwcmUtY3JlYXRlIGl0LgojIHdpdGggdGhlIHJlc2VydmVkIENQVXMgc2V0IGFoZWFkIG9mIHRpbWUsIHNvIHdoZW4gaXNvbGF0ZWQgcHJvY2Vzc2VzIGJlZ2luLCB0aGUgY2dyb3VwIGRvZXMgbm90IGhhdmUgYW4gb3ZlcmxhcHBpbmcgY3B1c2V0IGJldHdlZW4gbWFjaGluZS5zbGljZSBhbmQgaXNvbGF0ZWQgY29udGFpbmVycy4KbWtkaXIgLXAgIiRtYWNoaW5lIgoKIyBJdCdzIHVubGlrZWx5LCBidXQgcG9zc2libGUsIHRoYXQgdGhpcyBjcHVzZXQgYWxyZWFkeSBleGlzdGVkLiBJdGVyYXRlIGp1c3QgaW4gY2FzZS4KZm9yIGZpbGUgaW4gJChmaW5kICIkbWFjaGluZSIgLW5hbWUgY3B1c2V0LmNwdXMgfCBzb3J0IC1yKTsgZG8gZWNobyAiJHJlc2VydmVkX3NldCIgPiAiJGZpbGUiOyBkb25lCgojIE9WUyBpcyBydW5uaW5nIGluIGl0cyBvd24gc2xpY2UgdGhhdCBzcGFucyBhbGwgY3B1cy4gVGhlIHJlYWwgYWZmaW5pdHkgaXMgbWFuYWdlZCBieSBPVk4tSyBvdm5rdWJlLW5vZGUgZGFlbW9uc2V0CiMgTWFrZSBzdXJlIHRoaXMgc2xpY2Ugd2lsbCBub3QgZW5hYmxlIGNwdSBiYWxhbmNpbmcgZm9yIG90aGVyIHNsaWNlIGNvbmZpZ3VyZWQgYnkgdGhpcyBzY3JpcHQuCiMgVGhpcyBtaWdodCBzZWVtIGNvdW50ZXItaW50dWl0aXZlLCBidXQgdGhpcyB3aWxsIGFjdHVhbGx5IE5PVCBkaXNhYmxlIGNwdSBiYWxhbmNpbmcgZm9yIE9WUyBpdHNlbGYuCiMgLSBPVlMgaGFzIGFjY2VzcyB0byByZXNlcnZlZCBjcHVzLCBidXQgdGhvc2UgaGF2ZSBiYWxhbmNpbmcgZW5hYmxlZCB2aWEgdGhlIGBzeXN0ZW1gIGNncm91cCBjcmVhdGVkIGFib3ZlCiMgLSBPVlMgaGFzIGFjY2VzcyB0byBpc29sYXRlZCBjcHVzIHRoYXQgYXJlIGN1cnJlbnRseSBub3QgYXNzaWduZWQgdG8gcGlubmVkIHBvZHMuIFRob3NlIGhhdmUgYmFsYW5jaW5nIGVuYWJsZWQgYnkgdGhlCiMgICBwb2RzIHJ1bm5pbmcgdGhlcmUgKGJ1cnN0YWJsZSBhbmQgYmVzdC1lZmZvcnQgcG9kcyBoYXZlIGJhbGFuY2luZyBlbmFibGVkIGluIHRoZSBjb250YWluZXIgY2dyb3VwIGFuZCBhY2Nlc3MgdG8gYWxsCiMgICB1bnBpbm5lZCBjcHVzKS4KCiMgc3lzdGVtZCBkb2VzIG5vdCBtYW5hZ2UgdGhlIGNwdXNldCBjZ3JvdXAgY29udHJvbGxlciwgc28gbW92ZSBldmVyeXRoaW5nIGZyb20gdGhlIG1hbmFnZWQgcGlkcyBjb250cm9sbGVyJ3Mgb3ZzLnNsaWNlCiMgdG8gdGhlIGNwdXNldCBjb250cm9sbGVyLgoKIyBDcmVhdGUgdGhlIG92cy5zbGljZQpta2RpciAtcCAiJG92c3NsaWNlIgplY2hvIDAgPiAiJG92c3NsaWNlIi9jcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlCmNhdCAiJHJvb3QiL2NwdXNldC5jcHVzID4gIiRvdnNzbGljZSIvY3B1c2V0LmNwdXMKY2F0ICIkcm9vdCIvY3B1c2V0Lm1lbXMgPiAiJG92c3NsaWNlIi9jcHVzZXQubWVtcwoKIyBNb3ZlIE9WUyBvdmVyCmZvciBwcm9jZXNzIGluICQoY2F0ICIkb3Zzc2xpY2Vfc3lzdGVtZCIvKi9jZ3JvdXAucHJvY3MgfCBzb3J0IC1yKTsgZG8KICAgICAgICBlY2hvICRwcm9jZXNzID4gIiRvdnNzbGljZSIvY2dyb3VwLnByb2NzIDI+JjEgfCBncmVwIC12ICJJbnZhbGlkIEFyZ3VtZW50IiB8fCB0cnVlOwpkb25lCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/cpuset-configure.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs.slice
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/openvswitch.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs-vswitchd.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovsdb-server.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBUaGlzIGZpbGUgZW5hYmxlcyB0aGUgZHluYW1pYyBjcHUgYWZmaW5pdHkgbWFuYWdlbWVudCBvZiB0aGUgT1ZTIHNlcnZpY2VzCiMKIyBJdCBpcyByZWFkIGJ5IHRoZSBPVk4ncyBvdm5rdWJlLW5vZGUgRGFlbW9uU2V0IGNvbnRhaW5lciBhbmQgdGhlIGZlYXR1cmUKIyBpcyBlbmFibGVkIHdoZW4gdGhpcyBmaWxlIGV4aXN0cyBhbmQgaXMgbm90IGVtcHR5ICh0aGlzIGNvbW1lbnRhcnkgdGV4dAojIGVuc3VyZXMgdGhhdCkKIwojIEZvciBkaXNhYmxpbmcgdGhpcyBmZWF0dXJlIGluIGVtZXJnZW5jaWVzLCBlaXRoZXI6CiMgMSkgZGVsZXRlIHRoaXMgZmlsZSBhbmQgc2V0IHRoZSBjcHUgYWZmaW5pdHkgb2YgT1ZTIHNlcnZpY2VzIG1hbnVhbGx5CiMgMikgb3IgcmVwbGFjZSB0aGUgY29udGVudHMgb2YgdGhpcyBmaWxlIHdpdGggYW4gZW1wdHkgc3RyaW5nCiMgICAgdmlhIGEgTWFjaGluZUNvbmZpZwo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
+        user: {}
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Hugepages-1048576kB allocation on the node 0
+          Before=kubelet.service
+
+          [Service]
+          Environment=HUGEPAGES_COUNT=1
+          Environment=HUGEPAGES_SIZE=1048576
+          Environment=NUMA_NODE=0
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/hugepages-allocation.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: hugepages-allocation-1048576kB-NUMA0.service
+      - contents: |
+          [Unit]
+          Description=Move services to reserved cpuset
+          Before=kubelet.service
+          After=crio.service
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/cpuset-configure.sh
+
+          [Install]
+          WantedBy=multi-user.target crio.service
+        enabled: true
+        name: cpuset-configure.service
+      - contents: |
+          [Unit]
+          Description=Set cpus offline: 2,3
+          Before=kubelet.service
+
+          [Service]
+          Environment=OFFLINE_CPUS=2,3
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/set-cpus-offline.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: set-cpus-offline.service
+      - contents: |
+          [Unit]
+          Description=Clear the IRQBalance Banned CPU mask early in the boot
+          Before=kubelet.service
+          Before=irqbalance.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/clear-irqbalance-banned-cpus.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: realtime
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_node.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_node.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  creationTimestamp: null
+  labels:
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: cluster
+spec:
+  cgroupMode: v1
+status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_runtimeclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: node.k8s.io/v1
+handler: high-performance
+kind: RuntimeClass
+metadata:
+  creationTimestamp: null
+  labels:
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: performance-manual
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_tuned.yaml
@@ -1,0 +1,149 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  creationTimestamp: null
+  labels:
+    performance.openshift.io/weak-owner-reference-name: manual
+  name: openshift-node-performance-manual
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: "[main]\nsummary=Openshift node optimized for deterministic performance
+      at the cost of increased power consumption, focused on low latency network performance.
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\n\n# The final result of
+      the include depends on cpu vendor, cpu architecture, and whether the real time
+      kernel is enabled\n# The first line will be evaluated based on the CPU vendor
+      and architecture\n# This has three possible results:\n#   include=openshift-node-performance-amd-x86;\n#
+      \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
+      The second line will be evaluated based on whether the real time kernel is enabled\n#
+      This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
+      \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
+      ID\\:\\s*AuthenticAMD:amd:Architecture\\:\\s*aarch64:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
+      Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
+      -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
+      All values are mapped with a comment where a parent profile contains them.\n#
+      Different values will override the original values in parent profiles.\n\n[variables]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
+      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
+      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
+      plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
+      It can be racy if TuneD restarts for whatever reason.\n#> cpu-partitioning\nenabled=false\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\ngroup.ktimers=0:f:11:*:ktimers.*\n\ndefault_irq_smp_affinity
+      = ignore\nirq_process=false\n\n\n[sysctl]\n\n#> cpu-partitioning #RealTimeHint\nkernel.hung_task_timeout_secs=600\n#>
+      cpu-partitioning #RealTimeHint\nkernel.nmi_watchdog=0\n#> RealTimeHint\nkernel.sched_rt_runtime_us=-1\n#>
+      cpu-partitioning  #RealTimeHint\nvm.stat_interval=10\n\n# cpu-partitioning and
+      RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n#> scheduled timers when starting a guaranteed workload
+      (= 1)\nkernel.timer_migration=1\n#> network-latency\nnet.ipv4.tcp_fastopen=3\n\n#
+      If a workload mostly uses anonymous memory and it hits this limit, the entire\n#
+      working set is buffered for I/O, and any more write buffering would require\n#
+      swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n#
+      that mostly use file mappings may be able to use even higher values.\n#\n# The
+      generator of dirty data starts writeback at this percentage (system default\n#
+      is 20%)\n#> latency-performance\nvm.dirty_ratio=10\n\n# Start background writeback
+      (via writeback threads) at this percentage (system\n# default is 10%)\n#> latency-performance\nvm.dirty_background_ratio=3\n\n#
+      The swappiness parameter controls the tendency of the kernel to move\n# processes
+      out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
+      swapping processes out of physical memory\n# for as long as possible\n# 100
+      tells the kernel to aggressively swap processes out of physical memory\n# and
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
+      configured via a sysctl.d file\n# placed here for documentation purposes and
+      commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
+      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
+    name: openshift-node-performance-manual
+  - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
+      time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
+      profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
+    name: openshift-node-performance-rt-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for AMD x86
+
+      [bootloader]
+      cmdline_iommu_amd=iommu=pt
+
+
+      cmdline_pstate=amd_pstate=guided
+
+
+
+      cmdline_realtime_amd=tsc=reliable nmi_watchdog=0 mce=off
+
+
+
+
+
+    name: openshift-node-performance-amd-x86-manual
+  - data: |
+      [main]
+      summary=Platform specific tuning for aarch64
+
+      [bootloader]
+      # No cstate for ARM
+      # No pstate args for ARM
+
+      # aarch64 specific tuning options
+      cmdline_iommu_arm=iommu.passthrough=1
+    name: openshift-node-performance-arm-aarch64-manual
+  - data: |+
+      [main]
+      summary=Platform specific tuning for Intel x86
+
+      [bootloader]
+      # DO NOT REMOVE THIS BLOCK
+      # It makes sure the kernel arguments for Intel are applied
+      # in the order compatible with OCP 4.17 which is important
+      # for preventing an extra reboot during upgrade
+      cmdline_cpu_part=
+      cmdline_iommu_intel=
+      cmdline_isolation=
+      cmdline_realtime_nohzfull=
+      cmdline_realtime_intel=
+      cmdline_realtime_nosoftlookup=
+      cmdline_realtime_intel_nmi=
+      cmdline_realtime_common=
+      cmdline_power_performance=
+      cmdline_power_performance_intel=
+      cmdline_idle_poll=
+      cmdline_idle_poll_intel=
+      cmdline_hugepages=
+      cmdline_pstate=
+
+      # Here comes the Intel specific tuning
+
+      cmdline_iommu_intel=intel_iommu=on iommu=pt
+
+
+      cmdline_realtime_intel=tsc=reliable
+      cmdline_realtime_intel_nmi=nmi_watchdog=0 mce=off
+
+
+
+
+
+
+
+      cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
+
+
+    name: openshift-node-performance-intel-x86-manual
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: worker-cnf
+    operand:
+      tunedConfig:
+        reapply_sysctl: null
+    priority: 20
+    profile: openshift-node-performance-manual
+status: {}


### PR DESCRIPTION
Centralize the RPS enabled logic into just one function and add a way to force RPS off.

This is prep-work for disabling RPS globally for all use cases.