### PR TITLE
WIP: CNF-16642: Dynamic memory enforcement

### DIFF
--- a/assets/performanceprofile/scripts/dynamic-memory-enforcement.py
+++ b/assets/performanceprofile/scripts/dynamic-memory-enforcement.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Dynamic Memory Enforcement Service
+# This service is used to protect the cluster from memory exhaustion.
+# It is used to set the memory.max value for the kubepods-burstable.slice and kubepods-besteffort.slice.
+
+from datetime import datetime
+import os
+import os.path
+
+ROOT="/sys/fs/cgroup/kubepods.slice"
+ROOT_MAX=os.path.join(ROOT, "memory.max")
+
+BESTEFFORT_MAX=os.path.join(ROOT, "kubepods-besteffort.slice", "memory.max")
+
+BURSTABLE_CURRENT=os.path.join(ROOT, "kubepods-burstable.slice", "memory.current")
+BURSTABLE_MAX=os.path.join(ROOT, "kubepods-burstable.slice", "memory.max")
+
+def guaranteed_max():
+    sum = 0
+    
+    for d in os.listdir(ROOT):
+        if not d.startswith("kubepods-pod"):
+            continue
+        try:
+            sum += int(open(os.path.join(ROOT, d, "memory.max")).read().strip())
+        except IOError as e:
+            continue
+
+    return sum
+
+if __name__ == "__main__":
+    root_max = int(open(ROOT_MAX).read().strip())
+    burstable_current = int(open(BURSTABLE_CURRENT).read().strip())
+    guaranteed_current = guaranteed_max()
+
+    burstable_max = root_max - guaranteed_current
+    besteffort_max = burstable_max - burstable_current
+
+    now = datetime.now().isoformat(' ', timespec='microseconds')
+    print(f"\n{now}\n")
+    print(f"root: {root_max}\nburstable: {burstable_current}\nguaranteed: {guaranteed_current}\n\nburstable max: {burstable_max}\nbest-effort max: {besteffort_max}\n")
+    
+    with open(BURSTABLE_MAX, "w") as f:
+        f.write(str(burstable_max))
+
+    with open(BESTEFFORT_MAX, "w") as f:
+        f.write(str(besteffort_max))
+

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -34,6 +34,10 @@ const PerformanceProfileEnablePhysicalRpsAnnotation = "performance.openshift.io/
 // that ignores the removal of all RPS settings when realtime workload hint is explicitly set to false.
 const PerformanceProfileEnableRpsAnnotation = "performance.openshift.io/enable-rps"
 
+// PerformanceProfileEnforceReservedMemoryAnnotation enables dynamic memory enforcement
+// service that manages memory limits for kubepods slices.
+const PerformanceProfileEnforceReservedMemoryAnnotation = "enforce-reserved-memory.experimental"
+
 // PerformanceProfileSpec defines the desired state of PerformanceProfile.
 type PerformanceProfileSpec struct {
 	// CPU defines a set of CPU related parameters.

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -315,8 +315,9 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, opts *componen
 		addContent(ignitionConfig, content, dst, &mode)
 	}
 
-	// Add dynamic memory enforcement service only if annotation is enabled
-	if profilecomponent.IsEnforceReservedMemoryEnabled(profile) {
+	// Add dynamic memory enforcement service only if annotation is enabled and workload partitioning is enabled
+	clusterHasWorkloadPartitioning := opts.PinningMode != nil && *opts.PinningMode == apiconfigv1.CPUPartitioningAllNodes
+	if profilecomponent.IsEnforceReservedMemoryEnabled(profile) && clusterHasWorkloadPartitioning {
 		dynamicMemoryEnforcementService, err := getSystemdContent(getDynamicMemoryEnforcementUnitOptions())
 		if err != nil {
 			return nil, err

--- a/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/profile/profile.go
@@ -95,3 +95,17 @@ func IsMixedCPUsEnabled(profile *performancev2.PerformanceProfile) bool {
 	}
 	return *profile.Spec.WorkloadHints.MixedCpus
 }
+
+// IsEnforceReservedMemoryEnabled checks if dynamic memory enforcement should be enabled
+func IsEnforceReservedMemoryEnabled(profile *performancev2.PerformanceProfile) bool {
+	if profile.Annotations == nil {
+		return false
+	}
+
+	isEnabled, ok := profile.Annotations[performancev2.PerformanceProfileEnforceReservedMemoryAnnotation]
+	if ok && isEnabled == "enable" {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
This series adds a systemd service to the tuned system. This service runs in the cpu manager-like reconcile loop fashion, monitors all pod cgroups' memory and sets the limits to kubepods-burstable and kubepods-besteffort to protect the system from runaway pods without limits of their own.

kubepods-burstable is set to = node allocatable memory - sum(all guaranteed containers memory limit)
kubepods-besteffort is set to = kubepods-burstable limit - kubepods-bustable current consumption


Note: The boilerplate code was generated by the claude-4-sonnet AI model as interpreted by the Cursor IDE. The python service is my own.