### PR TITLE
OCPBUGS-56416: E2E: use  4 cpus for  reserved  from available cpus

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -1047,9 +1047,13 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 				sort.Ints(coreids)
 				Expect(len(coreids)).ToNot(Equal(0))
-				middleCoreIds := coreids[len(coreids)/2]
-				coresiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, middleCoreIds)
-				reserved = reserved.Union(coresiblings)
+				middleIndex := len(coreids) / 2
+				// we need at least 4 cpus for reserved cpus
+				middleCoreIds := coreids[middleIndex-2 : middleIndex+2]
+				for _, cores := range middleCoreIds {
+					coresiblings := nodes.GetAndRemoveCpuSiblingsFromMap(numaCoreSiblings, cores)
+					reserved = reserved.Union(coresiblings)
+				}
 			}
 			for numaNode := range numaCoreSiblings {
 				for coreids := range numaCoreSiblings[numaNode] {


### PR DESCRIPTION
Earlier we were using only cpu as reserved cpu
and the rest for isolated, this causes issues as
one reserved cpu for control plane nodes is not enough and can cause issues.

This PR fixes this issues by using 4 reserved cpus and the rest for isolated