### PR TITLE
NO-JIRA: Add support for running binaries from NVIDIA driver directory

### DIFF
--- a/pkg/tuned/controller.go
+++ b/pkg/tuned/controller.go
@@ -84,6 +84,7 @@ const (
 	ocpTunedPersist       = ocpTunedRunDir + "/persist"
 	ocpTunedProvider      = ocpTunedHome + "/provider"
 	tunedPersistHome      = "/var/lib/tuned"
+	nvidiaDriverBinDir    = "/run/nvidia/driver/usr/bin"
 	// With the less aggressive rate limiter, retries will happen at 100ms*2^(retry_n-1):
 	// 100ms, 200ms, 400ms, 800ms, 1.6s, 3.2s, 6.4s, 12.8s, 25.6s, 51.2s, 102.4s, 3.4m, 6.8m, 13.7m, 27.3m
 	maxRetries = 15

--- a/pkg/tuned/run.go
+++ b/pkg/tuned/run.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+
+	"github.com/openshift/cluster-node-tuning-operator/pkg/util"
 )
 
 func TunedCreateCmdline(debug bool) (string, []string) {
@@ -99,6 +101,10 @@ func TunedRunNoDaemon(timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	if err := util.AddToPath(nvidiaDriverBinDir); err != nil {
+		return err
+	}
+
 	command, args := TunedCreateCmdline(false)
 	if timeout > 0 {
 		// CommandContext sets Cancel to call the Kill (SIGKILL) method on the command's Process.
@@ -119,6 +125,10 @@ func TunedRunNoDaemon(timeout time.Duration) error {
 
 func TunedRun(cmd *exec.Cmd, daemon *Daemon, onDaemonReload func()) error {
 	klog.Infof("running cmd...")
+
+	if err := util.AddToPath(nvidiaDriverBinDir); err != nil {
+		return err
+	}
 
 	cmdReader, err := cmd.StderrPipe()
 	if err != nil {

--- a/pkg/util/os.go
+++ b/pkg/util/os.go
@@ -1,7 +1,13 @@
 package util
 
 import (
+	"fmt"
 	"os"
+	"strings"
+)
+
+const (
+	pathSeparator = string(os.PathListSeparator)
 )
 
 // Delete a file if it exists.  Returns nil if 'file' does not exist.
@@ -24,4 +30,22 @@ func Symlink(target, linkName string) error {
 	}
 
 	return nil
+}
+
+// AddToPath adds 'path' to PATH environment variable unless it exists.
+// Returns nil unless os.Setenv() call fails.
+func AddToPath(path string) error {
+	currentPath := os.Getenv("PATH")
+
+	paths := strings.Split(currentPath, pathSeparator)
+	for _, p := range paths {
+		if p == path {
+			// 'path' already exists in PATH
+			return nil
+		}
+	}
+
+	newPath := fmt.Sprintf("%s%s%s", currentPath, pathSeparator, path)
+
+	return os.Setenv("PATH", newPath)
 }

--- a/pkg/util/os_test.go
+++ b/pkg/util/os_test.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"os"
+	"testing"
+)
+
+// TestAddToPath tests basic functionality of AddToPath.
+func TestAddToPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		initialPath string
+		pathToAdd   string
+		expected    string
+	}{
+		{
+			name:        "Add new path to existing PATH",
+			initialPath: "/usr/bin" + pathSeparator + "/usr/local/bin",
+			pathToAdd:   "/opt/bin",
+			expected:    "/usr/bin" + pathSeparator + "/usr/local/bin" + pathSeparator + "/opt/bin",
+		},
+		{
+			name:        "Path already exists in PATH",
+			initialPath: "/usr/bin" + pathSeparator + "/usr/local/bin" + pathSeparator + "/opt/bin",
+			pathToAdd:   "/usr/bin",
+			expected:    "/usr/bin" + pathSeparator + "/usr/local/bin" + pathSeparator + "/opt/bin",
+		},
+		{
+			name:        "Path exists as substring but not as the exact match",
+			initialPath: "/usr/bin" + pathSeparator + "/usr/local/bin",
+			pathToAdd:   "/usr",
+			expected:    "/usr/bin" + pathSeparator + "/usr/local/bin" + pathSeparator + "/usr",
+		},
+		// A zero-length (null) directory name in the value of PATH indicates the current directory.
+		// Examples: PATH="", PATH=/usr/bin:, PATH=/usr/bin::/usr/local/bin
+		{
+			name:        "Add path to empty PATH",
+			initialPath: "",
+			pathToAdd:   "/usr/bin",
+			expected:    pathSeparator + "/usr/bin",
+		},
+		{
+			name:        "Add empty path",
+			initialPath: "/usr/bin",
+			pathToAdd:   "",
+			expected:    "/usr/bin" + pathSeparator,
+		},
+		{
+			name:        "Single empty path exists in the middle of non-empty PATH",
+			initialPath: "/usr/bin" + pathSeparator + pathSeparator + "/usr/local/bin",
+			pathToAdd:   "",
+			expected:    "/usr/bin" + pathSeparator + pathSeparator + "/usr/local/bin",
+		},
+		{
+			name:        "Single empty path exists at the end of in non-empty PATH",
+			initialPath: "/usr/bin" + pathSeparator,
+			pathToAdd:   "",
+			expected:    "/usr/bin" + pathSeparator,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use t.Setenv instead of os.Setenv() to restore the original PATH automatically.
+			t.Setenv("PATH", tt.initialPath)
+			err := AddToPath(tt.pathToAdd)
+			if err != nil {
+				t.Errorf("Expected no error from AddToPath() but got: %v", err)
+			}
+
+			newPath := os.Getenv("PATH")
+			if newPath != tt.expected {
+				t.Errorf("Expected PATH to be %q, but got %q", tt.expected, newPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for running binaries from NVIDIA driver directory mounted by NVIDIA GPU operator to `/run/nvidia/driver/usr/bin`.  This is in support of the new TuneD functionality requested by [RHEL-88914](https://issues.redhat.com//browse/RHEL-88914) and supports both one-shot and daemon mode TuneD invocations.