### PR TITLE
[release-4.18]: OCPBUGS-57947: Support hugepage size selection for ARM-based clusters [2/3]

### DIFF
--- a/hack/render-sync.sh
+++ b/hack/render-sync.sh
@@ -43,3 +43,4 @@ rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap/no-mcp
 rendersync bootstrap-cluster/performance pinned-cluster/default bootstrap-cluster/extra-mcp bootstrap/extra-mcp
 rendersync --owner-ref none -- base/performance manual-cluster/performance no-ref 
 rendersync --owner-ref none -- base/performance manual-cluster/cpuFrequency default/cpuFrequency 
+rendersync --owner-ref none -- base/performance manual-cluster/arm default/arm

--- a/test/e2e/performanceprofile/cluster-setup/manual-cluster/arm/kustomization.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/manual-cluster/arm/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base/performance
+
+resources:
+  - performance_profile.yaml

--- a/test/e2e/performanceprofile/cluster-setup/manual-cluster/arm/performance_profile.yaml
+++ b/test/e2e/performanceprofile/cluster-setup/manual-cluster/arm/performance_profile.yaml
@@ -1,0 +1,26 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: manual
+spec:
+  cpu:
+    isolated: "1"
+    reserved: "0"
+    offlined: "2,3"
+  hugepages:
+    defaultHugepagesSize: "32M"
+    pages:
+      - size: "32M"
+        count: 4
+        node: 0
+      - size: "512M"
+        count: 1
+  kernelPageSize: "64k"
+  numa:
+    topologyPolicy: "single-numa-node"
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  workloadHints:
+    highPowerConsumption: false
+    realTime: true
+    perPodPowerManagement: false

--- a/test/e2e/performanceprofile/functests-render-command/1_render_command/render_test.go
+++ b/test/e2e/performanceprofile/functests-render-command/1_render_command/render_test.go
@@ -18,18 +18,20 @@ const (
 	bootstrapExpectedDir    = "bootstrap"
 	noRefExpectedDir        = "no-ref"
 	cpuFrequencyExpectedDir = defaultExpectedDir + "/" + "cpuFrequency"
+	armExpectedDir          = defaultExpectedDir + "/" + "arm"
 )
 
 var (
-	assetsOutDir                           string
-	assetsInDirs, assetsCpuFrequencyInDirs []string
-	ppDir                                  string
-	ppCpuFrequencyDir                      string
-	testDataPath                           string
-	defaultPinnedDir                       string
-	snoLegacyPinnedDir                     string
-	bootstrapPPDir                         string
-	extraMCPDir                            string
+	assetsOutDir                                            string
+	assetsInDirs, assetsCpuFrequencyInDirs, assetsARMInDirs []string
+	ppDir                                                   string
+	ppCpuFrequencyDir                                       string
+	armDir                                                  string
+	testDataPath                                            string
+	defaultPinnedDir                                        string
+	snoLegacyPinnedDir                                      string
+	bootstrapPPDir                                          string
+	extraMCPDir                                             string
 )
 
 var _ = Describe("render command e2e test", func() {
@@ -41,10 +43,12 @@ var _ = Describe("render command e2e test", func() {
 		extraMCPDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "bootstrap-cluster", "extra-mcp")
 		ppDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "manual-cluster", "performance")
 		ppCpuFrequencyDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "manual-cluster", "cpuFrequency")
+		armDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "manual-cluster", "arm")
 		defaultPinnedDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "pinned-cluster", "default")
 		snoLegacyPinnedDir = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "cluster-setup", "pinned-cluster", "single-node-legacy")
 		testDataPath = filepath.Join(workspaceDir, "test", "e2e", "performanceprofile", "testdata")
 		assetsInDirs = []string{assetsInDir, ppDir}
+		assetsARMInDirs = []string{assetsInDir, armDir}
 		assetsCpuFrequencyInDirs = []string{assetsInDir, ppCpuFrequencyDir}
 	})
 
