### PR TITLE
NO-JIRA:e2e:hugepages: changing tests to use hugepages-allocator tool

### DIFF
--- a/test/e2e/performanceprofile/functests/utils/images/images.go
+++ b/test/e2e/performanceprofile/functests/utils/images/images.go
@@ -17,7 +17,7 @@ func init() {
 
 	cnfTestsImage, ok = os.LookupEnv("CNF_TESTS_IMAGE")
 	if !ok {
-		cnfTestsImage = "cnf-tests:4.14"
+		cnfTestsImage = "cnf-tests:4.19"
 	}
 }
 


### PR DESCRIPTION
We want to use rhel9 as the image for the test pod which does not have libhugetlbfs.so.
Instead we're using a small in-house tool allocate the hugepages
and test functionality.