### PR TITLE
OCPBUGS-61051: E2E: skip stalld test case checking sched_fifo

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -210,6 +210,7 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 			}
 		})
 		It("[test_id:42400][crit:medium][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running as sched_fifo", func() {
+			testutils.KnownIssueJira("RHEL-108827")
 			for _, node := range workerRTNodes {
 				out, err := nodes.ExecCommand(context.TODO(), &node, []string{"pidof", "stalld"})
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Skip test case checking if stalld is setting
sched_fifo scheduling algorithm due to
known issue https://issues.redhat.com/browse/RHEL-108827