### PR TITLE
OCPBUGS-62091: E2E: Add function to check control plane nodes are schedulable. 

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -405,7 +405,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			if len(nonPerformancesWorkers) > 1 {
 				newCnfNode = &nonPerformancesWorkers[0]
 			}
-			ok, err := cluster.IsControlPlaneSchedulable()
+			ok, err := cluster.IsControlPlaneSchedulable(context.TODO())
 			Expect(err).ToNot(HaveOccurred(), "Unable to fetch schedulable information of control plane nodes: %v", err)
 			if ok {
 				Skip("Skipping the test - Control plane nodes are schedulable")

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -31,6 +31,7 @@ import (
 	testutils "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cgroup/runtime"
 	testclient "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/client"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/cluster"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/discovery"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/hypershift"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
@@ -404,6 +405,12 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			if len(nonPerformancesWorkers) > 1 {
 				newCnfNode = &nonPerformancesWorkers[0]
 			}
+			ok, err := cluster.IsControlPlaneSchedulable()
+			Expect(err).ToNot(HaveOccurred(), "Unable to fetch schedulable information of control plane nodes: %v", err)
+			if ok {
+				Skip("Skipping the test - Control plane nodes are schedulable")
+			}
+
 			if newCnfNode == nil {
 				Skip("Skipping the test - cluster does not have another available worker node ")
 			}

--- a/test/e2e/performanceprofile/functests/utils/cluster/cluster.go
+++ b/test/e2e/performanceprofile/functests/utils/cluster/cluster.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 // IsSingleNode validates if the environment is single node cluster
@@ -33,10 +34,12 @@ func ComputeTestTimeout(baseTimeout time.Duration, isSno bool) time.Duration {
 
 // Check if the control plane nodes are schedulable, returns true if schedulable else false
 func IsControlPlaneSchedulable(ctx context.Context) (bool, error) {
-	cfg, err := testclient.GetRestConfigFromClient(testclient.Client)
+	// Get the rest.Config using the helper function
+	cfg, err := config.GetConfig()
 	if err != nil {
 		return false, err
 	}
+
 	openshiftConfigClient := clientconfigv1.NewForConfigOrDie(cfg)
 	schedulerInfo, err := openshiftConfigClient.Schedulers().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
This PR adds util function to check if Control  plane nodes are schedulable and
if so skips Node selector tests 