### PR TITLE
NO-JIRA: Bump golangci-lint to 1.64.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ PAO_CRD_APIS :=$(addprefix ./$(API_TYPES_DIR)/performanceprofile/,v2 v1 v1alpha1
 PAO_E2E_SUITES := $(shell hack/list-test-bin.sh)
 
 # golangci-lint variables
-GOLANGCI_LINT_VERSION=1.62.2
+GOLANGCI_LINT_VERSION=1.64.8
 GOLANGCI_LINT_BIN=$(OUT_DIR)/golangci-lint
 GOLANGCI_LINT_VERSION_TAG=v${GOLANGCI_LINT_VERSION}
 


### PR DESCRIPTION
When using the older version of golangci-lint with go 1.24.x, there's an OoM issue.  Bumping to 1.64.8 fixes this issue.

In the future, we'll probably need to migrate to golangci-lint 2.x.

See: https://github.com/openshift/cluster-node-tuning-operator/pull/1338#issuecomment-2984023262

