### PR TITLE
OCPBUGS-56852: e2e: arm: fix ginkgo doesn't recognize kernelPageSize suite

### DIFF
--- a/test/e2e/performanceprofile/functests/14_arm/14_arm_suite_test.go
+++ b/test/e2e/performanceprofile/functests/14_arm/14_arm_suite_test.go
@@ -1,4 +1,4 @@
-package __arm
+package __arm_test
 
 import (
 	"log"


### PR DESCRIPTION
Fixed an issue where ginkgo didn't recognize the kernelPageSize suite running ```ginkgo -v --require 14_arm``` results in: ```Skipping ./test/e2e/performanceprofile/functests/14_arm (no test files)```. Changing the suite's file name to ```14_arm_suite_test.go``` instead of ```test_suite_arm_test.go``` and changing the package name to __arm_test fixes the issue and results in ginkgo recognizing the 14_arm suite.