### PR TITLE
PSAP-1608: Obsolete pod label-based matching

### DIFF
--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -133,6 +133,17 @@ spec:
       for: 30m
       labels:
         severity: warning
+    - alert: NTOPodLabelsUsed
+      annotations:
+        description: >-
+          The Node Tuning Operator is using deprecated functionality.
+          Using pod label matching has been discouraged since OCP 4.4 and this functionality will be removed in future versions.
+          Please revise and adjust your configuration (Tuned custom resources).
+        summary: The Node Tuning Operator is using deprecated functionality.
+      expr: nto_pod_labels_used_info == 1
+      for: 30m
+      labels:
+        severity: warning
     - alert: NTOInvalidTunedExist
       annotations:
         description: Invalid custom Tuned resource exists. View your custom Tuned resources and operator logs for further details.

--- a/pkg/operator/profilecalculator.go
+++ b/pkg/operator/profilecalculator.go
@@ -683,6 +683,16 @@ func (pc *ProfileCalculator) tunedsUseNodeLabels(tunedSlice []*tunedv1.Tuned) bo
 	return false
 }
 
+// tunedMatchesPodLabels returns true if Tuned CRs 'tuned' uses Pod labels.
+func (pc *ProfileCalculator) tunedMatchesPodLabels(tuned *tunedv1.Tuned) bool {
+	for _, recommend := range tuned.Spec.Recommend {
+		if pc.tunedUsesPodLabels(recommend.Match) {
+			return true
+		}
+	}
+	return false
+}
+
 // tunedsUsePodLabels returns true if any of the Tuned CRs uses Pod labels.
 func (pc *ProfileCalculator) tunedsUsePodLabels(tunedSlice []*tunedv1.Tuned) bool {
 	for _, recommend := range TunedRecommend(tunedSlice) {

--- a/pkg/operator/validator.go
+++ b/pkg/operator/validator.go
@@ -40,6 +40,14 @@ func (c *Controller) validateTunedCRs() error {
 		tunedValid := true
 		message := "" // Do not add any unnecessary clutter when configuration is valid.
 
+		// Check for deprecated functionality first.
+		if c.pc.tunedMatchesPodLabels(tuned) {
+			tunedValid = false
+			allTunedValid = false
+			klog.Errorf("tuned/%s uses pod label matching", tuned.Name)
+			message = "Deprecated pod label matching detected."
+		}
+
 		switch e := errProfilesGet.(type) {
 		case nil:
 		case *DuplicateProfileError:


### PR DESCRIPTION
The Pod label matching functionality has been mentioned as a candidate for deprecation since OCP 4.4.  Reasons for this change:
  * the Pod label matching functionality does not scale well in larger clusters
  * ease merging the two NTO control loops into one

Report Tuned CRs which use Pod label matching functionality as invalid and trigger an alert (NTOPodLabelsUsed) for this to give cluster administrators time to update their configuration.

Implements: [PSAP-1608](https://issues.redhat.com//browse/PSAP-1608)