### PR TITLE
NO-JIRA: ote: embed extended testdata in cluster-node-tuning-operator-test-ext binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ tmp
 /*.sh
 /TODO
 pkg/manifests/bindata.go
+test/extended/bindata/bindata.go
 cover.out

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,11 @@ endif
 # Build-specific variables
 OUT_DIR=_output
 GOBINDATA_BIN=$(OUT_DIR)/go-bindata
-BINDATA=pkg/manifests/bindata.go
+BINDATA_NTO=pkg/manifests/bindata.go
+BINDATA_OTE=test/extended/bindata/bindata.go
+BINDATA=$(BINDATA_NTO) $(BINDATA_OTE)
+TESTDATA_OTE_DIR=test/extended/testdata
+TESTDATA_OTE=$(shell find $(TESTDATA_OTE_DIR) -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null)
 ASSETS=$(shell find assets -name \*.yaml)
 GO=GOARCH=$(GOARCH) GO111MODULE=on GOFLAGS=-mod=vendor go
 GO_BUILD_RECIPE=$(GO) build -o $(OUT_DIR)/$(PACKAGE_BIN) -ldflags '-X $(PACKAGE)/version.Version=$(REV)' $(PACKAGE_MAIN)
@@ -79,9 +83,11 @@ update-tuned-submodule:
 build: $(BINDATA) pkg/generated build-performance-profile-creator build-gather-sysinfo cluster-node-tuning-operator-test-ext
 	$(GO_BUILD_RECIPE)
 
-$(BINDATA): $(GOBINDATA_BIN) $(ASSETS)
-	$(GOBINDATA_BIN) -mode 420 -modtime 1 -pkg manifests -o $(BINDATA) assets/...
-	gofmt -s -w $(BINDATA)
+$(BINDATA): $(GOBINDATA_BIN) $(ASSETS) $(TESTDATA_OTE)
+	$(GOBINDATA_BIN) -mode 420 -modtime 1 -pkg manifests -o $(BINDATA_NTO) assets/...
+	gofmt -s -w $(BINDATA_NTO)
+	$(GOBINDATA_BIN) -mode 420 -modtime 1 -pkg manifests_ote -prefix $(TESTDATA_OTE_DIR) -o $(BINDATA_OTE) $(TESTDATA_OTE_DIR)/...
+	gofmt -s -w $(BINDATA_OTE)
 
 pkg/generated: $(API_TYPES)
 	hack/update-codegen.sh
@@ -312,6 +318,6 @@ pao-clean-e2e:
 
 
 .PHONY: cluster-node-tuning-operator-test-ext
-cluster-node-tuning-operator-test-ext:
+cluster-node-tuning-operator-test-ext: $(BINDATA_OTE)
 	@echo "Building cluster-node-tuning-operator-test-ext"
 	GO_COMPLIANCE_POLICY=exempt_all CGO_ENABLED=0 $(GO) build -mod=vendor -v -o $(OUT_DIR)/cluster-node-tuning-operator-test-ext ./cmd/cluster-node-tuning-operator-test-ext

--- a/cmd/cluster-node-tuning-operator-test-ext/main.go
+++ b/cmd/cluster-node-tuning-operator-test-ext/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	// The import below is necessary to ensure that the NTO operator tests are registered with the extension.
-	_ "github.com/openshift/cluster-node-tuning-operator/test/extended"
+	_ "github.com/openshift/cluster-node-tuning-operator/test/extended/specs"
 )
 
 func main() {
@@ -33,7 +33,8 @@ func main() {
 		Name:    "openshift/cluster-node-tuning-operator/conformance/parallel",
 		Parents: []string{"openshift/conformance/parallel"},
 		Qualifiers: []string{
-			`!(name.contains("[Serial]") || name.contains("[Slow]"))`,
+			`(labels.exists(l, l=="ReleaseGate")) &&
+			!(name.contains("[Serial]") || name.contains("[Slow]"))`,
 		},
 	})
 
@@ -42,7 +43,20 @@ func main() {
 		Name:    "openshift/cluster-node-tuning-operator/conformance/serial",
 		Parents: []string{"openshift/conformance/serial"},
 		Qualifiers: []string{
-			`name.contains("[Serial]")`,
+			`(labels.exists(l, l=="ReleaseGate")) &&
+			name.contains("[Serial]")`,
+			// refer to https://github.com/openshift/origin/blob/main/pkg/testsuites/standard_suites.go
+		},
+	})
+
+	// Suite: disruptive
+	// See: https://github.com/openshift/release/blob/508c08ff3d8dbff48604b94484a0ce63983710ba/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml#L2462
+	ext.AddSuite(e.Suite{
+		Name:    "openshift/cluster-node-tuning-operator/disruptive",
+		Parents: []string{"openshift/disruptive-longrunning"},
+		Qualifiers: []string{
+			`(labels.exists(l, l=="ReleaseGate")) &&
+			name.contains("[Disruptive]")`,
 		},
 	})
 
@@ -51,30 +65,23 @@ func main() {
 		Name:    "openshift/cluster-node-tuning-operator/optional/slow",
 		Parents: []string{"openshift/optional/slow"},
 		Qualifiers: []string{
-			`name.contains("[Slow]")`,
+			`(labels.exists(l, l=="ReleaseGate")) &&
+			name.contains("[Slow]")`,
 		},
 	})
 
 	// Suite: all (includes everything)
 	ext.AddSuite(e.Suite{
 		Name: "openshift/cluster-node-tuning-operator/all",
+		Qualifiers: []string{
+			`(labels.exists(l, l=="ReleaseGate"))`,
+		},
 	})
 
 	specs, err := g.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()
 	if err != nil {
 		panic(fmt.Sprintf("couldn't build extension test specs from ginkgo: %+v", err.Error()))
 	}
-
-	// Ensure [Disruptive] tests are also [Serial]
-	specs = specs.Walk(func(spec *et.ExtensionTestSpec) {
-		if strings.Contains(spec.Name, "[Disruptive]") && !strings.Contains(spec.Name, "[Serial]") {
-			spec.Name = strings.ReplaceAll(
-				spec.Name,
-				"[Disruptive]",
-				"[Serial][Disruptive]",
-			)
-		}
-	})
 
 	// Preserve original-name labels for renamed tests
 	specs = specs.Walk(func(spec *et.ExtensionTestSpec) {

--- a/test/extended/bindata/manifests.go
+++ b/test/extended/bindata/manifests.go
@@ -1,0 +1,1 @@
+package manifests_ote

--- a/test/extended/specs/nto.go
+++ b/test/extended/specs/nto.go
@@ -1,4 +1,4 @@
-package extended
+package specs
 
 import (
 	"strings"
@@ -7,16 +7,15 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	oteg "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 )
 
-var _ = g.Describe("[sig-tuning-node] PSAP should", g.Label("conformance"), func() {
+var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] should", g.Label("conformance"), func() {
 	defer g.GinkgoRecover()
 
 	var (
-		oc            = utils.NewCLIWithoutNamespace("nto-test")
-		ntoNamespace  = "openshift-cluster-node-tuning-operator"
-		ntoFixture    = func(name string) string { return utils.FixturePath("nto", name) }
-		ntoIRQSMPFile = ntoFixture("default-irq-smp-affinity.yaml")
+		oc           = utils.NewCLIWithoutNamespace("nto-test")
+		ntoNamespace = "openshift-cluster-node-tuning-operator"
 
 		isNTO         bool
 		iaasPlatform  string
@@ -35,11 +34,33 @@ var _ = g.Describe("[sig-tuning-node] PSAP should", g.Label("conformance"), func
 		utils.Logf("Cloud provider is: %v", iaasPlatform)
 	})
 
-	g.It("[Jira:NTO]OCP-37415-Allow setting isolated_cores without touching the default_irq_affinity[OTP][Disruptive][Suite:openshift/conformance/serial]", g.Label("Serial"), func() {
+	// A dummy test that should always pass.  It should land in "openshift/cluster-node-tuning-operator/conformance/parallel" suite.
+	g.It("support passing tests", g.Label("ReleaseGate"), func() {
+		o.Expect(true).To(o.BeTrue())
+	})
+
+	// A dummy test that should always pass.  It should land in "openshift/cluster-node-tuning-operator/conformance/serial" suite.
+	g.It("support passing tests [Serial]", g.Label("ReleaseGate"), func() {
+		o.Expect(true).To(o.BeTrue())
+	})
+
+	// A dummy test that should always pass.  It should land in "openshift/cluster-node-tuning-operator/disruptive" suite.
+	g.It("support passing tests [Disruptive]", g.Label("ReleaseGate"), func() {
+		o.Expect(true).To(o.BeTrue())
+	})
+
+	// A dummy test that should always pass.  It should land in "openshift/cluster-node-tuning-operator/optional/slow" suite.
+	g.It("support passing tests [Slow]", g.Label("ReleaseGate"), func() {
+		o.Expect(true).To(o.BeTrue())
+	})
+
+	g.It("[test_id:37415][OTP]Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]", g.Label("ReleaseGate"), oteg.Informing(), func() {
 		// test requires NTO to be installed
 		if !isNTO {
 			g.Skip("NTO is not installed - skipping test ...")
 		}
+
+		ntoIRQSMPFile := utils.TestdataFixturePath(g.GinkgoT(), "nto", "default-irq-smp-affinity.yaml")
 
 		isSNO := utils.IsSNOCluster(oc)
 		// Prior to choose worker nodes with machineset

--- a/test/extended/testdata/nto/default-irq-smp-affinity.yaml
+++ b/test/extended/testdata/nto/default-irq-smp-affinity.yaml
@@ -28,4 +28,4 @@ objects:
 parameters:
 - name: TUNED_NAME
 - name: SYSCTLPARM
-- name: SYSCTLVALUE    
+- name: SYSCTLVALUE

--- a/test/extended/utils/nto_util.go
+++ b/test/extended/utils/nto_util.go
@@ -6,80 +6,62 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
+
+	extendedbindata "github.com/openshift/cluster-node-tuning-operator/test/extended/bindata"
 
 	o "github.com/onsi/gomega"
 )
 
-var (
-	fixtureDirLock sync.Once
-	fixtureDir     string
-)
+type FixtureTB interface {
+	Helper()
+	TempDir() string
+}
 
 // Logf is a simple logging function to replace e2e.Logf
 func Logf(format string, args ...interface{}) {
 	fmt.Printf(format+"\n", args...)
 }
 
-// FixturePath returns the path to a test fixture file
-func FixturePath(elem ...string) string {
-	if len(elem) == 0 {
-		panic("must specify path")
+// bindataAssetKey returns the go-bindata asset name (paths under the testdata tree; see Makefile -prefix).
+func bindataAssetKey(elem []string) string {
+	key := filepath.ToSlash(filepath.Join(elem...))
+	if key == "testdata" {
+		return ""
 	}
+	return strings.TrimPrefix(key, "testdata/")
+}
 
-	// Determine the base directory for test fixtures
-	// This should be the absolute path to test/extended/testdata
-	fixtureDirLock.Do(func() {
-		// Get the current working directory or package directory
-		cwd, err := os.Getwd()
-		if err != nil {
-			panic(err)
-		}
-
-		// Find the project root by looking for go.mod
-		projectRoot := cwd
-		for {
-			if _, err := os.Stat(filepath.Join(projectRoot, "go.mod")); err == nil {
-				break
-			}
-			parent := filepath.Dir(projectRoot)
-			if parent == projectRoot {
-				// Reached filesystem root without finding go.mod
-				panic("could not find project root (go.mod)")
-			}
-			projectRoot = parent
-		}
-
-		fixtureDir = filepath.Join(projectRoot, "test", "extended", "testdata")
-	})
-
-	// Build the path to the fixture
-	var pathComponents []string
-	switch {
-	case len(elem) > 3 && elem[0] == ".." && elem[1] == ".." && elem[2] == "examples":
-		pathComponents = append([]string{filepath.Dir(filepath.Dir(fixtureDir))}, elem[2:]...)
-	case len(elem) > 3 && elem[0] == ".." && elem[1] == ".." && elem[2] == "install":
-		pathComponents = append([]string{filepath.Dir(filepath.Dir(fixtureDir))}, elem[2:]...)
-	case len(elem) > 3 && elem[0] == ".." && elem[1] == "integration":
-		pathComponents = append([]string{filepath.Dir(fixtureDir), "test"}, elem[1:]...)
-	case elem[0] == "testdata":
-		pathComponents = append([]string{fixtureDir}, elem[1:]...)
-	default:
-		pathComponents = append([]string{fixtureDir}, elem...)
+func materializeTestdataFixture(tb FixtureTB, rel string, data []byte) string {
+	tb.Helper()
+	base := tb.TempDir()
+	dest := filepath.Join(base, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(dest), 0750); err != nil {
+		panic(fmt.Sprintf("TestdataFixturePath: mkdir: %v", err))
 	}
-
-	fullPath := filepath.Join(pathComponents...)
-
-	// Verify the path exists
-	if _, err := os.Stat(fullPath); err != nil {
-		panic(fmt.Sprintf("Fixture path does not exist: %s (error: %v)", fullPath, err))
+	if err := os.WriteFile(dest, data, 0644); err != nil {
+		panic(fmt.Sprintf("TestdataFixturePath: write %q: %v", dest, err))
 	}
-
-	p, err := filepath.Abs(fullPath)
+	p, err := filepath.Abs(dest)
 	if err != nil {
 		panic(err)
 	}
 	return p
+}
+
+// TestdataFixturePath materializes a manifest from go-bindata into a file under tb.TempDir()
+// and returns its absolute path for use with oc -f.  The directory is removed when the test
+// completes.
+func TestdataFixturePath(tb FixtureTB, elem ...string) string {
+	tb.Helper()
+	if len(elem) == 0 {
+		panic("must specify path")
+	}
+	key := bindataAssetKey(elem)
+	data, err := extendedbindata.Asset(key)
+	if err != nil {
+		panic(fmt.Sprintf("TestdataFixturePath: unknown asset %q (from %v): %v", key, elem, err))
+	}
+	return materializeTestdataFixture(tb, key, data)
 }
 
 // IsNTOPodInstalled will return true if any pod is found in the given namespace, and false otherwise


### PR DESCRIPTION
Ship YAML under test/extended/testdata inside cluster-node-tuning-operator-test-ext using the same go-bindata pattern as operator manifests.

Changes:
  * Add Makefile targets to regenerate test/extended/bindata/bindata.go and make sure cluster-node-tuning-operator-test-ext build depends on them.
  * Replace filesystem-based FixturePath with TestdataFixturePath, which only loads assets from bindata and materializes them to a temp path for `oc -f`.
  * Update the default-irq-smp-affinity conformance spec to use the new helper.
  * Do not add the [Serial] label for [Disruptive] tests automatically.
  * Add disruptive-longrunning test suite.
  * Add 4 dummy tests that always pass for debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a second bindata generation flow for OTE testdata and made the test-extension depend on that artifact.

* **Tests**
  * Moved extended tests to a specs package, updated suite descriptions and metadata, and switched to ReleaseGate-based gating for suites.
  * Load and materialize test fixtures from embedded testdata per-test (no repo scan).

* **Chores**
  * Ignore the generated bindata file.

* **Fixes**
  * Trimmed trailing whitespace in a testdata template parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->