### PR TITLE
Run update-codegen.sh

### DIFF
--- a/pkg/generated/clientset/versioned/clientset.go
+++ b/pkg/generated/clientset/versioned/clientset.go
@@ -18,8 +18,8 @@ limitations under the License.
 package versioned
 
 import (
-	"fmt"
-	"net/http"
+	fmt "fmt"
+	http "net/http"
 
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned/typed/tuned/v1"
 	discovery "k8s.io/client-go/discovery"

--- a/pkg/generated/clientset/versioned/typed/tuned/v1/fake/fake_profile.go
+++ b/pkg/generated/clientset/versioned/typed/tuned/v1/fake/fake_profile.go
@@ -18,129 +18,30 @@ limitations under the License.
 package fake
 
 import (
-	"context"
-
 	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	labels "k8s.io/apimachinery/pkg/labels"
-	types "k8s.io/apimachinery/pkg/types"
-	watch "k8s.io/apimachinery/pkg/watch"
-	testing "k8s.io/client-go/testing"
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned/typed/tuned/v1"
+	gentype "k8s.io/client-go/gentype"
 )
 
-// FakeProfiles implements ProfileInterface
-type FakeProfiles struct {
+// fakeProfiles implements ProfileInterface
+type fakeProfiles struct {
+	*gentype.FakeClientWithList[*v1.Profile, *v1.ProfileList]
 	Fake *FakeTunedV1
-	ns   string
 }
 
-var profilesResource = v1.SchemeGroupVersion.WithResource("profiles")
-
-var profilesKind = v1.SchemeGroupVersion.WithKind("Profile")
-
-// Get takes name of the profile, and returns the corresponding profile object, and an error if there is any.
-func (c *FakeProfiles) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.Profile, err error) {
-	emptyResult := &v1.Profile{}
-	obj, err := c.Fake.
-		Invokes(testing.NewGetActionWithOptions(profilesResource, c.ns, name, options), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
+func newFakeProfiles(fake *FakeTunedV1, namespace string) tunedv1.ProfileInterface {
+	return &fakeProfiles{
+		gentype.NewFakeClientWithList[*v1.Profile, *v1.ProfileList](
+			fake.Fake,
+			namespace,
+			v1.SchemeGroupVersion.WithResource("profiles"),
+			v1.SchemeGroupVersion.WithKind("Profile"),
+			func() *v1.Profile { return &v1.Profile{} },
+			func() *v1.ProfileList { return &v1.ProfileList{} },
+			func(dst, src *v1.ProfileList) { dst.ListMeta = src.ListMeta },
+			func(list *v1.ProfileList) []*v1.Profile { return gentype.ToPointerSlice(list.Items) },
+			func(list *v1.ProfileList, items []*v1.Profile) { list.Items = gentype.FromPointerSlice(items) },
+		),
+		fake,
 	}
-	return obj.(*v1.Profile), err
-}
-
-// List takes label and field selectors, and returns the list of Profiles that match those selectors.
-func (c *FakeProfiles) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ProfileList, err error) {
-	emptyResult := &v1.ProfileList{}
-	obj, err := c.Fake.
-		Invokes(testing.NewListActionWithOptions(profilesResource, profilesKind, c.ns, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1.ProfileList{ListMeta: obj.(*v1.ProfileList).ListMeta}
-	for _, item := range obj.(*v1.ProfileList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested profiles.
-func (c *FakeProfiles) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchActionWithOptions(profilesResource, c.ns, opts))
-
-}
-
-// Create takes the representation of a profile and creates it.  Returns the server's representation of the profile, and an error, if there is any.
-func (c *FakeProfiles) Create(ctx context.Context, profile *v1.Profile, opts metav1.CreateOptions) (result *v1.Profile, err error) {
-	emptyResult := &v1.Profile{}
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateActionWithOptions(profilesResource, c.ns, profile, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.Profile), err
-}
-
-// Update takes the representation of a profile and updates it. Returns the server's representation of the profile, and an error, if there is any.
-func (c *FakeProfiles) Update(ctx context.Context, profile *v1.Profile, opts metav1.UpdateOptions) (result *v1.Profile, err error) {
-	emptyResult := &v1.Profile{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateActionWithOptions(profilesResource, c.ns, profile, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.Profile), err
-}
-
-// UpdateStatus was generated because the type contains a Status member.
-// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeProfiles) UpdateStatus(ctx context.Context, profile *v1.Profile, opts metav1.UpdateOptions) (result *v1.Profile, err error) {
-	emptyResult := &v1.Profile{}
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceActionWithOptions(profilesResource, "status", c.ns, profile, opts), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.Profile), err
-}
-
-// Delete takes name of the profile and deletes it. Returns an error if one occurs.
-func (c *FakeProfiles) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(profilesResource, c.ns, name, opts), &v1.Profile{})
-
-	return err
-}
-
-// DeleteCollection deletes a collection of objects.
-func (c *FakeProfiles) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
-	action := testing.NewDeleteCollectionActionWithOptions(profilesResource, c.ns, opts, listOpts)
-
-	_, err := c.Fake.Invokes(action, &v1.ProfileList{})
-	return err
-}
-
-// Patch applies the patch and returns the patched profile.
-func (c *FakeProfiles) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Profile, err error) {
-	emptyResult := &v1.Profile{}
-	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceActionWithOptions(profilesResource, c.ns, name, pt, data, opts, subresources...), emptyResult)
-
-	if obj == nil {
-		return emptyResult, err
-	}
-	return obj.(*v1.Profile), err
 }

