### PR TITLE
OCPBUGS-83865: Revert stalld backend to sched_debug

### DIFF
--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -391,6 +391,16 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, opts *componen
 		addContent(ignitionConfig, content, ovsDynamicPinningTriggerHostFile, &ovsMode)
 	}
 
+	// Configure a systemd dropin and sysconfig file so stalld uses sched_debug as its backend.
+	// The dropin has no effect if stalld is not running, so it is safe to include unconditionally.
+	// This can potentially be removed when RHEL-175242 is fixed.
+	stalldSysconfigContent := []byte("BE=\"-b sched_debug\"\n")
+	stalldSysconfigMode := 0644
+	addContent(ignitionConfig, stalldSysconfigContent, "/etc/sysconfig/stalld-backend", &stalldSysconfigMode)
+
+	stalldDropinContent := []byte("[Service]\nEnvironmentFile=/etc/sysconfig/stalld-backend\n")
+	addContent(ignitionConfig, stalldDropinContent, "/etc/systemd/system/stalld.service.d/stalld-backend.conf", &stalldSysconfigMode)
+
 	if opts.MixedCPUsEnabled {
 		// ContainersLimit should be exposed as user-facing API in future updates
 		content, err := renderMixedCPUsConfig(defaultContainersLimit, filepath.Join("configs", mixedCPUsConfig))

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -258,6 +258,30 @@ var _ = Describe("Machine Config", func() {
 		})
 	})
 
+	Context("stalld backend configuration", func() {
+		It("should include stalld sysconfig and systemd dropin files", func() {
+			profile := testutils.NewPerformanceProfile("test")
+
+			mc, err := New(profile, &components.MachineConfigOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			result := igntypes.Config{}
+			Expect(json.Unmarshal(mc.Spec.Config.Raw, &result)).To(Succeed())
+
+			fileContents := map[string]string{}
+			for _, f := range result.Storage.Files {
+				Expect(f.Contents.Source).ToNot(BeNil(), "file %s has nil source", f.Path)
+				base64Data := strings.TrimPrefix(*f.Contents.Source, "data:text/plain;charset=utf-8;base64,")
+				decoded, err := base64.StdEncoding.DecodeString(base64Data)
+				Expect(err).ToNot(HaveOccurred())
+				fileContents[f.Path] = string(decoded)
+			}
+
+			Expect(fileContents).To(HaveKeyWithValue("/etc/sysconfig/stalld-backend", "BE=\"-b sched_debug\"\n"))
+			Expect(fileContents).To(HaveKeyWithValue("/etc/systemd/system/stalld.service.d/stalld-backend.conf", "[Service]\nEnvironmentFile=/etc/sysconfig/stalld-backend\n"))
+		})
+	})
+
 	Context("check listToString ", func() {
 		It("should create string from CPUSet", func() {
 			res := components.ListToString(CPUs)

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -342,6 +342,22 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				Expect(tunedExitTime).To(BeNumerically("<", kubeletStartTime), "kubelet started before ocp-tuned-one-shot.service exits")
 			}
 		})
+
+		It("Should have the stalld service configured with the stalld-backend drop-in", func() {
+			for _, node := range workerRTNodes {
+				By("verify that the stalld systemd unit has the stalld-backend drop-in path")
+				out, err := systemd.ShowProperty(context.TODO(), "stalld.service", "DropInPaths", &node)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(ContainSubstring("/etc/systemd/system/stalld.service.d/stalld-backend.conf"),
+					"stalld.service on node %s does not have the stalld-backend.conf drop-in: %s", node.Name, out)
+
+				By("verify that the stalld systemd unit has the stalld-backend environment file")
+				out, err = systemd.ShowProperty(context.TODO(), "stalld.service", "EnvironmentFiles", &node)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(ContainSubstring("/etc/sysconfig/stalld-backend"),
+					"stalld.service on node %s does not have /etc/sysconfig/stalld-backend in EnvironmentFiles: %s", node.Name, out)
+			}
+		})
 	})
 
 	Context("Tuned kernel parameters", Label(string(label.Tier0)), func() {

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -104,6 +104,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -104,6 +104,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_machineconfig.yaml
@@ -104,6 +104,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_machineconfig.yaml
@@ -104,6 +104,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_machineconfig.yaml
@@ -89,6 +89,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_machineconfig.yaml
@@ -89,6 +89,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
@@ -90,6 +90,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_machineconfig.yaml
@@ -90,6 +90,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |

--- a/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/manual_machineconfig.yaml
@@ -116,6 +116,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
@@ -89,6 +89,20 @@ spec:
         mode: 420
         path: /var/lib/ovn-ic/etc/enable_dynamic_cpu_affinity
         user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QkU9Ii1iIHNjaGVkX2RlYnVnIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/sysconfig/stalld-backend
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W1NlcnZpY2VdCkVudmlyb25tZW50RmlsZT0vZXRjL3N5c2NvbmZpZy9zdGFsbGQtYmFja2VuZAo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/systemd/system/stalld.service.d/stalld-backend.conf
+        user: {}
     systemd:
       units:
       - contents: |


### PR DESCRIPTION
Updating the MC to revert the stalld backend to sched_debug. This is necessary because the new default queue_task backend causes an unacceptable latency penalty (see [RHEL-175242](https://redhat.atlassian.net/browse/RHEL-175242)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * stalld is now automatically configured to use the sched_debug backend via a provisioned backend config and a corresponding systemd override.

* **Tests**
  * Added unit and end-to-end tests that verify the stalld backend configuration is generated and applied in rendered system configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->