@@ -124,6 +128,20 @@ var _ = Describe("render command e2e test", func() {
 
 			cmd := exec.Command(cmdline[0], cmdline[1:]...)
 			runAndCompare(cmd, cpuFrequencyExpectedDir)
+		})
+
+		It("should produces the expected components for ARM cluster", func() {
+			cmdline := []string{
+				filepath.Join(binPath, "cluster-node-tuning-operator"),
+				"render",
+				"--asset-input-dir", strings.Join(assetsARMInDirs, ","),
+				"--asset-output-dir", assetsOutDir,
+				"--owner-ref", "none",
+			}
+			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			runAndCompare(cmd, armExpectedDir)
 		})
 	})
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_kubeletconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_kubeletconfig.yaml
@@ -1,0 +1,66 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  creationTimestamp: null
+  name: performance-manual
+spec:
+  kubeletConfig:
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous: {}
+      webhook:
+        cacheTTL: 0s
+      x509: {}
+    authorization:
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    containerRuntimeEndpoint: ""
+    cpuManagerPolicy: static
+    cpuManagerPolicyOptions:
+      full-pcpus-only: "true"
+    cpuManagerReconcilePeriod: 5s
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 0s
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMaximumGCAge: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      memory: 500Mi
+    logging:
+      flushFrequency: 0
+      options:
+        json:
+          infoBufferSize: "0"
+        text:
+          infoBufferSize: "0"
+      verbosity: 0
+    memoryManagerPolicy: Static
+    memorySwap: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    reservedMemory:
+    - limits:
+        memory: 1100Mi
+      numaNode: 0
+    reservedSystemCPUs: "0"
+    runtimeRequestTimeout: 0s
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      memory: 500Mi
+    topologyManagerPolicy: single-numa-node
+    volumeStatsAggPeriod: 0s
+  machineConfigPoolSelector:
+    matchLabels:
+      machineconfiguration.openshift.io/role: worker-cnf
+status:
+  conditions: null

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_machineconfig.yaml
@@ -1,0 +1,243 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+  name: 50-performance-manual
+spec:
+  baseOSExtensionsContainerImage: ""
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCm5vZGVzX3BhdGg9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vbm9kZSIKaHVnZXBhZ2VzX2ZpbGU9IiR7bm9kZXNfcGF0aH0vbm9kZSR7TlVNQV9OT0RFfS9odWdlcGFnZXMvaHVnZXBhZ2VzLSR7SFVHRVBBR0VTX1NJWkV9a0IvbnJfaHVnZXBhZ2VzIgoKaWYgWyAhIC1mICIke2h1Z2VwYWdlc19maWxlfSIgXTsgdGhlbgogIGVjaG8gIkVSUk9SOiAke2h1Z2VwYWdlc19maWxlfSBkb2VzIG5vdCBleGlzdCIKICBleGl0IDEKZmkKCnRpbWVvdXQ9NjAKc2FtcGxlPTEKY3VycmVudF90aW1lPTAKd2hpbGUgWyAiJChjYXQgIiR7aHVnZXBhZ2VzX2ZpbGV9IikiIC1uZSAiJHtIVUdFUEFHRVNfQ09VTlR9IiBdOyBkbwogIGVjaG8gIiR7SFVHRVBBR0VTX0NPVU5UfSIgPiIke2h1Z2VwYWdlc19maWxlfSIKCiAgY3VycmVudF90aW1lPSQoKGN1cnJlbnRfdGltZSArIHNhbXBsZSkpCiAgaWYgWyAkY3VycmVudF90aW1lIC1ndCAkdGltZW91dCBdOyB0aGVuCiAgICBlY2hvICJFUlJPUjogJHtodWdlcGFnZXNfZmlsZX0gZG9lcyBub3QgaGF2ZSB0aGUgZXhwZWN0ZWQgbnVtYmVyIG9mIGh1Z2VwYWdlcyAke0hVR0VQQUdFU19DT1VOVH0iCiAgICBleGl0IDEKICBmaQoKICBzbGVlcCAkc2FtcGxlCmRvbmUK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/hugepages-allocation.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZnVuY3Rpb24gc2V0X3F1ZXVlX3Jwc19tYXNrKCkgewojIHJlcGxhY2UgeDJkIHdpdGggaHlwaGVuICgtKSB3aGljaCBpcyBhbiBlc2NhcGVkIGNoYXJhY3RlcgojIHRoYXQgd2FzIGFkZGVkIGJ5IHN5c3RlbWQtZXNjYXBlIGluIG9yZGVyIHRvIGVzY2FwZSB0aGUgc3lzdGVtZCB1bml0IG5hbWUgdGhhdCBpbnZva2VzIHRoaXMgc2NyaXB0CnBhdGg9JHtwYXRoL3gyZC8tfQojIHNldCBycHMgYWZmaW5pdHkgZm9yIHRoZSBxdWV1ZQplY2hvICIke21hc2t9IiAgMj4gL2Rldi9udWxsID4gIi9zeXMvJHtwYXRofS9ycHNfY3B1cyIKIyB3ZSByZXR1cm4gMCBiZWNhdXNlIHRoZSAnZWNobycgY29tbWFuZCBtaWdodCBmYWlsIGlmIHRoZSBkZXZpY2UgcGF0aCB0byB3aGljaCB0aGUgcXVldWUgYmVsb25ncyBoYXMgY2hhbmdlZC4KIyB0aGlzIGNhbiBoYXBwZW4gaW4gY2FzZSBvZiBTUkktT1YgZGV2aWNlcyByZW5hbWluZy4KcmV0dXJuIDAKfQoKZnVuY3Rpb24gc2V0X25ldF9kZXZfcnBzX21hc2soKSB7CiAgIyBpbiBjYXNlIG9mIGRldmljZSB3ZSB3YW50IHRvIGl0ZXJhdGUgdGhyb3VnaCBhbGwgcXVldWVzCmZvciBpIGluIC9zeXMvIiR7cGF0aH0iL3F1ZXVlcy9yeC0qOyBkbwogIGVjaG8gIiR7bWFza30iIDI+IC9kZXYvbnVsbCA+ICIke2l9L3Jwc19jcHVzIgpkb25lCiMgd2UgcmV0dXJuIDAgYmVjYXVzZSB0aGUgJ2VjaG8nIGNvbW1hbmQgbWlnaHQgZmFpbCBpZiB0aGUgZGV2aWNlIHBhdGggdG8gd2hpY2ggdGhlIHF1ZXVlIGJlbG9uZ3MgaGFzIGNoYW5nZWQuCiMgdGhpcyBjYW4gaGFwcGVuIGluIGNhc2Ugb2YgU1JJLU9WIGRldmljZXMgcmVuYW1pbmcuCnJldHVybiAwCiB9CgpwYXRoPSR7MX0KWyAtbiAiJHtwYXRofSIgXSB8fCB7IGVjaG8gIlRoZSBkZXZpY2UgcGF0aCBhcmd1bWVudCBpcyBtaXNzaW5nIiA+JjIgOyBleGl0IDE7IH0KCm1hc2s9JHsyfQpbIC1uICIke21hc2t9IiBdIHx8IHsgZWNobyAiVGhlIG1hc2sgYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgppZiBbWyAiJHtwYXRofSIgPX4gInF1ZXVlcyIgXV07IHRoZW4KIHNldF9xdWV1ZV9ycHNfbWFzawplbHNlCiBzZXRfbmV0X2Rldl9ycHNfbWFzawpmaQo=
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-rps-mask.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9iYXNoCgpzZXQgLWV1byBwaXBlZmFpbAoKZm9yIGNwdSBpbiAke09GRkxJTkVfQ1BVUy8vLC8gfTsKICBkbwogICAgb25saW5lX2NwdV9maWxlPSIvc3lzL2RldmljZXMvc3lzdGVtL2NwdS9jcHUkY3B1L29ubGluZSIKICAgIGlmIFsgISAtZiAiJHtvbmxpbmVfY3B1X2ZpbGV9IiBdOyB0aGVuCiAgICAgIGVjaG8gIkVSUk9SOiAke29ubGluZV9jcHVfZmlsZX0gZG9lcyBub3QgZXhpc3QsIGFib3J0IHNjcmlwdCBleGVjdXRpb24iCiAgICAgIGV4aXQgMQogICAgZmkKICBkb25lCgplY2hvICJBbGwgY3B1cyBvZmZsaW5lZCBleGlzdHMsIHNldCB0aGVtIG9mZmxpbmUiCgpmb3IgY3B1IGluICR7T0ZGTElORV9DUFVTLy8sLyB9OwogIGRvCiAgICBvbmxpbmVfY3B1X2ZpbGU9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vY3B1L2NwdSRjcHUvb25saW5lIgogICAgZWNobyAwID4gIiR7b25saW5lX2NwdV9maWxlfSIKICAgIGVjaG8gIm9mZmxpbmUgY3B1IG51bSAkY3B1IgogIGRvbmUKCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-cpus-offline.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLWV1byBwaXBlZmFpbApzZXQgLXgKCiMgY29uc3QKU0VEPSIvdXNyL2Jpbi9zZWQiCiMgdHVuYWJsZSAtIG92ZXJyaWRhYmxlIGZvciB0ZXN0aW5nIHB1cnBvc2VzCklSUUJBTEFOQ0VfQ09ORj0iJHsxOi0vZXRjL3N5c2NvbmZpZy9pcnFiYWxhbmNlfSIKQ1JJT19PUklHX0JBTk5FRF9DUFVTPSIkezI6LS9ldGMvc3lzY29uZmlnL29yaWdfaXJxX2Jhbm5lZF9jcHVzfSIKTk9ORT0wCgpbICEgLWYgIiR7SVJRQkFMQU5DRV9DT05GfSIgXSAmJiBleGl0IDAKCiR7U0VEfSAtaSAnL15ccypJUlFCQUxBTkNFX0JBTk5FRF9DUFVTXGIvZCcgIiR7SVJRQkFMQU5DRV9DT05GfSIgfHwgZXhpdCAwCiMgQ1BVIG51bWJlcnMgd2hpY2ggaGF2ZSB0aGVpciBjb3JyZXNwb25kaW5nIGJpdHMgc2V0IHRvIG9uZSBpbiB0aGlzIG1hc2sKIyB3aWxsIG5vdCBoYXZlIGFueSBpcnEncyBhc3NpZ25lZCB0byB0aGVtIG9uIHJlYmFsYW5jZS4KIyBzbyB6ZXJvIG1lYW5zIGFsbCBjcHVzIGFyZSBwYXJ0aWNpcGF0aW5nIGluIGxvYWQgYmFsYW5jaW5nLgplY2hvICJJUlFCQUxBTkNFX0JBTk5FRF9DUFVTPSR7Tk9ORX0iID4+ICIke0lSUUJBTEFOQ0VfQ09ORn0iCgojIHdlIG5vdyBvd24gdGhpcyBjb25maWd1cmF0aW9uLiBCdXQgQ1JJLU8gaGFzIGNvZGUgdG8gcmVzdG9yZSB0aGUgY29uZmlndXJhdGlvbiwKIyBhbmQgdW50aWwgaXQgZ2FpbnMgdGhlIG9wdGlvbiB0byBkaXNhYmxlIHRoaXMgcmVzdG9yZSBmbG93LCB3ZSBuZWVkIHRvIG1ha2UKIyB0aGUgY29uZmlndXJhdGlvbiBjb25zaXN0ZW50IHN1Y2ggYXMgdGhlIENSSS1PIHJlc3RvcmUgd2lsbCBkbyBub3RoaW5nLgppZiBbIC1uICIke0NSSU9fT1JJR19CQU5ORURfQ1BVU30iIF0gJiYgWyAtZiAiJHtDUklPX09SSUdfQkFOTkVEX0NQVVN9IiBdOyB0aGVuCgllY2hvICIke05PTkV9IiA+ICIke0NSSU9fT1JJR19CQU5ORURfQ1BVU30iCmZpCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/clear-irqbalance-banned-cpus.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMCIKCgoKCiMgVGhlIENSSS1PIHdpbGwgY2hlY2sgdGhlIGFsbG93ZWRfYW5ub3RhdGlvbnMgdW5kZXIgdGhlIHJ1bnRpbWUgaGFuZGxlciBhbmQgYXBwbHkgaGlnaC1wZXJmb3JtYW5jZSBob29rcyB3aGVuIG9uZSBvZgojIGhpZ2gtcGVyZm9ybWFuY2UgYW5ub3RhdGlvbnMgcHJlc2VudHMgdW5kZXIgaXQuCiMgV2Ugc2hvdWxkIHByb3ZpZGUgdGhlIHJ1bnRpbWVfcGF0aCBiZWNhdXNlIHdlIG5lZWQgdG8gaW5mb3JtIHRoYXQgd2Ugd2FudCB0byByZS11c2UgcnVuYyBiaW5hcnkgYW5kIHdlCiMgZG8gbm90IGhhdmUgaGlnaC1wZXJmb3JtYW5jZSBiaW5hcnkgdW5kZXIgdGhlICRQQVRIIHRoYXQgd2lsbCBwb2ludCB0byBpdC4KW2NyaW8ucnVudGltZS5ydW50aW1lcy5oaWdoLXBlcmZvcm1hbmNlXQppbmhlcml0X2RlZmF1bHRfcnVudGltZSA9IHRydWUKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LWMtc3RhdGVzLmNyaW8uaW8iLCAiY3B1LWZyZXEtZ292ZXJub3IuY3Jpby5pbyJdCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-runtimes.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBBcHBseSB0aGUgUlBTIG1hc2sgb24gdGhlIHZpcnR1YWwgaW50ZXJmYWNlcyBvZiB0aGUgaG9zdCBieSBkZWZhdWx0LCBiZWNhc3VlCiMgZnJvbSB0aGUgY29udGFpbmVyIHBlcnNwZWN0aXZlIHRoZSBSUFMgbWFzayB0aGUgd2lsbCBiZSBjb25zdWx0ZWQsIGlzIHRoZSBvbmUgb24gdGhlIFJYIHNpZGUgb2YgdGhlIHZldGggaW4gdGhlIGhvc3QuCiMgQ29uc2lkZXIgdGhlIGZvbGxvd2luZyBkaWFncmFtOgojIFBvZCBBIDx2ZXRoMSAtIHZldGgyPiBob3N0IDx2ZXRoMyAtIHZldGg0PiBQb2QgQgojICB2ZXRoMidzIFJQUyBhZmZpbml0eSBpcyB0aGUgb25lIGRldGVybWluaW5nIHRoZSBDUFVzIHRoYXQgYXJlIGhhbmRsaW5nIHRoZSBwYWNrZXQgcHJvY2Vzc2luZyB3aGVuIHNlbmRpbmcgZGF0YSBmcm9tIFBvZCBBIHRvIHBvZCBCLgojIEFkZGl0aW9uYWwgY29tbW9uIHNjZW5hcmlvczoKIyAxLiBQb2QgQSA9IHNlbmRlciwgaG9zdCA9IHJlY2VpdmVyCiMgIFRoZSBSUFMgYWZmaW5pdHkgb2YgdGhlIGhvc3Qgc2lkZSBzaG91bGQgYmUgY29uc3VsdGVkIChiZWNhdXNlIGl04oCZcyB0aGUgcmVjZWl2ZXIpIGFuZCBpdCBzaG91bGQgYmUgc2V0IHRvIGNwdXMgbm90IHNlbnNpdGl2ZSB0byBwcmVlbXB0aW9uIChyZXNlcnZlZCBwb29sKS4KIyAyLiBQb2QgQSA9IHJlY2VpdmVyLCBob3N0ID0gc2VuZGVyCiMgIEluIGNhc2Ugb2Ygbm8gUlBTIG1hc2sgb24gdGhlIHJlY2VpdmVyIHNpZGUsIHRoZSBzZW5kZXIgbmVlZHMgdG8gcGF5IHRoZSBwcmljZSBhbmQgZG8gYWxsIHRoZSBwcm9jZXNzaW5nIG9uIGl0cyBjb3Jlcy4KbmV0LmNvcmUucnBzX2RlZmF1bHRfbWFzayA9IDAwMDAwMDAxCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysctl.d/99-default-rps-mask.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0icXVldWVzIiwgQUNUSU9OPT0iYWRkIiwgRU5We0RFVlBBVEh9PT0iL2RldmljZXMvcGNpKi9xdWV1ZXMvcngqIiwgVEFHKz0ic3lzdGVtZCIsIFBST0dSQU09Ii9iaW4vc3lzdGVtZC1lc2NhcGUgLS1wYXRoIC0tdGVtcGxhdGU9dXBkYXRlLXJwc0Auc2VydmljZSAkZW52e0RFVlBBVEh9IiwgRU5We1NZU1RFTURfV0FOVFN9PSIlYyIKCiMgU1ItSU9WIGRldmljZXMgYXJlIG1vdmVkIChyZW5hbWVkKSwgaGVuY2Ugd2Ugd2FudCB0byBjYXRjaCB0aGlzIGV2ZW50IGFzIHdlbGwKU1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0ibW92ZSIsIEVOVntERVZQQVRIfSE9Ii9kZXZpY2VzL3ZpcnR1YWwvbmV0LyoiLCBUQUcrPSJzeXN0ZW1kIiwgUFJPR1JBTT0iL2Jpbi9zeXN0ZW1kLWVzY2FwZSAtLXBhdGggLS10ZW1wbGF0ZT11cGRhdGUtcnBzQC5zZXJ2aWNlICRlbnZ7REVWUEFUSH0iLCBFTlZ7U1lTVEVNRF9XQU5UU309IiVjIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/99-netdev-physical-rps.rules
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCiMgY3B1c2V0LWNvbmZpZ3VyZS5zaCBjb25maWd1cmVzIHRocmVlIGNwdXNldHMgaW4gcHJlcGFyYXRpb24gZm9yIGFsbG93aW5nIGNvbnRhaW5lcnMgdG8gaGF2ZSBjcHUgbG9hZCBiYWxhbmNpbmcgZGlzYWJsZWQuCiMgVG8gY29uZmlndXJlIGEgY3B1c2V0IHRvIGhhdmUgbG9hZCBiYWxhbmNlIGRpc2FibGVkIChvbiBjZ3JvdXAgdjEpLCBhIGNwdXNldCBjZ3JvdXAgbXVzdCBoYXZlIGBjcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlYAojIHNldCB0byAwIChkaXNhYmxlKSwgYW5kIGFueSBjcHVzZXQgdGhhdCBjb250YWlucyB0aGUgc2FtZSBzZXQgYXMgYGNwdXNldC5jcHVzYCBtdXN0IGFsc28gaGF2ZSBgY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZWAgc2V0IHRvIGRpc2FibGVkLgoKc2V0IC1ldW8gcGlwZWZhaWwKCmlmIHRlc3QgIiQoc3RhdCAtZiAtYyVUIC9zeXMvZnMvY2dyb3VwKSIgPSAiY2dyb3VwMmZzIjsgdGhlbgoJZWNobyAiTm9kZSBpcyB1c2luZyBjZ3JvdXAgdjIsIG5vIGNvbmZpZ3VyYXRpb24gbmVlZGVkIgoJZXhpdCAwCmZpCgpyb290PS9zeXMvZnMvY2dyb3VwL2NwdXNldApzeXN0ZW09IiRyb290Ii9zeXN0ZW0uc2xpY2UKbWFjaGluZT0iJHJvb3QiL21hY2hpbmUuc2xpY2UKCm92c3NsaWNlPSIke3Jvb3R9L292cy5zbGljZSIKb3Zzc2xpY2Vfc3lzdGVtZD0iL3N5cy9mcy9jZ3JvdXAvcGlkcy9vdnMuc2xpY2UiCgojIEFzIHN1Y2gsIHRoZSByb290IGNncm91cCBuZWVkcyB0byBoYXZlIGNwdXNldC5zY2hlZF9sb2FkX2JhbGFuY2U9MC4gCmVjaG8gMCA+ICIkcm9vdCIvY3B1c2V0LnNjaGVkX2xvYWRfYmFsYW5jZQoKIyBIb3dldmVyLCB0aGlzIHdvdWxkIHByZXNlbnQgYSBwcm9ibGVtIGZvciBzeXN0ZW0gZGFlbW9ucywgd2hpY2ggc2hvdWxkIGhhdmUgbG9hZCBiYWxhbmNpbmcgZW5hYmxlZC4KIyBBcyBzdWNoLCBhIHNlY29uZCBjcHVzZXQgbXVzdCBiZSBjcmVhdGVkLCBoZXJlIGR1YmJlZCBgc3lzdGVtYCwgd2hpY2ggd2lsbCB0YWtlIGFsbCBzeXN0ZW0gZGFlbW9ucy4KIyBTaW5jZSBzeXN0ZW1kIHN0YXJ0cyBpdHMgY2hpbGRyZW4gd2l0aCB0aGUgY3B1c2V0IGl0IGlzIGluLCBtb3Zpbmcgc3lzdGVtZCB3aWxsIGVuc3VyZSBhbGwgcHJvY2Vzc2VzIHN5c3RlbWQgYmVnaW5zIHdpbGwgYmUgaW4gdGhlIGNvcnJlY3QgY2dyb3VwLgpta2RpciAtcCAiJHN5c3RlbSIKIyBjcHVzZXQubWVtcyBtdXN0IGJlIGluaXRpYWxpemVkIG9yIHByb2Nlc3NlcyB3aWxsIGZhaWwgdG8gYmUgbW92ZWQgaW50byBpdC4KY2F0ICIkcm9vdC9jcHVzZXQubWVtcyIgPiAiJHN5c3RlbSIvY3B1c2V0Lm1lbXMKIyBSZXRyaWV2ZSB0aGUgY3B1c2V0IG9mIHN5c3RlbWQsIGFuZCB3cml0ZSBpdCB0byBjcHVzZXQuY3B1cyBvZiB0aGUgc3lzdGVtIGNncm91cC4KcmVzZXJ2ZWRfc2V0PSQodGFza3NldCAtY3AgIDEgIHwgYXdrICdORnsgcHJpbnQgJE5GIH0nKQplY2hvICIkcmVzZXJ2ZWRfc2V0IiA+ICIkc3lzdGVtIi9jcHVzZXQuY3B1cwoKIyBBbmQgbW92ZSB0aGUgc3lzdGVtIHByb2Nlc3NlcyBpbnRvIGl0LgojIE5vdGUsIHNvbWUga2VybmVsIHRocmVhZHMgd2lsbCBmYWlsIHRvIGJlIG1vdmVkIHdpdGggIkludmFsaWQgQXJndW1lbnQiLiBUaGlzIHNob3VsZCBiZSBpZ25vcmVkLgpmb3IgcHJvY2VzcyBpbiAkKGNhdCAiJHJvb3QiL2Nncm91cC5wcm9jcyB8IHNvcnQgLXIpOyBkbwoJZWNobyAkcHJvY2VzcyA+ICIkc3lzdGVtIi9jZ3JvdXAucHJvY3MgMj4mMSB8IGdyZXAgLXYgIkludmFsaWQgQXJndW1lbnQiIHx8IHRydWU7CmRvbmUKCiMgRmluYWxseSwgYSB0aGUgYG1hY2hpbmUuc2xpY2VgIGNncm91cCBtdXN0IGJlIHByZWNvbmZpZ3VyZWQuIFBvZG1hbiB3aWxsIGNyZWF0ZSBjb250YWluZXJzIGFuZCBtb3ZlIHRoZW0gaW50byB0aGUgYG1hY2hpbmUuc2xpY2VgLCBidXQgdGhlcmUncwojIG5vIHdheSB0byB0ZWxsIHBvZG1hbiB0byB1cGRhdGUgbWFjaGluZS5zbGljZSB0byBub3QgaGF2ZSB0aGUgZnVsbCBzZXQgb2YgY3B1cy4gSW5zdGVhZCBvZiBkaXNhYmxpbmcgbG9hZCBiYWxhbmNpbmcgaW4gaXQsIHdlIGNhbiBwcmUtY3JlYXRlIGl0LgojIHdpdGggdGhlIHJlc2VydmVkIENQVXMgc2V0IGFoZWFkIG9mIHRpbWUsIHNvIHdoZW4gaXNvbGF0ZWQgcHJvY2Vzc2VzIGJlZ2luLCB0aGUgY2dyb3VwIGRvZXMgbm90IGhhdmUgYW4gb3ZlcmxhcHBpbmcgY3B1c2V0IGJldHdlZW4gbWFjaGluZS5zbGljZSBhbmQgaXNvbGF0ZWQgY29udGFpbmVycy4KbWtkaXIgLXAgIiRtYWNoaW5lIgoKIyBJdCdzIHVubGlrZWx5LCBidXQgcG9zc2libGUsIHRoYXQgdGhpcyBjcHVzZXQgYWxyZWFkeSBleGlzdGVkLiBJdGVyYXRlIGp1c3QgaW4gY2FzZS4KZm9yIGZpbGUgaW4gJChmaW5kICIkbWFjaGluZSIgLW5hbWUgY3B1c2V0LmNwdXMgfCBzb3J0IC1yKTsgZG8gZWNobyAiJHJlc2VydmVkX3NldCIgPiAiJGZpbGUiOyBkb25lCgojIE9WUyBpcyBydW5uaW5nIGluIGl0cyBvd24gc2xpY2UgdGhhdCBzcGFucyBhbGwgY3B1cy4gVGhlIHJlYWwgYWZmaW5pdHkgaXMgbWFuYWdlZCBieSBPVk4tSyBvdm5rdWJlLW5vZGUgZGFlbW9uc2V0CiMgTWFrZSBzdXJlIHRoaXMgc2xpY2Ugd2lsbCBub3QgZW5hYmxlIGNwdSBiYWxhbmNpbmcgZm9yIG90aGVyIHNsaWNlIGNvbmZpZ3VyZWQgYnkgdGhpcyBzY3JpcHQuCiMgVGhpcyBtaWdodCBzZWVtIGNvdW50ZXItaW50dWl0aXZlLCBidXQgdGhpcyB3aWxsIGFjdHVhbGx5IE5PVCBkaXNhYmxlIGNwdSBiYWxhbmNpbmcgZm9yIE9WUyBpdHNlbGYuCiMgLSBPVlMgaGFzIGFjY2VzcyB0byByZXNlcnZlZCBjcHVzLCBidXQgdGhvc2UgaGF2ZSBiYWxhbmNpbmcgZW5hYmxlZCB2aWEgdGhlIGBzeXN0ZW1gIGNncm91cCBjcmVhdGVkIGFib3ZlCiMgLSBPVlMgaGFzIGFjY2VzcyB0byBpc29sYXRlZCBjcHVzIHRoYXQgYXJlIGN1cnJlbnRseSBub3QgYXNzaWduZWQgdG8gcGlubmVkIHBvZHMuIFRob3NlIGhhdmUgYmFsYW5jaW5nIGVuYWJsZWQgYnkgdGhlCiMgICBwb2RzIHJ1bm5pbmcgdGhlcmUgKGJ1cnN0YWJsZSBhbmQgYmVzdC1lZmZvcnQgcG9kcyBoYXZlIGJhbGFuY2luZyBlbmFibGVkIGluIHRoZSBjb250YWluZXIgY2dyb3VwIGFuZCBhY2Nlc3MgdG8gYWxsCiMgICB1bnBpbm5lZCBjcHVzKS4KCiMgc3lzdGVtZCBkb2VzIG5vdCBtYW5hZ2UgdGhlIGNwdXNldCBjZ3JvdXAgY29udHJvbGxlciwgc28gbW92ZSBldmVyeXRoaW5nIGZyb20gdGhlIG1hbmFnZWQgcGlkcyBjb250cm9sbGVyJ3Mgb3ZzLnNsaWNlCiMgdG8gdGhlIGNwdXNldCBjb250cm9sbGVyLgoKIyBDcmVhdGUgdGhlIG92cy5zbGljZQpta2RpciAtcCAiJG92c3NsaWNlIgplY2hvIDAgPiAiJG92c3NsaWNlIi9jcHVzZXQuc2NoZWRfbG9hZF9iYWxhbmNlCmNhdCAiJHJvb3QiL2NwdXNldC5jcHVzID4gIiRvdnNzbGljZSIvY3B1c2V0LmNwdXMKY2F0ICIkcm9vdCIvY3B1c2V0Lm1lbXMgPiAiJG92c3NsaWNlIi9jcHVzZXQubWVtcwoKIyBNb3ZlIE9WUyBvdmVyCmZvciBwcm9jZXNzIGluICQoY2F0ICIkb3Zzc2xpY2Vfc3lzdGVtZCIvKi9jZ3JvdXAucHJvY3MgfCBzb3J0IC1yKTsgZG8KICAgICAgICBlY2hvICRwcm9jZXNzID4gIiRvdnNzbGljZSIvY2dyb3VwLnByb2NzIDI+JjEgfCBncmVwIC12ICJJbnZhbGlkIEFyZ3VtZW50IiB8fCB0cnVlOwpkb25lCg==
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/cpuset-configure.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs.slice
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/openvswitch.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovs-vswitchd.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdClNsaWNlPW92cy5zbGljZQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/ovsdb-server.service.d/01-use-ovs-slice.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBUaGlzIGZpbGUgZW5hYmxlcyB0aGUgZHluYW1pYyBjcHUgYWZmaW5pdHkgbWFuYWdlbWVudCBvZiB0aGUgT1ZTIHNlcnZpY2VzCiMKIyBJdCBpcyByZWFkIGJ5IHRoZSBPVk4ncyBvdm5rdWJlLW5vZGUgRGFlbW9uU2V0IGNvbnRhaW5lciBhbmQgdGhlIGZlYXR1cmUKIyBpcyBlbmFibGVkIHdoZW4gdGhpcyBmaWxlIGV4aXN0cyBhbmQgaXMgbm90IGVtcHR5ICh0aGlzIGNvbW1lbnRhcnkgdGV4dAojIGVuc3VyZXMgdGhhdCkKIwojIEZvciBkaXNhYmxpbmcgdGhpcyBmZWF0dXJlIGluIGVtZXJnZW5jaWVzLCBlaXRoZXI6CiMgMSkgZGVsZXRlIHRoaXMgZmlsZSBhbmQgc2V0IHRoZSBjcHUgYWZmaW5pdHkgb2YgT1ZTIHNlcnZpY2VzIG1hbnVhbGx5CiMgMikgb3IgcmVwbGFjZSB0aGUgY29udGVudHMgb2YgdGhpcyBmaWxlIHdpdGggYW4gZW1wdHkgc3RyaW5nCiMgICAgdmlhIGEgTWFjaGluZUNvbmZpZwo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
+        user: {}
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Sets network devices RPS mask
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/set-rps-mask.sh %I 0
+        name: update-rps@.service
+      - contents: |
+          [Unit]
+          Description=Hugepages-32768kB allocation on the node 0
+          Before=kubelet.service
+
+          [Service]
+          Environment=HUGEPAGES_COUNT=4
+          Environment=HUGEPAGES_SIZE=32768
+          Environment=NUMA_NODE=0
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/hugepages-allocation.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: hugepages-allocation-32768kB-NUMA0.service
+      - contents: |
+          [Unit]
+          Description=Move services to reserved cpuset
+          Before=kubelet.service
+          After=crio.service
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/cpuset-configure.sh
+
+          [Install]
+          WantedBy=multi-user.target crio.service
+        enabled: true
+        name: cpuset-configure.service
+      - contents: |
+          [Unit]
+          Description=Set cpus offline: 2,3
+          Before=kubelet.service
+
+          [Service]
+          Environment=OFFLINE_CPUS=2,3
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/set-cpus-offline.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: set-cpus-offline.service
+      - contents: |
+          [Unit]
+          Description=Clear the IRQBalance Banned CPU mask early in the boot
+          Before=kubelet.service
+          Before=irqbalance.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/clear-irqbalance-banned-cpus.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: clear-irqbalance-banned-cpus.service
+      - contents: |
+          [Unit]
+          Description=TuneD service from NTO image
+          After=firstboot-osupdate.target systemd-sysctl.service network.target polkit.service
+          # Requires is necessary to start this unit before kubelet-dependencies.target
+          Requires=kubelet-dependencies.target
+          Before=kubelet-dependencies.target
+          ConditionPathExists=/var/lib/ocp-tuned/image.env
+
+          [Service]
+          # https://www.redhat.com/sysadmin/podman-shareable-systemd-services
+          # and also "podman systemd generate" uses "forking".  However, this
+          # is strongly discouraged by "man systemd.service" and results in
+          # failed dependency for the kubelet service.
+          Type=oneshot
+          Restart=on-failure
+          # Time to wait between restart attempts.
+          RestartSec=5s
+          ExecReload=/bin/pkill --signal HUP --pidfile /run/tuned/tuned.pid
+          ExecStartPre=/bin/bash -c " \
+            mkdir -p /run/tuned "
+          ExecStart=/usr/bin/podman run \
+              --rm \
+              --name openshift-tuned \
+              --privileged \
+              --authfile /var/lib/kubelet/config.json \
+              --net=host \
+              --pid=host \
+              --security-opt label=disable \
+              --log-driver=none \
+              --volume /var/lib/kubelet:/var/lib/kubelet:rslave,ro \
+              --volume /var/lib/ocp-tuned:/host/var/lib/ocp-tuned:rslave \
+              --volume /var/lib/tuned:/host/var/lib/tuned:rslave \
+              --volume /etc/modprobe.d:/etc/modprobe.d:rslave \
+              --volume /etc/sysconfig:/etc/sysconfig:rslave \
+              --volume /etc/sysctl.d:/etc/sysctl.d:rslave,ro \
+              --volume /etc/sysctl.conf:/etc/sysctl.conf:rslave,ro \
+              --volume /etc/systemd:/etc/systemd:rslave \
+              --volume /run/tuned:/run/tuned:rslave \
+              --volume /run/systemd:/run/systemd:rslave \
+              --volume /sys:/sys:rslave \
+              --entrypoint '["/usr/bin/cluster-node-tuning-operator","ocp-tuned","--in-cluster=false","--one-shot=true","-v=1"]' \
+              $NTO_IMAGE
+          Environment=PODMAN_SYSTEMD_UNIT=%n
+          EnvironmentFile=/etc/mco/proxy.env
+          EnvironmentFile=-/var/lib/ocp-tuned/image.env
+          ExecStop=/usr/bin/podman stop -t 20 --ignore openshift-tuned
+          ExecStopPost=/usr/bin/podman rm -f --ignore openshift-tuned
+
+          [Install]
+          # RequiredBy causes kubelet to depend on this service.
+          RequiredBy=kubelet-dependencies.target
+        enabled: true
+        name: ocp-tuned-one-shot.service
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: 64k-pages
+  osImageURL: ""

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_runtimeclass.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_runtimeclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: node.k8s.io/v1
+handler: high-performance
+kind: RuntimeClass
+metadata:
+  creationTimestamp: null
+  name: performance-manual
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""


### PR DESCRIPTION
This PR is a backport #1294. It introduces support for selecting hugepage sizes on ARM-based clusters. It complements the work done in https://github.com/openshift/cluster-node-tuning-operator/pull/1086 and ensures that hugepage configurations are correctly applied.

E2E tests are planned to be added in a future update.