--- a/pkg/generated/clientset/versioned/typed/tuned/v1/fake/fake_tuned_client.go
+++ b/pkg/generated/clientset/versioned/typed/tuned/v1/fake/fake_tuned_client.go
@@ -28,11 +28,11 @@ type FakeTunedV1 struct {
 }
 
 func (c *FakeTunedV1) Profiles(namespace string) v1.ProfileInterface {
-	return &FakeProfiles{c, namespace}
+	return newFakeProfiles(c, namespace)
 }
 
 func (c *FakeTunedV1) Tuneds(namespace string) v1.TunedInterface {
-	return &FakeTuneds{c, namespace}
+	return newFakeTuneds(c, namespace)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/generated/clientset/versioned/typed/tuned/v1/profile.go
+++ b/pkg/generated/clientset/versioned/typed/tuned/v1/profile.go
@@ -18,9 +18,9 @@ limitations under the License.
 package v1
 
 import (
-	"context"
+	context "context"
 
-	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	scheme "github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,33 +36,34 @@ type ProfilesGetter interface {
 
 // ProfileInterface has methods to work with Profile resources.
 type ProfileInterface interface {
-	Create(ctx context.Context, profile *v1.Profile, opts metav1.CreateOptions) (*v1.Profile, error)
-	Update(ctx context.Context, profile *v1.Profile, opts metav1.UpdateOptions) (*v1.Profile, error)
+	Create(ctx context.Context, profile *tunedv1.Profile, opts metav1.CreateOptions) (*tunedv1.Profile, error)
+	Update(ctx context.Context, profile *tunedv1.Profile, opts metav1.UpdateOptions) (*tunedv1.Profile, error)
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-	UpdateStatus(ctx context.Context, profile *v1.Profile, opts metav1.UpdateOptions) (*v1.Profile, error)
+	UpdateStatus(ctx context.Context, profile *tunedv1.Profile, opts metav1.UpdateOptions) (*tunedv1.Profile, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Profile, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.ProfileList, error)
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*tunedv1.Profile, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*tunedv1.ProfileList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Profile, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *tunedv1.Profile, err error)
 	ProfileExpansion
 }
 
 // profiles implements ProfileInterface
 type profiles struct {
-	*gentype.ClientWithList[*v1.Profile, *v1.ProfileList]
+	*gentype.ClientWithList[*tunedv1.Profile, *tunedv1.ProfileList]
 }
 
 // newProfiles returns a Profiles
 func newProfiles(c *TunedV1Client, namespace string) *profiles {
 	return &profiles{
-		gentype.NewClientWithList[*v1.Profile, *v1.ProfileList](
+		gentype.NewClientWithList[*tunedv1.Profile, *tunedv1.ProfileList](
 			"profiles",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1.Profile { return &v1.Profile{} },
-			func() *v1.ProfileList { return &v1.ProfileList{} }),
+			func() *tunedv1.Profile { return &tunedv1.Profile{} },
+			func() *tunedv1.ProfileList { return &tunedv1.ProfileList{} },
+		),
 	}
 }

--- a/pkg/generated/clientset/versioned/typed/tuned/v1/tuned.go
+++ b/pkg/generated/clientset/versioned/typed/tuned/v1/tuned.go
@@ -18,9 +18,9 @@ limitations under the License.
 package v1
 
 import (
-	"context"
+	context "context"
 
-	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	scheme "github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,33 +36,34 @@ type TunedsGetter interface {
 
 // TunedInterface has methods to work with Tuned resources.
 type TunedInterface interface {
-	Create(ctx context.Context, tuned *v1.Tuned, opts metav1.CreateOptions) (*v1.Tuned, error)
-	Update(ctx context.Context, tuned *v1.Tuned, opts metav1.UpdateOptions) (*v1.Tuned, error)
+	Create(ctx context.Context, tuned *tunedv1.Tuned, opts metav1.CreateOptions) (*tunedv1.Tuned, error)
+	Update(ctx context.Context, tuned *tunedv1.Tuned, opts metav1.UpdateOptions) (*tunedv1.Tuned, error)
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-	UpdateStatus(ctx context.Context, tuned *v1.Tuned, opts metav1.UpdateOptions) (*v1.Tuned, error)
+	UpdateStatus(ctx context.Context, tuned *tunedv1.Tuned, opts metav1.UpdateOptions) (*tunedv1.Tuned, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Tuned, error)
-	List(ctx context.Context, opts metav1.ListOptions) (*v1.TunedList, error)
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*tunedv1.Tuned, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*tunedv1.TunedList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Tuned, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *tunedv1.Tuned, err error)
 	TunedExpansion
 }
 
 // tuneds implements TunedInterface
 type tuneds struct {
-	*gentype.ClientWithList[*v1.Tuned, *v1.TunedList]
+	*gentype.ClientWithList[*tunedv1.Tuned, *tunedv1.TunedList]
 }
 
 // newTuneds returns a Tuneds
 func newTuneds(c *TunedV1Client, namespace string) *tuneds {
 	return &tuneds{
-		gentype.NewClientWithList[*v1.Tuned, *v1.TunedList](
+		gentype.NewClientWithList[*tunedv1.Tuned, *tunedv1.TunedList](
 			"tuneds",
 			c.RESTClient(),
 			scheme.ParameterCodec,
 			namespace,
-			func() *v1.Tuned { return &v1.Tuned{} },
-			func() *v1.TunedList { return &v1.TunedList{} }),
+			func() *tunedv1.Tuned { return &tunedv1.Tuned{} },
+			func() *tunedv1.TunedList { return &tunedv1.TunedList{} },
+		),
 	}
 }

--- a/pkg/generated/clientset/versioned/typed/tuned/v1/tuned_client.go
+++ b/pkg/generated/clientset/versioned/typed/tuned/v1/tuned_client.go
@@ -18,10 +18,10 @@ limitations under the License.
 package v1
 
 import (
-	"net/http"
+	http "net/http"
 
-	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
-	"github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned/scheme"
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	scheme "github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -89,10 +89,10 @@ func New(c rest.Interface) *TunedV1Client {
 }
 
 func setConfigDefaults(config *rest.Config) error {
-	gv := v1.SchemeGroupVersion
+	gv := tunedv1.SchemeGroupVersion
 	config.GroupVersion = &gv
 	config.APIPath = "/apis"
-	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = rest.CodecFactoryForGeneratedClient(scheme.Scheme, scheme.Codecs).WithoutConversion()
 
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()

--- a/pkg/generated/informers/externalversions/generic.go
+++ b/pkg/generated/informers/externalversions/generic.go
@@ -18,7 +18,7 @@ limitations under the License.
 package externalversions
 
 import (
-	"fmt"
+	fmt "fmt"
 
 	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/generated/informers/externalversions/tuned/v1/profile.go
+++ b/pkg/generated/informers/externalversions/tuned/v1/profile.go
@@ -18,13 +18,13 @@ limitations under the License.
 package v1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
-	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	apistunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	versioned "github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned"
 	internalinterfaces "github.com/openshift/cluster-node-tuning-operator/pkg/generated/informers/externalversions/internalinterfaces"
-	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/generated/listers/tuned/v1"
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/generated/listers/tuned/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -35,7 +35,7 @@ import (
 // Profiles.
 type ProfileInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1.ProfileLister
+	Lister() tunedv1.ProfileLister
 }
 
 type profileInformer struct {
@@ -70,7 +70,7 @@ func NewFilteredProfileInformer(client versioned.Interface, namespace string, re
 				return client.TunedV1().Profiles(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&tunedv1.Profile{},
+		&apistunedv1.Profile{},
 		resyncPeriod,
 		indexers,
 	)
@@ -81,9 +81,9 @@ func (f *profileInformer) defaultInformer(client versioned.Interface, resyncPeri
 }
 
 func (f *profileInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&tunedv1.Profile{}, f.defaultInformer)
+	return f.factory.InformerFor(&apistunedv1.Profile{}, f.defaultInformer)
 }
 
-func (f *profileInformer) Lister() v1.ProfileLister {
-	return v1.NewProfileLister(f.Informer().GetIndexer())
+func (f *profileInformer) Lister() tunedv1.ProfileLister {
+	return tunedv1.NewProfileLister(f.Informer().GetIndexer())
 }

--- a/pkg/generated/informers/externalversions/tuned/v1/tuned.go
+++ b/pkg/generated/informers/externalversions/tuned/v1/tuned.go
@@ -18,13 +18,13 @@ limitations under the License.
 package v1
 
 import (
-	"context"
+	context "context"
 	time "time"
 
-	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	apistunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	versioned "github.com/openshift/cluster-node-tuning-operator/pkg/generated/clientset/versioned"
 	internalinterfaces "github.com/openshift/cluster-node-tuning-operator/pkg/generated/informers/externalversions/internalinterfaces"
-	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/generated/listers/tuned/v1"
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/generated/listers/tuned/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
@@ -35,7 +35,7 @@ import (
 // Tuneds.
 type TunedInformer interface {
 	Informer() cache.SharedIndexInformer
-	Lister() v1.TunedLister
+	Lister() tunedv1.TunedLister
 }
 
 type tunedInformer struct {
@@ -70,7 +70,7 @@ func NewFilteredTunedInformer(client versioned.Interface, namespace string, resy
 				return client.TunedV1().Tuneds(namespace).Watch(context.TODO(), options)
 			},
 		},
-		&tunedv1.Tuned{},
+		&apistunedv1.Tuned{},
 		resyncPeriod,
 		indexers,
 	)
@@ -81,9 +81,9 @@ func (f *tunedInformer) defaultInformer(client versioned.Interface, resyncPeriod
 }
 
 func (f *tunedInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&tunedv1.Tuned{}, f.defaultInformer)
+	return f.factory.InformerFor(&apistunedv1.Tuned{}, f.defaultInformer)
 }
 
-func (f *tunedInformer) Lister() v1.TunedLister {
-	return v1.NewTunedLister(f.Informer().GetIndexer())
+func (f *tunedInformer) Lister() tunedv1.TunedLister {
+	return tunedv1.NewTunedLister(f.Informer().GetIndexer())
 }

--- a/pkg/generated/listers/tuned/v1/profile.go
+++ b/pkg/generated/listers/tuned/v1/profile.go
@@ -18,10 +18,10 @@ limitations under the License.
 package v1
 
 import (
-	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // ProfileLister helps list Profiles.
@@ -29,7 +29,7 @@ import (
 type ProfileLister interface {
 	// List lists all Profiles in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.Profile, err error)
+	List(selector labels.Selector) (ret []*tunedv1.Profile, err error)
 	// Profiles returns an object that can list and get Profiles.
 	Profiles(namespace string) ProfileNamespaceLister
 	ProfileListerExpansion
@@ -37,17 +37,17 @@ type ProfileLister interface {
 
 // profileLister implements the ProfileLister interface.
 type profileLister struct {
-	listers.ResourceIndexer[*v1.Profile]
+	listers.ResourceIndexer[*tunedv1.Profile]
 }
 
 // NewProfileLister returns a new ProfileLister.
 func NewProfileLister(indexer cache.Indexer) ProfileLister {
-	return &profileLister{listers.New[*v1.Profile](indexer, v1.Resource("profile"))}
+	return &profileLister{listers.New[*tunedv1.Profile](indexer, tunedv1.Resource("profile"))}
 }
 
 // Profiles returns an object that can list and get Profiles.
 func (s *profileLister) Profiles(namespace string) ProfileNamespaceLister {
-	return profileNamespaceLister{listers.NewNamespaced[*v1.Profile](s.ResourceIndexer, namespace)}
+	return profileNamespaceLister{listers.NewNamespaced[*tunedv1.Profile](s.ResourceIndexer, namespace)}
 }
 
 // ProfileNamespaceLister helps list and get Profiles.
@@ -55,15 +55,15 @@ func (s *profileLister) Profiles(namespace string) ProfileNamespaceLister {
 type ProfileNamespaceLister interface {
 	// List lists all Profiles in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.Profile, err error)
+	List(selector labels.Selector) (ret []*tunedv1.Profile, err error)
 	// Get retrieves the Profile from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.Profile, error)
+	Get(name string) (*tunedv1.Profile, error)
 	ProfileNamespaceListerExpansion
 }
 
 // profileNamespaceLister implements the ProfileNamespaceLister
 // interface.
 type profileNamespaceLister struct {
-	listers.ResourceIndexer[*v1.Profile]
+	listers.ResourceIndexer[*tunedv1.Profile]
 }

--- a/pkg/generated/listers/tuned/v1/tuned.go
+++ b/pkg/generated/listers/tuned/v1/tuned.go
@@ -18,10 +18,10 @@ limitations under the License.
 package v1
 
 import (
-	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/listers"
-	"k8s.io/client-go/tools/cache"
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	listers "k8s.io/client-go/listers"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // TunedLister helps list Tuneds.
@@ -29,7 +29,7 @@ import (
 type TunedLister interface {
 	// List lists all Tuneds in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.Tuned, err error)
+	List(selector labels.Selector) (ret []*tunedv1.Tuned, err error)
 	// Tuneds returns an object that can list and get Tuneds.
 	Tuneds(namespace string) TunedNamespaceLister
 	TunedListerExpansion
@@ -37,17 +37,17 @@ type TunedLister interface {
 
 // tunedLister implements the TunedLister interface.
 type tunedLister struct {
-	listers.ResourceIndexer[*v1.Tuned]
+	listers.ResourceIndexer[*tunedv1.Tuned]
 }
 
 // NewTunedLister returns a new TunedLister.
 func NewTunedLister(indexer cache.Indexer) TunedLister {
-	return &tunedLister{listers.New[*v1.Tuned](indexer, v1.Resource("tuned"))}
+	return &tunedLister{listers.New[*tunedv1.Tuned](indexer, tunedv1.Resource("tuned"))}
 }
 
 // Tuneds returns an object that can list and get Tuneds.
 func (s *tunedLister) Tuneds(namespace string) TunedNamespaceLister {
-	return tunedNamespaceLister{listers.NewNamespaced[*v1.Tuned](s.ResourceIndexer, namespace)}
+	return tunedNamespaceLister{listers.NewNamespaced[*tunedv1.Tuned](s.ResourceIndexer, namespace)}
 }
 
 // TunedNamespaceLister helps list and get Tuneds.
@@ -55,15 +55,15 @@ func (s *tunedLister) Tuneds(namespace string) TunedNamespaceLister {
 type TunedNamespaceLister interface {
 	// List lists all Tuneds in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.Tuned, err error)
+	List(selector labels.Selector) (ret []*tunedv1.Tuned, err error)
 	// Get retrieves the Tuned from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.Tuned, error)
+	Get(name string) (*tunedv1.Tuned, error)
 	TunedNamespaceListerExpansion
 }
 
 // tunedNamespaceLister implements the TunedNamespaceLister
 // interface.
 type tunedNamespaceLister struct {
-	listers.ResourceIndexer[*v1.Tuned]
+	listers.ResourceIndexer[*tunedv1.Tuned]
 }


### PR DESCRIPTION
During the latest k8s vendoring, it was forgotten to run the `pkg/generated` Makefile target, which uses k8s.io/code-generator.  Fix this.