### PR TITLE
OCPBUGS-62016: E2E: llc: Create testing namespace before Runtime tests

### DIFF
--- a/test/e2e/performanceprofile/functests/13_llc/llc.go
+++ b/test/e2e/performanceprofile/functests/13_llc/llc.go
@@ -917,6 +917,15 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			testPod *corev1.Pod
 		)
 
+		BeforeAll(func(ctx context.Context) {
+			testNS := *namespaces.TestingNamespace
+			Expect(testclient.DataPlaneClient.Create(ctx, &testNS)).ToNot(HaveOccurred())
+			DeferCleanup(func() {
+				Expect(testclient.DataPlaneClient.Delete(ctx, &testNS)).ToNot(HaveOccurred())
+				Expect(namespaces.WaitForDeletion(testutils.NamespaceTesting, 5*time.Minute)).ToNot(HaveOccurred())
+			})
+		})
+
 		BeforeEach(func() {
 			targetNodeName = workerRTNodes[0].Name // pick random node
 			var ok bool


### PR DESCRIPTION
This PR creates testing namespace before Runtime tests are run. 