### PR TITLE
NO-JIRA: test/extended: scope oc process to NTO namespace

### DIFF
--- a/test/extended/utils/nto_util.go
+++ b/test/extended/utils/nto_util.go
@@ -308,7 +308,7 @@ func (ntoRes *NtoResource) CreateIRQSMPAffinityProfileIfNotExist(oc *CLI) {
 	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", ntoRes.Name, "-n", ntoRes.Namespace).Output()
 	if strings.Contains(output, "NotFound") || strings.Contains(output, "No resources") || err != nil {
 		Logf("no tuned in project: %s, create one: %s", ntoRes.Namespace, ntoRes.Name)
-		processedTemplate, err := oc.AsAdmin().WithoutNamespace().Run("process").Args("--ignore-unknown-parameters=true", "-f", ntoRes.Template, "-p", "TUNED_NAME="+ntoRes.Name, "-p", "SYSCTLPARM="+ntoRes.Sysctlparm, "-p", "SYSCTLVALUE="+ntoRes.Sysctlvalue, "-o", "yaml").Output()
+		processedTemplate, err := oc.AsAdmin().WithoutNamespace().Run("process").Args("-n", ntoRes.Namespace, "--ignore-unknown-parameters=true", "-f", ntoRes.Template, "-p", "TUNED_NAME="+ntoRes.Name, "-p", "SYSCTLPARM="+ntoRes.Sysctlparm, "-p", "SYSCTLVALUE="+ntoRes.Sysctlvalue, "-o", "yaml").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		Logf("Processed template:\n%s", processedTemplate)
 		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-n", ntoRes.Namespace, "-f", "-").InputString(processedTemplate).Execute()


### PR DESCRIPTION
WithoutNamespace() does not add `-n`, so `oc` used the kubeconfig context namespace. If the namespace (e.g. an OTE project) was deleted, the `oc` process would fail. Pass `-n` with the resource (openshift-cluster-node-tuning-operator) namespace.

Resolves: https://github.com/openshift/release/pull/78471#issuecomment-4387338847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced namespace specification in test utility procedures for template processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->