### PR TITLE
MON-4506: Migrate Prometheus targets discovering from Endpoints to EndpointSlices

### DIFF
--- a/manifests/30-monitoring.yaml
+++ b/manifests/30-monitoring.yaml
@@ -58,6 +58,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -104,6 +112,7 @@ spec:
   selector:
     matchLabels:
       name: node-tuning-operator
+  serviceDiscoveryRole: EndpointSlice
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**

Due to the scope of changes across multiple repositories, these modifications were generated with Claude assistance.
