### PR TITLE
[release-4.18]: OCPBUGS-57947: kernelPageSize + hugepages combinations validation [3/3]

### DIFF
--- a/docs/performanceprofile/performance_profile.md
+++ b/docs/performanceprofile/performance_profile.md
@@ -72,7 +72,12 @@ HugePage defines the number of allocated huge pages of the specific size.
 
 ## HugePageSize
 
-HugePageSize defines size of huge pages, can be 2M or 1G.
+HugePageSize defines the size of huge pages, which depends on the CPU architecture:
+
+- **For x86/amd64**, the valid values are **2M** and **1G**.
+- **For aarch64**, the valid values depend on the kernel page size:
+  - With **[kernelPageSize](#kernelpagesize) set to 4k**: **64k, 2M, 32M, 1G**
+  - With **[kernelPageSize](#kernelpagesize) set to 64k**: **2M, 512M, 16G**
 
 HugePageSize is of type `string`.
 

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -143,8 +143,12 @@ type KernelPageSize string
 
 // HugePageSize defines size of huge pages
 // The allowed values for this depend on CPU architecture
-// For x86/amd64, the valid values are 2M and 1G
-// For aarch64, the valid values are 2M, 32M, and 512M
+// For x86/amd64, the valid values are 2M and 1G.
+// For aarch64, the valid huge page sizes depend on the kernel page size:
+// - With a 4k kernel page size: 64k, 2M, 32M, 1G
+// - With a 64k kernel page size: 2M, 512M, 16G
+//
+// Reference: https://docs.kernel.org/mm/vmemmap_dedup.html
 type HugePageSize string
 
 // HugePages defines a set of huge pages that we want to allocate at boot.

--- a/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_validation_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -96,6 +97,7 @@ func GetFakeValidatorClient(nodeSpecs []NodeSpecifications) client.Client {
 // NewPerformanceProfile returns new performance profile object that used for tests
 func NewPerformanceProfile(name string) *PerformanceProfile {
 	size := HugePageSize1G
+	kernelPageSize := KernelPageSize(kernelPageSize4k)
 	isolatedCPUs := IsolatedCPUs
 	reservedCPUs := ReservedCPUs
 	offlinedCPUs := OfflinedCPUs
@@ -129,6 +131,7 @@ func NewPerformanceProfile(name string) *PerformanceProfile {
 			RealTimeKernel: &RealTimeKernel{
 				Enabled: pointer.Bool(true),
 			},
+			KernelPageSize: &kernelPageSize,
 			NUMA: &NUMA{
 				TopologyPolicy: &numaPolicy,
 			},
@@ -608,9 +611,10 @@ var _ = Describe("PerformanceProfile", func() {
 				Node:  pointer.Int32(0),
 				Size:  "14M",
 			})
+			kernelPageSize := *profile.Spec.KernelPageSize
 			errors := profile.validateHugePages(nodes)
 			Expect(errors).NotTo(BeEmpty(), "should have validation error when page with invalid format presents")
-			Expect(errors[0].Error()).To(ContainSubstring(fmt.Sprintf("the page size should be equal to one of %v", aarch64ValidHugepagesSizes)))
+			Expect(errors[0].Error()).To(ContainSubstring(fmt.Sprintf("the page size should be equal to one of %v", aarch64HugePagesByKernelPageSize[string(kernelPageSize)])))
 		})
 
 		It("should pass when no nodes are detected with a valid hugepage size", func() {
@@ -647,6 +651,58 @@ var _ = Describe("PerformanceProfile", func() {
 			errors := profile.validateHugePages(nodes)
 			Expect(errors).ToNot(BeEmpty())
 			Expect(errors[0].Error()).To(ContainSubstring(("the page size should be equal to one of")))
+		})
+		Context("KernelPageSize with HugePages validation", func() {
+			var kernelToHugePageSizeByArch = map[string]map[string][]string{
+				aarch64: aarch64HugePagesByKernelPageSize,
+				amd64:   x86HugePagesByKernelPageSize,
+			}
+
+			var tableEntries []TableEntry
+			hugepagesSizes := allHugePageSizes()
+
+			for arch, kernelToHugePageSize := range kernelToHugePageSizeByArch {
+				for kernelPageSize, hugePageSizes := range kernelToHugePageSize {
+					for hugePageSize := range hugepagesSizes {
+						isSupported := !slices.Contains(hugePageSizes, hugePageSize)
+						tableEntries = append(tableEntries, Entry(
+							fmt.Sprintf("Arch: %s, KernelPageSize: %s, HugePageSize: %s", arch, kernelPageSize, hugePageSize),
+							arch, kernelPageSize, hugePageSize, isSupported,
+						))
+					}
+				}
+			}
+			DescribeTable("KernelPageSize with HugePages validation",
+				func(arch string, kernelPageSize string, hugePageSize string, expectError bool) {
+					nodeSpecs := []NodeSpecifications{
+						{architecture: arch, cpuCapacity: 1000, name: "node"},
+					}
+					validatorClient = GetFakeValidatorClient(nodeSpecs)
+
+					nodes, err := profile.getNodesList()
+					Expect(err).ToNot(HaveOccurred())
+
+					*profile.Spec.HugePages.DefaultHugePagesSize = HugePageSize(hugePageSize)
+					profile.Spec.HugePages.Pages = []HugePage{
+						{
+							Count: 1,
+							Node:  ptr.To(int32(0)),
+							Size:  HugePageSize(hugePageSize),
+						},
+					}
+					profile.Spec.KernelPageSize = ptr.To(KernelPageSize(kernelPageSize))
+
+					errors := profile.validateHugePages(nodes)
+					if expectError {
+						Expect(errors).ToNot(BeEmpty(), "should have validation error")
+						Expect(errors[0].Error()).To(ContainSubstring("hugepages default size should be equal"))
+						Expect(errors[1].Error()).To(ContainSubstring("the page size should be equal to one of"))
+					} else {
+						Expect(errors).To(BeEmpty(), "should not have validation error")
+					}
+				},
+				tableEntries,
+			)
 		})
 
 		When("pages have duplication", func() {
@@ -888,6 +944,7 @@ var _ = Describe("PerformanceProfile", func() {
 			incorrectDefaultSize := HugePageSize("!#@")
 			profile.Spec.HugePages.DefaultHugePagesSize = &incorrectDefaultSize
 
+			profile.Spec.KernelPageSize = ptr.To(KernelPageSize("!#@"))
 			profile.Spec.WorkloadHints = &WorkloadHints{
 				RealTime: pointer.Bool(false),
 			}
@@ -906,10 +963,10 @@ var _ = Describe("PerformanceProfile", func() {
 			type void struct{}
 			var member void
 			errorMsgs := make(map[string]void)
-
 			errorMsgs["reserved CPUs can not be empty"] = member
 			errorMsgs["you should provide only 1 MachineConfigLabel"] = member
-			errorMsgs[fmt.Sprintf("hugepages default size should be equal to one of %v", x86ValidHugepagesSizes)] = member
+			errorMsgs[fmt.Sprintf("hugepages default size should be equal to one of %v. doc reference=%s", x86ValidHugepagesSizes, "https://docs.kernel.org/mm/vmemmap_dedup.html")] = member
+			errorMsgs[fmt.Sprintf("KernelPageSize should be equal to one of: %v", kernelPageSize4k)] = member
 			errorMsgs["device name cannot be empty"] = member
 			errorMsgs[fmt.Sprintf("device vendor ID %s has an invalid format. Vendor ID should be represented as 0x<4 hexadecimal digits> (16 bit representation)", invalidVendor)] = member
 			errorMsgs[fmt.Sprintf("device model ID %s has an invalid format. Model ID should be represented as 0x<4 hexadecimal digits> (16 bit representation)", invalidDevice)] = member


### PR DESCRIPTION
This PR is a backport of #296. It includes these changes:

* Corrected valid huge page sizes for ARM.
* Improved huge pages validation to depend on the configured kernelPageSize.
* Added unit tests to validate all `kernelPageSize` and `hugepages` combinations, covering both valid and invalid cases.

This improves validation coverage and prevents misconfiguration.
