### PR TITLE
CNF-17656: Fix CPU parsing for `rcu_nocbs` kernel parameter

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -202,7 +202,9 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			rcuNocbsArgument := re.FindString(cmdline)
 			Expect(rcuNocbsArgument).To(ContainSubstring("rcu_nocbs="))
 			rcuNocbsCpu := strings.Split(rcuNocbsArgument, "=")[1]
-			Expect(rcuNocbsCpu).To(Equal(isolatedCPU))
+			rcuNocbsCPUSet, err := cpuset.Parse(rcuNocbsCpu)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rcuNocbsCPUSet.Equals(isolatedCPUSet)).To(BeTrue(), "rcu_nocbs CPUs do not match isolated CPUs")
 
 			By("checking that new rcuo processes are running on non_isolated cpu")
 			cmd = []string{"pgrep", "rcuo"}


### PR DESCRIPTION
The test case associated with rcu_nocbs verification experienced flakiness due to incorrect parsing of the CPUs specified by the `rcu_nocbs` kernel parameter. Previously, the CPUs were parsed as a string, leading to mismatches with the isolated CPUs during string-based comparisons. This has been corrected by converting both values to **cpuset** type, ensuring accurate CPU set comparisons and improving test stability.