### PR TITLE
NO-JIRA:chore:e2e: replace Getenv with LookupEnv

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -1395,16 +1395,16 @@ func checkSchedulingDomains(workerRTNode *corev1.Node, podCpus cpuset.CPUSet, te
 // This is required for running tests on disconnected environment where images are mirrored
 // in private registries.
 func busyCpuImageEnv() string {
-	qeImageRegistry := os.Getenv("IMAGE_REGISTRY")
-	busyCpusImage := os.Getenv("BUSY_CPUS_IMAGE")
+	qeImageRegistry, ok := os.LookupEnv("IMAGE_REGISTRY")
+	if !ok {
+		qeImageRegistry = "quay.io/ocp-edge-qe/"
+	}
 
-	if busyCpusImage == "" {
+	busyCpusImage, ok := os.LookupEnv("BUSY_CPUS_IMAGE")
+	if !ok {
 		busyCpusImage = "busycpus"
 	}
 
-	if qeImageRegistry == "" {
-		qeImageRegistry = "quay.io/ocp-edge-qe/"
-	}
 	return fmt.Sprintf("%s%s", qeImageRegistry, busyCpusImage)
 }
 

--- a/test/e2e/performanceprofile/functests/9_reboot/devices.go
+++ b/test/e2e/performanceprofile/functests/9_reboot/devices.go
@@ -69,8 +69,8 @@ var _ = Describe("[disruptive][node][kubelet][devicemanager] Device management t
 	)
 
 	BeforeEach(func() {
-		targetNode = os.Getenv(targetNodeEnvVar)
-		if targetNode == "" {
+		targetNode, ok := os.LookupEnv(targetNodeEnvVar)
+		if !ok {
 			Skip(fmt.Sprintf("Need an explicit target node name, got none (env var: %q)", targetNodeEnvVar))
 		}
 		testlog.Infof("target node name: %q", targetNode)

--- a/test/e2e/performanceprofile/functests/utils/consts.go
+++ b/test/e2e/performanceprofile/functests/utils/consts.go
@@ -33,17 +33,18 @@ var NTOImage string
 var MustGatherDir string
 
 func init() {
-	RoleWorkerCNF = os.Getenv("ROLE_WORKER_CNF")
-	if RoleWorkerCNF == "" {
+	var ok bool
+	RoleWorkerCNF, ok = os.LookupEnv("ROLE_WORKER_CNF")
+	if !ok {
 		RoleWorkerCNF = "worker-cnf"
 	}
 
-	PerformanceProfileName = os.Getenv("PERF_TEST_PROFILE")
-	if PerformanceProfileName == "" {
+	PerformanceProfileName, ok = os.LookupEnv("PERF_TEST_PROFILE")
+	if !ok {
 		PerformanceProfileName = "performance"
 	}
 
-	NodesSelector = os.Getenv("NODES_SELECTOR")
+	NodesSelector, _ = os.LookupEnv("NODES_SELECTOR")
 
 	if !hypershift.IsHypershiftCluster() {
 		NodeSelectorLabels = map[string]string{
@@ -55,13 +56,12 @@ func init() {
 		}
 	}
 
-	NTOImage = os.Getenv("NTO_IMAGE")
-
-	if NTOImage == "" {
+	NTOImage, ok = os.LookupEnv("NTO_IMAGE")
+	if !ok {
 		NTOImage = "quay.io/openshift/origin-cluster-node-tuning-operator:latest"
 	}
 
-	MustGatherDir = os.Getenv("MUSTGATHER_DIR")
+	MustGatherDir, _ = os.LookupEnv("MUSTGATHER_DIR")
 
 	if discovery.Enabled() {
 		profile, err := discovery.GetDiscoveryPerformanceProfile(NodesSelector)

--- a/test/e2e/performanceprofile/functests/utils/discovery/discovery.go
+++ b/test/e2e/performanceprofile/functests/utils/discovery/discovery.go
@@ -21,7 +21,11 @@ type ConditionIterator func(performancev2.PerformanceProfile) bool
 
 // Enabled indicates whether test discovery mode is enabled.
 func Enabled() bool {
-	discoveryMode, _ := strconv.ParseBool(os.Getenv("DISCOVERY_MODE"))
+	discoveryModeStr, ok := os.LookupEnv("DISCOVERY_MODE")
+	if !ok {
+		return false
+	}
+	discoveryMode, _ := strconv.ParseBool(discoveryModeStr)
 	return discoveryMode
 }
 

--- a/test/e2e/performanceprofile/functests/utils/images/images.go
+++ b/test/e2e/performanceprofile/functests/utils/images/images.go
@@ -9,15 +9,15 @@ var registry string
 var cnfTestsImage string
 
 func init() {
-	registry = os.Getenv("IMAGE_REGISTRY")
-	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
-
-	if cnfTestsImage == "" {
-		cnfTestsImage = "cnf-tests:4.14"
+	var ok bool
+	registry, ok = os.LookupEnv("IMAGE_REGISTRY")
+	if !ok {
+		registry = "quay.io/openshift-kni/"
 	}
 
-	if registry == "" {
-		registry = "quay.io/openshift-kni/"
+	cnfTestsImage, ok = os.LookupEnv("CNF_TESTS_IMAGE")
+	if !ok {
+		cnfTestsImage = "cnf-tests:4.14"
 	}
 }
 

--- a/test/e2e/performanceprofile/functests/utils/utils.go
+++ b/test/e2e/performanceprofile/functests/utils/utils.go
@@ -72,8 +72,8 @@ func knownIssueIsFixedByStatus(status string) bool {
 // Check status of an issue in Jira and skip the test when the issue
 // is not yet resolved (Verified or Closed)
 func KnownIssueJira(key string) {
-	val := os.Getenv(SkipBzChecksEnvVar)
-	if val != "" {
+	val, ok := os.LookupEnv(SkipBzChecksEnvVar)
+	if ok && val != "" {
 		testlog.Infof(fmt.Sprintf("Skipping Jira issue %s status check", key))
 		return
 	}
@@ -96,8 +96,8 @@ func KnownIssueJira(key string) {
 // Check status of an issue in Bugzilla and skip the test when the issue
 // is not yet resolved (Verified or Closed)
 func KnownIssueBugzilla(bugId int) {
-	val := os.Getenv(SkipBzChecksEnvVar)
-	if val != "" {
+	val, ok := os.LookupEnv(SkipBzChecksEnvVar)
+	if ok && val != "" {
 		testlog.Infof(fmt.Sprintf("Skipping rhbz#%d status check", bugId))
 		return
 	}


### PR DESCRIPTION
It's usually preferred to use `LookupEnv` because it allows to distinguish between empty value and unset value.

The reason why this sudden change is only because
now we have AI tools that make these refactoring
tasks easier and faster.