### PR TITLE
OCPBUGS-62835: E2E: llc: make sure to remove any trailing newspaces

### DIFF
--- a/test/e2e/performanceprofile/functests/13_llc/llc.go
+++ b/test/e2e/performanceprofile/functests/13_llc/llc.go
@@ -984,7 +984,7 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			logs, err := pods.GetLogs(testclient.K8sClient, testPod)
 			Expect(err).ToNot(HaveOccurred(), "Cannot get logs from test pod")
 
-			allocatedCPUs, err := cpuset.Parse(logs)
+			allocatedCPUs, err := cpuset.Parse(strings.TrimSpace(logs))
 			Expect(err).ToNot(HaveOccurred(), "Cannot get cpuset for pod %s/%s from logs %q", testPod.Namespace, testPod.Name, logs)
 			Expect(allocatedCPUs.Size()).To(Equal(askingCPUs), "asked %d exclusive CPUs got %v", askingCPUs, allocatedCPUs)
 
@@ -1006,7 +1006,7 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			logs, err := pods.GetLogs(testclient.K8sClient, testPod)
 			Expect(err).ToNot(HaveOccurred(), "Cannot get logs from test pod")
 
-			allocatedCPUs, err := cpuset.Parse(logs)
+			allocatedCPUs, err := cpuset.Parse(strings.TrimSpace(logs))
 			Expect(err).ToNot(HaveOccurred(), "Cannot get cpuset for pod %s/%s from logs %q", testPod.Namespace, testPod.Name, logs)
 			Expect(allocatedCPUs.Size()).To(Equal(askingCPUs), "asked %d exclusive CPUs got %v", askingCPUs, allocatedCPUs)
 


### PR DESCRIPTION
E2E: llc: make sure to remove any trailing newspace or newline characters

when using cpuset.Parse the logs from pods.GetLogs which returns 
new line characters. This PR trims to remove any new line characters