### PR TITLE
NO-JIRA: Set minimum TLS 1.3 for metrics and webhook servers

### DIFF
--- a/cmd/cluster-node-tuning-operator/main.go
+++ b/cmd/cluster-node-tuning-operator/main.go
@@ -121,6 +121,16 @@ func operatorRun() {
 		return
 	}
 
+	tlsOpts := []func(*tls.Config){
+		func(c *tls.Config) {
+			// CVE-2023-44487
+			c.NextProtos = []string{"http/1.1"}
+			// Default minimum version is TLS 1.3.  PQ algorithms will only be supported in TLS 1.3+.
+			// Hybrid key agreements for TLS 1.3 X25519MLKEM768 is supported by default in go 1.24.
+			c.MinVersion = tls.VersionTLS13
+		},
+	}
+
 	// We have two namespaces that we need to watch:
 	// 1. NTO namespace: for NTO resources.  Note this is not necessarily where the operator itself
 	//    runs, for example operator managing HyperShift hosted clusters.
@@ -147,7 +157,7 @@ func operatorRun() {
 			CertDir:  webhookCertDir,
 			CertName: webhookCertName,
 			KeyName:  webhookKeyName,
-			TLSOpts:  []func(config *tls.Config){func(c *tls.Config) { c.NextProtos = []string{"http/1.1"} }}, // CVE-2023-44487
+			TLSOpts:  tlsOpts,
 		}),
 	})
 

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -69,8 +69,9 @@ func buildServer(port int, caBundle string) *http.Server {
 	if caCertPool.AppendCertsFromPEM([]byte(caBundle)) {
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 		tlsConfig.ClientCAs = caCertPool
-		// Default minimum version is TLS 1.2, previous versions are insecure and deprecated.
-		tlsConfig.MinVersion = tls.VersionTLS12
+		// Default minimum version is TLS 1.3.  PQ algorithms will only be supported in TLS 1.3+.
+		// Hybrid key agreements for TLS 1.3 X25519MLKEM768 is supported by default in go 1.24.
+		tlsConfig.MinVersion = tls.VersionTLS13
 		tlsConfig.CipherSuites = []uint16{
 			// Drop
 			// - 64-bit block cipher 3DES as it is vulnerable to SWEET32 attack.


### PR DESCRIPTION
Set the minimum default version to TLS 1.3.  PQ algorithms will only be supported in TLS 1.3+.  Hybrid key agreements for TLS 1.3 X25519MLKEM768 is automatically supported by default in go 1.24.

See: [OCPSTRAT-1858](https://issues.redhat.com//browse/OCPSTRAT-1858)