### PR TITLE
PSAP-1655: Make machineConfigLabels-related misconfiguration more visible

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -163,6 +163,20 @@ func (c *Controller) numProfilesWithBootcmdlineConflict(profileList []*tunedv1.P
 	return numConflict
 }
 
+// numMCLabelsAcrossMCP returns the total number
+// of Profiles in the internal operator's cache (mcLabelsAcrossMCP)
+// tracked as using machineConfigLabels that match across multiple MCPs.
+func (c *Controller) numMCLabelsAcrossMCP(profileList []*tunedv1.Profile) int {
+	n := 0
+	for _, profile := range profileList {
+		if c.mcLabelsAcrossMCP[profile.Name] {
+			n++
+		}
+	}
+
+	return n
+}
+
 // computeStatus computes the operator's current status.
 func (c *Controller) computeStatus(tuned *tunedv1.Tuned, conditions []configv1.ClusterOperatorStatusCondition) ([]configv1.ClusterOperatorStatusCondition, string, error) {
 	const (
@@ -316,6 +330,14 @@ func (c *Controller) computeStatus(tuned *tunedv1.Tuned, conditions []configv1.C
 			degradedCondition.Status = configv1.ConditionTrue
 			degradedCondition.Reason = "ProfileConflict"
 			degradedCondition.Message = fmt.Sprintf("%v/%v Profiles with bootcmdline conflict", numConflict, len(profileList))
+		}
+
+		numMCLabelsAcrossMCP := c.numMCLabelsAcrossMCP(profileList)
+		if numMCLabelsAcrossMCP > 0 {
+			klog.Infof("%v/%v Profiles use machineConfigLabels that match across multiple MCPs", numMCLabelsAcrossMCP, len(profileList))
+			degradedCondition.Status = configv1.ConditionTrue
+			degradedCondition.Reason = "MCLabelsAcrossMCPs"
+			degradedCondition.Message = fmt.Sprintf("%v/%v Profiles use machineConfigLabels that match across multiple MCPs", numMCLabelsAcrossMCP, len(profileList))
 		}
 
 		// If the operator is not available for an extensive period of time, set the Degraded operator status.


### PR DESCRIPTION
NTO Tuned CRs support machine config labels (mcLabels) based matching. This involves finding a MachineConfigPool with machineConfigSelector matching mcLabels and setting a TuneD profile on all nodes that are assigned the found MachineConfigPool.  We do not support configurations, where more than 1 MachineConfigPool matches the mcLabels.  While this configuration is not supported, users often unwittingly configure their clusters in this way.  In this case, NTO issues an error message in the operator logs.

This is often not sufficient, so we make this misconfiguration more visible by making ClusterOperator/node-tuning object Degraded.