### PR TITLE
OCPBUGS-56902: fix: stop referencing non existing git references in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,20 +185,20 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.1 // indirect
 	k8s.io/apiserver v0.32.3 // indirect
-	k8s.io/cloud-provider v0.0.0 // indirect
+	k8s.io/cloud-provider v0.32.3 // indirect
 	k8s.io/component-base v0.32.3 // indirect
 	k8s.io/component-helpers v0.32.3 // indirect
 	k8s.io/controller-manager v0.32.3 // indirect
 	k8s.io/cri-api v0.32.3 // indirect
 	k8s.io/cri-client v0.32.3 // indirect
-	k8s.io/csi-translation-lib v0.0.0 // indirect
+	k8s.io/csi-translation-lib v0.32.3 // indirect
 	k8s.io/dynamic-resource-allocation v0.26.2 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 	k8s.io/kms v0.32.3 // indirect
 	k8s.io/kube-aggregator v0.32.3 // indirect
-	k8s.io/kube-openapi v0.32.3 // indirect
-	k8s.io/kube-scheduler v0.0.0 // indirect
-	k8s.io/mount-utils v0.0.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
+	k8s.io/kube-scheduler v0.32.3 // indirect
+	k8s.io/mount-utils v0.32.3 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1713,7 +1713,7 @@ k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/watchlist
 k8s.io/client-go/util/workqueue
-# k8s.io/cloud-provider v0.0.0 => k8s.io/cloud-provider v0.32.3
+# k8s.io/cloud-provider v0.32.3 => k8s.io/cloud-provider v0.32.3
 ## explicit; go 1.23.0
 k8s.io/cloud-provider
 k8s.io/cloud-provider/app/config
@@ -1821,7 +1821,7 @@ k8s.io/cri-client/pkg
 k8s.io/cri-client/pkg/internal
 k8s.io/cri-client/pkg/logs
 k8s.io/cri-client/pkg/util
-# k8s.io/csi-translation-lib v0.0.0 => k8s.io/csi-translation-lib v0.32.3
+# k8s.io/csi-translation-lib v0.32.3 => k8s.io/csi-translation-lib v0.32.3
 ## explicit; go 1.23.0
 k8s.io/csi-translation-lib
 k8s.io/csi-translation-lib/plugins
@@ -1865,7 +1865,7 @@ k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
 k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme
 k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1
-# k8s.io/kube-openapi v0.32.3 => k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f
+# k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f => k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f
 ## explicit; go 1.20
 k8s.io/kube-openapi/cmd/openapi-gen
 k8s.io/kube-openapi/cmd/openapi-gen/args
@@ -1891,7 +1891,7 @@ k8s.io/kube-openapi/pkg/validation/errors
 k8s.io/kube-openapi/pkg/validation/spec
 k8s.io/kube-openapi/pkg/validation/strfmt
 k8s.io/kube-openapi/pkg/validation/strfmt/bson
-# k8s.io/kube-scheduler v0.0.0 => k8s.io/kube-scheduler v0.32.3
+# k8s.io/kube-scheduler v0.32.3 => k8s.io/kube-scheduler v0.32.3
 ## explicit; go 1.23.0
 k8s.io/kube-scheduler/config/v1
 k8s.io/kube-scheduler/extender/v1
@@ -2038,7 +2038,7 @@ k8s.io/kubernetes/pkg/volume/util/volumepathhandler
 k8s.io/kubernetes/third_party/forked/golang/expansion
 k8s.io/kubernetes/third_party/forked/libcontainer/apparmor
 k8s.io/kubernetes/third_party/forked/libcontainer/utils
-# k8s.io/mount-utils v0.0.0 => k8s.io/mount-utils v0.32.3
+# k8s.io/mount-utils v0.32.3 => k8s.io/mount-utils v0.32.3
 ## explicit; go 1.23.0
 k8s.io/mount-utils
 # k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e


### PR DESCRIPTION
In https://github.com/openshift/cluster-node-tuning-operator/issues/1331 I reported that Go projects that reference github.com/openshift/cluster-node-tuning-operator as a library cannot use it because parts of the Go tooling fail due to go.mod containing references to git tags that do not exist. This causes errors in Go tooling like for example when running "go list -m -json all" where it ends up failing indicating that the non existing revisions do not exist. This errors occur even when the dependencies have a corresponding replace statement replacing to an existing reference. See that issue for details on how to reproduce the error.

This commit updates the go.mod to remove any dependencies references to non existing git tags. Specifically, the non existing references have been updating pointing to the same existing references as the ones specified in their corresponding replace statement in the go.mod file.

Jira reference: https://issues.redhat.com/browse/OCPBUGS-56902