### PR TITLE
OCPBUGS-60461: E2E: llc test fix:  Get updated Performance profile before modifying

### DIFF
--- a/test/e2e/performanceprofile/functests/13_llc/llc.go
+++ b/test/e2e/performanceprofile/functests/13_llc/llc.go
@@ -241,10 +241,7 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				Eventually(func() bool {
 					for _, node := range workerRTNodes {
 						kubeletconfig, err := nodes.GetKubeletConfig(ctx, &node)
-						if err != nil {
-							testlog.Errorf("Failed to get kubelet config from node %s: %v", node.Name, err)
-							return false
-						}
+						Expect(err).ToNot(HaveOccurred(), "Failed to get kubelet config from node %s", node.Name)
 						if kubeletconfig.CPUManagerPolicyOptions != nil {
 							if _, exists := kubeletconfig.CPUManagerPolicyOptions["prefer-align-cpus-by-uncorecache"]; exists {
 								testlog.Infof("Node %s still has prefer-align-cpus-by-uncorecache", node.Name)


### PR DESCRIPTION
Get latest performance Profile object before modifying. 
In latest downstream tests we saw that test case related to Disabling the annotation "prefer-align-cpus-by-uncorecache"  did not propagate. This PR fixes by fetching latest performance profile object before modifying the profile.