### PR TITLE
OCPBUGS-66337: E2E:PPC:Use default worker mcp instead worker-cnf

### DIFF
--- a/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go
+++ b/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go
@@ -63,7 +63,7 @@ func PPCTestCreateUtil() *PPCTestIntegration {
 
 var _ = Describe("[rfe_id: 38968] PerformanceProfile setup helper and platform awareness", Label(string(label.PerformanceProfileCreator)), func() {
 	mustgatherDir := testutils.MustGatherDir
-	mcpName := testutils.RoleWorkerCNF
+	mcpName := "worker"
 	ntoImage := testutils.NTOImage
 	Context("PPC Sanity Tests", Label(string(label.Tier0)), func() {
 		ppcIntgTest := PPCTestCreateUtil()

--- a/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go
+++ b/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go
@@ -63,7 +63,7 @@ func PPCTestCreateUtil() *PPCTestIntegration {
 
 var _ = Describe("[rfe_id: 38968] PerformanceProfile setup helper and platform awareness", Label(string(label.PerformanceProfileCreator)), func() {
 	mustgatherDir := testutils.MustGatherDir
-	mcpName := "worker"
+	mcpName := testutils.RoleWorker
 	ntoImage := testutils.NTOImage
 	Context("PPC Sanity Tests", Label(string(label.Tier0)), func() {
 		ppcIntgTest := PPCTestCreateUtil()


### PR DESCRIPTION
PPC tests relied on using worker-cnf mcp
but this assumes that mustgather provided to ppc
tests contains worker-cnf mcp, which may not be the case.

So modifying to use default worker mcp instead worker-cnf