### PR TITLE
OCPBUGS-84938: e2e: Add irqbalance StartLimitBurst >= 100 config test

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/pods"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profilesupdate"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/systemd"
 	e2etuned "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/tuned"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/util"
 	"github.com/openshift/cluster-node-tuning-operator/test/framework"
@@ -49,7 +51,7 @@ var (
 	cs = framework.NewClientSet()
 )
 
-var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
+var _ = Describe("[performance] IRQBalance", Ordered, func() {
 	var workerRTNodes []corev1.Node
 	var targetNode *corev1.Node
 	var profile, initialProfile *performancev2.PerformanceProfile
@@ -380,6 +382,19 @@ var _ = Describe("[performance] Checking IRQBalance settings", Ordered, func() {
 			Entry("[test_id:86343] Verify housekeeping CPUs are sibling paired and applied to IRQ affinity", context.TODO(), 1),
 			Entry("[test_id:86345] Verify first cpu core defines housekeeping CPUs in multi-container pod", context.TODO(), 2),
 		)
+	})
+
+	// Automates OCPBUGS-45112 - Config test
+	// Default StartLimitBurst=5 was too low - each pod created/deleted would trigger a restart of irqbalance
+	// Systemd coalesces concurrent requests, making the reproduction by deployment impractical.
+	It("[test_id:88711] should have irqbalance StartLimitBurst >= 100", Label(string(label.Tier0)), func() {
+		startLimitBurst, err := systemd.ShowPropertyValue(context.TODO(), "irqbalance.service", "StartLimitBurst", targetNode)
+		Expect(err).ToNot(HaveOccurred())
+		startLimitBurst = strings.TrimSpace(startLimitBurst)
+		testlog.Infof("irqbalance.service StartLimitBurst=%s on node %s", startLimitBurst, targetNode.Name)
+		startLimitBurstInt, err := strconv.Atoi(startLimitBurst)
+		Expect(err).ToNot(HaveOccurred(), "unexpected StartLimitBurst value %q", startLimitBurst)
+		Expect(startLimitBurstInt).To(BeNumerically(">=", 100), "irqbalance StartLimitBurst must be >=100 (OCPBUGS-45112)")
 	})
 
 })

--- a/test/e2e/performanceprofile/functests/utils/systemd/systemd.go
+++ b/test/e2e/performanceprofile/functests/utils/systemd/systemd.go
@@ -19,3 +19,9 @@ func ShowProperty(ctx context.Context, unitfile string, property string, node *c
 	out, err := nodes.ExecCommand(ctx, node, cmd)
 	return string(out), err
 }
+
+func ShowPropertyValue(ctx context.Context, unitfile string, property string, node *corev1.Node) (string, error) {
+	cmd := []string{"/bin/bash", "-c", fmt.Sprintf("chroot /rootfs systemctl show -p %s %s --value --no-pager", property, unitfile)}
+	out, err := nodes.ExecCommand(ctx, node, cmd)
+	return string(out), err
+}


### PR DESCRIPTION
This pr Is test automation for OCPBUGS-45112

The bug:
The underlying cause was the default configuration:
`StartLimitIntervalUSec=10s ` `StartLimitBurst=5` meaning over 5 restarts in a 10 sec window would cause `ActiveState=failed` 
Each pod create/delete with `irq-load-balancing.crio.io = "disable"` annotation causes irqbalance to restart.
In addition restarts coalesce meaning this is timing dependent thus not every deployment with more than 5 pods actually causes over 5 restarts.

The fix:
drop-in sets `StartLimitBurst=100`.
Checking this irqbalance systemd property is enough - no functional test is required 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Renamed a performance test suite for clearer identification of IRQBalance checks, improving test readability.
  * Added a new Tier0 end-to-end test that verifies the IRQBalance service startup limit burst is exactly 100, increasing coverage for system startup configuration and catching regressions early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->