### PR TITLE
OCPBUGS-59354: E2E add test to verify guaranteed pod is running after kubelet restart

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -387,7 +387,8 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 					// Check pod ready condition
 					for _, condition := range updatedPod.Status.Conditions {
 						if condition.Type == corev1.PodReady && condition.Status != corev1.ConditionTrue {
-							return fmt.Errorf("Pod ondition is not in Ready state after kubelet restart: condition: %v", updatedPod.Status.Conditions)
+							return fmt.Errorf("Pod condition is not in Ready state after kubelet restart: reason: %v, message: %v", condition.Reason, condition.Message)
+
 						}
 					}
 					return nil

--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -346,6 +346,11 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 				cpuManagerCpusetBeforeRestart, err := nodes.CpuManagerCpuSet(ctx, workerRTNode)
 				Expect(err).ToNot(HaveOccurred())
 				testlog.Infof("pre kubelet restart default cpuset: %v", cpuManagerCpusetBeforeRestart.String())
+
+				By("capturing test pod state before restart")
+				originalPodUID := testpod.UID
+				testlog.Infof("pre kubelet restart pod UID: %v", originalPodUID)
+
 				kubeletRestartCmd := []string{
 					"chroot",
 					"/rootfs",
@@ -361,6 +366,34 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 				time.Sleep(restartCooldownTime)
 
 				testlog.Infof("post restart: finished cooldown time: %v", restartCooldownTime)
+
+				By("verify test pod comes back after kubelet restart")
+				Eventually(func() error {
+					updatedPod := &corev1.Pod{}
+					err := testclient.DataPlaneClient.Get(ctx, client.ObjectKeyFromObject(testpod), updatedPod)
+					if err != nil {
+						return fmt.Errorf("failed to get pod after restart: %v", err)
+					}
+
+					// Verify it's the same pod (same UID)
+					if updatedPod.UID != originalPodUID {
+						return fmt.Errorf("pod UID changed after restart: original=%v, current=%v", originalPodUID, updatedPod.UID)
+					}
+
+					// Verify pod is ready
+					if updatedPod.Status.Phase != corev1.PodRunning {
+						return fmt.Errorf("pod is not running after restart: phase=%v", updatedPod.Status.Phase)
+					}
+					// Check pod ready condition
+					for _, condition := range updatedPod.Status.Conditions {
+						if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+							testlog.Infof("post kubelet restart pod is ready with UID: %v", updatedPod.UID)
+							return nil
+						}
+					}
+
+					return fmt.Errorf("pod ready condition not found or not true")
+				}).WithTimeout(5*time.Minute).WithPolling(10*time.Second).Should(Succeed(), "test pod should come back after kubelet restart")
 
 				By("fetch Default cpuset from cpu manager state after restart")
 				cpuManagerCpusetAfterRestart, err := nodes.CpuManagerCpuSet(ctx, workerRTNode)


### PR DESCRIPTION
This PR addresses issue where we are verifying
if the cpu manager state file is same after kubelet restart while we are verifying the above, we are not checking if Guranteed pod started before kubelet restart is also still running.

Refer: https://issues.redhat.com/browse/OCPBUGS-43280