### PR TITLE
[release-4.18] OCPBUGS-57947: CNF-18142: Add kernel page size field [1/3]

### DIFF
--- a/docs/performanceprofile/performance_profile.md
+++ b/docs/performanceprofile/performance_profile.md
@@ -22,6 +22,7 @@ This document documents the PerformanceProfile API introduced by the Performance
 * [PerformanceProfileSpec](#performanceprofilespec)
 * [PerformanceProfileStatus](#performanceprofilestatus)
 * [RealTimeKernel](#realtimekernel)
+* [KernelPageSize](#kernelpagesize)
 * [WorkloadHints](#workloadhints)
 
 ## CPU
@@ -163,6 +164,7 @@ PerformanceProfileSpec defines the desired state of PerformanceProfile.
 | machineConfigPoolSelector | MachineConfigPoolSelector defines the MachineConfigPool label to use in the MachineConfigPoolSelector of resources like KubeletConfigs created by the operator. Defaults to \"machineconfiguration.openshift.io/role=&lt;same role as in NodeSelector label key&gt;\" | map[string]string | false |
 | nodeSelector | NodeSelector defines the Node label to use in the NodeSelectors of resources like Tuned created by the operator. It most likely should, but does not have to match the node label in the NodeSelector of the MachineConfigPool which targets this performance profile. In the case when machineConfigLabels or machineConfigPoolSelector are not set, we are expecting a certain NodeSelector format &lt;domain&gt;/&lt;role&gt;: \"\" in order to be able to calculate the default values for the former mentioned fields. | map[string]string | true |
 | realTimeKernel | RealTimeKernel defines a set of real time kernel related parameters. RT kernel won't be installed when not set. | *[RealTimeKernel](#realtimekernel) | false |
+| kernelPageSize | KernelPageSize defines the kernel page size. 4k is the default, 64k is only supported on aarch64 | *[kernelPageSize](#kernelpagesize) | false |
 | additionalKernelArgs | Additional kernel arguments. | []string | false |
 | numa | NUMA defines options related to topology aware affinities | *[NUMA](#numa) | false |
 | net | Net defines a set of network related features | *[Net](#net) | false |
@@ -190,6 +192,13 @@ RealTimeKernel defines the set of parameters relevant for the real time kernel.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | enabled | Enabled defines if the real time kernel packages should be installed. Defaults to \"false\" | *bool | false |
+
+[Back to TOC](#table-of-contents)
+
+## KernelPageSize
+
+KernelPageSize defines the kernel page size that will be used by the kernel.
+4k is the default value, 64k is only supported on aarch64 with realTimeKernel disabled.
 
 [Back to TOC](#table-of-contents)
 

--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -580,6 +580,10 @@ spec:
                           size:
                             description: Size defines huge page size, maps to the 'hugepagesz' kernel boot parameter.
                             type: string
+                kernelPageSize:
+                  description: KernelPageSize defines the kernel page size. 4k is the default, 64k is only supported on aarch64
+                  type: string
+                  default: 4k
                 machineConfigLabel:
                   description: |-
                     MachineConfigLabel defines the label to add to the MachineConfigs the operator creates. It has to be

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -65,6 +65,10 @@ type PerformanceProfileSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector"`
 	// RealTimeKernel defines a set of real time kernel related parameters. RT kernel won't be installed when not set.
 	RealTimeKernel *RealTimeKernel `json:"realTimeKernel,omitempty"`
+	// KernelPageSize defines the kernel page size. 4k is the default, 64k is only supported on aarch64
+	// +default="4k"
+	// +optional
+	KernelPageSize *KernelPageSize `json:"kernelPageSize,omitempty"`
 	// Additional kernel arguments.
 	// +optional
 	AdditionalKernelArgs []string `json:"additionalKernelArgs,omitempty"`
@@ -130,6 +134,12 @@ type HardwareTuning struct {
 	// ReservedCpuFreq defines a maximum frequency to be set across reserved cpus
 	ReservedCpuFreq *CPUfrequency `json:"reservedCpuFreq,omitempty"`
 }
+
+// KernelPageSize defines the size of the kernel pages.
+// The allowed values for this depend on CPU architecture
+// For x86/amd64, the only valid value is 4k.
+// For aarch64, the valid values are 4k, 64k.
+type KernelPageSize string
 
 // HugePageSize defines size of huge pages
 // The allowed values for this depend on CPU architecture

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -718,6 +718,87 @@ var _ = Describe("PerformanceProfile", func() {
 		})
 	})
 
+	Describe("KernelPagesSize validation", func() {
+		var nodes corev1.NodeList
+		var err error
+
+		Context("validation on x86 arch", func() {
+			BeforeEach(func() {
+				nodeSpecs := []NodeSpecifications{}
+				nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: amd64, cpuCapacity: 1000, name: "node"})
+				validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+				nodes, err = profile.getNodesList()
+				Expect(err).To(BeNil())
+			})
+			It("should accept 4k pages kernel pages size", func() {
+				KernelPageSize := KernelPageSize(kernelPageSize4k)
+				profile.Spec.KernelPageSize = &KernelPageSize
+				errors := profile.validateKernelPageSize(nodes)
+				Expect(errors).To(BeEmpty(), "expected no validation errors for 4k kernel page size")
+			})
+			It("should reject invalid input values for pages kernel page size", func() {
+				invalidInputs := [3]string{"", "aaa", "64k"}
+				for _, input := range invalidInputs {
+					invalidKernelPageSize := KernelPageSize(input)
+					profile.Spec.KernelPageSize = &invalidKernelPageSize
+					errors := profile.validateKernelPageSize(nodes)
+					Expect(errors).NotTo(BeEmpty(), "should have validation error when kernel page size is invalid")
+					Expect(errors[0].Error()).To(ContainSubstring("KernelPageSize should be equal to one of"))
+				}
+			})
+		})
+		Context("validation on aarch64", func() {
+			BeforeEach(func() {
+				nodeSpecs := []NodeSpecifications{}
+				nodeSpecs = append(nodeSpecs, NodeSpecifications{architecture: aarch64, cpuCapacity: 1000, name: "node"})
+				validatorClient = GetFakeValidatorClient(nodeSpecs)
+				nodes, err = profile.getNodesList()
+				Expect(err).To(BeNil())
+
+			})
+			It("should accept 4k kernel page size", func() {
+				KernelPageSize := KernelPageSize(kernelPageSize4k)
+				profile.Spec.KernelPageSize = &KernelPageSize
+				errors := profile.validateKernelPageSize(nodes)
+				Expect(errors).To(BeEmpty(), "expected no validation errors for 4k kernel page size")
+			})
+			It("should reject invalid input values for pages kernel page size", func() {
+				invalidInputs := [4]string{"", "aaa", "4", "64"}
+				for _, input := range invalidInputs {
+					invalidKernelPageSize := KernelPageSize(input)
+					profile.Spec.KernelPageSize = &invalidKernelPageSize
+					errors := profile.validateKernelPageSize(nodes)
+					Expect(errors).NotTo(BeEmpty(), "should have validation error when kernel page size is invalid")
+					Expect(errors[0].Error()).To(ContainSubstring("KernelPageSize should be equal to one of"))
+				}
+			})
+			When("real time kernel disabled", func() {
+				It("should accept 64k page size", func() {
+					profile.Spec.RealTimeKernel = &RealTimeKernel{
+						Enabled: ptr.To(false),
+					}
+					KernelPageSize := KernelPageSize(kernelPageSize64k)
+					profile.Spec.KernelPageSize = &KernelPageSize
+					errors := profile.validateKernelPageSize(nodes)
+					Expect(errors).To(BeEmpty(), "expected no validation errors for 64k kernel page size")
+				})
+			})
+			When("real time kernel enabled", func() {
+				It("should reject 64k page size", func() {
+					profile.Spec.RealTimeKernel = &RealTimeKernel{
+						Enabled: ptr.To(true),
+					}
+					KernelPageSize := KernelPageSize(kernelPageSize64k)
+					profile.Spec.KernelPageSize = &KernelPageSize
+					errors := profile.validateKernelPageSize(nodes)
+					Expect(errors).ToNot(BeEmpty())
+					Expect(errors[0].Error()).To(ContainSubstring("64k pages are not supported on ARM64 with a real-time kernel yet"))
+				})
+			})
+		})
+	})
+
 	Describe("Net validation", func() {
 		Context("with properly populated fields", func() {
 			It("should have net fields properly populated", func() {

--- a/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/performanceprofile/v2/zz_generated.deepcopy.go
@@ -326,6 +326,11 @@ func (in *PerformanceProfileSpec) DeepCopyInto(out *PerformanceProfileSpec) {
 		*out = new(RealTimeKernel)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.KernelPageSize != nil {
+		in, out := &in.KernelPageSize, &out.KernelPageSize
+		*out = new(KernelPageSize)
+		**out = **in
+	}
 	if in.AdditionalKernelArgs != nil {
 		in, out := &in.AdditionalKernelArgs, &out.AdditionalKernelArgs
 		*out = make([]string, len(*in))

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -39,6 +39,8 @@ const (
 	MCKernelRT = "realtime"
 	// MCKernelDefault is the value of the kernel setting in MachineConfig for the default kernel
 	MCKernelDefault = "default"
+	// MCKernel64kPages is the value of the kernel setting in MachineConfig for 64k-pages kernel on aarch64
+	MCKernel64kPages = "64k-pages"
 	// HighPerformanceRuntime contains the name of the high-performance runtime
 	HighPerformanceRuntime = "high-performance"
 
@@ -148,8 +150,13 @@ func New(profile *performancev2.PerformanceProfile, opts *components.MachineConf
 		profile.Spec.RealTimeKernel.Enabled != nil &&
 		*profile.Spec.RealTimeKernel.Enabled
 
+	// Real time kernel with 64k-pages for aarch64 not yet supported and rejected in the validation webhook.
 	if enableRTKernel {
 		mc.Spec.KernelType = MCKernelRT
+	} else if profile.Spec.KernelPageSize != nil && *profile.Spec.KernelPageSize == performancev2.KernelPageSize("64k") {
+		// During validation, we ensure that nodes are based on aarch64 when the administrator specifies 64k for this field.
+		// Hence, this assignment is guaranteed to be safe.
+		mc.Spec.KernelType = MCKernel64kPages
 	} else {
 		mc.Spec.KernelType = MCKernelDefault
 	}


### PR DESCRIPTION

This PR is a backport of #1262 and introduces the following changes:
* KernelPageSize field has been added to performance profile API.
This field defines the kernel page size: for x86/amd64, the only valid value is 4k, while for aarch64, the valid values are 4k, 64k.
The default value is 4k if none is specified.
* Validation has been added
* Modified [kernel Type](https://github.com/openshift/machine-config-operator/blob/f0d60f54b8318a84c4d6e6e9e54319b02bdc4dc9/pkg/controller/common/constants.go#L26-L32) selection process, adding the new kernel type `64k-pages` alongside `default` and `realtime` 
* Documented this



