### PR TITLE
OCPBUGS-62277: Requeue PerformanceStatus update when status write fails

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile_controller.go
+++ b/pkg/performanceprofile/controller/performanceprofile_controller.go
@@ -62,6 +62,9 @@ import (
 const (
 	openshiftFinalizer  = "foreground-deletion"
 	hypershiftFinalizer = "hypershift.openshift.io/foreground-deletion"
+
+	// statusUpdateRequeueAfter is the delay before retrying reconcile after a failure to update performance profile status.
+	statusUpdateRequeueAfter = 30 * time.Second
 )
 
 // PerformanceProfileReconciler reconciles a PerformanceProfile object
@@ -615,13 +618,14 @@ func (r *PerformanceProfileReconciler) Reconcile(ctx context.Context, req ctrl.R
 		conditions := status.GetDegradedConditions(status.ConditionReasonComponentsCreationFailed, err.Error())
 		if err := r.StatusWriter.Update(ctx, instance, conditions); err != nil {
 			klog.Errorf("failed to update performance profile %q status: %v", instance.GetName(), err)
-			return reconcile.Result{}, err
+			return reconcile.Result{RequeueAfter: statusUpdateRequeueAfter}, nil
 		}
 		return reconcile.Result{}, err
 	}
 	err = r.StatusWriter.UpdateOwnedConditions(ctx, instance)
 	if err != nil {
 		klog.Errorf("failed to update performance profile %q status: %v", instance.GetName(), err)
+		return ctrl.Result{RequeueAfter: statusUpdateRequeueAfter}, nil
 	}
 	return ctrl.Result{}, nil
 }
@@ -651,7 +655,7 @@ func (r *PerformanceProfileReconciler) getAndValidateMCP(ctx context.Context, in
 		conditions := status.GetDegradedConditions(status.ConditionFailedToFindMachineConfigPool, err.Error())
 		if err := r.StatusWriter.Update(ctx, profile, conditions); err != nil {
 			klog.Errorf("failed to update performance profile %q status: %v", profile.GetName(), err)
-			return nil, &reconcile.Result{}, err
+			return nil, &reconcile.Result{RequeueAfter: statusUpdateRequeueAfter}, nil
 		}
 		return nil, &reconcile.Result{}, nil
 	}
@@ -660,7 +664,7 @@ func (r *PerformanceProfileReconciler) getAndValidateMCP(ctx context.Context, in
 		conditions := status.GetDegradedConditions(status.ConditionBadMachineConfigLabels, err.Error())
 		if err := r.StatusWriter.Update(ctx, profile, conditions); err != nil {
 			klog.Errorf("failed to update performance profile %q status: %v", profile.GetName(), err)
-			return nil, &reconcile.Result{}, err
+			return nil, &reconcile.Result{RequeueAfter: statusUpdateRequeueAfter}, nil
 		}
 		return nil, &reconcile.Result{}, nil
 	}


### PR DESCRIPTION
The old code logged an error when not able to save status, but it never retried. This caused stale conditions to be reported until the next reconcile (possibly long time in the future).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery for status update failures: when status synchronization encounters transient errors, the controller now retries after a 30-second delay, reducing missed updates and improving overall system resilience and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->