### PR TITLE
NO-JIRA: Add observedGeneration to Profile status

### DIFF
--- a/manifests/20-profile.crd.yaml
+++ b/manifests/20-profile.crd.yaml
@@ -140,6 +140,10 @@ spec:
                       type:
                         description: type specifies the aspect reported by this condition.
                         type: string
+                observedGeneration:
+                  description: If set, this represents the .metadata.generation that the conditions were set based upon.
+                  type: integer
+                  format: int64
                 tunedProfile:
                   description: the current profile in use by the Tuned daemon
                   type: string

--- a/pkg/apis/tuned/v1/tuned_types.go
+++ b/pkg/apis/tuned/v1/tuned_types.go
@@ -204,6 +204,10 @@ type ProfileStatus struct {
 	// +patchStrategy=merge
 	// +optional
 	Conditions []StatusCondition `json:"conditions,omitempty"  patchStrategy:"merge" patchMergeKey:"type"`
+
+	// If set, this represents the .metadata.generation that the conditions were set based upon.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,1,opt,name=observedGeneration"`
 }
 
 // StatusCondition represents a partial state of the per-node Profile application.

--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -1366,6 +1366,7 @@ func (c *Controller) updateTunedProfileStatus(ctx context.Context, change Change
 
 	profile.Status.TunedProfile = activeProfile
 	profile.Status.Conditions = statusConditions
+	profile.Status.ObservedGeneration = profile.Generation
 	_, err = c.clients.Tuned.TunedV1().Profiles(operandNamespace).UpdateStatus(ctx, profile, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update Profile %s status: %v", profile.Name, err)


### PR DESCRIPTION
`profiles.tuned.openshift.io` are managed both by the NTO operator and the operands.  The operator manages the `.Spec` part, while the operand reports the status of the TuneD profile application via the `.Status` part.

As it is impossible to tell whether the current `.Status` reflects potential `.Spec` changes without `.Status.ObservedGeneration`, introduce the new field.