### PR TITLE
OCPBUGS-60463: E2E:  ovs dynamic pinning test case fixes 

### DIFF
--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
@@ -458,9 +458,9 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, Label(string(lab
 					// wait till the ovs process affinity is reverted back
 					pidList, err := ovsPids(ctx, ovsSystemdServices, workerRTNode)
 					Expect(err).ToNot(HaveOccurred())
-					cpumaskList, err := getCPUMaskForPids(ctx, pidList, workerRTNode)
-					Expect(err).ToNot(HaveOccurred())					
 					Eventually(func() bool {
+						cpumaskList, err := getCPUMaskForPids(ctx, pidList, workerRTNode)
+						Expect(err).ToNot(HaveOccurred(), "Unable to fetch affinity of ovs services")
 						for _, cpumask := range cpumaskList {
 							testlog.Warningf("ovs services cpu mask is %s instead of %s", cpumask.String(), onlineCPUSet.String())
 							// since cpuset.CPUSet contains map in its struct field we can't compare
@@ -472,7 +472,7 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, Label(string(lab
 							}
 						}
 						return true
-					}, 2*time.Minute, 10*time.Second).Should(BeTrue())
+					}, 5*time.Minute, 10*time.Second).Should(BeTrue())
 				}()
 
 				ovnPod, err := ovnCnfNodePod(ctx, workerRTNode)

--- a/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
+++ b/test/e2e/performanceprofile/functests/7_performance_kubelet_node/cgroups.go
@@ -460,7 +460,7 @@ var _ = Describe("[performance] Cgroups and affinity", Ordered, Label(string(lab
 							// the structs directly. After the deployment is deleted, the cpu mask
 							// of ovs services should contain all cpus , which is generally 0-N (where
 							// N is total number of cpus, this should be easy to compare.
-							if cpumask.String() != onlineCPUSet.String() {
+							if !cpumask.Equals(onlineCPUSet) {
 								return false
 							}
 						}


### PR DESCRIPTION
This PR contains following fixes:
1. Use reboot instead of modifying profile
2. Remove using wait.PollUntilContextTimeout for checking deployment status
3. Fetch cpu mask of ovs services inside of Eventually loop