### PR TITLE
OCPBUGS-52484: Treat all aarch64 platforms as equals in tuned [4.18]

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -12,7 +12,7 @@ summary=Openshift node optimized for deterministic performance at the cost of in
 #     openshift-node,cpu-partitioning
 #     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
 include=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:};
-    openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Vendor ID\:\s*ARM:arm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}-{{.PerformanceProfileName}}
+    openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Architecture\:\s*aarch64:arm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}-{{.PerformanceProfileName}}
 
 # Inheritance of base profiles legend:
 # cpu-partitioning -> network-latency -> latency-performance

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -19,7 +19,7 @@ spec:
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
       name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:};\n
       \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
+      ID\\:\\s*AuthenticAMD:amd:Architecture\\:\\s*aarch64:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -19,7 +19,7 @@ spec:
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
       name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:};\n
       \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master\n\n#
+      ID\\:\\s*AuthenticAMD:amd:Architecture\\:\\s*aarch64:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -19,7 +19,7 @@ spec:
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
       name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-worker:};\n
       \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
+      ID\\:\\s*AuthenticAMD:amd:Architecture\\:\\s*aarch64:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-worker\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_tuned.yaml
@@ -2,9 +2,7 @@ apiVersion: tuned.openshift.io/v1
 kind: Tuned
 metadata:
   creationTimestamp: null
-  labels:
-    performance.openshift.io/weak-owner-reference-name: openshift-bootstrap-master
-  name: openshift-node-performance-openshift-bootstrap-master
+  name: openshift-node-performance-manual
   namespace: openshift-cluster-node-tuning-operator
 spec:
   profile:
@@ -17,16 +15,16 @@ spec:
       \  include=openshift-node-performance-arm-aarch64;\n#   include=openshift-node-performance-intel-x86;\n#
       The second line will be evaluated based on whether the real time kernel is enabled\n#
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
-      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-openshift-bootstrap-master:};\n
+      name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
       \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Architecture\\:\\s*aarch64:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-openshift-bootstrap-master\n\n#
+      ID\\:\\s*AuthenticAMD:amd:Architecture\\:\\s*aarch64:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
       All values are mapped with a comment where a parent profile contains them.\n#
       Different values will override the original values in parent profiles.\n\n[variables]\n#>
-      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=0-1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n\n\n[service]\nservice.stalld=start,enable\n\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n# Disable the
       plugin entirely, which was enabled by the parent profile `cpu-partitioning`.\n#
@@ -58,13 +56,14 @@ spec:
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
-    name: openshift-node-performance-openshift-bootstrap-master
+      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=32M
+      \  hugepagesz=512M hugepages=1 \n\n\n\n[rtentsk]\n\n\n"
+    name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
       if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n"
-    name: openshift-node-performance-rt-openshift-bootstrap-master
+    name: openshift-node-performance-rt-manual
   - data: |+
       [main]
       summary=Platform specific tuning for AMD x86
@@ -83,7 +82,7 @@ spec:
 
 
 
-    name: openshift-node-performance-amd-x86-openshift-bootstrap-master
+    name: openshift-node-performance-amd-x86-manual
   - data: |
       [main]
       summary=Platform specific tuning for aarch64
@@ -94,7 +93,7 @@ spec:
 
       # aarch64 specific tuning options
       cmdline_iommu_arm=iommu.passthrough=1
-    name: openshift-node-performance-arm-aarch64-openshift-bootstrap-master
+    name: openshift-node-performance-arm-aarch64-manual
   - data: |+
       [main]
       summary=Platform specific tuning for Intel x86
@@ -136,13 +135,13 @@ spec:
       cmdline_pstate=intel_pstate=${f:intel_recommended_pstate}
 
 
-    name: openshift-node-performance-intel-x86-openshift-bootstrap-master
+    name: openshift-node-performance-intel-x86-manual
   recommend:
   - machineConfigLabels:
-      machineconfiguration.openshift.io/role: master
+      machineconfiguration.openshift.io/role: worker-cnf
     operand:
       tunedConfig:
         reapply_sysctl: null
     priority: 20
-    profile: openshift-node-performance-openshift-bootstrap-master
+    profile: openshift-node-performance-manual
 status: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -17,7 +17,7 @@ spec:
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
       name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
       \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
+      ID\\:\\s*AuthenticAMD:amd:Architecture\\:\\s*aarch64:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -19,7 +19,7 @@ spec:
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
       name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
       \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
+      ID\\:\\s*AuthenticAMD:amd:Architecture\\:\\s*aarch64:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -17,7 +17,7 @@ spec:
       This has two possible results:\n#     openshift-node,cpu-partitioning\n#     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile
       name>\ninclude=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-manual:};\n
       \   openshift-node-performance-${f:lscpu_check:Vendor ID\\:\\s*GenuineIntel:intel:Vendor
-      ID\\:\\s*AuthenticAMD:amd:Vendor ID\\:\\s*ARM:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
+      ID\\:\\s*AuthenticAMD:amd:Architecture\\:\\s*aarch64:arm}-${f:lscpu_check:Architecture\\:\\s*x86_64:x86:Architecture\\:\\s*aarch64:aarch64}-manual\n\n#
       Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
       -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
       https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#


### PR DESCRIPTION
Manual backport of https://github.com/openshift/cluster-node-tuning-operator/pull/1303/

We are commonly testing on two different ARM based platforms that use different cpu architecture designators ARM and APM.

The per-platform tuning profile selector did not expect APM and failed to include the proper profile.

Since we currently do not distinguish between the ARM vendors in any way, the patch changes the detection to be based on Architecture instead of on Vendor ID.