### PR TITLE
OCPBUGS-74027: AA: E2E: LLC: Add tests related to odd cpus

### DIFF
--- a/test/e2e/performanceprofile/functests/13_llc/llc.go
+++ b/test/e2e/performanceprofile/functests/13_llc/llc.go
@@ -914,12 +914,10 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				Expect(testclient.Client.List(ctx, podList, listOptions)).To(Succeed())
 				Expect(len(podList.Items)).To(Equal(1), "Expected exactly one pod in the list")
 				testpod := podList.Items[0]
-
 				verifyOddCPUAllocation(ctx, &targetNode, requestedCPUs, cpusetCfg, &testpod)
 			})
 
 			It("[test_id:87073] Large odd integer CPU request should take full uncore plus partial from another", func(ctx context.Context) {
-				targetNode := workerRTNodes[0]
 				// Get the actual uncore cache size
 				getCCX := nodes.GetL3SharedCPUs(&targetNode)
 				uncoreCache, err := getCCX(0)


### PR DESCRIPTION
Adds tests related to Odd integer cpu alignment
with full-pcpus-only: false

Assisted-by: Cursor v2.1.39
AI Attribution: AIA PAI Hin v1.0 Model: Auto 