### PR TITLE
OCPBUGS-54628: Add retry method if we hit jira rate limit

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/jira/status.go
+++ b/test/e2e/performanceprofile/functests/utils/jira/status.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strconv"
 	"time"
+
+	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 )
 
 const (
@@ -55,12 +57,15 @@ func RetrieveJiraStatus(key string) (*JiraIssueStatusResponse, error) {
 		case http.StatusTooManyRequests:
 			if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
 				retryTime, err := convertRetryAfterTime(retryAfter)
+				testlog.Infof("Using Retry-After header to retry after %s seconds", retryTime.String())
 				if err != nil {
 					return nil, err
 				}
 				time.Sleep(retryTime)
 			} else {
+				testlog.Info("No Retry-After header found using exponential backoff method to retry")
 				delay := retryWithBackOff(retryCount)
+				testlog.Infof("Wait for %s seconds before retry to fetch bug status", delay.String())
 				time.Sleep(delay)
 			}
 		default:

--- a/test/e2e/performanceprofile/functests/utils/jira/status.go
+++ b/test/e2e/performanceprofile/functests/utils/jira/status.go
@@ -3,11 +3,14 @@ package jira
 import (
 	"encoding/json"
 	"github.com/pkg/errors"
+	"math/rand"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 const JIRA_BASE_URL = "https://issues.redhat.com"
+const MAX_RETRIES = 3
 
 type JiraIssueStatusResponseFieldsStatus = struct {
 	Name string `json:"name"`
@@ -32,22 +35,63 @@ func RetrieveJiraStatus(key string) (*JiraIssueStatusResponse, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create request for Jira status of %s", key)
 	}
-	ret, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create client to get jira status of %s", key)
 	}
-	defer ret.Body.Close()
-
-	if ret.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("failed to get jira status of %s: %d %s", key, ret.StatusCode, ret.Status)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			for retryCount := 0; retryCount <= MAX_RETRIES; retryCount++ {
+				delay := retryWithBackOff(retryCount)
+				time.Sleep(delay)
+				resp, err = retryRequest(req)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to create request for Jira status of %s", key)
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					break
+				}
+			}
+		} else {
+			return nil, errors.Errorf("failed to get jira status of %s: %d %s", key, resp.StatusCode, resp.Status)
+		}
 	}
-
-	response := JiraIssueStatusResponse{}
-	decoder := json.NewDecoder(ret.Body)
-	err = decoder.Decode(&response)
+	jiraResponse := JiraIssueStatusResponse{}
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&jiraResponse)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to decode jira status of %s", key)
 	}
+	return &jiraResponse, nil
+}
 
-	return &response, nil
+// retryWithBackOff use exponential backoff retries when we hit rate limit
+func retryWithBackOff(attempts int) time.Duration {
+	// we have a limit of 5 req/sec
+	initialDelay := 200 * time.Millisecond
+	maxDelay := 5 * time.Second
+	delay := initialDelay * (1 << attempts)
+
+	// add jitter
+	jitter := time.Duration(rand.Int63n(int64(delay / 2)))
+	delay += jitter
+
+	if delay > maxDelay {
+		delay = maxDelay
+	}
+	return delay
+}
+
+// retryRequest creates new http request
+func retryRequest(req *http.Request) (*http.Response, error) {
+	newReq, err := http.NewRequest("GET", req.URL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	// copy headers
+	newReq.Header = req.Header.Clone()
+	resp, err := http.DefaultClient.Do(newReq)
+	return resp, err
 }

--- a/test/e2e/performanceprofile/functests/utils/jira/status.go
+++ b/test/e2e/performanceprofile/functests/utils/jira/status.go
@@ -11,8 +11,10 @@ import (
 	"time"
 )
 
-const JIRA_BASE_URL = "https://issues.redhat.com"
-const MAX_RETRIES = 3
+const (
+	JIRA_BASE_URL = "https://issues.redhat.com"
+	MAX_RETRIES   = 3
+)
 
 type JiraIssueStatusResponseFieldsStatus = struct {
 	Name string `json:"name"`
@@ -44,13 +46,13 @@ func RetrieveJiraStatus(key string) (*JiraIssueStatusResponse, error) {
 		}
 		defer resp.Body.Close()
 		switch resp.StatusCode {
-		case 200:
+		case http.StatusOK:
 			decoder := json.NewDecoder(resp.Body)
 			err = decoder.Decode(&jiraResponse)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to decode jira status of %s", key)
 			}
-		case 429:
+		case http.StatusTooManyRequests:
 			if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
 				retryTime, err := convertRetryAfterTime(retryAfter)
 				if err != nil {


### PR DESCRIPTION
Jira implemented rate limit due to which tests
which should be skipped due to known issues do not get skipped.

This PR implements retry with exponential backoff
to retry the request if we hit http status code 429(too many requests)