### PR TITLE
WIP: fix: openshift-node-performance now has a default platform agnostic fallback

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -12,7 +12,7 @@ summary=Openshift node optimized for deterministic performance at the cost of in
 #     openshift-node,cpu-partitioning
 #     openshift-node,cpu-partitioning,openshift-node-performance-rt-<PerformanceProfile name>
 include=openshift-node,cpu-partitioning${f:regex_search_ternary:${f:exec:uname:-r}:rt:,openshift-node-performance-rt-{{.PerformanceProfileName}}:};
-    openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Architecture\:\s*aarch64:arm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}-{{.PerformanceProfileName}}
+    openshift-node-performance-${f:lscpu_check:Vendor ID\:\s*GenuineIntel:intel:Vendor ID\:\s*AuthenticAMD:amd:Architecture\:\s*aarch64:arm:Architecture\:\s*ppc64le:ibm}-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64:Architecture\:\s*ppc64le:ppc64le}-{{.PerformanceProfileName}}
 
 # Inheritance of base profiles legend:
 # cpu-partitioning -> network-latency -> latency-performance

--- a/assets/performanceprofile/tuned/openshift-node-performance--
+++ b/assets/performanceprofile/tuned/openshift-node-performance--
@@ -1,0 +1,2 @@
+[main]
+summary=Platform agnostic include file

--- a/assets/performanceprofile/tuned/openshift-node-performance-ibm-ppc64le
+++ b/assets/performanceprofile/tuned/openshift-node-performance-ibm-ppc64le
@@ -1,0 +1,6 @@
+[main]
+summary=Platform specific tuning for IBM POWER (ppc64le)
+
+[bootloader]
+# No specific IOMMU settings for POWER
+# No pstate args for POWER

--- a/pkg/performanceprofile/controller/performanceprofile/components/consts.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/consts.go
@@ -30,7 +30,7 @@ const (
 	// ProfileNameIntelX86 defines the Intel X86 specific tuning parameters
 	ProfileNameIntelX86 = "openshift-node-performance-intel-x86"
 	// ProfileNameIbmPpc64le defines the IBM POWER ppc64le specific tuning parameters
-	ProfileNameIbmPpc64le = "openshift-node-performance--ppc64le"
+	ProfileNameIbmPpc64le = "openshift-node-performance-ibm-ppc64le"
 )
 
 const (

--- a/pkg/performanceprofile/controller/performanceprofile/components/consts.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/consts.go
@@ -29,6 +29,8 @@ const (
 	ProfileNameArmAarch64 = "openshift-node-performance-arm-aarch64"
 	// ProfileNameIntelX86 defines the Intel X86 specific tuning parameters
 	ProfileNameIntelX86 = "openshift-node-performance-intel-x86"
+	// ProfileNameIbmPpc64le defines the IBM POWER ppc64le specific tuning parameters
+	ProfileNameIbmPpc64le = "openshift-node-performance--ppc64le"
 )
 
 const (

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned.go
@@ -240,6 +240,12 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 	}
 	IntelX86ProfileName := components.GetComponentName(profile.Name, components.ProfileNameIntelX86)
 
+	IbmPpc64leProfileData, err := getProfileData(filepath.Join("tuned", components.ProfileNameIbmPpc64le), templateArgs)
+	if err != nil {
+		return nil, err
+	}
+	IbmPpc64leProfileName := components.GetComponentName(profile.Name, components.ProfileNameIbmPpc64le)
+
 	profiles := []tunedv1.TunedProfile{
 		{
 			Name: &name,
@@ -260,6 +266,10 @@ func NewNodePerformance(profile *performancev2.PerformanceProfile) (*tunedv1.Tun
 		{
 			Name: &IntelX86ProfileName,
 			Data: &IntelX86ProfileData,
+		},
+		{
+			Name: &IbmPpc64leProfileName,
+			Data: &IbmPpc64leProfileData,
 		},
 	}
 


### PR DESCRIPTION
fix: openshift-node-performance now has a default platform agnostic fallback

