### PR TITLE
Add more OTE tests, drop ReleaseGate, fix test races

### DIFF
--- a/cmd/cluster-node-tuning-operator-test-ext/main.go
+++ b/cmd/cluster-node-tuning-operator-test-ext/main.go
@@ -55,8 +55,7 @@ func main() {
 		Name:    "openshift/cluster-node-tuning-operator/disruptive",
 		Parents: []string{"openshift/disruptive-longrunning"},
 		Qualifiers: []string{
-			`(labels.exists(l, l=="ReleaseGate")) &&
-			name.contains("[Disruptive]")`,
+			`name.contains("[Disruptive]")`,
 		},
 	})
 
@@ -65,17 +64,14 @@ func main() {
 		Name:    "openshift/cluster-node-tuning-operator/optional/slow",
 		Parents: []string{"openshift/optional/slow"},
 		Qualifiers: []string{
-			`(labels.exists(l, l=="ReleaseGate")) &&
-			name.contains("[Slow]") && !name.contains("[Disruptive]")`,
+			`name.contains("[Slow]") && !name.contains("[Disruptive]")`,
 		},
 	})
 
 	// Suite: all (includes everything)
 	ext.AddSuite(e.Suite{
-		Name: "openshift/cluster-node-tuning-operator/all",
-		Qualifiers: []string{
-			`(labels.exists(l, l=="ReleaseGate"))`,
-		},
+		Name:       "openshift/cluster-node-tuning-operator/all",
+		Qualifiers: []string{},
 	})
 
 	specs, err := g.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()
@@ -97,7 +93,7 @@ func main() {
 
 	// Ignore obsolete tests
 	ext.IgnoreObsoleteTests(
-	// "[sig-node-tuning] <test name here>",
+	// "[sig-tuning-node] <test name here>",
 	)
 
 	// Initialize environment before running any tests

--- a/cmd/cluster-node-tuning-operator-test-ext/main.go
+++ b/cmd/cluster-node-tuning-operator-test-ext/main.go
@@ -33,8 +33,7 @@ func main() {
 		Name:    "openshift/cluster-node-tuning-operator/conformance/parallel",
 		Parents: []string{"openshift/conformance/parallel"},
 		Qualifiers: []string{
-			`(labels.exists(l, l=="ReleaseGate")) &&
-			!(name.contains("[Serial]") || name.contains("[Slow]") || name.contains("[Disruptive]"))`,
+			`!(name.contains("[Serial]") || name.contains("[Slow]") || name.contains("[Disruptive]")) && !name.contains("[Manual]")`,
 		},
 	})
 
@@ -43,45 +42,53 @@ func main() {
 		Name:    "openshift/cluster-node-tuning-operator/conformance/serial",
 		Parents: []string{"openshift/conformance/serial"},
 		Qualifiers: []string{
-			`(labels.exists(l, l=="ReleaseGate")) &&
-			name.contains("[Serial]") && !name.contains("[Disruptive]")`,
+			`name.contains("[Serial]") && !name.contains("[Disruptive]") && !name.contains("[Manual]")`,
 			// refer to https://github.com/openshift/origin/blob/main/pkg/testsuites/standard_suites.go
 		},
 	})
 
 	// Suite: disruptive
 	// See: https://github.com/openshift/release/blob/508c08ff3d8dbff48604b94484a0ce63983710ba/ci-operator/config/openshift/release/openshift-release-main__nightly-4.22.yaml#L2462
+	// This suite currently doesn't run in any CI jobs.
 	ext.AddSuite(e.Suite{
-		Name:    "openshift/cluster-node-tuning-operator/disruptive",
-		Parents: []string{"openshift/disruptive-longrunning"},
+		Name: "openshift/cluster-node-tuning-operator/disruptive",
+		// Tests running in the "openshift/disruptive-longrunning" parent suite already struggle to complete within 4 hours.
+		// Create a separate openshift/release config for this if it is decided to run these in the CI.
 		Qualifiers: []string{
-			`(labels.exists(l, l=="ReleaseGate")) &&
-			name.contains("[Disruptive]")`,
+			`name.contains("[Disruptive]") && !name.contains("[Manual]")`,
 		},
 	})
 
 	// Suite: optional/slow (long-running tests)
+	// This suite doesn't run in any CI jobs.
 	ext.AddSuite(e.Suite{
-		Name:    "openshift/cluster-node-tuning-operator/optional/slow",
-		Parents: []string{"openshift/optional/slow"},
+		Name: "openshift/cluster-node-tuning-operator/optional/slow",
 		Qualifiers: []string{
-			`(labels.exists(l, l=="ReleaseGate")) &&
-			name.contains("[Slow]") && !name.contains("[Disruptive]")`,
+			`name.contains("[Slow]") && !name.contains("[Disruptive]") && !name.contains("[Manual]")`,
 		},
 	})
 
-	// Suite: all (includes everything)
+	// Suite: all (includes everything except [Manual] tests)
 	ext.AddSuite(e.Suite{
-		Name: "openshift/cluster-node-tuning-operator/all",
-		Qualifiers: []string{
-			`(labels.exists(l, l=="ReleaseGate"))`,
-		},
+		Name:       "openshift/cluster-node-tuning-operator/all",
+		Qualifiers: []string{`!name.contains("[Manual]")`},
 	})
 
 	specs, err := g.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite()
 	if err != nil {
 		panic(fmt.Sprintf("couldn't build extension test specs from ginkgo: %+v", err.Error()))
 	}
+
+	// Ensure [Disruptive] tests are also [Serial]
+	specs = specs.Walk(func(spec *et.ExtensionTestSpec) {
+		if strings.Contains(spec.Name, "[Disruptive]") && !strings.Contains(spec.Name, "[Serial]") {
+			spec.Name = strings.ReplaceAll(
+				spec.Name,
+				"[Disruptive]",
+				"[Serial][Disruptive]",
+			)
+		}
+	})
 
 	// Preserve original-name labels for renamed tests
 	specs = specs.Walk(func(spec *et.ExtensionTestSpec) {
@@ -93,16 +100,6 @@ func main() {
 				}
 			}
 		}
-	})
-
-	// Ignore obsolete tests
-	ext.IgnoreObsoleteTests(
-	// "[sig-node-tuning] <test name here>",
-	)
-
-	// Initialize environment before running any tests
-	specs.AddBeforeAll(func() {
-		// do stuff
 	})
 
 	ext.AddSpecs(specs)

--- a/test/extended/AGENTS.md
+++ b/test/extended/AGENTS.md
@@ -1,0 +1,332 @@
+# AGENTS.md
+
+This file provides AI agents with comprehensive context about the NTO QE Test Extension project to enable effective test development, debugging, and maintenance.
+
+## Scope and Working Directory
+
+### Applicability
+This AGENTS.md applies to the **NTO QE Test Cases** located at:
+```
+cluster-node-tuning-operator/test/extended/
+```
+
+**IMPORTANT**: This file is specifically for the **QE migration test code** in the `test/extended/` directory, not for:
+- Product code in the main `cluster-node-tuning-operator` repository
+
+### Required Working Directory
+For this AGENTS.md to be effective, ensure your working directory is set to:
+```bash
+<repo-root>/cluster-node-tuning-operator/test/extended/
+```
+
+### Working Directory Verification for AI Agents
+
+**Context Awareness**: This AGENTS.md may be loaded even when not actively working with QE test files (e.g., user briefly left `test/extended/` for another repo path). Apply these guidelines intelligently based on the actual task.
+
+#### When to Apply This AGENTS.md
+
+**ONLY apply this AGENTS.md when the user is working with QE migration test files**, identified by:
+- File paths containing `test/extended/`
+- Tasks explicitly about "NTO QE tests", "QE migration", "test extension", "sig-tuning-node"
+
+**DO NOT apply this AGENTS.md when**:
+- Working with files outside these directories (e.g., e2e tests, product code)
+- User is in a different part of the repository
+- Even if this AGENTS.md was previously loaded
+
+#### Directory Check (Only for QE Test File Operations)
+
+When the user asks to work with QE test files (files under `test/extended/`):
+
+1. **Check current working directory**:
+   ```bash
+   pwd
+   ```
+
+2. **Verify directory alignment**:
+   - Preferred: Current directory should be `test/extended/` or subdirectory
+   - This ensures AGENTS.md context is automatically available
+
+3. **If working directory is not aligned**:
+
+   **Inform (don't block) the user**:
+   ```
+   💡 Note: Working Directory Suggestion
+
+   You're working with QE test files under test/extended/,
+   but your current directory is elsewhere. For better context and auto-completion:
+
+   Consider running: cd test/extended/
+
+   I can still help you, but setting the working directory correctly
+   ensures I have full access to the test documentation.
+
+   Do you want to continue in the current directory, or should I wait
+   for you to switch?
+   ```
+
+**Important**: This is a suggestion, not a blocker. If the user wants to proceed, assist them normally.
+
+### Path Structure Reference
+```
+cluster-node-tuning-operator/                  ← OpenShift downstream product repo
+└── test/                                      ← Test directory root
+    └── extended/                              ← OpenShift Test Extension (OTE) root
+        ├── bindata/                           ← Embedded test data for QE tests
+        ├── specs/                             ← OTE test specifications
+        ├── testdata/                          ← Raw test manifests to be compiled into bindata
+        └── utils/                             ← Test helpers/utilities
+```
+
+## Project Overview
+
+This is a **Quality Engineering (QE) test extension** for Node Tuning Operator (NTO) on OpenShift. It provides end-to-end functional tests that validate NTO features and functionality in real OpenShift clusters.
+
+### Purpose
+- Validate NTO functionality across different OpenShift topologies
+- Ensure NTO works correctly in various cluster configurations (SNO, standard OCP, etc.)
+- Provide regression testing for NTO bug fixes and enhancements
+
+**Note**: NTO currently does NOT support MicroShift topology. Support may be added in future releases.
+
+### Key Characteristics
+- **Framework**: Built on Ginkgo v2 BDD testing framework and OpenShift Tests Extension (OTE)
+- **Test Organization**: Polarion-ID based test case management
+- **Integration**: Extends `openshift-tests-extension` framework
+
+## Test Case Sources and Organization
+
+**Reference**: For OpenShift CI requirements, see [Choosing a Test Suite](https://docs.google.com/document/d/1cFZj9QdzW8hbHc3H0Nce-2xrJMtpDJrwAse9H7hLiWk/edit?tab=t.0#heading=h.tjtqedd47nnu)
+
+## Test Suite Definitions
+
+**IMPORTANT**: Suite definitions are sourced from **[cmd/cluster-node-tuning-operator-test-ext/main.go](../../cmd/cluster-node-tuning-operator-test-ext/main.go)** and may change over time. Always refer to that file for the most current definitions.
+
+For detailed explanations and code examples, see **[README.md](./README.md)** section "Suite Definitions".
+
+## Test Case Migration Guide
+
+For complete migration guidelines including code changes and label requirements, refer to **[README.md](./README.md)** section "Test Case Migration Guide".
+
+## Test Architecture and Patterns
+
+### Test Structure Pattern
+
+For complete test structure examples, refer to existing test files:
+- **Standard tests**: `specs/nto.go`
+- **Key patterns**: Look for `g.Describe`, `g.BeforeEach`, `g.AfterEach`, `g.It` blocks
+
+**Basic structure**:
+```go
+var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] feature description", func() {
+    defer g.GinkgoRecover()
+    var oc = exutil.NewCLIWithoutNamespace("nto-test")
+
+    g.BeforeEach(func() {
+        // ensure NTO operator is installed
+        utils.SkipNoNTO(oc, ntoNamespace)
+        // get IaaS platform
+        platformOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platform}").Output()
+        if err == nil {
+            iaasPlatform = strings.ToLower(platformOutput)
+        }
+        utils.Logf("Cloud provider is: %v", iaasPlatform)
+    })
+
+    g.AfterEach(func() {
+        // Cleanup resources (use defer)
+    })
+
+    g.It("[test_id:37415][OTP] description", g.Label("ReleaseGate"), func() {
+        // Test implementation
+    })
+})
+```
+
+## Local Development Workflow
+
+For complete local development workflow, build instructions, testing procedures, PR submission requirements, and disconnected environment support, refer to **[README.md](./README.md)** section "Local Development Workflow".
+
+**Quick reference**:
+- Build: `make`
+- Find test: `_output/cluster-node-tuning-operator-test-ext list -o names | grep "keyword_from_your_test_name"`
+- Run test: `_output/cluster-node-tuning-operator-test-ext run-test <full test name>`
+- openshift-tests integration: See [README.md](./README.md) for environment variables and suite selection
+
+**Important for Disconnected Tests**: With IDMS/ITMS in place, tests work the same in both connected and disconnected environments. See README.md for `ValidateAccessEnvironment` usage
+
+## Test Automation Code Requirements
+
+For complete code quality guidelines, best practices, logging best practices, and security considerations, refer to **[README.md](./README.md)** section "Test Automation Code Requirements".
+
+**Critical rules for AI agents**:
+- ✅ Use `defer` for cleanup (BEFORE resource creation): `defer resource.Delete(oc)` then `resource.Create(oc)`
+- ✅ Use case ID for resource naming (NOT random strings): `name := "test-extension-" + caseID`
+- ❌ Don't use `o.Expect` inside `wait.Poll` loops (use `if err != nil { return false, err }`)
+- ❌ Don't execute logic in `g.Describe` blocks (only initialization, move logic to `g.BeforeEach`)
+- ❌ Don't use quotes in test titles (breaks XML parsing)
+- ❌ Don't put large log outputs in error messages (use proper log messages instead of `o.Expect` with large output)
+
+## Key Utilities
+
+For complete utility APIs and usage examples, refer to the source code and existing tests:
+
+### `utils` Package
+**Location**: `utils/` directory (e.g., `utils/cli_wrapper.go`, `utils/nto_util.go`)
+
+**Key functions**:
+- CLI management: `NewCLIWithoutNamespace()`
+- Cluster detection: `IsSNOCluster()`, `IsROSACluster()`
+- Skip functions: `SkipNoNTO()`
+
+## Anti-Patterns to Avoid
+
+For complete anti-patterns with detailed code examples and explanations, refer to **[README.md](./README.md)** section "Test Automation Code Requirements".
+
+**Common mistakes for AI agents to avoid**:
+- ❌ No cleanup: Always use `defer resource.Delete(oc)` BEFORE `resource.Create(oc)`
+- ❌ Hardcoded names: Use case ID for naming: `name := "test-extension-" + caseID`
+- ❌ Missing timeouts: Always specify timeout for Wait functions
+- ❌ Hard sleeps: Use Wait functions instead of `time.Sleep()`
+- ❌ `o.Expect` in `wait.Poll`: Use `if err != nil { return false, err }` pattern instead
+
+## Quick Reference
+
+### Test Naming Convention
+```
+[Jira:Node Tuning Operator][sig-tuning-node] should [test_id:12345][OTP]Description [Parallel|Serial|Disruptive|Slow]
+```
+
+## Resources
+
+- [NTO OpenShift Product Code](https://github.com/openshift/cluster-node-tuning-operator)
+- [Ginkgo v2 Documentation](https://onsi.github.io/ginkgo/)
+- [OpenShift Tests Extension](https://github.com/openshift-eng/openshift-tests-extension)
+- [Test Extensions in Origin](https://github.com/openshift/origin/blob/main/docs/test_extensions.md)
+- [OpenShift CI Requirements](https://docs.google.com/document/d/1cFZj9QdzW8hbHc3H0Nce-2xrJMtpDJrwAse9H7hLiWk/edit?tab=t.0#heading=h.tjtqedd47nnu)
+
+## Debugging
+
+**Investigation Priority** when tests fail:
+1. Check test code in `test/extended/`
+2. Check resource status and conditions via `oc describe`
+3. Refer to product code to understand expected behavior
+
+**For deeper investigation** (when you need to refer to product code):
+1. **Locate NTO OpenShift product code**
+2. **Trace code flow**: Use the product code to understand expected behavior
+3. **Compare implementation**: Check if test expectations match product implementation
+4. **Check recent changes**: Look for recent commits that might have changed the behavior
+
+**Key Namespaces** (OpenShift):
+- `openshift-cluster-node-tuning-operator`: NTO operator and tuned pods
+
+**Common Debugging Commands**:
+```bash
+# Check resource status
+oc get tuned -n openshift-cluster-node-tuning-operator
+oc get profile -n openshift-cluster-node-tuning-operator
+
+# Check logs
+oc logs -l name=cluster-node-tuning-operator -n openshift-cluster-node-tuning-operator
+oc logs -l name=tuned -n openshift-cluster-node-tuning-operator
+```
+
+## Notes for AI Agents
+
+### Suggesting Test Locations
+
+When discussing whether a feature needs testing:
+
+**✅ DO**: Provide simple, focused guidance on QE test placement
+- Example: "If you need to write QE tests for this functionality, they should go in `test/extended/specs/`."
+- Keep suggestions within the scope of this AGENTS.md (QE tests only)
+
+**❌ DON'T**:
+- Discuss DEV test locations (e.g., unit tests in product code directories)
+- Explain the difference between QE and DEV tests unless explicitly asked
+- Provide detailed test categorization unless the user is actively writing tests
+
+**Remember**: This AGENTS.md is for QE test code in `test/extended/` only. Product code testing (DEV tests) is outside this scope.
+
+### Critical Points
+
+1. **Test Scope**:
+   - This AGENTS.md applies ONLY to QE migration test code under `test/extended/`
+
+2. **Suite Definitions Source**:
+   - Always check `cmd/cluster-node-tuning-operator-test-ext/main.go` for current suite definitions
+   - Suite qualifiers may change over time
+
+3. **ReleaseGate Label Mechanism**:
+   - Only `ReleaseGate` cases can be used in OpenShift General Jobs
+
+4. **ReleaseGate is Critical**:
+   - Determines if Extended case can be used in OpenShift General Jobs and PR Presubmit Jobs
+   - All cases are executed via `openshift-tests` command
+
+5. **Most Failures are Test Code Issues**:
+   - Always investigate test code first before looking at product code
+   - Refer to Debugging section for investigation priority
+
+### Test Development Guidelines
+
+1. **Component Tag**: Always use `[sig-tuning-node]`
+2. **Utilities**: Use `utils` package
+3. **API Focus**: Test NTO APIs (tuneds.tuned.openshift.io, performanceprofiles.performance.openshift.io)
+4. **Cleanup**: Always use defer for cleanup to ensure resources are removed
+5. **Suite Logic**: Understand the qualifier logic for different test suites
+   - Refer to Test Suite Definitions section for suite hierarchy
+   - Understand which suite your test belongs to based on labels
+
+### Cluster Topologies
+
+**Note**: NTO currently supports only a subset of OpenShift topologies.
+
+**Currently Supported**:
+- **Standard OCP**: Regular OpenShift clusters
+- **SNO (Single Node OpenShift)**: Single-node clusters
+- **HyperShift Hosted**: Hosted control plane clusters
+- **HyperShift Management**: Management clusters for hosted control planes
+
+**NOT Currently Supported**:
+- **MicroShift**: Lightweight OpenShift for edge (not yet supported by NTO)
+
+**Network Connectivity**:
+- **Connected**: Full internet access
+- **Disconnected**: No internet access (air-gapped)
+- **Proxy**: Internet access through proxy
+
+### Common Pitfalls
+
+**Test Code Issues**:
+1. ❌ **Don't** use `o.Expect` inside `wait.Poll` loops (causes panic)
+2. ❌ **Don't** use quotes in test titles (breaks XML parsing)
+3. ❌ **Don't** execute logic in `g.Describe` blocks (only initialization)
+4. ❌ **Don't** add `ReleaseGate` to `[Disruptive]` and `[Slow]` cases
+5. ❌ **Don't** forget cleanup in `g.AfterEach` with defer
+
+### Best Practices
+
+**General Test Practices**:
+1. ✅ **Do** check suite definitions in `cmd/cluster-node-tuning-operator-test-ext/main.go` before adding tests
+2. ✅ **Do** use case ID for naming resources (NOT random strings)
+3. ✅ **Do** add proper test_id (Polarion ID) to all test cases
+4. ✅ **Do** use skip functions for topology-specific tests
+5. ✅ **Do** register defer cleanup BEFORE creating resources
+   - Pattern: `defer resource.Delete(oc)` then `resource.Create(oc)`
+   - Why: Ensures cleanup even if Create partially succeeds then fails
+6. ✅ **Do** test locally with `cluster-node-tuning-operator-test-ext` before submitting PR
+7. ✅ **Do** test with `openshift-tests` to verify suite selection
+8. ✅ **Do** run stability tests (`/payload-job`) for ReleaseGate test cases
+
+### Build and Run
+
+For complete workflow and detailed commands, refer to **[README.md](./README.md)** section "Local Development Workflow" and the **[Quick Reference](#quick-reference)** section above.
+
+**Essential pattern for AI agents**:
+1. Build: `make`
+2. Find test: `_output/cluster-node-tuning-operator-test-ext list -o names | grep <keyword>`
+3. Run locally: `_output/cluster-node-tuning-operator-test-ext run-test "<full test name>"`
+4. Test with openshift-tests: See README.md for environment variables and suite selection
+5. Run stability tests: `/payload-job` for ReleaseGate test cases (see README.md for details)

--- a/test/extended/AGENTS.md
+++ b/test/extended/AGENTS.md
@@ -1,0 +1,331 @@
+# AGENTS.md
+
+This file provides AI agents with comprehensive context about the NTO QE Test Extension project to enable effective test development, debugging, and maintenance.
+
+## Scope and Working Directory
+
+### Applicability
+This AGENTS.md applies to the **NTO QE Test Cases** located at:
+```text
+cluster-node-tuning-operator/test/extended/
+```
+
+**IMPORTANT**: This file is specifically for the **QE migration test code** in the `test/extended/` directory, not for:
+- Product code in the main `cluster-node-tuning-operator` repository
+
+### Required Working Directory
+For this AGENTS.md to be effective, ensure your working directory is set to:
+```bash
+<repo-root>/test/extended/
+```
+
+### Working Directory Verification for AI Agents
+
+**Context Awareness**: This AGENTS.md may be loaded even when not actively working with QE test files (e.g., user briefly left `test/extended/` for another repo path). Apply these guidelines intelligently based on the actual task.
+
+#### When to Apply This AGENTS.md
+
+**ONLY apply this AGENTS.md when the user is working with QE migration test files**, identified by:
+- File paths containing `test/extended/`
+- Tasks explicitly about "NTO QE tests", "QE migration", "test extension", "sig-tuning-node"
+
+**DO NOT apply this AGENTS.md when**:
+- Working with files outside these directories (e.g., e2e tests, product code)
+- User is in a different part of the repository
+- Even if this AGENTS.md was previously loaded
+
+#### Directory Check (Only for QE Test File Operations)
+
+When the user asks to work with QE test files (files under `test/extended/`):
+
+1. **Check current working directory**:
+   ```bash
+   pwd
+   ```
+
+2. **Verify directory alignment**:
+   - Preferred: Current directory should be `test/extended/` or subdirectory
+   - This ensures AGENTS.md context is automatically available
+
+3. **If working directory is not aligned**:
+
+   **Inform (don't block) the user**:
+    ```text
+    💡 Note: Working Directory Suggestion
+
+   You're working with QE test files under test/extended/,
+   but your current directory is elsewhere. For better context and auto-completion:
+
+   Consider running: cd test/extended/
+
+   I can still help you, but setting the working directory correctly
+   ensures I have full access to the test documentation.
+
+   Do you want to continue in the current directory, or should I wait
+   for you to switch?
+   ```
+
+**Important**: This is a suggestion, not a blocker. If the user wants to proceed, assist them normally.
+
+### Path Structure Reference
+```text
+<repo-root>/                                   ← OpenShift downstream product repo
+└── test/                                      ← Test directory root
+    └── extended/                              ← OpenShift Test Extension (OTE) root
+        ├── bindata/                           ← Embedded test data for QE tests
+        ├── specs/                             ← OTE test specifications
+        ├── testdata/                          ← Raw test manifests to be compiled into bindata
+        └── utils/                             ← Test helpers/utilities
+```
+
+## Project Overview
+
+This is a **Quality Engineering (QE) test extension** for Node Tuning Operator (NTO) on OpenShift. It provides end-to-end functional tests that validate NTO features and functionality in real OpenShift clusters.
+
+### Purpose
+- Validate NTO functionality across different OpenShift topologies
+- Ensure NTO works correctly in various cluster configurations (SNO, standard OCP, etc.)
+- Provide regression testing for NTO bug fixes and enhancements
+
+**Note**: NTO currently does NOT support MicroShift topology. Support may be added in future releases.
+
+### Key Characteristics
+- **Framework**: Built on Ginkgo v2 BDD testing framework and OpenShift Tests Extension (OTE)
+- **Test Organization**: Polarion-ID based test case management
+- **Integration**: Extends `openshift-tests-extension` framework
+
+## Test Case Sources and Organization
+
+**Reference**: For OpenShift CI requirements, see [Choosing a Test Suite](https://docs.google.com/document/d/1cFZj9QdzW8hbHc3H0Nce-2xrJMtpDJrwAse9H7hLiWk/edit?tab=t.0#heading=h.tjtqedd47nnu)
+
+## Test Suite Definitions
+
+**IMPORTANT**: Suite definitions are sourced from **[cmd/cluster-node-tuning-operator-test-ext/main.go](../../cmd/cluster-node-tuning-operator-test-ext/main.go)** and may change over time. Always refer to that file for the most current definitions.
+
+For detailed explanations and code examples, see **[README.md](./README.md)** section "Suite Definitions".
+
+## Test Case Migration Guide
+
+For complete migration guidelines including code changes and label requirements, refer to **[README.md](./README.md)** section "Test Case Migration Guide".
+
+## Test Architecture and Patterns
+
+### Test Structure Pattern
+
+For complete test structure examples, refer to existing test files:
+- **Standard tests**: `specs/nto.go`
+- **Key patterns**: Look for `g.Describe`, `g.BeforeEach`, `g.It` blocks. Use `g.AfterEach` only for non-resource hooks (e.g., temp directory cleanup); all resource cleanup must use `g.DeferCleanup`.
+
+**Basic structure**:
+```go
+var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] should", g.Label("conformance"), func() {
+    defer g.GinkgoRecover()
+    var oc = utils.NewCLIWithoutNamespace()
+
+    g.BeforeEach(func() {
+        // ensure NTO operator is installed
+        utils.SkipNoNTO(oc, ntoNamespace)
+        // get IaaS platform
+        platformOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platform}").Output()
+        if err == nil {
+            iaasPlatform = strings.ToLower(platformOutput)
+        }
+        utils.Logf("Cloud provider is: %v", iaasPlatform)
+    })
+
+    g.It("[test_id:37415][OTP]set isolated_cores without affecting default_irq_smp_affinity [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+        // Register cleanup BEFORE creating resources
+        g.DeferCleanup(func(cleanupCtx context.Context) {
+            resource.Delete(oc)
+            utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+        })
+        resource.Create(oc)
+        // Test implementation
+    })
+})
+```
+
+## Local Development Workflow
+
+For complete local development workflow, build instructions, testing procedures, PR submission requirements, and disconnected environment support, refer to **[README.md](./README.md)** section "Local Development Workflow".
+
+**Quick reference**:
+- Build: `make`
+- Find test: `_output/cluster-node-tuning-operator-test-ext list -o names | grep "keyword_from_your_test_name"`
+- Run test: `_output/cluster-node-tuning-operator-test-ext run-test <full test name>`
+- openshift-tests integration: See [README.md](./README.md) for environment variables and suite selection
+
+## Test Automation Code Requirements
+
+For complete code quality guidelines, best practices, logging best practices, and security considerations, refer to **[README.md](./README.md)** section "Test Automation Code Requirements".
+
+**Critical rules for AI agents**:
+- ✅ Use `g.DeferCleanup` for cleanup (BEFORE resource creation): `g.DeferCleanup(resource.Delete, oc)` then `resource.Create(oc)`
+- ✅ Pass `cleanupCtx context.Context` to `DeferCleanup` functions that need a context: `g.DeferCleanup(func(cleanupCtx context.Context) { utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace) })`
+- ❌ Don't use `defer` for test cleanup — use `g.DeferCleanup` instead (Ginkgo provides a fresh context for cleanup, avoiding cancelled-context issues)
+- ❌ Don't use `o.Expect` inside `wait.Poll` loops (use `if err != nil { return false, err }`)
+- ❌ Don't execute logic in `g.Describe` blocks (only initialization, move logic to `g.BeforeEach`)
+- ❌ Don't use quotes in test titles (breaks XML parsing)
+- ❌ Don't put large log outputs in error messages (use proper log messages instead of `o.Expect` with large output)
+
+## Key Utilities
+
+For complete utility APIs and usage examples, refer to the source code and existing tests:
+
+### `utils` Package
+**Location**: `utils/` directory (e.g., `utils/cli_wrapper.go`, `utils/nto_util.go`)
+
+**Key functions**:
+- CLI management: `NewCLIWithoutNamespace()`
+- Cluster detection: `IsSNOCluster()`, `IsROSACluster()`
+- Skip functions: `SkipNoNTO()`
+
+## Anti-Patterns to Avoid
+
+For complete anti-patterns with detailed code examples and explanations, refer to **[README.md](./README.md)** section "Test Automation Code Requirements".
+
+**Common mistakes for AI agents to avoid**:
+- ❌ No cleanup: Always use `g.DeferCleanup(resource.Delete, oc)` BEFORE `resource.Create(oc)`
+- ❌ Missing timeouts: Always specify timeout for Wait functions
+- ❌ Hard sleeps: Use Wait functions instead of `time.Sleep()`
+- ❌ `o.Expect` in `wait.Poll`: Use `if err != nil { return false, err }` pattern instead
+
+## Quick Reference
+
+### Test Naming Convention
+```text
+[Jira:Node Tuning Operator][sig-tuning-node] should [test_id:12345][OTP]Description [Parallel|Serial|Disruptive|Slow]
+```
+
+The `g.Describe` block ends with `"should"`, so every `g.It` statement must be a natural continuation describing what the operator should do. For example:
+- `g.It("[test_id:29789][OTP]preserve sysctl values set via /etc/sysctl when reapply_sysctl is true", ...)`
+- Produces: *"Node Tuning Operator should preserve sysctl values set via /etc/sysctl when reapply_sysctl is true"*
+
+## Resources
+
+- [NTO OpenShift Product Code](https://github.com/openshift/cluster-node-tuning-operator)
+- [Ginkgo v2 Documentation](https://onsi.github.io/ginkgo/)
+- [OpenShift Tests Extension](https://github.com/openshift-eng/openshift-tests-extension)
+- [Test Extensions in Origin](https://github.com/openshift/origin/blob/main/docs/test_extensions.md)
+- [OpenShift CI Requirements](https://docs.google.com/document/d/1cFZj9QdzW8hbHc3H0Nce-2xrJMtpDJrwAse9H7hLiWk/edit?tab=t.0#heading=h.tjtqedd47nnu)
+
+## Debugging
+
+**Investigation Priority** when tests fail:
+1. Check test code in `test/extended/`
+2. Check resource status and conditions via `oc describe`
+3. Refer to product code to understand expected behavior
+
+**For deeper investigation** (when you need to refer to product code):
+1. **Locate NTO OpenShift product code**
+2. **Trace code flow**: Use the product code to understand expected behavior
+3. **Compare implementation**: Check if test expectations match product implementation
+4. **Check recent changes**: Look for recent commits that might have changed the behavior
+
+**Key Namespaces** (OpenShift):
+- `openshift-cluster-node-tuning-operator`: NTO operator and tuned pods
+
+**Common Debugging Commands**:
+```bash
+# Check resource status
+oc get tuned -n openshift-cluster-node-tuning-operator
+oc get profile -n openshift-cluster-node-tuning-operator
+
+# Check logs
+oc logs -l name=cluster-node-tuning-operator -n openshift-cluster-node-tuning-operator
+oc logs -l name=tuned -n openshift-cluster-node-tuning-operator
+```
+
+## Notes for AI Agents
+
+### Suggesting Test Locations
+
+When discussing whether a feature needs testing:
+
+**✅ DO**: Provide simple, focused guidance on QE test placement
+- Example: "If you need to write QE tests for this functionality, they should go in `test/extended/specs/`."
+- Keep suggestions within the scope of this AGENTS.md (QE tests only)
+
+**❌ DON'T**:
+- Discuss DEV test locations (e.g., unit tests in product code directories)
+- Explain the difference between QE and DEV tests unless explicitly asked
+- Provide detailed test categorization unless the user is actively writing tests
+
+**Remember**: This AGENTS.md is for QE test code in `test/extended/` only. Product code testing (DEV tests) is outside this scope.
+
+### Critical Points
+
+1. **Test Scope**:
+   - This AGENTS.md applies ONLY to QE migration test code under `test/extended/`
+
+2. **Suite Definitions Source**:
+   - Always check `cmd/cluster-node-tuning-operator-test-ext/main.go` for current suite definitions
+   - Suite qualifiers may change over time
+
+3. **Most Failures are Test Code Issues**:
+   - Always investigate test code first before looking at product code
+   - Refer to Debugging section for investigation priority
+
+### Test Development Guidelines
+
+1. **Component Tag**: Always use `[sig-tuning-node]`
+2. **`g.It` Statement Naming**: The `g.It` statement must be a grammatically correct continuation of the `g.Describe` block. The Describe block ends with `"should"`, so the `g.It` text should read naturally after it. For example:
+   - `g.Describe("... should", ...)` with `g.It("preserve sysctl values when reapply_sysctl is true", ...)`
+   - Produces the test name: *"Node Tuning Operator should preserve sysctl values when reapply_sysctl is true"*
+   - Write clear, concise descriptions that state what the operator **does** or **should do**, not a vague label like "Test NTO for X"
+3. **Utilities**: Use `utils` package
+4. **API Focus**: Test NTO APIs (tuneds.tuned.openshift.io, performanceprofiles.performance.openshift.io)
+5. **Cleanup**: Always use `g.DeferCleanup` for cleanup to ensure resources are removed with a fresh context
+6. **Suite Logic**: Understand the qualifier logic for different test suites
+   - Refer to Test Suite Definitions section for suite hierarchy
+   - Understand which suite your test belongs to based on labels
+
+### Cluster Topologies
+
+**Note**: NTO currently supports only a subset of OpenShift topologies.
+
+**Currently Supported**:
+- **Standard OCP**: Regular OpenShift clusters
+- **SNO (Single Node OpenShift)**: Single-node clusters
+- **HyperShift Hosted**: Hosted control plane clusters
+- **HyperShift Management**: Management clusters for hosted control planes
+
+**NOT Currently Supported**:
+- **MicroShift**: Lightweight OpenShift for edge (not yet supported by NTO)
+
+**Network Connectivity**:
+- **Connected**: Full internet access
+- **Disconnected**: No internet access (air-gapped)
+- **Proxy**: Internet access through proxy
+
+### Common Pitfalls
+
+**Test Code Issues**:
+1. ❌ **Don't** use `o.Expect` inside `wait.Poll` loops (causes panic)
+2. ❌ **Don't** use quotes in test titles (breaks XML parsing)
+3. ❌ **Don't** execute logic in `g.Describe` blocks (only initialization)
+4. ❌ **Don't** forget cleanup — use `g.DeferCleanup` for resource cleanup (BEFORE resource creation). Reserve `g.AfterEach` for non-resource hooks only (e.g., temp directory cleanup), never for cluster resource cleanup.
+
+### Best Practices
+
+**General Test Practices**:
+1. ✅ **Do** check suite definitions in `cmd/cluster-node-tuning-operator-test-ext/main.go` before adding tests
+2. ✅ **Do** add proper test_id (Polarion ID) to all test cases
+3. ✅ **Do** use skip functions for topology-specific tests
+4. ✅ **Do** register `g.DeferCleanup` BEFORE creating resources
+   - Pattern: `g.DeferCleanup(resource.Delete, oc)` then `resource.Create(oc)`
+   - Why: Ginkgo provides a fresh `cleanupCtx` for cleanup, avoiding cancelled-context issues from the test's context
+5. ✅ **Do** test locally with `cluster-node-tuning-operator-test-ext` before submitting PR
+6. ✅ **Do** test with `openshift-tests` to verify suite selection
+7. ✅ **Do** run stability tests (`/payload-job`) for test cases, especially non-Informing ones
+
+### Build and Run
+
+For complete workflow and detailed commands, refer to **[README.md](./README.md)** section "Local Development Workflow" and the **[Quick Reference](#quick-reference)** section above.
+
+**Essential pattern for AI agents**:
+1. Build: `make`
+2. Find test: `_output/cluster-node-tuning-operator-test-ext list -o names | grep <keyword>`
+3. Run locally: `_output/cluster-node-tuning-operator-test-ext run-test "<full test name>"`
+4. Test with openshift-tests: See README.md for environment variables and suite selection
+5. Run stability tests: `/payload-job` for test cases (see README.md for details)

--- a/test/extended/CLAUDE.md
+++ b/test/extended/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/test/extended/CLAUDE.md
+++ b/test/extended/CLAUDE.md
@@ -1,0 +1,1 @@
+IMPORTANT: Ensure you’ve thoroughly reviewed the AGENTS.md file before beginning any work.

--- a/test/extended/README.md
+++ b/test/extended/README.md
@@ -1,0 +1,266 @@
+# NTO QE Test Extension
+
+> **For AI Agents**: This directory contains comprehensive documentation for AI coding assistants.
+> Please read [AGENTS.md](./AGENTS.md) for detailed context about the NTO QE test framework,
+> migration guidelines, suite definitions, and best practices.
+>
+> **Using Claude Code**: If you are using Claude Code as your AI coding assistant:
+> 1. Start Claude Code from `test/extended/` directory
+> 2. On first launch from a subdirectory, Claude Code will prompt you to load the parent AGENTS.md - select **Yes** (subsequent launches will auto-load)
+> 3. If starting from `test/extended/` itself, AGENTS.md is automatically loaded
+> 4. Use `/memory` to verify AGENTS.md is loaded and view its content
+>
+> This ensures Claude Code has access to test framework architecture, migration guidelines,
+> suite definitions, and code quality standards.
+
+## Implementation Strategy
+
+### Test Case Organization
+
+1. If the author believes a case meets OpenShift CI requirements, add the `ReleaseGate` label:
+   ```go
+   g.It("xxxxxx", g.Label("ReleaseGate"), func() {
+   ```
+   - This makes the case equivalent to origin cases for openshift-tests
+   - For the cases with `ReleaseGate` that need `Informing`, add:
+     ```go
+     import oteg "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
+     g.It("xxxxxx", g.Label("ReleaseGate"), oteg.Informing(), func() {
+     ```
+
+## Suite Definitions
+
+### Suites for openshift-tests and PR presubmit jobs:
+
+#### Parallel Suite
+```go
+	ext.AddSuite(e.Suite{
+		Name:    "openshift/cluster-node-tuning-operator/conformance/parallel",
+		Parents: []string{"openshift/conformance/parallel"},
+		Qualifiers: []string{
+			`(labels.exists(l, l=="ReleaseGate")) &&
+			!(name.contains("[Serial]") || name.contains("[Slow]") || name.contains("[Disruptive]"))`,
+		},
+	})
+```
+
+#### Serial Suite
+```go
+	ext.AddSuite(e.Suite{
+		Name:    "openshift/cluster-node-tuning-operator/conformance/serial",
+		Parents: []string{"openshift/conformance/serial"},
+		Qualifiers: []string{
+			`(labels.exists(l, l=="ReleaseGate")) &&
+			name.contains("[Serial]") && !name.contains("[Disruptive]")`,
+			// refer to https://github.com/openshift/origin/blob/main/pkg/testsuites/standard_suites.go
+		},
+	})
+```
+
+#### Disruptive Suite
+```go
+	ext.AddSuite(e.Suite{
+		Name:    "openshift/cluster-node-tuning-operator/disruptive",
+		Parents: []string{"openshift/disruptive-longrunning"},
+		Qualifiers: []string{
+			`name.contains("[Disruptive]")`,
+		},
+	})
+```
+
+#### Slow Suite
+```go
+	ext.AddSuite(e.Suite{
+		Name:    "openshift/cluster-node-tuning-operator/optional/slow",
+		Parents: []string{"openshift/optional/slow"},
+		Qualifiers: []string{
+			`name.contains("[Slow]") && !name.contains("[Disruptive]")`,
+		},
+	})
+```
+
+#### All Suite
+```go
+	ext.AddSuite(e.Suite{
+		Name: "openshift/cluster-node-tuning-operator/all",
+		Qualifiers: []string{
+		},
+	})
+```
+
+## Test Case Migration Guide
+
+**Required For all QE cases**:
+- Do not use `&|!,()/` in case title
+- Do NOT remove the test_id number from the `original-name` label. The test_id in `g.Label("original-name:...")` must include the case ID number.
+  Case ID is a 5 digit number between `-` symbols.
+  - ✅ **Correct**: `g.Label("[OTP][Disruptive][test_id:37415] Allow setting isolated_cores without touching the default_irq_affinity")`
+  - ❌ **Wrong**: `g.Label("[OTP][Disruptive] Allow setting isolated_cores without touching the default_irq_affinity")` (missing case ID)
+
+### A. Code Changes for Migrated Cases
+
+All migrated test case code needs the following changes to run in the new test framework:
+
+1. Change `compat_otp.By()` to `g.By()`
+2. Change `compat_otp.XYZ()` to `utils.XYZ()`, where `XYZ` are such as `IsSNOCluster`
+3. Adjust functions missing in the `utils` package from the `compat_otp` package
+4. Change `ntoResource` to `NtoResource` and export its fields
+5. Change `e2e.Logf()` to `utils.Logf()`
+6. When using `oc.AsAdmin().WithoutNamespace()`, always use `-n` with the appropriate namespace either from the resource being created itself or NTO namespace.
+   This will prevent issues in the CI when temporary OTE namespaces no longer exist.
+7. Change the comments missing a space after `//`:
+  - ✅ **Correct**: // test requires NTO to be installed
+  - ❌ **Wrong**: //test requires NTO to be installed
+
+
+### B. Label Requirements for Migrated and New Cases
+
+#### Required Labels
+1. **Component annotation**: Add `[sig-tuning-node]` in case title
+2. **Jira Component**: Add `[Jira:Node Tuning Operator]` in case title
+3. **OpenShift CI compatibility**: If you believe the case meets OpenShift CI requirements, add `ReleaseGate` label to Ginkgo
+4. **Required For Migrated case from test-private**: Add `[OTP]` in case title
+
+#### Optional Labels in Migration/New test cases' title
+1. **Author**: Deprecated, remove it.
+2. **ConnectedOnly**: Add `[Skipped:Disconnected]` in title
+3. **DisconnectedOnly**: Add `[Skipped:Connected][Skipped:Proxy]` in title
+4. **Case ID**: change it to `[test_id:xxxxxx]` format, and remove the old one from the case title. Such as `-37415-` strings.
+   - **IMPORTANT**: The test_id number should only appear ONCE in the test title - at the beginning as `[test_id:xxxxx]`. Do NOT repeat the number anywhere else in the title.
+   - **IMPORTANT**: Do NOT add `-` between two consecutive square brackets. Adjacent tags should be written directly together.
+   - ✅ **Correct**: `[test_id:12345][OTP][Skipped:Disconnected]Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]`
+   - ❌ **Wrong**: `[test_id:12345][OTP]-[Skipped:Disconnected]Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]` (dash between brackets)
+   - ❌ **Wrong**: `[test_id:12345][OTP][Skipped:Disconnected]12345-Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]` (repeated ID)
+5. **Importance**: Deprecated, remove it. Such as `Critical`, `High`, `Medium` and `Low` strings.
+6. **NonPrerelease**: Deprecated, remove it.
+    - **Longduration**: Change it to `[Slow]` in case title.
+    - **ChkUpg**: Deprecated, remove it. Not supported (openshift-tests upgrade differs from OpenShift QE)
+7.  **VMonly**: Deprecated, and don't migrate the `VMonly` test cases to here.
+8.  **Slow, Serial, Disruptive**: Preserved, but add them in the end of the title as above.
+9.  **CPaasrunOnly, CPaasrunBoth, StagerunOnly, StagerunBoth, ProdrunOnly, ProdrunBoth**: Deprecated, remove them.
+10. **NonHyperShiftHOST**: Use Ginkgo label `g.Label("NonHyperShiftHOST")` or use `IsHypershiftHostedCluster` judgment, then skip
+11. **HyperShiftMGMT**: Deprecated. For cases needing hypershift mgmt execution, use `g.Label("NonHyperShiftHOST")` and `ValidHypershiftAndGetGuestKubeConf` validation
+12. **MicroShiftOnly**: Deprecated. For cases not supporting microshift, use `SkipMicroshift` judgment, then skip
+13. **ROSA**: Deprecated. Three ROSA job types:
+    - `rosa-sts-ovn`: equivalent to OCP
+    - `rosa-sts-hypershift-ovn`: equivalent to hypershift hosted
+    - `rosa-classic-sts`: doesn't use openshift-tests
+14. **ARO**: Deprecated. All ARO jobs based on HCP are equivalent to hypershift hosted (don't actually use openshift-test)
+15. **OSD_CCS**: Deprecated. Only one job type: `osd-ccs-gcp` equivalent to OCP
+16. **Feature Gates**: Handle test cases based on their feature gate requirements:
+
+    **Case 1: Test only runs when feature gate is enabled**
+    - The test should not execute if the feature gate is disabled
+    - Add `[OCPFeatureGate:xxxx]` in `g.It` title (where xxxx is feature gate name)
+    - Or use `IsFeaturegateEnabled` check, then skip if disabled
+    - Remove label/check when feature no longer requires gate
+
+    **Case 2: Test runs with/without feature gate but with different behaviors**
+    - The test executes regardless of feature gate status, but behaves differently
+    - Use `IsFeaturegateEnabled` check to handle different behaviors
+    - Do NOT add `[OCPFeatureGate:xxxx]` label
+    - Remove `IsFeaturegateEnabled` check when feature no longer requires gate
+
+    **Case 3: Test runs with/without feature gate with same behavior**
+    - The test executes the same way regardless of feature gate status
+    - Do NOT use `IsFeaturegateEnabled` check
+    - Do NOT add `[OCPFeatureGate:xxxx]` label
+17. **Exclusive**: change to `Serial`
+
+## Test Automation Code Requirements
+
+Consider these requirements when writing and reviewing code:
+
+### Security Considerations
+- Does the test case generate sensitive information in logs?
+- Does the code contain sensitive information in output or commands?
+
+### Test Isolation
+- Will this test case affect other test executions?
+- Will this test case be affected by other test executions?
+
+### Labeling and Cleanup
+- Are correct labels applied?
+- What changes does this case make to the cluster?
+- Can changes be restored for both normal and abnormal exits?
+- During recovery, are both actions and results correct?
+- Should recovery restore to predetermined or dynamically determined values?
+
+### Logging Best Practices
+- Avoid excessive logs or large error messages
+- Don't put large log outputs in error messages (use proper log messages instead). Don't use `o.Expect` to assert large messages (appears in error message on failure)
+- Avoid logging `oc logs` output directly
+
+### Code Quality
+- Don't modify shared libraries (e.g., Ginkgo) or global settings affecting other tests
+- Don't execute logic code in `g.Describe` except for initing oc, and move to `g.BeforeEach`
+- Don't use single/double quotes in case titles (causes XML parse failures)
+- Avoid `o.Expect` in `wait.Poll`:
+  ```go
+  // Wrong:
+  wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
+		response, err := c.AuthorizationV1().SelfSubjectAccessReviews().Create(context.Background(), review, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred()) // in wait.Poll
+		return response.Status.Allowed == allowed, nil
+	})
+
+  // Correct:
+  wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
+		response, err := c.AuthorizationV1().SelfSubjectAccessReviews().Create(context.Background(), review, metav1.CreateOptions{})
+		if err != nil {
+			return false, err
+		}
+		return response.Status.Allowed == allowed, nil
+	})
+  ```
+
+## Local Development Workflow
+
+### Before Submitting PR
+
+1. **Build and compile**:
+   ```bash
+   make
+   ```
+
+2. **Check test name**:
+   ```bash
+   # List all test names and search for your test using a keyword
+   _output/cluster-node-tuning-operator-test-ext list -o names | grep "keyword_from_your_test_name"
+   ```
+
+3. **Run test locally**:
+   ```bash
+   _output/cluster-node-tuning-operator-test-ext run-test <full test name>
+   ```
+
+4. **Test with openshift-tests**:
+   - Switch to origin repo
+   - Follow [test extensions documentation](https://github.com/openshift/origin/blob/main/docs/test_extensions.md)
+   - Set environment variables:
+     ```bash
+     export OPENSHIFT_TESTS_DISABLE_CACHE=1
+     export EXTENSION_BINARY_OVERRIDE_INCLUDE_TAGS=tests,cluster-node-tuning-operator
+     export EXTENSION_BINARY_OVERRIDE_CLUSTER_NODE_TUNING_OPERATOR=<path to local NTO repo>/_output/cluster-node-tuning-operator-test-ext
+     export EXTENSIONS_PAYLOAD_OVERRIDE=quay.io/openshift-release-dev/ocp-release:4.21.12-x86_64
+     ```
+   - Run appropriate suite based on your test characteristics:
+     ```bash
+     # Choose the suite that matches your test type:
+
+     # For all tests:
+     ./openshift-tests run openshift/cluster-node-tuning-operator/all --monitor watch-namespaces
+     ```
+
+5. **Create PR**
+
+### PR Submission Requirements
+
+#### Pre-submission Checks
+1. Check failed presubmit jobs - verify both your new cases and whether other case failures are caused by your changes
+
+#### Stability Testing
+2. Identify release blocking jobs and run them either using `/payload-job` or `/payload-aggregate`.  For example:
+   ```bash
+   /payload-job periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-gcp-ovn-rt-upgrade
+   ```

--- a/test/extended/README.md
+++ b/test/extended/README.md
@@ -1,0 +1,275 @@
+# NTO QE Test Extension
+
+> **For AI Agents**: This directory contains comprehensive documentation for AI coding assistants.
+> Please read [AGENTS.md](./AGENTS.md) for detailed context about the NTO QE test framework,
+> migration guidelines, suite definitions, and best practices.
+>
+> **Using Claude Code**: If you are using Claude Code as your AI coding assistant:
+> 1. Start Claude Code from `test/extended/` directory
+> 2. On first launch from a subdirectory, Claude Code will prompt you to load the parent AGENTS.md - select **Yes** (subsequent launches will auto-load)
+> 3. If starting from `test/extended/` itself, AGENTS.md is automatically loaded
+> 4. Use `/memory` to verify AGENTS.md is loaded and view its content
+>
+> This ensures Claude Code has access to test framework architecture, migration guidelines,
+> suite definitions, and code quality standards.
+
+## Implementation Strategy
+
+### Test Case Organization
+
+1. If a case does not meet OpenShift CI requirements, add the `Informing` label:
+     ```go
+     import oteg "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
+     g.It("xxxxxx", oteg.Informing(), func() {
+     ```
+     oteg.Informing() attaches the `Lifecycle:Informing` Ginkgo label to the test; it does not change
+     the test's own behavior. The consuming runner (`openshift-tests`, or `run-test`/`run-suite`) treats
+     failures of `Informing` tests as non-blocking: they are reported but do not cause a non-zero exit
+     code or fail the CI job.
+
+## Suite Definitions
+
+### Suites for openshift-tests and PR presubmit jobs:
+
+Both *Parallel* and *Serial* Suites have a conformance parent.  These tests provide test coverage for functionality considered core and critical
+to a functional cluster (i.e. not exotic features/configurations) and which is not overlapping with coverage provided in other conformance tests.
+
+#### Parallel Suite
+
+Parallel tests can run alongside other tests without conflicts.
+
+```go
+	ext.AddSuite(e.Suite{
+		Name:    "openshift/cluster-node-tuning-operator/conformance/parallel",
+		Parents: []string{"openshift/conformance/parallel"},
+		Qualifiers: []string{
+			`!(name.contains("[Serial]") || name.contains("[Slow]") || name.contains("[Disruptive]")) && !name.contains("[Manual]")`,
+		},
+	})
+```
+
+#### Serial Suite
+
+If a test cannot be run in parallel with other tests (e.g. it takes too many resources or restarts nodes), it is labeled [Serial],
+and should be run in serial as part of a separate suite.
+
+```go
+	ext.AddSuite(e.Suite{
+		Name:    "openshift/cluster-node-tuning-operator/conformance/serial",
+		Parents: []string{"openshift/conformance/serial"},
+		Qualifiers: []string{
+			`name.contains("[Serial]") && !name.contains("[Disruptive]") && !name.contains("[Manual]")`,
+			// refer to https://github.com/openshift/origin/blob/main/pkg/testsuites/standard_suites.go
+		},
+	})
+```
+
+#### Disruptive Suite
+
+Disruptive tests cause disruption, e.g. take API servers down, reboot nodes, etc.  Disruptive implies Serial.
+Disruptive tests do not block release payload.
+
+```go
+	ext.AddSuite(e.Suite{
+		Name:    "openshift/cluster-node-tuning-operator/disruptive",
+		Qualifiers: []string{
+			`name.contains("[Disruptive]") && !name.contains("[Manual]")`,
+		},
+	})
+```
+
+#### Slow Suite
+
+If a test takes more than five minutes to run (by itself or in parallel with many other tests), it is labeled [Slow].
+This partition allows us to run almost all of our tests quickly in parallel, without waiting for the stragglers to finish.
+
+```go
+	ext.AddSuite(e.Suite{
+		Name:    "openshift/cluster-node-tuning-operator/optional/slow",
+		Qualifiers: []string{
+			`name.contains("[Slow]") && !name.contains("[Disruptive]") && !name.contains("[Manual]")`,
+		},
+	})
+```
+
+#### All Suite
+```go
+	ext.AddSuite(e.Suite{
+		Name:       "openshift/cluster-node-tuning-operator/all",
+		Qualifiers: []string{`!name.contains("[Manual]")`},
+	})
+```
+
+#### Manual Tests
+
+Tests tagged [Manual] are two-part upgrade tests: the *before upgrading* part is meant to run in the
+pre-upgrade phase and the *after upgrading* part in the post-upgrade phase of an upgrade job.
+The first part intentionally leaves resources (Tuneds, labels, MachineConfigPools, PerformanceProfiles)
+behind until the second part runs, so these tests must never be part of regular (non-upgrade) CI jobs —
+running the parts without the upgrade in between would orphan state and pollute later tests.
+
+They are excluded from all suites (including `all`) and must be run individually by name
+(e.g. `run-test "<test name>"` or `--ginkgo.focus`).
+
+## Test Case Migration Guide
+
+**Required For all QE cases**:
+- Do NOT remove the test_id number from the `original-name` label. The test_id in `g.Label("original-name:...")` must include the case ID number.
+  Case ID is a 5-digit number between `-` symbols.
+  - ✅ **Correct**: `g.Label("[OTP][test_id:37415] Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]")`
+  - ❌ **Wrong**: `g.Label("[OTP] Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]")` (missing case ID)
+
+### A. Code Changes for Migrated Cases
+
+All migrated test case code needs the following changes to run in the new test framework:
+
+1. Change `compat_otp.By()` to `g.By()`
+2. Change `compat_otp.XYZ()` to `utils.XYZ()`, where `XYZ` are such as `IsSNOCluster`
+3. Adjust functions missing in the `utils` package from the `compat_otp` package
+4. Change `ntoResource` to `NtoResource` and export its fields
+5. Do not use "k8s.io/kubernetes/test/e2e/framework".  You'll need to for example change `e2e.Logf()` to `utils.Logf()`
+6. When using `oc.AsAdmin().WithoutNamespace()`, always use `-n` with the appropriate namespace either from the resource being created itself or NTO namespace.
+   This will prevent issues in the CI when temporary OTE namespaces no longer exist.
+7. Change the comments missing a space after `//`:
+  - ✅ **Correct**: // test requires NTO to be installed
+  - ❌ **Wrong**: //test requires NTO to be installed
+
+
+### B. Label Requirements for Migrated and New Cases
+
+#### Required Labels
+1. **Component annotation**: Add `[sig-tuning-node]` in case title
+2. **Jira Component**: Add `[Jira:Node Tuning Operator]` in case title
+3. **Required For Migrated case from test-private**: Add `[OTP]` in case title
+
+#### Optional Labels in Migration/New test cases' title
+1. **Author**: Deprecated, remove it.
+2. **ConnectedOnly**: Add `[Skipped:Disconnected]` in title
+3. **DisconnectedOnly**: Add `[Skipped:Connected][Skipped:Proxy]` in title
+4. **Case ID**: change it to `[test_id:xxxxx]` format, and remove the old one from the case title. Such as `-37415-` strings.
+   - **IMPORTANT**: The test_id number should only appear ONCE in the test title - at the beginning as `[test_id:xxxxx]`. Do NOT repeat the number anywhere else in the title.
+   - **IMPORTANT**: Do NOT add `-` between two consecutive square brackets. Adjacent tags should be written directly together.
+   - ✅ **Correct**: `[test_id:12345][OTP][Skipped:Disconnected]Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]`
+   - ❌ **Wrong**: `[test_id:12345][OTP]-[Skipped:Disconnected]Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]` (dash between brackets)
+   - ❌ **Wrong**: `[test_id:12345][OTP][Skipped:Disconnected]12345-Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]` (repeated ID)
+5. **Importance**: Deprecated, remove it. Such as `Critical`, `High`, `Medium` and `Low` strings.
+6. **NonPrerelease**: Deprecated, remove it.
+    - **Longduration**: Change it to `[Slow]` in case title.
+    - **ChkUpg**: Deprecated, remove it. Not supported (openshift-tests upgrade differs from OpenShift QE)
+7.  **VMonly**: Deprecated, and don't migrate the `VMonly` test cases to here.
+8.  **Slow, Serial, Disruptive**: Preserved, but add them in the end of the title as above.
+9.  **CPaasrunOnly, CPaasrunBoth, StagerunOnly, StagerunBoth, ProdrunOnly, ProdrunBoth**: Deprecated, remove them.
+10. **NonHyperShiftHOST**: Use Ginkgo label `g.Label("NonHyperShiftHOST")` or use `utils.IsHyperShiftHostedCluster` judgment, then skip
+11. **HyperShiftMGMT**: Deprecated. For cases needing hypershift mgmt execution, use `g.Label("NonHyperShiftHOST")` and `ValidHypershiftAndGetGuestKubeConf` validation
+12. **MicroShiftOnly**: Deprecated. For cases not supporting microshift, use `SkipMicroshift` judgment, then skip
+13. **ROSA**: Deprecated. Three ROSA job types:
+    - `rosa-sts-ovn`: equivalent to OCP
+    - `rosa-sts-hypershift-ovn`: equivalent to hypershift hosted
+    - `rosa-classic-sts`: doesn't use openshift-tests
+14. **ARO**: Deprecated. All ARO jobs based on HCP are equivalent to hypershift hosted (don't actually use openshift-test)
+15. **OSD_CCS**: Deprecated. Only one job type: `osd-ccs-gcp` equivalent to OCP
+16. **Exclusive**: change to `Serial`
+
+## Test Automation Code Requirements
+
+Consider these requirements when writing and reviewing code:
+
+### Security Considerations
+- Does the test case generate sensitive information in logs?
+- Does the code contain sensitive information in output or commands?
+
+### Test Isolation
+- Will this test case affect other test executions?
+- Will this test case be affected by other test executions?
+
+### Labeling and Cleanup
+- Are correct labels applied?
+- What changes does this case make to the cluster?
+- All cluster resource cleanup must use `g.DeferCleanup`, registered before the resource is created, so changes are restored on both normal and abnormal test exits. Don't use plain `defer` or `g.AfterEach` for resource cleanup (reserve `g.AfterEach` for non-resource hooks, e.g. temp directory cleanup).
+- Cleanup functions must use or preserve the fresh `cleanupCtx context.Context` that Ginkgo provides to `g.DeferCleanup`, not the (possibly already-cancelled) test context.
+- During recovery, are both actions and results correct?
+- Should recovery restore to predetermined or dynamically determined values?
+
+### Logging Best Practices
+- Avoid excessive logs or large error messages
+- Don't put large log outputs in error messages (use proper log messages instead). Don't use `o.Expect` to assert large messages (appears in error message on failure)
+- Avoid logging `oc logs` output directly
+
+### Code Quality
+- Don't modify shared libraries (e.g., Ginkgo) or global settings affecting other tests
+- Don't execute logic code in `g.Describe` except for initializing `oc`, and move to `g.BeforeEach`
+- Don't use single/double quotes in case titles (causes XML parse failures)
+- Avoid `o.Expect` in `wait.Poll`:
+  ```go
+  // Wrong:
+  wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
+		response, err := c.AuthorizationV1().SelfSubjectAccessReviews().Create(context.Background(), review, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred()) // in wait.Poll
+		return response.Status.Allowed == allowed, nil
+	})
+
+  // Correct:
+  err := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
+		response, err := c.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, review, metav1.CreateOptions{})
+		if err != nil {
+			return false, err
+		}
+		return response.Status.Allowed == allowed, nil
+	})
+  o.Expect(err).NotTo(o.HaveOccurred())
+  ```
+
+## Local Development Workflow
+
+### Before Submitting PR
+
+1. **Build and compile**:
+   ```bash
+   make
+   ```
+
+2. **Check test name**:
+   ```bash
+   # List all test names and search for your test using a keyword
+   _output/cluster-node-tuning-operator-test-ext list -o names | grep "keyword_from_your_test_name"
+   ```
+
+3. **Run test locally**:
+   ```bash
+   _output/cluster-node-tuning-operator-test-ext run-test <full test name>
+   ```
+
+4. **Test with openshift-tests**:
+   - Switch to origin repo
+   - Follow [test extensions documentation](https://github.com/openshift/origin/blob/main/docs/test_extensions.md)
+   - Set environment variables:
+     ```bash
+     export OPENSHIFT_TESTS_DISABLE_CACHE=1
+     export EXTENSION_BINARY_OVERRIDE_INCLUDE_TAGS=tests,cluster-node-tuning-operator
+     export EXTENSION_BINARY_OVERRIDE_CLUSTER_NODE_TUNING_OPERATOR=<path to local NTO repo>/_output/cluster-node-tuning-operator-test-ext
+     export EXTENSIONS_PAYLOAD_OVERRIDE=quay.io/openshift-release-dev/ocp-release:4.21.12-x86_64
+     ```
+   - Run appropriate suite based on your test characteristics:
+     ```bash
+     # Choose the suite that matches your test type:
+
+     # For all tests:
+     ./openshift-tests run openshift/cluster-node-tuning-operator/all --monitor watch-namespaces
+     ```
+
+5. **Create PR**
+
+### PR Submission Requirements
+
+#### Pre-submission Checks
+1. Check failed presubmit jobs - verify both your new cases and whether other case failures are caused by your changes.  For example:
+   ```bash
+   /test e2e-aws-nto-ext
+   ```
+   will run all OTE test cases apart from tests cases tagged by the [Manual] tag.
+
+#### Stability Testing
+2. Identify release-blocking jobs, and run them either using `/payload-job` or `/payload-aggregate`.  For example:
+   ```bash
+   /payload-job periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-gcp-ovn-rt-upgrade
+   ```

--- a/test/extended/specs/helpers.go
+++ b/test/extended/specs/helpers.go
@@ -1,0 +1,43 @@
+// Package-level helpers that depend on the Ginkgo/Gomega test framework.
+//
+// Convention: the test/extended/utils package is intentionally Ginkgo- and
+// Gomega-free so its helpers stay framework-agnostic and unit-testable outside
+// Ginkgo. Any helper that needs test-control flow (e.g. g.Skip) or Gomega
+// assertions (e.g. o.Eventually) belongs HERE, in the specs package, rather
+// than in test/extended/utils. These wrappers are thin shims over the pure
+// predicates/helpers provided by utils (e.g. utils.IsSNOCluster).
+package specs
+
+import (
+	"fmt"
+
+	g "github.com/onsi/ginkgo/v2"
+
+	utils "github.com/openshift/cluster-node-tuning-operator/test/extended/utils"
+)
+
+// SkipNoNTO skips the owning test when the NTO operator is not installed.
+// It lives in the specs package (not utils) so that utils stays Ginkgo/Gomega-free.
+func SkipNoNTO(oc *utils.CLI, namespace string) {
+	installed, err := utils.IsNTOInstalled(oc, namespace)
+	if err != nil {
+		g.Fail(fmt.Sprintf("failed to check if NTO is installed: %v", err))
+	}
+	if !installed {
+		g.Skip("NTO is not installed - skipping test")
+	}
+}
+
+// SkipIsSNO skips the owning test on Single Node OpenShift clusters.
+func SkipIsSNO(oc *utils.CLI) {
+	if utils.IsSNOCluster(oc) {
+		g.Skip("Single Node Cluster - skipping test")
+	}
+}
+
+// SkipIsHyperShiftHostedCluster skips the owning test on HyperShift hosted clusters.
+func SkipIsHyperShiftHostedCluster(oc *utils.CLI) {
+	if utils.IsHyperShiftHostedCluster(oc) {
+		g.Skip("HyperShift Hosted Cluster - skipping test")
+	}
+}

--- a/test/extended/specs/hypernto.go
+++ b/test/extended/specs/hypernto.go
@@ -1,0 +1,114 @@
+package specs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	utils "github.com/openshift/cluster-node-tuning-operator/test/extended/utils"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	oteg "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
+)
+
+var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] should", g.Label("conformance"), func() {
+	defer g.GinkgoRecover()
+
+	const (
+		ntoNamespace = "openshift-cluster-node-tuning-operator"
+	)
+
+	var (
+		oc           = utils.NewCLIWithoutNamespace()
+		iaasPlatform string
+		fx           *ntoFx
+	)
+
+	g.BeforeEach(func() {
+		var err error
+		fx = &ntoFx{}
+		fx.baseDir, err = os.MkdirTemp("", "cluster-node-tuning-operator-test-ext-")
+		if err != nil {
+			g.Fail(fmt.Sprintf("failed to create fixtures temp dir: %v", err))
+		}
+
+		// ensure NTO operator is installed
+		SkipNoNTO(oc, ntoNamespace)
+
+		// get IaaS platform
+		platformOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platform}").Output()
+		if err == nil {
+			iaasPlatform = strings.ToLower(platformOutput)
+		}
+		utils.Logf("cloud provider is: %v", iaasPlatform)
+	})
+
+	g.AfterEach(func() {
+		if fx != nil && fx.baseDir != "" {
+			if err := os.RemoveAll(fx.baseDir); err != nil {
+				utils.Logf("warning: failed to remove fixture temp dir %s: %v", fx.baseDir, err)
+			}
+		}
+	})
+
+	// Consider dropping this test case.  It mostly duplicates HyperShift tests and
+	// setting "vm.dirty_ratio" via sysctl is deprecated now using tuned; [vm] dirty_bytes with % should be used instead.
+	// author: liqcui@redhat.com
+	g.It("[test_id:63223][OTP]tune sysctl and kernel parameters for all nodes in a HyperShift nodepool [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		// This is a ROSA HCP pre-defined case, only check result, ROSA team will create NTO tuned profile when ROSA HCP created, remove Disruptive
+		// Only execute on ROSA hosted cluster
+		isROSA := utils.IsROSAHostedCluster(oc)
+		if !isROSA {
+			g.Skip("It's not ROSA hosted cluster - skipping test")
+		}
+
+		// For ROSA Environment, we are unable to access management cluster, so discussed with ROSA team,
+		// ROSA team create pre-defined configmap and applied to specified nodepool with hardcode profile name.
+		// NTO will only check if all setting applied to the worker node on hosted cluster.
+		g.By("check if the tuned hc-nodepool-vmdratio is created in hosted cluster nodepool")
+		tunedNameList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", "-n", ntoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNameList).NotTo(o.BeEmpty())
+		utils.Logf("The list of tuned profiles is: \n%v", tunedNameList)
+		o.Expect(tunedNameList).To(o.And(o.ContainSubstring("hc-nodepool-vmdratio"),
+			o.ContainSubstring("tuned-hugepages")))
+
+		appliedProfileList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("profiles.tuned.openshift.io", "-n", ntoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(appliedProfileList).NotTo(o.BeEmpty())
+		o.Expect(appliedProfileList).To(o.And(o.ContainSubstring("hc-nodepool-vmdratio"),
+			o.ContainSubstring("openshift-node-hugepages")))
+
+		g.By("get the node name that applied to the profile hc-nodepool-vmdratio")
+		tunedNodeNameOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("profiles.tuned.openshift.io", "-n", ntoNamespace, `-ojsonpath={.items[?(@..status.tunedProfile=="hc-nodepool-vmdratio")].metadata.name}`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNodeNameOutput).NotTo(o.BeEmpty())
+		vmDirtyRatioNodeNames := strings.Fields(tunedNodeNameOutput)
+		o.Expect(vmDirtyRatioNodeNames).NotTo(o.BeEmpty())
+
+		g.By("assert the value of sysctl vm.dirty_ratio, the expected value should be 55")
+		for _, tunedNodeName := range vmDirtyRatioNodeNames {
+			debugNodeStdout, err := utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "sysctl", "vm.dirty_ratio")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			utils.Logf("the value of sysctl vm.dirty_ratio on node %v is: \n%v\n", tunedNodeName, debugNodeStdout)
+			o.Expect(debugNodeStdout).To(o.ContainSubstring("vm.dirty_ratio = 55"))
+		}
+
+		g.By("get the node name that applied to the profile openshift-node-hugepages")
+		tunedNodeNameOutput, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("profiles.tuned.openshift.io", "-n", ntoNamespace, `-ojsonpath={.items[?(@..status.tunedProfile=="openshift-node-hugepages")].metadata.name}`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNodeNameOutput).NotTo(o.BeEmpty())
+		hugepagesNodeNames := strings.Fields(tunedNodeNameOutput)
+		o.Expect(hugepagesNodeNames).NotTo(o.BeEmpty())
+
+		g.By("assert the value of cat /proc/cmdline, the expected value should be hugepagesz=2M hugepages=50")
+		for _, tunedNodeName := range hugepagesNodeNames {
+			debugNodeStdout, err := utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "cat", "/proc/cmdline")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			utils.Logf("the value of /proc/cmdline on node %v is: \n%v\n", tunedNodeName, debugNodeStdout)
+			o.Expect(debugNodeStdout).To(o.ContainSubstring("hugepagesz=2M hugepages=50"))
+		}
+	})
+})

--- a/test/extended/specs/nto.go
+++ b/test/extended/specs/nto.go
@@ -17,7 +17,6 @@ var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] should", g.Labe
 		oc           = utils.NewCLIWithoutNamespace("nto-test")
 		ntoNamespace = "openshift-cluster-node-tuning-operator"
 
-		isNTO         bool
 		iaasPlatform  string
 		tunedNodeName string
 		err           error
@@ -25,13 +24,17 @@ var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] should", g.Labe
 
 	g.BeforeEach(func() {
 		// ensure NTO operator is installed
-		isNTO = utils.IsNTOPodInstalled(oc, ntoNamespace)
+		utils.SkipNoNTO(oc, ntoNamespace)
 		// get IaaS platform
 		platformOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platform}").Output()
 		if err == nil {
 			iaasPlatform = strings.ToLower(platformOutput)
 		}
 		utils.Logf("Cloud provider is: %v", iaasPlatform)
+	})
+
+	g.AfterEach(func() {
+		// Cleanup resources (use defer)
 	})
 
 	// A dummy test that should always pass.  It should land in "openshift/cluster-node-tuning-operator/conformance/parallel" suite.
@@ -54,12 +57,7 @@ var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] should", g.Labe
 		o.Expect(true).To(o.BeTrue())
 	})
 
-	g.It("[test_id:37415][OTP]Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]", g.Label("ReleaseGate"), oteg.Informing(), func() {
-		// test requires NTO to be installed
-		if !isNTO {
-			g.Skip("NTO is not installed - skipping test ...")
-		}
-
+	g.It("[test_id:37415][OTP]Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]", oteg.Informing(), func() {
 		ntoIRQSMPFile := utils.TestdataFixturePath(g.GinkgoT(), "nto", "default-irq-smp-affinity.yaml")
 
 		isSNO := utils.IsSNOCluster(oc)

--- a/test/extended/specs/nto.go
+++ b/test/extended/specs/nto.go
@@ -1,82 +1,761 @@
 package specs
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	utils "github.com/openshift/cluster-node-tuning-operator/test/extended/utils"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	oteg "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+// ntoFx manages per-test temporary fixture files.  Each test gets its own temp
+// directory, created in BeforeEach and removed in AfterEach.  Fixtures are
+// materialized lazily -- only the files a test actually uses are written.
+type ntoFx struct {
+	baseDir string
+}
+
+func (f *ntoFx) file(subdir, name string) string {
+	path, err := utils.TestdataFixturePathBase(f.baseDir, subdir, name)
+	if err != nil {
+		g.Fail(fmt.Sprintf("failed to create fixture file %s/%s: %v", subdir, name, err))
+	}
+	return path
+}
+
+var cloudPlatforms = []string{"aws", "gcp", "azure", "ibmcloud", "alibabacloud"}
 
 var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] should", g.Label("conformance"), func() {
 	defer g.GinkgoRecover()
 
-	var (
-		oc           = utils.NewCLIWithoutNamespace("nto-test")
+	const (
 		ntoNamespace = "openshift-cluster-node-tuning-operator"
+		paoNamespace = "openshift-performance-addon-operator"
+		nginxAlpine  = "quay.io/openshifttest/nginx-alpine@sha256:04f316442d48ba60e3ea0b5a67eb89b0b667abf1c198a3d0056ca748736336a0"
+	)
 
-		isNTO         bool
-		iaasPlatform  string
-		tunedNodeName string
-		err           error
+	var (
+		oc           = utils.NewCLIWithoutNamespace()
+		iaasPlatform string
+		fx           *ntoFx
 	)
 
 	g.BeforeEach(func() {
+		var err error
+		fx = &ntoFx{}
+		fx.baseDir, err = os.MkdirTemp("", "cluster-node-tuning-operator-test-ext-")
+		if err != nil {
+			g.Fail(fmt.Sprintf("failed to create fixtures temp dir: %v", err))
+		}
+
+		// this file should not contain any tests for HyperShift hosted clusters
+		SkipIsHyperShiftHostedCluster(oc)
+
 		// ensure NTO operator is installed
-		isNTO = utils.IsNTOPodInstalled(oc, ntoNamespace)
+		SkipNoNTO(oc, ntoNamespace)
+
 		// get IaaS platform
 		platformOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platform}").Output()
 		if err == nil {
 			iaasPlatform = strings.ToLower(platformOutput)
 		}
-		utils.Logf("Cloud provider is: %v", iaasPlatform)
+		utils.Logf("cloud provider is: %v", iaasPlatform)
+	})
+
+	g.AfterEach(func() {
+		if fx != nil && fx.baseDir != "" {
+			if err := os.RemoveAll(fx.baseDir); err != nil {
+				utils.Logf("warning: failed to remove fixture temp dir %s: %v", fx.baseDir, err)
+			}
+		}
 	})
 
 	// A dummy test that should always pass.  It should land in "openshift/cluster-node-tuning-operator/conformance/parallel" suite.
-	g.It("support passing tests", g.Label("ReleaseGate"), func() {
+	g.It("support passing tests", func() {
 		o.Expect(true).To(o.BeTrue())
 	})
 
 	// A dummy test that should always pass.  It should land in "openshift/cluster-node-tuning-operator/conformance/serial" suite.
-	g.It("support passing tests [Serial]", g.Label("ReleaseGate"), func() {
+	g.It("support passing tests [Serial]", func() {
 		o.Expect(true).To(o.BeTrue())
 	})
 
 	// A dummy test that should always pass.  It should land in "openshift/cluster-node-tuning-operator/disruptive" suite.
-	g.It("support passing tests [Disruptive]", g.Label("ReleaseGate"), func() {
+	g.It("support passing tests [Disruptive]", func() {
 		o.Expect(true).To(o.BeTrue())
 	})
 
 	// A dummy test that should always pass.  It should land in "openshift/cluster-node-tuning-operator/optional/slow" suite.
-	g.It("support passing tests [Slow]", g.Label("ReleaseGate"), func() {
+	g.It("support passing tests [Slow]", func() {
 		o.Expect(true).To(o.BeTrue())
 	})
 
-	g.It("[test_id:37415][OTP]Allow setting isolated_cores without touching the default_irq_affinity [Disruptive]", g.Label("ReleaseGate"), oteg.Informing(), func() {
-		// test requires NTO to be installed
-		if !isNTO {
-			g.Skip("NTO is not installed - skipping test ...")
-		}
+	// author: liqcui@redhat.com
+	g.It("[test_id:29789][OTP]preserve sysctl values set via system sysctl *.conf files when reapply_sysctl is true and allow override when false [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		g.By("pick one worker node and one tuned pod on same node")
+		workerNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		ntoIRQSMPFile := utils.TestdataFixturePath(g.GinkgoT(), "nto", "default-irq-smp-affinity.yaml")
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", workerNodeName, "tuned.openshift.io/override-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ntoNamespace, "tuneds.tuned.openshift.io", "override").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
 
-		isSNO := utils.IsSNOCluster(oc)
-		// Prior to choose worker nodes with machineset
-		if !isSNO {
-			tunedNodeName = utils.ChoseOneWorkerNodeToRunCase(oc, 0)
-		} else {
-			tunedNodeName, err = utils.GetFirstLinuxWorkerNode(oc)
-			o.Expect(tunedNodeName).NotTo(o.BeEmpty())
+		utils.Logf("worker Node: %v", workerNodeName)
+		tunedPodName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-n", ntoNamespace, "--field-selector=spec.nodeName="+workerNodeName, "-l", "openshift-app=tuned", "-o=jsonpath={.items[0].metadata.name}").Output()
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("tuned Pod: %v", tunedPodName)
+
+		g.By("check values set by /etc/sysctl on node and store the values")
+		inotify, _, err := utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, workerNodeName, []string{"-q"}, "cat", "/etc/sysctl.d/inotify.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(inotify).To(o.And(
+			o.ContainSubstring("fs.inotify.max_user_watches"),
+			o.ContainSubstring("fs.inotify.max_user_instances")))
+		maxUserWatchesValue, err := utils.GetMaxUserWatchesValue(inotify)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		maxUserInstancesValue, err := utils.GetMaxUserInstancesValue(inotify)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("fs.inotify.max_user_watches has value of: %v", maxUserWatchesValue)
+		utils.Logf("fs.inotify.max_user_instances has value of: %v", maxUserInstancesValue)
+
+		g.By("mount /etc/sysctl on node")
+		_, err = oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", ntoNamespace, tunedPodName, "--", "mount").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check sysctl kernel.pid_max on node and store the value")
+		kernel, _, err := utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, workerNodeName, []string{"-q"}, "sysctl", "kernel.pid_max")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(kernel).To(o.ContainSubstring("kernel.pid_max"))
+		pidMaxValue, err := utils.GetKernelPidMaxValue(kernel)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("kernel.pid_max has value of: %v", pidMaxValue)
+
+		// tuned can not override parameters set via /etc/sysctl{.conf,.d} when reapply_sysctl=true
+		// The settings in /etc/sysctl.d/inotify.conf as below
+		//      fs.inotify.max_user_watches = 65536     => Try to override to 163840 by tuned, expect the old value 65536
+		//      fs.inotify.max_user_instances = 8192    => Not override by tuned, expect the old value 8192
+		//      kernel.pid_max = 4194304                => Default value is 4194304
+		// The settings in custom tuned profile as below
+		//      fs.inotify.max_user_watches = 163840    => Try to override to 163840 by tuned, expect the old value 65536
+		//      kernel.pid_max = 1048576                => Override by tuned, expect the new value 1048576
+
+		g.By("create new NTO CR with reapply_sysctl=true and label the node")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", workerNodeName, "tuned.openshift.io/override=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		overrideYaml := fx.file("nto", "override.yaml")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", overrideYaml, "-p", "REAPPLY_SYSCTL=true")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new NTO profile was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, workerNodeName, "override")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check value of fs.inotify.max_user_instances on node (set by sysctl, should be the same as before), expected value is 8192")
+		maxUserInstanceCheck, _, err := utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, workerNodeName, []string{"-q"}, "sysctl", "fs.inotify.max_user_instances")
+		utils.Logf("fs.inotify.max_user_instances has value of: %v", maxUserInstanceCheck)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(maxUserInstanceCheck).To(o.ContainSubstring("fs.inotify.max_user_instances = " + maxUserInstancesValue))
+
+		g.By("check value of fs.inotify.max_user_watches on node (set by sysctl, should be the same as before), expected value is 65536")
+		maxUserWatchesCheck, _, err := utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, workerNodeName, []string{"-q"}, "sysctl", "fs.inotify.max_user_watches")
+		utils.Logf("fs.inotify.max_user_watches has value of: %v", maxUserWatchesCheck)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(maxUserWatchesCheck).To(o.ContainSubstring("fs.inotify.max_user_watches = " + maxUserWatchesValue))
+
+		g.By("check value of kernel.pid_max on node (set by override tuned, should be the same value of override custom profile), expected value is 1048576")
+		pidMaxCheck, _, err := utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, workerNodeName, []string{"-q"}, "sysctl", "kernel.pid_max")
+		utils.Logf("kernel.pid_max has value of: %v", pidMaxCheck)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(pidMaxCheck).To(o.ContainSubstring("kernel.pid_max = 1048576"))
+
+		// tuned can override parameters set via /etc/sysctl{.conf,.d} when reapply_sysctl=false
+		// The settings in /etc/sysctl.d/inotify.conf as below
+		//     fs.inotify.max_user_watches = 65536     => Try to override to 163840 by tuned, expect the old value 163840
+		//     fs.inotify.max_user_instances = 8192    => Not override by tuned, expect the old value 8192
+		//     kernel.pid_max = 4194304                => Default value is 4194304
+		// The settings in custom tuned profile as below
+		//     fs.inotify.max_user_watches = 163840    => Try to override to 163840 by tuned, expect the old value 163840
+		//     kernel.pid_max = 1048576                => Override by tuned, expect the new value 1048576
+
+		g.By("create new CR with reapply_sysctl=false")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", overrideYaml, "-p", "REAPPLY_SYSCTL=false")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check value of fs.inotify.max_user_instances on node (set by sysctl, should be the same as before), expected value is 8192")
+		maxUserInstanceCheck, _, err = utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, workerNodeName, []string{"-q"}, "sysctl", "fs.inotify.max_user_instances")
+		utils.Logf("fs.inotify.max_user_instances has value of: %v", maxUserInstanceCheck)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(maxUserInstanceCheck).To(o.ContainSubstring("fs.inotify.max_user_instances = " + maxUserInstancesValue))
+
+		g.By("check value of fs.inotify.max_user_watches on node (set by sysctl, should be the same value of override custom profile), expected value is 163840")
+		maxUserWatchesCheck, _, err = utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, workerNodeName, []string{"-q"}, "sysctl", "fs.inotify.max_user_watches")
+		utils.Logf("fs.inotify.max_user_watches has value of: %v", maxUserWatchesCheck)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(maxUserWatchesCheck).To(o.ContainSubstring("fs.inotify.max_user_watches = 163840"))
+
+		g.By("check value of kernel.pid_max on node (set by override tuned, should be the same value of override custom profile), expected value is 1048576")
+		pidMaxCheck, _, err = utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, workerNodeName, []string{"-q"}, "sysctl", "kernel.pid_max")
+		utils.Logf("kernel.pid_max has value of: %v", pidMaxCheck)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(pidMaxCheck).To(o.ContainSubstring("kernel.pid_max = 1048576"))
+	})
+
+	// author: nweinber@redhat.com
+	g.It("[test_id:33237][OTP]support operatorapi Managed and Unmanaged states [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var profileCheck string
+
+		masterNodeName, err := utils.GetFirstMasterNodeName(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defaultMasterProfileName, err := utils.GetDefaultProfileNameOnMaster(oc, masterNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/elasticsearch-").Execute()
+			_ = utils.PatchTunedState(oc, ntoNamespace, "default", "Managed")
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ntoNamespace, "tuned", "nf-conntrack-max", "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		isSNOOrCompact := utils.IsSNOOrCompact(oc)
+
+		g.By("patch default tuned to 'Unmanaged'")
+		err = utils.PatchTunedState(oc, ntoNamespace, "default", "Unmanaged")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		state, err := utils.GetTunedState(oc, ntoNamespace, "default")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(state).To(o.Equal("Unmanaged"))
+
+		g.By("label the node with tuned.openshift.io/elasticsearch=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/elasticsearch=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("tuned Pod: %v", tunedPodName)
+
+		g.By("create new profile from CR")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "tuned-nf-conntrack-max-node.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("current profile on each node:")
+		stdOut, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("profile Name Per Nodes: %v", stdOut)
+
+		if isSNOOrCompact {
+			profileCheck, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
 			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(profileCheck).To(o.Equal(defaultMasterProfileName))
+		} else {
+			profileCheck, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(profileCheck).To(o.Equal("openshift-node"))
 		}
 
-		defer func() {
-			if err := oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/default-irq-smp-affinity-").Execute(); err != nil {
-				utils.Logf("Warning: failed to remove label: %v", err)
+		nodeList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "kubernetes.io/os=linux", "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		nodes := strings.Fields(nodeList)
+
+		for _, node := range nodes {
+			output, _, err := utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, node, nil, "sysctl", "net.netfilter.nf_conntrack_max")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(output).To(o.ContainSubstring("net.netfilter.nf_conntrack_max = 1048576"))
+		}
+
+		g.By("remove custom profile and patch default tuned back to Managed")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ntoNamespace, "tuned", "nf-conntrack-max").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.PatchTunedState(oc, ntoNamespace, "default", "Managed")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		state, err = utils.GetTunedState(oc, ntoNamespace, "default")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(state).To(o.Equal("Managed"))
+
+		g.By("label the node with tuned.openshift.io/elasticsearch=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/elasticsearch=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedPodName, err = utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("tuned Pod: %v", tunedPodName)
+
+		g.By("create new profile from CR")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "tuned-nf-conntrack-max-node.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("current profile on each node:")
+		stdOut, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("profile Name Per Nodes: %v", stdOut)
+
+		g.By("assert nf-conntrack-max applied to the labeled node")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "nf-conntrack-max")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		profileCheck, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("nf-conntrack-max"))
+
+		g.By("current profile on each node:")
+		stdOut, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("profile Name Per Nodes: %v", stdOut)
+
+		// tuned nodes should have value of 1048578, others should be 1048576
+		for _, node := range nodes {
+			output, _, err := utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, node, nil, "sysctl", "net.netfilter.nf_conntrack_max")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if node == tunedNodeName {
+				o.Expect(output).To(o.ContainSubstring("net.netfilter.nf_conntrack_max = 1048578"))
+			} else {
+				o.Expect(output).To(o.ContainSubstring("net.netfilter.nf_conntrack_max = 1048576"))
 			}
-		}()
+		}
+
+		g.By("change tuned state back to Unmanaged and delete custom tuned")
+		err = utils.PatchTunedState(oc, ntoNamespace, "default", "Unmanaged")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		state, err = utils.GetTunedState(oc, ntoNamespace, "default")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(state).To(o.Equal("Unmanaged"))
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ntoNamespace, "tuned", "nf-conntrack-max").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		profileCheck, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("nf-conntrack-max"))
+
+		g.By("assert the log contains recommended profile (nf-conntrack-max) matches current configuration")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "20", 180, `'nf-conntrack-max' applied|recommended profile \(nf-conntrack-max\) matches current configuration`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("current profile on each node:")
+		stdOut, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("profile Name Per Nodes: %v", stdOut)
+
+		// tuned nodes should have value of 1048578, others should be 1048576
+		for _, node := range nodes {
+			output, _, err := utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, node, nil, "sysctl", "net.netfilter.nf_conntrack_max")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if node == tunedNodeName {
+				o.Expect(output).To(o.ContainSubstring("net.netfilter.nf_conntrack_max = 1048578"))
+			} else {
+				o.Expect(output).To(o.ContainSubstring("net.netfilter.nf_conntrack_max = 1048576"))
+			}
+		}
+
+		g.By("change tuned state back to Managed")
+		err = utils.PatchTunedState(oc, ntoNamespace, "default", "Managed")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		state, err = utils.GetTunedState(oc, ntoNamespace, "default")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(state).To(o.Equal("Managed"))
+
+		if isSNOOrCompact {
+			err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, defaultMasterProfileName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			profileCheck, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(profileCheck).To(o.Equal(defaultMasterProfileName))
+		} else {
+			err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			profileCheck, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(profileCheck).To(o.Equal("openshift-node"))
+		}
+
+		g.By("current profile on each node:")
+		stdOut, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("profile Name Per Nodes: %v", stdOut)
+
+		for _, node := range nodes {
+			output, _, err := utils.DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, node, nil, "sysctl", "net.netfilter.nf_conntrack_max")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(output).To(o.ContainSubstring("net.netfilter.nf_conntrack_max = 1048576"))
+		}
+	})
+
+	// author: liqcui@redhat.com
+	// [Timeout:30m] applied because this test often exceeds the 15-minute default.
+	g.It("[test_id:36881][OTP]provide machine config for the master machine config pool when a performance profile is applied [Disruptive][Slow][Timeout:30m]", oteg.Informing(), func(ctx context.Context) {
+		isSingleMaster, err := utils.IsSingleMasterCluster(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isSingleMaster {
+			g.Skip("Cluster with a single master - skipping test")
+		}
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ntoNamespace, "tuneds.tuned.openshift.io", "openshift-node-performance-hp-performanceprofile", "--ignore-not-found").Execute()
+			_ = utils.WaitForMCPUpdate(cleanupCtx, oc, "master", 1800)
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("add new tuning profile from CR")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "hp-performanceprofile.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("verify new tuned profile was created")
+		profiles, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", "-n", ntoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profiles).To(o.ContainSubstring("openshift-node-performance-hp-performanceprofile"))
+
+		g.By("get NTO pod name and check logs for priority warning")
+		ntoPodName, err := utils.GetNTOPodName(oc, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("NTO pod name: %v", ntoPodName)
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, ntoPodName, "10", 180, `openshift-node-performance-hp-performanceprofile have the same priority 30.*please use a different priority for your custom profiles`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("patch priority for openshift-node-performance-hp-performanceprofile tuned to 18")
+		err = utils.PatchTunedProfile(oc, ntoNamespace, "openshift-node-performance-hp-performanceprofile", fx.file("nto", "hp-performanceprofile-patch.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		tunedPriority, err := utils.GetTunedPriority(oc, ntoNamespace, "openshift-node-performance-hp-performanceprofile")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPriority).To(o.Equal("18"))
+
+		g.By("check MachineConfig for expected changes")
+		// NTO must generate the master MachineConfig for the master pool with
+		// the kernel arguments derived from the applied profile.
+		err = utils.WaitForMachineConfigWithKernelArg(ctx, oc, "50-nto-master", "default_hugepagesz", "2M", 300)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check MachineConfigPool for expected changes")
+		// Applying the master MachineConfig makes MCO reboot all master nodes
+		// sequentially, so the pool does not fully converge until the last
+		// master reboot is done, which routinely outlives the per-spec
+		// timeout.  Verify only that the pool picked up the new configuration;
+		// the full pool convergence is awaited in the cleanup.
+		err = utils.WaitForMCPUpdateStarted(ctx, oc, "master", 300)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check Nodes for expected changes")
+		masterNodeName, err := utils.WaitForSchedulingDisabledNode(ctx, oc, "node-role.kubernetes.io/control-plane=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("the master node %v is being rebooted", masterNodeName)
+
+		g.By("ensure the settings took effect on the master nodes, only check the first rebooted node")
+		err = utils.WaitForMasterNodeChanges(ctx, oc, masterNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:43173][OTP]affine blacklisted cgroup processes to the default cpuset [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get how many cpus on the specified worker node
+		g.By("get the number of CPU cores on the labeled worker node")
+		nodeCPUCores, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.capacity.cpu}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeCPUCores).NotTo(o.BeEmpty())
+
+		nodeCPUCoresInt, err := strconv.Atoi(nodeCPUCores)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if nodeCPUCoresInt <= 1 {
+			g.Skip("the worker node does not have enough cpus - skipping test")
+		}
+
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.By("remove custom profile (if not already removed) and remove node label")
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "-n", ntoNamespace, "cgroup-scheduler-affinecpuset").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned-scheduler-node-").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the specified linux node with label tuned-scheduler-node")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned-scheduler-node=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// setting cgroup_ps_blacklist=/kubepods\.slice/
+		// the process belonging to /kubepods\.slice/ can consume all cpuset
+		// The expected Cpus_allowed_list in /proc/$PID/status should be 0-N
+		// the process not belonging to /kubepods\.slice/ cannot consume all cpuset
+		// The expected Cpus_allowed_list in /proc/$PID/status should be 0 or 0,2-N
+
+		g.By("create NTO custom tuned profile cgroup-scheduler-affinecpuset")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "cgroup-scheduler-blacklist.yaml"), "-p", "PROFILE_NAME=cgroup-scheduler-affinecpuset", `CGROUP_BLACKLIST=/kubepods\.slice/`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if NTO custom tuned profile cgroup-scheduler-affinecpuset was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "cgroup-scheduler-affinecpuset")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		// The expected Cpus_allowed_list in /proc/$PID/status should be 0-N
+		g.By("verify the cpu allow list in cgroup black list for tuned")
+		result, err := utils.AssertProcessInCgroupSchedulerBlacklist(oc, tunedNodeName, ntoNamespace, "tuned", nodeCPUCoresInt)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result).To(o.Equal(true))
+
+		// The expected Cpus_allowed_list in /proc/$PID/status should be 0 or 0,2-N
+		g.By("verify the cpu allow list in cgroup black list for chronyd")
+		result, err = utils.AssertProcessExcludedFromCgroupScheduler(oc, tunedNodeName, ntoNamespace, "chronyd", nodeCPUCoresInt)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result).To(o.Equal(true))
+	})
+
+	g.It("[test_id:27491][OTP]support custom profiles via node label matching functionality [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		ntoRes := utils.NtoResource{
+			Name:        "user-max-mnt-namespaces",
+			Namespace:   ntoNamespace,
+			Template:    fx.file("nto", "custom-tuned-profiles-node.yaml"),
+			SysctlParam: "user.max_mnt_namespaces",
+			SysctlValue: "142214",
+		}
+
+		masterNodeName, err := utils.GetFirstMasterNodeName(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defaultMasterProfileName, err := utils.GetDefaultProfileNameOnMaster(oc, masterNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/elasticsearch-").Execute()
+			_ = ntoRes.Delete(oc)
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		isSNOOrCompact := utils.IsSNOOrCompact(oc)
+
+		g.By("label the node with tuned.openshift.io/elasticsearch=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/elasticsearch=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Apply new profile that match label tuned.openshift.io/elasticsearch=
+		g.By("create new profile from CR")
+		err = ntoRes.CreateCustomTunedProfile(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new profile user-max-mnt-namespaces applied to labeled node")
+		// Verify if the new profile is applied
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "user-max-mnt-namespaces")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		profileCheck, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("user-max-mnt-namespaces"))
+
+		g.By("assert 'user-max-mnt-namespaces' applied in tuned pod log")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "10", 180, `'user-max-mnt-namespaces' applied|recommended profile \(user-max-mnt-namespaces\) matches current configuration`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("compare the value user.max_mnt_namespaces on node with labeled node, should be 142214")
+		err = utils.CompareSysctlValueOnAllWorkerNodesWithRetry(ctx, oc, tunedNodeName, "user.max_mnt_namespaces", "", "142214")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("delete custom tuned profile user.max_mnt_namespaces")
+		err = ntoRes.Delete(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Check if restore to default profile.
+		if isSNOOrCompact {
+			g.By("the cluster is SNO or Compact Cluster")
+			err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, defaultMasterProfileName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By("assert default profile applied in tuned pod log")
+			err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "10", 180, "'"+defaultMasterProfileName+"' applied|recommended profile \\("+defaultMasterProfileName+"\\) matches current configuration")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			profileCheck, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(profileCheck).To(o.Equal(defaultMasterProfileName))
+		} else {
+			g.By("the cluster is regular OCP Cluster")
+			err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By("assert profile 'openshift-node' applied in tuned pod log")
+			err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "10", 180, `'openshift-node' applied|recommended profile \(openshift-node\) matches current configuration`)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			profileCheck, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(profileCheck).To(o.Equal("openshift-node"))
+		}
+
+		g.By("check all nodes for user.max_mnt_namespaces value, all nodes should be different from 142214")
+		err = utils.CompareSysctlDifferentFromSpecifiedValueByNameWithRetry(ctx, oc, "user.max_mnt_namespaces", "142214")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("[test_id:37125][OTP]enable and disable debug logging for tuned containers [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		ntoRes := utils.NtoResource{
+			Name:        "user-max-net-namespaces",
+			Namespace:   ntoNamespace,
+			Template:    fx.file("nto", "nto-tuned-debug-node.yaml"),
+			SysctlParam: "user.max_net_namespaces",
+			SysctlValue: "101010",
+		}
+
+		var (
+			isEnableDebug bool
+			isDebugInLog  bool
+			tunedPodName  string
+		)
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/elasticsearch-").Execute()
+			_ = ntoRes.Delete(oc)
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the node with tuned.openshift.io/elasticsearch=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/elasticsearch=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedPodName, err = utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Delete tuned pod to reset logs for re-entrancy (run safety)
+		oldPodName := tunedPodName
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("pod", oldPodName, "-n", ntoNamespace, "--ignore-not-found=true").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		pollCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		err = wait.PollUntilContextTimeout(pollCtx, 2*time.Second, 2*time.Minute, false, func(_ context.Context) (bool, error) {
+			newPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+			if err != nil {
+				utils.Logf("failed to get tuned pod name by node %s: %v", tunedNodeName, err)
+				return false, nil
+			}
+			if newPodName != "" && newPodName != oldPodName {
+				tunedPodName = newPodName
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.AssertPodToBeReady(ctx, oc, tunedPodName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify if debug was disabled by default
+		g.By("check node profile debug settings, it should be debug: false")
+		isEnableDebug, err = utils.AssertDebugSettings(oc, tunedNodeName, ntoNamespace, "false")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(isEnableDebug).To(o.Equal(true))
+
+		// Apply new profile that match label tuned.openshift.io/elasticsearch=
+		g.By("create new profile from CR with debug setting is false")
+		err = ntoRes.CreateDebugTunedProfile(oc, false)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify if the new profile is applied
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "user-max-net-namespaces", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		profileCheck, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("user-max-net-namespaces"))
+
+		// Verify nto tuned logs
+		g.By("check NTO tuned pod logs to confirm if user-max-net-namespaces applied")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "10", 180, `'user-max-net-namespaces' applied|recommended profile \(user-max-net-namespaces\) matches current configuration`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// Verify if debug is false by CR setting
+		g.By("check node profile debug settings, it should be debug: false")
+		isEnableDebug, err = utils.AssertDebugSettings(oc, tunedNodeName, ntoNamespace, "false")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(isEnableDebug).To(o.Equal(true))
+
+		// Check if the log contains debug, the expected result should be none
+		g.By("check if tuned pod log contains debug key word, the expected result should be no DEBUG")
+		isDebugInLog, err = utils.AssertPodLogsContain(oc, tunedPodName, ntoNamespace, "DEBUG")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(isDebugInLog).To(o.Equal(false))
+
+		g.By("delete custom profile and will apply a new one")
+		err = ntoRes.Delete(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create new profile from CR with debug setting is true")
+		debugLogFound := utils.StreamPodLogsForKeyword(oc, tunedPodName, ntoNamespace, "DEBUG", 180)
+		g.DeferCleanup(func() {
+			select {
+			case <-debugLogFound:
+			default:
+			}
+		})
+		err = ntoRes.CreateDebugTunedProfile(oc, true)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify if the new profile is applied
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "user-max-net-namespaces", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		profileCheck, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("user-max-net-namespaces"))
+
+		// Verify if debug was enabled by CR setting
+		g.By("check if the debug is true in node profile, the expected result should be true")
+		isEnableDebug, err = utils.AssertDebugSettings(oc, tunedNodeName, ntoNamespace, "true")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(isEnableDebug).To(o.Equal(true))
+
+		// The log should contain 'DEBUG' keyword in the pod logs
+		g.By(fmt.Sprintf("check if tuned pod '%s' log contains debug key word, the log should contain DEBUG", tunedPodName))
+		found := <-debugLogFound
+		o.Expect(found).To(o.BeTrue())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:37415][OTP]set isolated_cores without affecting default_irq_smp_affinity [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		ntoRes1 := utils.NtoResource{
+			Name:        "default-irq-smp-affinity",
+			Namespace:   ntoNamespace,
+			Template:    fx.file("nto", "default-irq-smp-affinity.yaml"),
+			SysctlParam: "#default_irq_smp_affinity",
+			SysctlValue: "1",
+		}
+
+		ntoRes2 := utils.NtoResource{
+			Name:        "default-irq-smp-affinity",
+			Namespace:   ntoNamespace,
+			Template:    fx.file("nto", "default-irq-smp-affinity.yaml"),
+			SysctlParam: "default_irq_smp_affinity",
+			SysctlValue: "1",
+		}
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/default-irq-smp-affinity-").Execute()
+			_ = ntoRes1.Delete(oc)
+			_ = ntoRes2.Delete(oc)
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
 
 		g.By("label the node with default-irq-smp-affinity ")
 		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/default-irq-smp-affinity=", "--overwrite").Execute()
@@ -85,36 +764,30 @@ var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] should", g.Labe
 		g.By("check the default values of /proc/irq/default_smp_affinity on worker nodes")
 
 		// This test case must got the value of default_smp_affinity without warning information
-		defaultSMPAffinity, err := oc.AsAdmin().WithoutNamespace().Run("debug").Args("-n", ntoNamespace, "--quiet=true", "node/"+tunedNodeName, "--", "chroot", "/host", "cat", "/proc/irq/default_smp_affinity").Output()
+		defaultSMPAffinity, err := utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "cat", "/proc/irq/default_smp_affinity")
 		utils.Logf("the default value of /proc/irq/default_smp_affinity without cpu affinity is: %v", defaultSMPAffinity)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(defaultSMPAffinity).NotTo(o.BeEmpty())
 		defaultSMPAffinity = strings.ReplaceAll(defaultSMPAffinity, ",", "")
-		defaultSMPAffinityMask := utils.GetDefaultSMPAffinityBitMaskbyCPUCores(oc, tunedNodeName)
+		defaultSMPAffinityMask, err := utils.GetDefaultSMPAffinityBitMaskByCPUCores(oc, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(defaultSMPAffinity).To(o.ContainSubstring(defaultSMPAffinityMask))
 
 		utils.Logf("the value of /proc/irq/default_smp_affinity: %v", defaultSMPAffinityMask)
-		cpuBitsMask := utils.ConvertCPUBitMaskToByte(defaultSMPAffinityMask)
+		cpuBitsMask, err := utils.ConvertCPUBitMaskToByte(defaultSMPAffinityMask)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(cpuBitsMask).NotTo(o.BeEmpty())
 
-		ntoRes1 := utils.NtoResource{
-			Name:        "default-irq-smp-affinity",
-			Namespace:   ntoNamespace,
-			Template:    ntoIRQSMPFile,
-			Sysctlparm:  "#default_irq_smp_affinity",
-			Sysctlvalue: "1",
-		}
-
-		defer ntoRes1.Delete(oc)
-
 		g.By("create default-irq-smp-affinity profile to enable isolated_cores=1")
-		ntoRes1.CreateIRQSMPAffinityProfileIfNotExist(oc)
+		err = ntoRes1.CreateIRQSMPAffinityProfile(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("check if new NTO profile was applied")
-		ntoRes1.AssertIfTunedProfileApplied(oc, ntoNamespace, tunedNodeName, "default-irq-smp-affinity", "True")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "default-irq-smp-affinity", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("check values of /proc/irq/default_smp_affinity on worker nodes after enabling isolated_cores=1")
-		isolatedcoresSMPAffinity, err := oc.AsAdmin().WithoutNamespace().Run("debug").Args("-n", ntoNamespace, "--quiet=true", "node/"+tunedNodeName, "--", "chroot", "/host", "cat", "/proc/irq/default_smp_affinity").Output()
+		isolatedcoresSMPAffinity, err := utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "cat", "/proc/irq/default_smp_affinity")
 		isolatedcoresSMPAffinity = strings.ReplaceAll(isolatedcoresSMPAffinity, ",", "")
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(isolatedcoresSMPAffinity).NotTo(o.BeEmpty())
@@ -122,42 +795,2757 @@ var _ = g.Describe("[Jira:Node Tuning Operator][sig-tuning-node] should", g.Labe
 
 		g.By("verify if the value of /proc/irq/default_smp_affinity is affected by isolated_cores=1")
 		// Isolate the second cpu cores, the default_smp_affinity should be changed
-		isolatedCPU := utils.ConvertIsolatedCPURange2CPUList("1")
+		isolatedCPU, err := utils.ConvertIsolatedCPURange2CPUList("1")
+		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(isolatedCPU).NotTo(o.BeEmpty())
 
-		newSMPAffinityMask := utils.AssertIsolateCPUCoresAffectedBitMask(cpuBitsMask, isolatedCPU)
-		o.Expect(newSMPAffinityMask).NotTo(o.BeEmpty())
-		o.Expect(isolatedcoresSMPAffinity).To(o.ContainSubstring(newSMPAffinityMask))
+		isMatch, err := utils.AssertIsolateCPUCoresAffectedBitMask(cpuBitsMask, isolatedCPU, isolatedcoresSMPAffinity)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(isMatch).To(o.Equal(true))
 
-		g.By("remove the old profile and create a new one later ...")
-		ntoRes1.Delete(oc)
+		g.By("remove the old profile and create a new one later")
+		err = ntoRes1.Delete(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		ntoRes2 := utils.NtoResource{
-			Name:        "default-irq-smp-affinity",
-			Namespace:   ntoNamespace,
-			Template:    ntoIRQSMPFile,
-			Sysctlparm:  "default_irq_smp_affinity",
-			Sysctlvalue: "1",
-		}
-
-		defer ntoRes2.Delete(oc)
 		g.By("create default-irq-smp-affinity profile to enable default_irq_smp_affinity=1")
-		ntoRes2.CreateIRQSMPAffinityProfileIfNotExist(oc)
+		err = ntoRes2.CreateIRQSMPAffinityProfile(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("check if new NTO profile was applied")
-		ntoRes2.AssertIfTunedProfileApplied(oc, ntoNamespace, tunedNodeName, "default-irq-smp-affinity", "True")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "default-irq-smp-affinity", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("check values of /proc/irq/default_smp_affinity on worker nodes")
 		// We only need to return the value /proc/irq/default_smp_affinity without stdErr
-		IRQSMPAffinity, _, err := utils.DebugNodeRetryWithOptionsAndChrootWithStdErr(oc, tunedNodeName, []string{"--quiet=true", "--to-namespace=" + ntoNamespace}, "cat", "/proc/irq/default_smp_affinity")
+		IRQSMPAffinity, _, err := utils.DebugNodeWithOptionsAndChrootWithStdErr(oc, tunedNodeName, []string{"--quiet=true", "--to-namespace=" + ntoNamespace}, "cat", "/proc/irq/default_smp_affinity")
 		IRQSMPAffinity = strings.ReplaceAll(IRQSMPAffinity, ",", "")
 		o.Expect(IRQSMPAffinity).NotTo(o.BeEmpty())
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// Isolate the second cpu cores, the default_smp_affinity should be changed
 		utils.Logf("the value of default_smp_affinity after setting default_irq_smp_affinity=1 is: %v", IRQSMPAffinity)
-		isMatch := utils.AssertDefaultIRQSMPAffinityAffectedBitMask(cpuBitsMask, isolatedCPU, IRQSMPAffinity)
+		isMatch, err = utils.AssertDefaultIRQSMPAffinityAffectedBitMask(cpuBitsMask, isolatedCPU, IRQSMPAffinity)
+		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(isMatch).To(o.Equal(true))
 	})
 
+	// This test can run in Parallel with other tests and is not Disruptive.
+	// author: liqcui@redhat.com
+	g.It("[test_id:44650][OTP]provide default tuned profiles with correct settings for openshift, openshift-control-plane, and openshift-node", func(ctx context.Context) {
+		// Get the tuned pod name that run on first worker node
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check kernel version of worker nodes")
+		kernelVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.nodeInfo.kernelVersion}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(kernelVersion).NotTo(o.BeEmpty())
+
+		g.By("check default tuned profile list, should contain openshift-control-plane and openshift-node")
+		defaultTunedOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned", "default", "-ojsonpath={.spec.recommend}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(defaultTunedOutput).NotTo(o.BeEmpty())
+		o.Expect(defaultTunedOutput).To(o.And(
+			o.ContainSubstring("openshift-control-plane"),
+			o.ContainSubstring("openshift-node")))
+
+		g.By("check content of tuned file /usr/lib/tuned/openshift/tuned.conf to match default NTO settings")
+		openshiftTunedConf, err := utils.RemoteShPod(oc, ntoNamespace, tunedPodName, "cat", "/usr/lib/tuned/openshift/tuned.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(openshiftTunedConf).NotTo(o.BeEmpty())
+		if strings.Contains(kernelVersion, "el8") || strings.Contains(kernelVersion, "el7") {
+			o.Expect(openshiftTunedConf).To(o.And(
+				o.ContainSubstring("avc_cache_threshold=8192"),
+				o.ContainSubstring("kernel.pid_max=>4194304"),
+				o.ContainSubstring("net.netfilter.nf_conntrack_max=1048576"),
+				o.ContainSubstring("net.ipv4.conf.all.arp_announce=2"),
+				o.ContainSubstring("net.ipv4.neigh.default.gc_thresh1=8192"),
+				o.ContainSubstring("net.ipv4.neigh.default.gc_thresh2=32768"),
+				o.ContainSubstring("net.ipv4.neigh.default.gc_thresh3=65536"),
+				o.ContainSubstring("net.ipv6.neigh.default.gc_thresh1=8192"),
+				o.ContainSubstring("net.ipv6.neigh.default.gc_thresh2=32768"),
+				o.ContainSubstring("net.ipv6.neigh.default.gc_thresh3=65536"),
+				o.ContainSubstring("vm.max_map_count=262144"),
+				o.ContainSubstring("/sys/module/nvme_core/parameters/io_timeout=4294967295"),
+				o.ContainSubstring(`cgroup_ps_blacklist=/kubepods\.slice/`),
+				o.ContainSubstring("runtime=0")))
+		} else {
+			o.Expect(openshiftTunedConf).To(o.And(
+				o.ContainSubstring("avc_cache_threshold=8192"),
+				o.ContainSubstring("nf_conntrack_hashsize=1048576"),
+				o.ContainSubstring("kernel.pid_max=>4194304"),
+				o.ContainSubstring("fs.aio-max-nr=>1048576"),
+				o.ContainSubstring("net.netfilter.nf_conntrack_max=1048576"),
+				o.ContainSubstring("net.ipv4.conf.all.arp_announce=2"),
+				o.ContainSubstring("net.ipv4.neigh.default.gc_thresh1=8192"),
+				o.ContainSubstring("net.ipv4.neigh.default.gc_thresh2=32768"),
+				o.ContainSubstring("net.ipv4.neigh.default.gc_thresh3=65536"),
+				o.ContainSubstring("net.ipv6.neigh.default.gc_thresh1=8192"),
+				o.ContainSubstring("net.ipv6.neigh.default.gc_thresh2=32768"),
+				o.ContainSubstring("net.ipv6.neigh.default.gc_thresh3=65536"),
+				o.ContainSubstring("vm.max_map_count=262144"),
+				o.ContainSubstring("/sys/module/nvme_core/parameters/io_timeout=4294967295"),
+				o.ContainSubstring(`cgroup_ps_blacklist=/kubepods\.slice/`),
+				o.ContainSubstring("runtime=0")))
+		}
+
+		g.By("check content of tuned file /usr/lib/tuned/openshift-control-plane/tuned.conf to match default NTO settings")
+		openshiftControlPlaneTunedConf, err := utils.RemoteShPod(oc, ntoNamespace, tunedPodName, "cat", "/usr/lib/tuned/openshift-control-plane/tuned.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(openshiftControlPlaneTunedConf).NotTo(o.BeEmpty())
+		o.Expect(openshiftControlPlaneTunedConf).To(o.ContainSubstring("include=openshift"))
+
+		if strings.Contains(kernelVersion, "el8") || strings.Contains(kernelVersion, "el7") {
+			o.Expect(openshiftControlPlaneTunedConf).To(o.And(
+				o.ContainSubstring("sched_wakeup_granularity_ns=4000000"),
+				o.ContainSubstring("sched_migration_cost_ns=5000000")))
+		} else {
+			o.Expect(openshiftControlPlaneTunedConf).NotTo(o.ContainSubstring("sched_wakeup_granularity_ns=4000000"))
+			o.Expect(openshiftControlPlaneTunedConf).NotTo(o.ContainSubstring("sched_migration_cost_ns=5000000"))
+		}
+
+		g.By("check content of tuned file /usr/lib/tuned/openshift-node/tuned.conf to match default NTO settings")
+		openshiftNodeTunedConf, err := utils.RemoteShPod(oc, ntoNamespace, tunedPodName, "cat", "/usr/lib/tuned/openshift-node/tuned.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(openshiftNodeTunedConf).To(o.And(
+			o.ContainSubstring("include=openshift"),
+			o.ContainSubstring("net.ipv4.tcp_fastopen=3"),
+			o.ContainSubstring("fs.inotify.max_user_watches=65536"),
+			o.ContainSubstring("fs.inotify.max_user_instances=8192")))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:33238][OTP]support operatorapi Removed state [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		g.By("remove custom profile (if not already removed) and patch default tuned back to Managed")
+
+		ntoRes := utils.NtoResource{
+			Name:        "tuning-pidmax",
+			Namespace:   ntoNamespace,
+			Template:    fx.file("nto", "custom-tuned-profiles-node.yaml"),
+			SysctlParam: "kernel.pid_max",
+			SysctlValue: "182218",
+		}
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Cleanup and switch NTO back to the managed state
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/elasticsearch-").Execute()
+			_ = utils.PatchTunedState(oc, ntoNamespace, "default", "Managed")
+			_ = ntoRes.Delete(oc)
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the node with tuned.openshift.io/elasticsearch=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/elasticsearch=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("the tuned name on node %v is %v", tunedNodeName, tunedPodName)
+
+		// Apply new profile that match label tuned.openshift.io/elasticsearch=
+		g.By("create new profile from CR")
+		err = ntoRes.CreateCustomTunedProfile(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify if the new profile is applied
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "tuning-pidmax", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		profileCheck, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("tuning-pidmax"))
+
+		g.By("check logs, profile changes SHOULD be applied since tuned is MANAGED")
+		logsCheck, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", ntoNamespace, "--tail=9", tunedPodName).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(logsCheck).To(o.ContainSubstring("tuning-pidmax"))
+
+		g.By("compare the value kernel.pid_max on node with labeled node, should be 182218")
+		err = utils.CompareSysctlValueOnAllWorkerNodesWithRetry(ctx, oc, tunedNodeName, "kernel.pid_max", "", "182218")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("patch default tuned to 'Removed'")
+		err = utils.PatchTunedState(oc, ntoNamespace, "default", "Removed")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		state, err := utils.GetTunedState(oc, ntoNamespace, "default")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(state).To(o.Equal("Removed"))
+
+		g.By("check logs, profiles, and nodes (profile changes SHOULD NOT be applied since tuned is REMOVED)")
+
+		g.By("check pod status, all tuned pod should be terminated since tuned is REMOVED")
+		err = utils.WaitForNoPodsAvailableByKind(ctx, oc, "daemonset", "tuned", ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		podCheck, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "pods").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(podCheck).NotTo(o.ContainSubstring("tuned"))
+
+		g.By("check profile status, all node profile should be removed since tuned is REMOVED)")
+		profileCheck, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io", "-o", "template", "--template={{len .items}}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("0"))
+
+		g.By("change tuned state back to managed")
+		err = utils.PatchTunedState(oc, ntoNamespace, "default", "Managed")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		state, err = utils.GetTunedState(oc, ntoNamespace, "default")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(state).To(o.Equal("Managed"))
+
+		g.By("get the tuned pod name")
+		tunedPodName, err = utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check logs, profiles, and nodes (profile changes SHOULD be applied since tuned is MANAGED)")
+		// Verify if the new profile is applied
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "tuning-pidmax", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		profileCheck, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("tuning-pidmax"))
+
+		g.By("check logs, profile changes SHOULD be applied since tuned is MANAGED)")
+		logsCheck, err = oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", ntoNamespace, "--tail=9", tunedPodName).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(logsCheck).To(o.ContainSubstring("tuning-pidmax"))
+
+		g.By("compare the value kernel.pid_max on node with labeled node, should be 182218")
+		err = utils.CompareSysctlValueOnAllWorkerNodesWithRetry(ctx, oc, tunedNodeName, "kernel.pid_max", "", "182218")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:30589][OTP]use machine configs to apply kernel parameters for realtime tuned profiles [Disruptive][Slow]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		tunedNodeName, pool, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		ocpArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.nodeInfo.architecture}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if ocpArch == "ppc64le" {
+			g.Skip("NTO with realtime is not supported on ppc64le, skipping test")
+		}
+
+		initialMachineCount, err := utils.GetPoolUpdatedMachineCount(ctx, oc, pool)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-rt-").Execute()
+			_ = utils.WaitForPoolUpdatedMachineCount(cleanupCtx, oc, pool, initialMachineCount)
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-realtime", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("mcp", "worker-rt", "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("create machine config pool")
+		err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "machine-config-pool.yaml"), "-p", "MCP_NAME=worker-rt")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("label the node with node-role.kubernetes.io/worker-rt=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-rt=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create openshift-realtime profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "realtime.yaml"), "-p", "INCLUDE=openshift-node,realtime")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("assert if machine config pool applied for worker nodes")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker", 600)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-rt", 600)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if openshift-realtime profile was applied")
+		// Verify if the new profile is applied
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-realtime")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		profileCheck, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("openshift-realtime"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("assert if isolcpus was applied in machineconfig")
+		err = utils.AssertTunedAppliedMC(oc, "nto-worker-rt", "isolcpus=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if isolcpus was applied in labeled node")
+		isMatch, err := utils.AssertTunedAppliedToNode(oc, tunedNodeName, "isolcpus=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(isMatch).To(o.Equal(true))
+
+		g.By("delete openshift-realtime tuned in labeled node")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-realtime", "-n", ntoNamespace, "--ignore-not-found").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check Nodes for expected changes")
+		_, err = utils.WaitForSchedulingDisabledNode(ctx, oc, "")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if machine config pool applied for worker nodes")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-rt", 600)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("assert if isolcpus was applied in labeled node")
+		isMatch, err = utils.AssertTunedAppliedToNode(oc, tunedNodeName, "isolcpus=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(isMatch).To(o.Equal(false))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:29804][OTP]update tuned profiles after fixing incorrect custom resource configurations [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		var (
+			tunedNodeName string
+			err           error
+		)
+
+		// Use the last worker node as labeled node
+		// Support 3 master/worker node, no dedicated worker nodes
+		tunedNodeName, _, err = utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		utils.Logf("tunedNodeName is:\n%v", tunedNodeName)
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "ips", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the node with tuned=ips")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned=ips", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create ips-host profile, new tuned should automatically handle duplicate sysctl settings")
+		// Define duplicated parameter and value
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "ips.yaml"), "-p", "SYSCTLPARM1=kernel.pid_max", "SYSCTLVALUE1=1048575", "SYSCTLPARM2=kernel.pid_max", "SYSCTLVALUE2=1048575")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert recommended profile (ips-host) matches current configuration in tuned pod log")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "15", 180, `'ips-host' applied|recommended profile \(ips-host\) matches current configuration`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new custom profile applied to label node")
+		ok, err := utils.AssertNTOCustomProfileStatus(oc, ntoNamespace, tunedNodeName, "ips-host", "True", "False")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(ok).To(o.Equal(true))
+
+		// Only used for debug info
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		// New tuned can automatically de-duplicate value of sysctl, no duplicate error anymore
+		g.By("assert if the duplicate value of sysctl kernel.pid_max takes effect on target node, expected value should be 1048575")
+		err = utils.CompareSpecifiedValueByNameOnLabelNode(ctx, oc, tunedNodeName, "kernel.pid_max", "1048575")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("get default value of fs.mount-max on label node")
+		defaultMaxMapCount, err := utils.GetValueOfSysctlByName(oc, tunedNodeName, "fs.mount-max")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(defaultMaxMapCount).NotTo(o.BeEmpty())
+		utils.Logf("the default value of sysctl fs.mount-max is %v", defaultMaxMapCount)
+
+		// setting an invalid value for ips-host profile
+		g.By("update ips-host profile with invalid value of fs.mount-max = -1")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "ips.yaml"), "-p", "SYSCTLPARM1=fs.mount-max", "SYSCTLVALUE1=-1", "SYSCTLPARM2=kernel.pid_max", "SYSCTLVALUE2=1048575")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert 'ips-host' applied in tuned pod log")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "20", 180, `recommended profile \(ips-host\) matches current configuration|'ips-host' applied`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new custom profile applied to label node")
+		ok, err = utils.AssertNTOCustomProfileStatus(oc, ntoNamespace, tunedNodeName, "ips-host", "True", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(ok).To(o.Equal(true))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		// The invalid value won't impact default value of fs.mount-max
+		g.By("assert if the value of sysctl fs.mount-max still use default value")
+		err = utils.CompareSpecifiedValueByNameOnLabelNode(ctx, oc, tunedNodeName, "fs.mount-max", defaultMaxMapCount)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// setting an new value of fs.mount-max for ips-host profile
+		g.By("update ips-host profile with new value of fs.mount-max = 868686")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "ips.yaml"), "-p", "SYSCTLPARM1=fs.mount-max", "SYSCTLVALUE1=868686", "SYSCTLPARM2=kernel.pid_max", "SYSCTLVALUE2=1048575")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert recommended profile (ips-host) matches current configuration in tuned pod log")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "15", 180, `recommended profile \(ips-host\) matches current configuration|'ips-host' applied`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new custom profile applied to label node")
+		ok, err = utils.AssertNTOCustomProfileStatus(oc, ntoNamespace, tunedNodeName, "ips-host", "True", "False")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(ok).To(o.Equal(true))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		// The invalid value won't impact default value of fs.mount-max
+		g.By("assert if the new value of sysctl fs.mount-max takes effect, expected value is 868686")
+		err = utils.CompareSpecifiedValueByNameOnLabelNode(ctx, oc, tunedNodeName, "fs.mount-max", "868686")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	// [Timeout:30m] applied because this test runs very close to the 15-minute default.
+	g.It("[test_id:39123][OTP]update tuned profiles after changing an included profile [Disruptive][Slow][Timeout:30m]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		workerInitialMachineCount, err := utils.GetPoolUpdatedMachineCount(ctx, oc, "worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedNodeName, pool, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-cnf-").Execute()
+			_ = utils.WaitForPoolUpdatedMachineCount(cleanupCtx, oc, pool, workerInitialMachineCount)
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "performance-patch", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("PerformanceProfile", "performance", "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("mcp", "worker-cnf", "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("label the node with node-role.kubernetes.io/worker-cnf=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-cnf=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		ocpArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.nodeInfo.architecture}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if (iaasPlatform == "aws" || iaasPlatform == "gcp") && ocpArch == "amd64" {
+			// Only GCP and AWS support realtime-kernel
+			g.By("apply performance profile")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-performanceprofile.yaml"), "-p", "ISENABLED=true")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		} else if ocpArch == "ppc64le" {
+			g.By("apply pao-baseprofile performance profile for ppc64le")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-baseprofile-ppc64le.yaml"), "-p", "ISENABLED=false")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		} else {
+			g.By("apply performance profile")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-performanceprofile.yaml"), "-p", "ISENABLED=false")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		g.By("apply worker-cnf machineconfigpool")
+		err = utils.CreateOperatorResourceByYaml(oc, paoNamespace, fx.file("pao", "pao-workercnf-mcp.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if the MCP worker-cnf has been successfully applied")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-cnf", 900)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new NTO profile openshift-node-performance-performance was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node-performance-performance")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if profile openshift-node-performance-performance applied on nodes")
+		nodeProfileName, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("openshift-node-performance-performance"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if tuned pod logs contains openshift-node-performance-performance on labeled nodes")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "20", 60, "openshift-node-performance-performance")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if the linux kernel parameter as vm.stat_interval = 10")
+		err = utils.CompareSpecifiedValueByNameOnLabelNode(ctx, oc, tunedNodeName, "vm.stat_interval", "10")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("apply performance-patch profile")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("pao", "pao-performance-patch.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if the MCP worker-cnf is ready after node rebooted")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-cnf", 750)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if the active profile is applied on nodes")
+		nodeProfileName, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("openshift-node-performance-performance"))
+
+		g.By("check if tuned pod logs contains Cannot find profile 'openshift-node-performance-example-performanceprofile' on labeled nodes")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "30", 60, "Cannot find profile 'openshift-node-performance-example-performanceprofile'")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if the linux kernel parameter as vm.stat_interval = 10")
+		err = utils.CompareSpecifiedValueByNameOnLabelNode(ctx, oc, tunedNodeName, "vm.stat_interval", "10")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("patch include to include=openshift-node-performance-performance")
+		err = utils.PatchTunedProfile(oc, ntoNamespace, "performance-patch", fx.file("pao", "pao-performance-fixpatch.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if the MCP worker-cnf is ready after node rebooted")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-cnf", 600)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new NTO profile performance-patch was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "performance-patch")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if contains 'performance-patch' applied in tuned pod logs on labeled nodes")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "30", 60, `recommended profile \(performance-patch\) matches current configuration|'performance-patch' applied`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if the linux kernel parameter as vm.stat_interval = 10")
+		err = utils.CompareSpecifiedValueByNameOnLabelNode(ctx, oc, tunedNodeName, "vm.stat_interval", "10")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:45686][OTP]create and apply a tuned profile after the referenced performance profile is created [Disruptive][Slow]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		workerInitialMachineCount, err := utils.GetPoolUpdatedMachineCount(ctx, oc, "worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedNodeName, pool, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-optimize-").Execute()
+			_ = utils.WaitForPoolUpdatedMachineCount(cleanupCtx, oc, pool, workerInitialMachineCount)
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "include-performance-profile", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("PerformanceProfile", "optimize", "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("mcp", "worker-optimize", "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Get the tuned pod name in the labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("label the node with node-role.kubernetes.io/worker-optimize=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-optimize=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("apply worker-optimize machineconfigpool")
+		err = utils.CreateOperatorResourceByYaml(oc, paoNamespace, fx.file("pao", "pao-workeroptimize-mcp.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if the MCP has been successfully applied")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-optimize", 600)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("apply include-performance-profile tuned profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-include-performance-profile.yaml"), "-p", "ROLENAME=worker-optimize")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("assert if the mcp is ready after server has been successfully rebooted")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-optimize", 600)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if the active profile is applied on nodes")
+		nodeProfileName, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("openshift-node"))
+
+		g.By("check if tuned pod logs contains Cannot find profile 'openshift-node-performance-optimize' on labeled nodes")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "10", 60, "Cannot find profile 'openshift-node-performance-optimize'")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("apply performance optimize profile")
+		err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-performance-optimize.yaml"), "-p", "ROLENAME=worker-optimize")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("assert if the mcp is ready after server has been successfully rebooted")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-optimize", 600)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check performance profile tuned profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).To(o.ContainSubstring("openshift-node-performance-optimize"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if new NTO profile performance-patch was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "include-performance-profile")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if the active profile is applied on nodes")
+		nodeProfileName, err = utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("include-performance-profile"))
+
+		g.By("check if contains 'include-performance-profile' applied in tuned pod logs on labeled nodes")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "20", 60, `'include-performance-profile' applied|recommended profile \(include-performance-profile\) matches current configuration`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// This test can run in Parallel with other tests and is not Disruptive.
+	// author: liqcui@redhat.com
+	g.It("[test_id:36152][OTP]expose metrics and alerts via the NTO metrics endpoint", func(ctx context.Context) {
+		// Get metric information that require ssl auth.
+		sslKey := "/etc/prometheus/secrets/metrics-client-certs/tls.key"
+		sslCrt := "/etc/prometheus/secrets/metrics-client-certs/tls.crt"
+
+		// Get NTO metrics data.
+		g.By("get NTO metrics information without ssl, should be denied access, throw error")
+		metricsOutput, _ := oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", "openshift-monitoring", "sts/prometheus-k8s", "-c", "prometheus", "--", "curl", "-k", "https://node-tuning-operator.openshift-cluster-node-tuning-operator.svc:60000/metrics").Output()
+		o.Expect(metricsOutput).NotTo(o.BeEmpty())
+		o.Expect(metricsOutput).To(o.Or(
+			o.ContainSubstring("bad certificate"),
+			o.ContainSubstring("errno = 104"),
+			o.ContainSubstring("certificate required"),
+			o.ContainSubstring("error:1409445C"),
+			o.ContainSubstring("exit code 56"),
+			o.ContainSubstring("Unauthorized"),
+			o.ContainSubstring("errno = 32")))
+
+		g.By("get NTO metrics information with ssl key and crt, should be access, get the metric information")
+		metricsOutput, metricsError := oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", "openshift-monitoring", "sts/prometheus-k8s", "-c", "prometheus", "--", "curl", "-k", "--key", sslKey, "--cert", sslCrt, "https://node-tuning-operator.openshift-cluster-node-tuning-operator.svc:60000/metrics").Output()
+		o.Expect(metricsOutput).NotTo(o.BeEmpty())
+		o.Expect(metricsError).NotTo(o.HaveOccurred())
+
+		utils.Logf("the metrics information of NTO as below: \n%v", metricsOutput)
+
+		// Assert the key metrics.
+		g.By("check if all metrics exist as expected")
+		o.Expect(metricsOutput).To(o.And(
+			o.ContainSubstring("nto_build_info"),
+			o.ContainSubstring("nto_pod_labels_used_info"),
+			o.ContainSubstring("nto_degraded_info"),
+			o.ContainSubstring("nto_profile_calculated_total")))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:49265][OTP]support automatic rotation of SSL certificates [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		if utils.IsSNOOrCompact(oc) {
+			g.Skip("Single Node or Compact Cluster - skipping test")
+		}
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		utils.Logf("the tuned node name is: \n%v", tunedNodeName)
+
+		// Get NTO operator pod name
+		ntoOperatorPod, err := utils.GetNTOPodName(oc, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("the tuned operator pod name is: \n%v", ntoOperatorPod)
+
+		metricEndpoint, err := utils.GetServiceEndpoint(oc, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("get information about the certificate the metrics server in NTO")
+		var certificateBefore string
+		pollCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		err = wait.PollUntilContextTimeout(pollCtx, 15*time.Second, 180*time.Second, false, func(_ context.Context) (bool, error) {
+			certificateBefore, err = utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "/bin/bash", "-c", "/bin/openssl s_client -connect "+metricEndpoint+" 2>/dev/null </dev/null | /bin/openssl x509")
+			if err != nil {
+				utils.Logf("failed to get certificate from %v: %v, retrying", tunedNodeName, err)
+				return false, nil
+			}
+			return true, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get openssl certificate information after retries")
+		utils.Logf("the certificate of NTO metrics server before rotate as below: \n%v", certificateBefore)
+
+		encodeBase64CertificateBefore := utils.StringToBASE64(certificateBefore)
+
+		// To improve the success rate, execute oc delete secret/node-tuning-operator-tls instead of oc -n openshift-service-ca secret/signing-key
+		// The last one "oc -n openshift-service-ca secret/signing-key" take more time to complete, but need to manually execute once failed.
+		g.By("delete secret/node-tuning-operator-tls to automatically create a new certificate")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ntoNamespace, "secret/node-tuning-operator-tls").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if NTO rotate certificates")
+		err = utils.WaitForNTOCertificateRotation(ctx, oc, ntoNamespace, tunedNodeName, encodeBase64CertificateBefore)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("the certificate extracted from the openssl command should match the first certificate from the tls.crt file in the secret")
+		err = utils.CompareCertificateBetweenOpenSSLandTLSSecret(ctx, oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:49371][OTP]not restart the tuned daemon when profile application takes too long [Disruptive][Slow]", oteg.Informing(), func(ctx context.Context) {
+		// Automatic tuned daemon restart was removed due to timeout in the bug https://issues.redhat.com/browse/OCPBUGS-30647
+
+		// Use the first worker node as labeled node
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "worker-stuck-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-profile-stuck", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the node with worker-stuck=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "worker-stuck=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create openshift-profile-stuck profile")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "worker-stuck-tuned.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check openshift-profile-stuck tuned profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).To(o.ContainSubstring("openshift-profile-stuck"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("assert recommended profile (openshift-profile-stuck) matches current configuration in tuned pod log")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "12", 300, `'openshift-profile-stuck' applied|recommended profile \(openshift-profile-stuck\) matches current configuration`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new NTO profile openshift-profile-stuck was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-profile-stuck")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if the active profile is applied on nodes")
+		nodeProfileName, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("openshift-profile-stuck"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("verify the tuned pod log does not contain [ timeout (120) to apply TuneD profile; restarting TuneD daemon ]")
+		ntoPodLogs, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", ntoNamespace, tunedPodName, "--tail=10").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(ntoPodLogs).NotTo(o.ContainSubstring("timeout (120) to apply TuneD profile; restarting TuneD daemon"))
+
+		g.By("verify the tuned pod log does not contain [ error waiting for tuned: signal: terminated ]")
+		ntoPodLogs, err = oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", ntoNamespace, tunedPodName, "--tail=10").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(ntoPodLogs).NotTo(o.ContainSubstring("error waiting for tuned: signal: terminated"))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:49370][OTP]support hugepages via the bootloader plug-in [Disruptive][Slow]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		tunedNodeName, pool, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		initialMachineCount, err := utils.GetPoolUpdatedMachineCount(ctx, oc, pool)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-hp-").Execute()
+			_ = utils.WaitForPoolUpdatedMachineCount(cleanupCtx, oc, pool, initialMachineCount)
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "hugepages", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("mcp", "worker-hp", "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the node with node-role.kubernetes.io/worker-hp=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-hp=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create hugepages tuned profile")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "hugepage-tuned-boottime.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check hugepages tuned profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).To(o.ContainSubstring("hugepages"))
+
+		g.By("create worker-hp machineconfigpool")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "hugepage-mcp.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if the MCP has been successfully applied")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-hp", 720)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if new NTO profile was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node-hugepages")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if profile openshift-node-hugepages applied on nodes")
+		nodeProfileName, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("openshift-node-hugepages"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check value of allocatable.hugepages-2Mi in labeled node")
+		nodeHugePagesOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.allocatable.hugepages-2Mi}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeHugePagesOutput).To(o.ContainSubstring("100M"))
+
+		g.DeferCleanup(oc.TeardownProject)
+		err = oc.SetupProject()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		ntoTestNS := oc.Namespace()
+
+		// Create a hugepages-app application pod
+		g.By("create a hugepages-app pod to consume hugepage in nto temp namespace")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoTestNS, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "hugepage-100m-pod.yaml"), "-p", "IMAGENAME="+nginxAlpine)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Check if hugepages-app is ready
+		g.By("check if a hugepages-app pod is ready")
+		err = utils.AssertPodToBeReady(ctx, oc, "hugepages-app", ntoTestNS)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check the value of /etc/podinfo/hugepages_2M_request, the value expected is 105")
+		podInfo, err := utils.RemoteShPod(oc, ntoTestNS, "hugepages-app", "cat", "/etc/podinfo/hugepages_2M_request")
+		utils.Logf("PodInfo is: \n%v", podInfo)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(podInfo).To(o.ContainSubstring("105"))
+
+		g.By("check the value of REQUESTS_HUGEPAGES in env on pod")
+		envInfo, err := utils.RemoteShPodWithBash(oc, ntoTestNS, "hugepages-app", "env | grep REQUESTS_HUGEPAGES")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(envInfo).To(o.ContainSubstring("REQUESTS_HUGEPAGES_2Mi=104857600"))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:49439][OTP]start and stop the stalld service via tuned service plug-in [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		// Use the first rhcos worker node as labeled node
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("tunedNodeName is [ %v ]", tunedNodeName)
+
+		if len(tunedNodeName) == 0 {
+			g.Skip("Skip Testing on RHEL worker or windows node")
+		}
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-stalld-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-stalld", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_, _ = utils.DebugNodeWithChroot(oc, tunedNodeName, "/usr/bin/throttlectl", "on")
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("set off for /usr/bin/throttlectl before enable stalld")
+		err = utils.SwitchThrottlectlOnOff(ctx, oc, ntoNamespace, tunedNodeName, "off", 30)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("label the node with node-role.kubernetes.io/worker-stalld=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-stalld=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create openshift-stalld tuned profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "stalld-tuned.yaml"), "-p", "STALLD_STATUS=start,enable")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check openshift-stalld tuned profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).To(o.ContainSubstring("openshift-stalld"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if new NTO profile was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-stalld")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if profile openshift-stalld applied on nodes")
+		nodeProfileName, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("openshift-stalld"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if stalld service is running")
+		stalldStatus, err := utils.DebugNodeWithChroot(oc, tunedNodeName, "systemctl", "status", "stalld")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stalldStatus).To(o.ContainSubstring("active (running)"))
+
+		g.By("apply openshift-stalld with stop,disable tuned profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "stalld-tuned.yaml"), "-p", "STALLD_STATUS=stop,disable")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new NTO profile was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-stalld")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if stalld service is inactive and stopped")
+		stalldStatus, _ = utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"-q", "--to-namespace", ntoNamespace}, "systemctl", "status", "stalld")
+		o.Expect(stalldStatus).NotTo(o.BeEmpty())
+		o.Expect(stalldStatus).To(o.ContainSubstring("inactive (dead)"))
+
+		g.By("apply openshift-stalld with start,enable tuned profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "stalld-tuned.yaml"), "-p", "STALLD_STATUS=start,enable")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new NTO profile was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-stalld")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if stalld service is running again")
+		stalldStatus, _, err = utils.DebugNodeWithOptionsAndChrootWithStdErr(oc, tunedNodeName, []string{"-q", "--to-namespace", ntoNamespace}, "systemctl", "status", "stalld")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stalldStatus).NotTo(o.BeEmpty())
+		o.Expect(stalldStatus).To(o.ContainSubstring("active (running)"))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:49441][OTP]apply a profile with multiple inheritance where parent profiles share a common ancestor [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		// trying to include two profiles that share the same parent profile "throughput-performance". An example of such profiles
+		// are the openshift-node --> openshift --> (virtual-guest) --> throughput-performance and postgresql profiles.
+		// Use the first worker node as labeled node
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/openshift-node-postgresql-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-node-postgresql", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the node with tuned.openshift.io/openshift-node-postgresql=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned.openshift.io/openshift-node-postgresql=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check postgresql profile /usr/lib/tuned/postgresql/tuned.conf include throughput-performance profile")
+		postGreSQLProfile, err := utils.RemoteShPod(oc, ntoNamespace, tunedPodName, "cat", "/usr/lib/tuned/postgresql/tuned.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(postGreSQLProfile).To(o.ContainSubstring("throughput-performance"))
+
+		g.By("check postgresql profile /usr/lib/tuned/openshift-node/tuned.conf include openshift profile")
+		openshiftNodeProfile, err := utils.RemoteShPod(oc, ntoNamespace, tunedPodName, "cat", "/usr/lib/tuned/openshift-node/tuned.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(openshiftNodeProfile).To(o.ContainSubstring(`include=openshift`))
+
+		g.By("check postgresql profile /usr/lib/tuned/openshift/tuned.conf include throughput-performance profile")
+		openshiftProfile, err := utils.RemoteShPod(oc, ntoNamespace, tunedPodName, "cat", "/usr/lib/tuned/openshift/tuned.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(openshiftProfile).To(o.ContainSubstring("throughput-performance"))
+
+		g.By("create openshift-node-postgresql tuned profile")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "openshift-node-postgresql.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check openshift-node-postgresql tuned profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).To(o.ContainSubstring("openshift-node-postgresql"))
+
+		g.By("check if new NTO profile was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node-postgresql")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if profile openshift-node-postgresql applied on nodes")
+		nodeProfileName, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("openshift-node-postgresql"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("assert recommended profile (openshift-node-postgresql) matches current configuration in tuned pod log")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "10", 300, `'openshift-node-postgresql' applied|recommended profile \(openshift-node-postgresql\) matches current configuration`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("[test_id:49705][OTP]handle network devices with n/a channel values using the net plug-in [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		if iaasPlatform == "vsphere" || iaasPlatform == "openstack" || iaasPlatform == "none" || iaasPlatform == "powervs" {
+			g.Skip("IAAS platform: " + iaasPlatform + " does not support cloud provider profile - skipping test")
+		}
+
+		isSNO := utils.IsSNOCluster(oc)
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check default channel for host network adapter, not expected Combined: 1, if so, skip testing")
+		// utils.AssertNetworkChannelQueuesStatus is used for checking if match Combined: 1
+		// If match <Combined: 1>, skip testing
+		isMatch, err := utils.AssertNetworkChannelQueuesStatus(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMatch {
+			g.Skip("Only one NIC queues or Unsupported NIC - skipping test")
+		}
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/netplugin-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "net-plugin", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the node with node-role.kubernetes.io/netplugin=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/netplugin=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create net-plugin tuned profile")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "net-plugin-tuned-node.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check net-plugin tuned profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(tunedNames).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).To(o.ContainSubstring("net-plugin"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("assert tuned.plugins.base: instance net: assigning devices match in tuned pod log")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "180", 300, "tuned.plugins.base: instance net: assigning devices")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert active and recommended profile (net-plugin) match in tuned pod log")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, tunedPodName, "180", 300, `'net-plugin' applied|recommended profile \(net-plugin\) matches current configuration`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if new NTO profile was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "net-plugin")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if profile net-plugin applied on nodes")
+		nodeProfileName, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(nodeProfileName).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("net-plugin"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check channel for host network adapter, expected Combined: 1")
+		result, err := utils.AssertNetworkChannelQueuesStatus(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result).To(o.BeTrue())
+
+		g.By("delete tuned net-plugin and check channel for host network adapter again")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "net-plugin", "-n", ntoNamespace, "--ignore-not-found").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if profile openshift-node|openshift-control-plane applied on nodes")
+		if isSNO {
+			err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-control-plane")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		} else {
+			err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check channel for host network adapter, not expected Combined: 1")
+		result, err = utils.AssertNetworkChannelQueuesStatus(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result).To(o.BeFalse())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:49617][OTP]support cloud-provider specific profiles [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		if iaasPlatform == "none" {
+			g.Skip("IAAS platform: " + iaasPlatform + " does not support cloud provider profile - skipping test")
+		}
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.By("get cloud provider name")
+		providerName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("profiles.tuned.openshift.io", tunedNodeName, "-n", ntoNamespace, "-ojsonpath={.spec.config.providerName}").Output()
+		o.Expect(providerName).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "provider-"+providerName, "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "provider-abc", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		providerID, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.spec.providerID}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(providerID).NotTo(o.BeEmpty())
+		o.Expect(providerID).To(o.ContainSubstring(providerName))
+
+		g.By("check the value of vm.admin_reserve_kbytes on target nodes, the expected value should be 8192")
+		sysctlOutput, err := utils.RemoteShPod(oc, ntoNamespace, tunedPodName, "sysctl", "vm.admin_reserve_kbytes")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(sysctlOutput).NotTo(o.BeEmpty())
+		o.Expect(sysctlOutput).To(o.ContainSubstring("vm.admin_reserve_kbytes = 8192"))
+
+		g.By("apply cloud-provider profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "cloud-provider-profile.yaml"), "-p", "PROVIDER_NAME="+providerName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check /var/lib/tuned/provider on target nodes")
+		openshiftProfile, err := utils.RemoteShPod(oc, ntoNamespace, tunedPodName, "cat", "/var/lib/ocp-tuned/provider")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(openshiftProfile).NotTo(o.BeEmpty())
+		o.Expect(openshiftProfile).To(o.ContainSubstring(providerName))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check tuned for NTO")
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned.tuned.openshift.io").Output()
+		o.Expect(output).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("current tuned for NTO: \n%v", output)
+
+		g.By("check provider + providerName profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).NotTo(o.BeEmpty())
+		o.Expect(tunedNames).To(o.ContainSubstring("provider-" + providerName))
+
+		g.By("check the value of vm.admin_reserve_kbytes on target nodes, the expected value is 16386")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "vm.admin_reserve_kbytes", "16386")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("remove cloud-provider profile, the value of vm.admin_reserve_kbytes rolls back to 8192")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "provider-"+providerName, "-n", ntoNamespace).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check the value of vm.admin_reserve_kbytes on target nodes, the expected value should be 8192")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "vm.admin_reserve_kbytes", "8192")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("apply cloud-provider-abc profile, where abc does not belong to any cloud provider")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "cloud-provider-profile.yaml"), "-p", "PROVIDER_NAME=abc")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check the value of vm.admin_reserve_kbytes on target nodes, the expected value should be no change, still is 8192")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "vm.admin_reserve_kbytes", "8192")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// This test can run in Parallel with other tests and is not Disruptive.
+	// author: liqcui@redhat.com
+	g.It("[test_id:45593][OTP]set the correct io_timeout for AWS Nitro instances", func(ctx context.Context) {
+		var err error
+		// currently test is only supported on AWS
+		if iaasPlatform == "aws" {
+			g.By("expect /sys/module/nvme_core/parameters/io_timeout value on each node: 4294967295")
+			err = utils.AssertIOTimeoutAndMaxRetries(ctx, oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+		} else {
+			g.Skip("Test Case 45593 does not support other cloud platforms, only AWS - skipping test")
+		}
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:27420][OTP]provide the default tuned resource [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		defaultTunedCreateTimeBefore, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", "default", "-n", ntoNamespace, "-ojsonpath={.metadata.creationTimestamp}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(defaultTunedCreateTimeBefore).NotTo(o.BeEmpty())
+
+		g.By("delete the default tuned")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "default", "-n", ntoNamespace).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("make sure the tuned default is created and ready")
+		err = utils.ConfirmedTunedReady(ctx, oc, ntoNamespace, "default", 60)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		defaultTunedCreateTimeAfter, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", "default", "-n", ntoNamespace, "-ojsonpath={.metadata.creationTimestamp}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(defaultTunedCreateTimeAfter).NotTo(o.BeEmpty())
+		o.Expect(defaultTunedCreateTimeAfter).NotTo(o.ContainSubstring(defaultTunedCreateTimeBefore))
+
+		defaultTunedCreateTimeBefore, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", "default", "-n", ntoNamespace, "-ojsonpath={.metadata.creationTimestamp}").Output()
+		o.Expect(defaultTunedCreateTimeBefore).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		defaultTunedCreateTimeAfter, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", "default", "-n", ntoNamespace, "-ojsonpath={.metadata.creationTimestamp}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(defaultTunedCreateTimeAfter).NotTo(o.BeEmpty())
+		o.Expect(defaultTunedCreateTimeAfter).To(o.ContainSubstring(defaultTunedCreateTimeBefore))
+
+		utils.Logf("defaultTunedCreateTimeBefore is : %v defaultTunedCreateTimeAfter is: %v", defaultTunedCreateTimeBefore, defaultTunedCreateTimeAfter)
+	})
+
+	// This test can run in Parallel with other tests and is not Disruptive.
+	// author: liqcui@redhat.com
+	g.It("[test_id:41552][OTP]report per-node tuned profile application status", func(ctx context.Context) {
+		isSNOOrCompact := utils.IsSNOOrCompact(oc)
+		masterNodeName, err := utils.GetFirstMasterNodeName(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defaultMasterProfileName, err := utils.GetDefaultProfileNameOnMaster(oc, masterNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// NTO will provide two default tuned profiles, one is openshift-control-plane, the other is openshift-node
+		g.By("check the default tuned profile list per nodes")
+		profileOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("profiles.tuned.openshift.io", "-n", ntoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileOutput).NotTo(o.BeEmpty())
+		if isSNOOrCompact {
+			o.Expect(profileOutput).To(o.ContainSubstring(defaultMasterProfileName))
+		} else {
+			o.Expect(profileOutput).To(o.ContainSubstring("openshift-control-plane"))
+			o.Expect(profileOutput).To(o.ContainSubstring("openshift-node"))
+		}
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:50052][OTP]run the stalld service with SCHED_FIFO scheduling policy [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		if iaasPlatform == "vsphere" || iaasPlatform == "none" {
+			g.Skip("IAAS platform: " + iaasPlatform + " is not automated yet - skipping test")
+		}
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("tunedNodeName is [ %v ]", tunedNodeName)
+
+		if len(tunedNodeName) == 0 {
+			g.Skip("Skip Testing on RHEL worker or windows node")
+		}
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-stalld-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-stalld", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_, _ = utils.DebugNodeWithChroot(oc, tunedNodeName, "/usr/bin/throttlectl", "on")
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Switch off throttlectl to improve successful rate of stalld starting
+		g.By("set off for /usr/bin/throttlectl before enable stalld")
+		err = utils.SwitchThrottlectlOnOff(ctx, oc, ntoNamespace, tunedNodeName, "off", 30)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("label the node with node-role.kubernetes.io/worker-stalld=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-stalld=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create openshift-stalld tuned profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "stalld-tuned.yaml"), "-p", "STALLD_STATUS=start,enable")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check openshift-stalld tuned profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).NotTo(o.BeEmpty())
+		o.Expect(tunedNames).To(o.ContainSubstring("openshift-stalld"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if new NTO profile was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-stalld")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if profile openshift-stalld applied on nodes")
+		nodeProfileName, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeProfileName).NotTo(o.BeEmpty())
+		o.Expect(nodeProfileName).To(o.ContainSubstring("openshift-stalld"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check if stalld service is running")
+		stalldStatus, _, err := utils.DebugNodeWithOptionsAndChrootWithStdErr(oc, tunedNodeName, []string{"-q", "--to-namespace=" + ntoNamespace}, "systemctl", "status", "stalld")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stalldStatus).NotTo(o.BeEmpty())
+		o.Expect(stalldStatus).To(o.ContainSubstring("active (running)"))
+
+		g.By("get stalld PID on labeled node")
+		stalldPIDStatus, _, err := utils.DebugNodeWithOptionsAndChrootWithStdErr(oc, tunedNodeName, []string{"-q", "--to-namespace=" + ntoNamespace}, "/bin/bash", "-c", "ps -efZ | grep stalld | grep -v grep")
+		utils.Logf("stalldPIDStatus is :\n%v", stalldPIDStatus)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stalldPIDStatus).NotTo(o.BeEmpty())
+		o.Expect(stalldPIDStatus).NotTo(o.ContainSubstring("unconfined_service_t"))
+		o.Expect(stalldPIDStatus).To(o.ContainSubstring("-t 20"))
+
+		g.By("get stalld PID on labeled node")
+		stalldPID, _, err := utils.DebugNodeWithOptionsAndChrootWithStdErr(oc, tunedNodeName, []string{"-q", "--to-namespace=" + ntoNamespace}, "/bin/bash", "-c", "ps -efL| grep stalld | grep -v grep | awk '{print $2}'")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stalldPID).NotTo(o.BeEmpty())
+
+		g.By("get status of chrt -p stalld PID on labeled node")
+		chrtStalldPIDOutput, _, err := utils.DebugNodeWithOptionsAndChrootWithStdErr(oc, tunedNodeName, []string{"-q", "--to-namespace=" + ntoNamespace}, "/bin/bash", "-c", "chrt -ap "+stalldPID)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(chrtStalldPIDOutput).NotTo(o.BeEmpty())
+		o.Expect(chrtStalldPIDOutput).To(o.ContainSubstring("SCHED_FIFO"))
+		utils.Logf("chrtStalldPIDOutput is :\n%v", chrtStalldPIDOutput)
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:51495][OTP]support basic PAO functionality [Disruptive][Slow]", oteg.Informing(), func(ctx context.Context) {
+		// on a worker with arch = ppc64le, pao-baseprofile-ppc64le.yaml is used instead to account for supported kernel parameters (tsc is x86_64 only)
+
+		SkipIsSNO(oc)
+
+		tunedNodeName, pool, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		initialMachineCount, err := utils.GetPoolUpdatedMachineCount(ctx, oc, pool)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-pao-").Execute()
+			_ = utils.WaitForPoolUpdatedMachineCount(cleanupCtx, oc, pool, initialMachineCount)
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("performanceprofile", "pao-baseprofile", "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("mcp", "worker-pao", "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Get how many cpus on the specified worker node
+		g.By("get the number of CPU cores on the labeled worker node")
+		nodeCPUCores, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.capacity.cpu}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeCPUCores).NotTo(o.BeEmpty())
+
+		nodeCPUCoresInt, err := strconv.Atoi(nodeCPUCores)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if nodeCPUCoresInt <= 1 {
+			g.Skip("the worker node does not have enough cpus - skipping test")
+		}
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.By("label the node with node-role.kubernetes.io/worker-pao=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-pao=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		ocpArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.nodeInfo.architecture}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if (iaasPlatform == "aws" || iaasPlatform == "gcp") && ocpArch == "amd64" {
+			// Only GCP and AWS support realtime-kernel
+			g.By("apply pao-baseprofile performance profile")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-baseprofile.yaml"), "-p", "ISENABLED=true")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		} else if ocpArch == "ppc64le" {
+			g.By("apply pao-baseprofile performance profile for ppc64le")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-baseprofile-ppc64le.yaml"), "-p", "ISENABLED=false")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		} else {
+			g.By("apply pao-baseprofile performance profile")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-baseprofile.yaml"), "-p", "ISENABLED=false")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		g.By("check Performance Profile pao-baseprofile was created automatically")
+		paoBasePerformanceProfile, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("performanceprofile").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(paoBasePerformanceProfile).NotTo(o.BeEmpty())
+		o.Expect(paoBasePerformanceProfile).To(o.ContainSubstring("pao-baseprofile"))
+
+		g.By("create machine config pool worker-pao")
+		err = utils.CreateOperatorResourceByYaml(oc, "", fx.file("pao", "pao-baseprofile-mcp.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if machine config pool applied for worker nodes")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-pao", 1200)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("verify PAO profile was applied correctly")
+		expectRT := (iaasPlatform == "aws" || iaasPlatform == "gcp") && ocpArch == "amd64"
+		err = utils.VerifyPAOProfile(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node-performance-pao-baseprofile", "pao-baseprofile", expectRT)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check allocatable system resource on labeled node")
+		allocatableResource, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.allocatable}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(allocatableResource).NotTo(o.BeEmpty())
+		utils.Logf("the allocatable system resource on labeled node: \n%v", allocatableResource)
+
+		g.DeferCleanup(oc.TeardownProject)
+		err = oc.SetupProject()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		ntoTestNS := oc.Namespace()
+
+		// Create a guaranteed-pod application pod
+		g.By("create a guaranteed-pod pod into temp namespace")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoTestNS, fx.file("pao", "pao-baseqos-pod.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Check if guaranteed-pod is ready
+		g.By("check if a guaranteed-pod pod is ready")
+		err = utils.AssertPodToBeReady(ctx, oc, "guaranteed-pod", ntoTestNS)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check the cpu bind to isolation CPU zone for a guaranteed-pod")
+		cpuManagerStateOutput, err := utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "/bin/bash", "-c", "cat /var/lib/kubelet/cpu_manager_state")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(cpuManagerStateOutput).NotTo(o.BeEmpty())
+		o.Expect(cpuManagerStateOutput).To(o.ContainSubstring("guaranteed-pod"))
+		utils.Logf("the settings of CPU Manager cpuManagerState on labeled nodes: \n%v", cpuManagerStateOutput)
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:53053][OTP]automatically delete profiles not bound to any nodes [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		if iaasPlatform == "none" {
+			g.Skip("IAAS platform: " + iaasPlatform + " is not automated yet - skipping test")
+		}
+
+		// Get NTO operator pod name
+		ntoOperatorPod, err := utils.GetNTOPodName(oc, ntoNamespace)
+		o.Expect(ntoOperatorPod).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("get cloud provider name")
+		providerName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("profiles.tuned.openshift.io", tunedNodeName, "-n", ntoNamespace, "-ojsonpath={.spec.config.providerName}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(providerName).NotTo(o.BeEmpty())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("profiles.tuned.openshift.io", "worker-does-not-exist-openshift-node", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("apply worker-does-not-exist-openshift-node profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "nto-unknown-profile.yaml"), "-p", "PROVIDER_NAME="+providerName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("the profile worker-does-not-exist-openshift-node will be deleted automatically once created.")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io").Output()
+		o.Expect(tunedNames).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).NotTo(o.ContainSubstring("worker-does-not-exist-openshift-node"))
+
+		g.By("assert NTO logs to match key words  Node 'worker-does-not-exist-openshift-node' not found")
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, ntoOperatorPod, "4", 120, " Node \"worker-does-not-exist-openshift-node\" not found")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:59884][OTP]support multiple regular expressions in cgroup blacklist configuration [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		// Get the tuned pod name that run on first worker node
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// TODO: Try to make this more generic not relying on nginx.
+		AppImageName := nginxAlpine
+
+		// Get how many cpus on the specified worker node
+		g.By("get the number of CPU cores on the labeled worker node")
+		nodeCPUCores, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.capacity.cpu}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeCPUCores).NotTo(o.BeEmpty())
+
+		nodeCPUCoresInt, err := strconv.Atoi(nodeCPUCores)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if nodeCPUCoresInt <= 1 {
+			g.Skip("the worker node does not have enough cpus - skipping test")
+		}
+
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "-n", ntoNamespace, "cgroup-scheduler-blacklist").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned-scheduler-node-").Execute()
+			if ns := oc.Namespace(); ns != "" {
+				_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("pod", "-n", ns, "app-web", "--ignore-not-found").Execute()
+			}
+			oc.TeardownProject()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		err = oc.SetupProject()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		ntoTestNS := oc.Namespace()
+
+		g.By("label the specified linux node with label tuned-scheduler-node")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "tuned-scheduler-node=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// setting cgroup_ps_blacklist=/kubepods\.slice/kubepods-burstable\.slice/;/system\.slice/
+		// the process belonging to /kubepods\.slice/kubepods-burstable\.slice/ or /system\.slice/ can consume all cpuset
+		// The expected Cpus_allowed_list in /proc/$PID/status should be 0-N
+		// the process not belonging to /kubepods\.slice/kubepods-burstable\.slice/ or /system\.slice/ cannot consume all cpuset
+		// The expected Cpus_allowed_list in /proc/$PID/status should be 0 or 0,2-N
+
+		g.By("create pod that detects the value of kernel.pid_max ")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoTestNS, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "cgroup-scheduler-besteffort-pod.yaml"), "-p", "IMAGE_NAME="+AppImageName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Check if nginx pod is ready
+		g.By("check if best effort pod is ready")
+		err = utils.AssertPodToBeReady(ctx, oc, "app-web", ntoTestNS)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create NTO custom tuned profile cgroup-scheduler-blacklist")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "cgroup-scheduler-blacklist.yaml"), "-p", "PROFILE_NAME=cgroup-scheduler-blacklist", `CGROUP_BLACKLIST=/kubepods\.slice/kubepods-burstable\.slice/;/system\.slice/`)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check if NTO custom tuned profile cgroup-scheduler-blacklist was applied")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "cgroup-scheduler-blacklist")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		// The expected Cpus_allowed_list in /proc/$PID/status should be 0-N
+		g.By("verify the cpu allow list in cgroup black list for tuned")
+		result, err := utils.AssertProcessInCgroupSchedulerBlacklist(oc, tunedNodeName, ntoNamespace, "tuned", nodeCPUCoresInt)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result).To(o.Equal(true))
+
+		// The expected Cpus_allowed_list in /proc/$PID/status should be 0-N
+		g.By("verify the cpu allow list in cgroup black list for chronyd")
+		result, err = utils.AssertProcessInCgroupSchedulerBlacklist(oc, tunedNodeName, ntoNamespace, "chronyd", nodeCPUCoresInt)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result).To(o.Equal(true))
+
+		// The expected Cpus_allowed_list in /proc/$PID/status should be 0 or 0,2-N
+		g.By("verify the cpu allow list in cgroup black list for nginx process")
+		result, err = utils.AssertProcessExcludedFromCgroupScheduler(oc, tunedNodeName, ntoNamespace, "nginx", nodeCPUCoresInt)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result).To(o.Equal(true))
+	})
+
+	// author: liqcui@redhat.com
+	// [Timeout:30m] applied because this test runs very close to the 15-minute default.
+	g.It("[test_id:60743][OTP]avoid race conditions when updating machine configs for nodes with different CPU counts in the same MCP [Disruptive][Slow][Timeout:30m]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		haveMachineSet, err := utils.MachineSetsExist(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if !haveMachineSet {
+			g.Skip("No machineset found, skipping test")
+		}
+
+		if !utils.ImplStringArrayContains(cloudPlatforms, iaasPlatform) {
+			g.Skip("IAAS platform: " + iaasPlatform + " is not automated yet - skipping test")
+		}
+
+		tunedNodeName, pool, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		initialMachineCount, err := utils.GetPoolUpdatedMachineCount(ctx, oc, pool)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			g.By(fmt.Sprintf("remove the worker-diff label from %v", tunedNodeName))
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-diffcpus-").Execute()
+			g.By("delete ocp-psap-qe-diffcpus machineset")
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("machineset", "ocp-psap-qe-diffcpus", "-n", "openshift-machine-api", "--ignore-not-found").Execute()
+			g.By(fmt.Sprintf("wait for %s machine config pool count to equal %v", pool, initialMachineCount))
+			_ = utils.WaitForPoolUpdatedMachineCount(cleanupCtx, oc, pool, initialMachineCount)
+			g.By("delete openshift-bootcmdline-cpu tuned")
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-bootcmdline-cpu", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			g.By("delete custom MCP")
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("mcp", "worker-diffcpus", "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("create openshift-bootcmdline-cpu tuned profile")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "node-diffcpus-tuned-bootloader.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create machine config pool")
+		err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "node-diffcpus-mcp.yaml"), "-p", "MCP_NAME=worker-diffcpus")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("label the last node with node-role.kubernetes.io/worker-diffcpus=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-diffcpus=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create a new machineset with different instance type.")
+		newMachinesetInstanceType, err := utils.SpecifyMachinesetWithDifferentInstanceType(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("4 newMachinesetInstanceType is %v, ", newMachinesetInstanceType)
+		o.Expect(newMachinesetInstanceType).NotTo(o.BeEmpty())
+
+		err = utils.CreateMachinesetByInstanceType(oc, "ocp-psap-qe-diffcpus", newMachinesetInstanceType)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("wait for new node is ready when machineset created")
+		// 1 means replicas=1
+		err = utils.WaitForMachinesRunning(ctx, oc, 1, "ocp-psap-qe-diffcpus")
+		if err == utils.ErrInsufficientInstanceCapacity || err == utils.ErrInsufficientResources || err == utils.ErrPGClusterPlacementGroupNotSupported {
+			g.Skip(err.Error())
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("label the second node with node-role.kubernetes.io/worker-diffcpus=")
+		secondTunedNodeName, err := utils.GetNodeNameByMachineset(oc, "ocp-psap-qe-diffcpus")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.DeferCleanup(func() {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", secondTunedNodeName, "node-role.kubernetes.io/worker-diffcpus-", "--overwrite").Execute()
+		})
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", secondTunedNodeName, "node-role.kubernetes.io/worker-diffcpus=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if the status of adding the two worker node into worker-diffcpus mcp, mcp applied")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-diffcpus", 480)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("assert if openshift-bootcmdline-cpu profile was applied")
+		// Verify if the new profile is applied
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-bootcmdline-cpu")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		profileCheck, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("openshift-bootcmdline-cpu"))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		ntoOperatorPodName, err := utils.GetNTOPodName(oc, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, ntoOperatorPodName, "25", 180, "Nodes in MCP worker-diffcpus agree on bootcmdline: cpus=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Comment out with an known issue, until it was fixed
+		g.By("assert if cmdline was applied in machineconfig")
+		err = utils.AssertTunedAppliedMC(oc, "nto-worker-diffcpus", "cpus=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if cmdline was applied in labeled node")
+		result, err := utils.AssertTunedAppliedToNode(oc, tunedNodeName, "cpus=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result).To(o.Equal(true))
+
+		g.By("<Profiles with bootcmdline conflict> warn message will show in oc get co/node-tuning")
+		err = utils.WaitForCOStatusWithKeywords(ctx, oc, 60*time.Second, "Profiles with bootcmdline conflict")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		// Verify if the <Profiles with bootcmdline conflict> warn message disappears after deactivating custom tuned profile
+
+		g.By(fmt.Sprintf("remove the worker-diff label from %v", tunedNodeName))
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-diffcpus-").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("delete ocp-psap-qe-diffcpus machineset")
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("machineset", "ocp-psap-qe-diffcpus", "-n", "openshift-machine-api", "--ignore-not-found").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("wait for %s machine config pool count to equal %v", pool, initialMachineCount))
+		err = utils.WaitForPoolUpdatedMachineCount(ctx, oc, pool, initialMachineCount)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("<Profiles with bootcmdline conflict> warn message will disappear after removing worker node from mcp worker-diffcpus")
+		err = utils.WaitForCONodeTuningStatusClear(ctx, oc, 180, "Profiles with bootcmdline conflict")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("assert the 'cpus' kernel command-line is no longer present in /proc/cmdline on %s", tunedNodeName))
+		result, err = utils.AssertTunedAppliedToNode(oc, tunedNodeName, "cpus=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(result).To(o.Equal(false))
+	})
+
+	// author: sahshah
+	g.It("[test_id:64908][OTP]expose the tuned socket interface for querying active profiles [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		g.By("pick one worker node to label")
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Clean up resources
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "-n", ntoNamespace, "tuning-maxpid").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-tuning-").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Label the node with node-role.kubernetes.io/worker-tuning
+		g.By("label the node with node-role.kubernetes.io/worker-tuning=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-tuning=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Apply new profile that match label node-role.kubernetes.io/worker-tuning=
+		g.By("create tuning-maxpid profile")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "tuning-maxpid.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// NTO will provide two default tuned profiles, one is default
+		g.By("check the default tuned list, expect tuning-maxpid")
+		allTuneds, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", "-n", ntoNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(allTuneds).To(o.ContainSubstring("tuning-maxpid"))
+
+		g.By("check if new profile tuning-maxpid applied to labeled node")
+		// Verify if the new profile is applied
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "tuning-maxpid")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		profileCheck, err := utils.GetTunedProfile(oc, ntoNamespace, tunedNodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(profileCheck).To(o.Equal("tuning-maxpid"))
+
+		g.By("get current profile for each node")
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("current profile for each node: \n%v", output)
+
+		g.By("check the custom profile as expected by debugging the node")
+		printfString := `printf '{"jsonrpc": "2.0", "method": "active_profile", "id": 1}' | nc -U /run/tuned/tuned.sock`
+		printfStringStdOut, err := utils.RemoteShPodWithBash(oc, ntoNamespace, tunedPodName, printfString)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(printfStringStdOut).NotTo(o.BeEmpty())
+		o.Expect(printfStringStdOut).To(o.ContainSubstring("tuning-maxpid"))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:65371][OTP]preserve node-level profile settings when the tuned pod is terminated [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(oc.TeardownProject)
+		err = oc.SetupProject()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		ntoTestNS := oc.Namespace()
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-tuning-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "tuning-pidmax", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the node with node-role.kubernetes.io/worker-tuning=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-tuning=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create tuning-pidmax profile")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "nto-tuned-pidmax.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert tuning-pidmax profile applied to nodes")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "tuning-pidmax", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		clusterVersion, _, err := utils.GetClusterVersion(oc)
+		utils.Logf("current clusterVersion is [ %v ]", clusterVersion)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(clusterVersion).NotTo(o.BeEmpty())
+
+		g.By("create pod that detects the value of kernel.pid_max ")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoTestNS, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "nto-sysctl-pod.yaml"), "-p", "IMAGE_NAME="+nginxAlpine, "RUNASNONROOT=true")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		// Check if sysctlpod pod is ready
+		err = utils.AssertPodToBeReady(ctx, oc, "sysctlpod", ntoTestNS)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("get the sysctlpod status")
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoTestNS, "pods").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("the status of pod sysctlpod: \n%v", output)
+
+		g.By("check the value of kernel.pid_max in the pod sysctlpod, the expected value should be kernel.pid_max = 181818")
+		podLogStdout, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("sysctlpod", "--tail=1", "-n", ntoTestNS).Output()
+		utils.Logf("logs of sysctlpod before delete tuned pod is [ %v ]", podLogStdout)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(podLogStdout).NotTo(o.BeEmpty())
+		o.Expect(podLogStdout).To(o.ContainSubstring("kernel.pid_max = 181818"))
+
+		g.By("delete tuned pod on the labeled node, and make sure kernel.pid_max does not revert to its original value")
+		o.Expect(oc.AsAdmin().WithoutNamespace().Run("delete").Args("pod", tunedPodName, "-n", ntoNamespace).Execute()).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check tuned pod status after delete tuned pod")
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err = utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// Check if tuned pod that deleted is ready
+		err = utils.AssertPodToBeReady(ctx, oc, tunedPodName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check the value of kernel.pid_max in the pod sysctlpod again, the expected value should still be kernel.pid_max = 181818")
+		podLogStdout, err = oc.AsAdmin().WithoutNamespace().Run("logs").Args("sysctlpod", "--tail=2", "-n", ntoTestNS).Output()
+		utils.Logf("logs of sysctlpod after delete tuned pod is [ %v ]", podLogStdout)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(podLogStdout).NotTo(o.BeEmpty())
+		o.Expect(podLogStdout).To(o.ContainSubstring("kernel.pid_max = 181818"))
+		o.Expect(podLogStdout).NotTo(o.ContainSubstring("kernel.pid_max not equal 181818"))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:49618][OTP]support core PAO and NTO functionality before upgrading the OCP cluster [Disruptive][Slow][Manual]", oteg.Informing(), func() {
+		// 49618 is a two-part test.  This is the first part: verify PAO+NTO works before upgrade.  Do not clean up any resources created here.
+		// Cleanup will be performed by the second part of the test.
+
+		SkipIsSNO(oc)
+
+		ctx := context.Background()
+
+		if !utils.ImplStringArrayContains(cloudPlatforms, iaasPlatform) {
+			g.Skip("IAAS platform: " + iaasPlatform + " is not automated yet - skipping test")
+		}
+
+		totalLinuxWorkerNode, err := utils.CountLinuxWorkerNodes(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		totalLinuxWorkerNodes := strconv.Itoa(totalLinuxWorkerNode)
+		if totalLinuxWorkerNode < 2 {
+			g.Skip("This test needs at least two worker nodes, have " + totalLinuxWorkerNodes + ", skipping test.")
+		}
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get how many cpus on the specified worker node
+		g.By("get the number of CPU cores on the labeled worker node")
+		nodeCPUCores, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.capacity.cpu}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeCPUCores).NotTo(o.BeEmpty())
+
+		nodeCPUCoresInt, err := strconv.Atoi(nodeCPUCores)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("Current CPU cores of worker node: %v", nodeCPUCoresInt)
+		if nodeCPUCoresInt < 4 {
+			g.Skip("the worker node does not have enough cpus - skipping test")
+		}
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.By("label the node with node-role.kubernetes.io/worker-pao=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-pao=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create machine config pool worker-pao")
+		err = utils.CreateOperatorResourceByYaml(oc, "", fx.file("pao", "pao-baseprofile-mcp.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-pao", 600)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		ocpArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.nodeInfo.architecture}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if (iaasPlatform == "aws" || iaasPlatform == "gcp") && ocpArch == "amd64" {
+			// Only GCP and AWS support realtime-kernel
+			g.By("apply pao-baseprofile performance profile")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-baseprofile.yaml"), "-p", "ISENABLED=true")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		} else {
+			g.By("apply pao-baseprofile performance profile")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-baseprofile.yaml"), "-p", "ISENABLED=false")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		g.By("check Performance Profile pao-baseprofile was created automatically")
+		paoBasePerformanceProfile, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("performanceprofile").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(paoBasePerformanceProfile).NotTo(o.BeEmpty())
+		o.Expect(paoBasePerformanceProfile).To(o.ContainSubstring("pao-baseprofile"))
+
+		g.By("assert if machine config pool applied to worker nodes that label with worker-pao")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-pao", 1800)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker", 300)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.WaitForMCPUpdate(ctx, oc, "master", 720)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("verify PAO profile was applied correctly")
+		expectRT := (iaasPlatform == "aws" || iaasPlatform == "gcp") && ocpArch == "amd64"
+		err = utils.VerifyPAOProfile(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node-performance-pao-baseprofile", "pao-baseprofile", expectRT)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check Kernel boot settings passed into /proc/cmdline in labeled node")
+		kernelCMDLineStdout, err := utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "cat", "/proc/cmdline")
+		utils.Logf("the settings of Kernel boot passed into /proc/cmdline  on labeled nodes: \n%v", kernelCMDLineStdout)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(kernelCMDLineStdout).NotTo(o.BeEmpty())
+		o.Expect(kernelCMDLineStdout).To(o.ContainSubstring("tsc=reliable"))
+		o.Expect(kernelCMDLineStdout).To(o.ContainSubstring("isolcpus="))
+		o.Expect(kernelCMDLineStdout).To(o.ContainSubstring("hugepagesz=1G"))
+
+		// o.Expect(kernelCMDLineStdout).To(o.ContainSubstring("nosmt"))
+		//     - nosmt  removed nosmt to improve success rate due to limited cpu cores
+		// but manually re-enabled when have enough cpu cores
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:49618][OTP]support core PAO and NTO functionality after upgrading the OCP cluster [Disruptive][Slow][Manual]", oteg.Informing(), func(ctx context.Context) {
+		// 49618 is a two-part test.  This is the second part: verify PAO+NTO survives upgrade.  Clean-up any resources created
+		// by the first part of the test.
+
+		SkipIsSNO(oc)
+
+		if !utils.ImplStringArrayContains(cloudPlatforms, iaasPlatform) {
+			g.Skip("IAAS platform: " + iaasPlatform + " is not automated yet - skipping test")
+		}
+
+		totalLinuxWorkerNode, err := utils.CountLinuxWorkerNodes(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		totalLinuxWorkerNodes := strconv.Itoa(totalLinuxWorkerNode)
+		if totalLinuxWorkerNode < 2 {
+			g.Skip("The total linux worker node is " + totalLinuxWorkerNodes + ". The OCP do not have enough worker node, skip it.")
+		}
+
+		tunedNodeNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker-pao", "-ojsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if len(tunedNodeNames) == 0 {
+			g.Skip("No labeled node was found, skipping testing")
+		}
+		tunedNodeNameList := strings.Fields(tunedNodeNames)
+		if len(tunedNodeNameList) > 1 {
+			utils.Logf("Warning: multiple nodes matched label node-role.kubernetes.io/worker-pao (%v); using first node %q", tunedNodeNames, tunedNodeNameList[0])
+		}
+		tunedNodeName := tunedNodeNameList[0]
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-pao-").Execute()
+			_ = utils.WaitForMCPUpdate(cleanupCtx, oc, "worker", 600)
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("performanceprofile", "pao-baseprofile", "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("mcp", "worker-pao", "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("check If Performance Profile pao-baseprofile and cloud-provider exist during Post Check Phase")
+		paoBasePerformanceProfile, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("performanceprofile").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if !strings.Contains(paoBasePerformanceProfile, "pao-baseprofile") {
+			g.Skip("No PerformanceProfile found skipping test")
+		}
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.By("assert if machine config pool applied for worker nodes")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-pao", 1200)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("verify PAO profile was applied correctly")
+		ocpArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.nodeInfo.architecture}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		expectRT := (iaasPlatform == "aws" || iaasPlatform == "gcp") && ocpArch == "amd64"
+		err = utils.VerifyPAOProfile(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node-performance-pao-baseprofile", "pao-baseprofile", expectRT)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check Kernel boot settings passed into /proc/cmdline in labeled node")
+		kernelCMDLineStdout, err := utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "cat", "/proc/cmdline")
+		utils.Logf("the settings of Kernel boot passed into /proc/cmdline  on labeled nodes: \n%v", kernelCMDLineStdout)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(kernelCMDLineStdout).NotTo(o.BeEmpty())
+		o.Expect(kernelCMDLineStdout).To(o.ContainSubstring("tsc=reliable"))
+		o.Expect(kernelCMDLineStdout).To(o.ContainSubstring("isolcpus="))
+		o.Expect(kernelCMDLineStdout).To(o.ContainSubstring("hugepagesz=1G"))
+
+		// o.Expect(kernelCMDLineStdout).To(o.ContainSubstring("nosmt"))
+		//     - nosmt  removed nosmt to improve success rate due to limited cpu cores
+		// but manually re-enabled when have enough cpu cores
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:21995][OTP]support core functionality before upgrading the OCP cluster [Disruptive][Manual]", oteg.Informing(), func(ctx context.Context) {
+		// 21995 is a two-part test.  This is the first part: verify NTO works before upgrade.  Do not clean up any resources created here.
+		// Cleanup will be performed by the second part of the test.
+
+		if !utils.ImplStringArrayContains(cloudPlatforms, iaasPlatform) {
+			g.Skip("IAAS platform: " + iaasPlatform + " is not automated yet - skipping test")
+		}
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var providerName string
+
+		g.By("label the node with node-role.kubernetes.io/worker-tuning=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-tuning=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		ntoRes := utils.NtoResource{
+			Name:        "tuning-pidmax",
+			Namespace:   ntoNamespace,
+			Template:    fx.file("nto", "nto-sysctl-template.yaml"),
+			SysctlParam: "kernel.pid_max",
+			SysctlValue: "282828",
+			Label:       "node-role.kubernetes.io/worker-tuning",
+		}
+
+		g.By("create tuning-pidmax profile")
+		err = ntoRes.ApplyNTOTunedProfile(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert tuning-pidmax profile applied to nodes")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "tuning-pidmax", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("compare the value kernel.pid_max on labeled node, should be 282828")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.pid_max", "282828")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("get cloud provider name")
+		providerName, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("profiles.tuned.openshift.io", tunedNodeName, "-n", ntoNamespace, "-ojsonpath={.spec.config.providerName}").Output()
+		o.Expect(providerName).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		providerID, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.spec.providerID}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(providerID).NotTo(o.BeEmpty())
+		o.Expect(providerID).To(o.ContainSubstring(providerName))
+
+		g.By("apply cloud-provider profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "cloud-provider-profile.yaml"), "-p", "PROVIDER_NAME="+providerName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check provider + providerName profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).NotTo(o.BeEmpty())
+		o.Expect(tunedNames).To(o.ContainSubstring("provider-" + providerName))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check the value of vm.admin_reserve_kbytes on target nodes, the expected value is 16386")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "vm.admin_reserve_kbytes", "16386")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:21995][OTP]support core functionality after upgrading the OCP cluster [Disruptive][Manual]", oteg.Informing(), func(ctx context.Context) {
+		// 21995 is a two-part test.  This is the second part: verify PAO+NTO survives upgrade.  Clean-up any resources created
+		// by the first part of the test.
+
+		if !utils.ImplStringArrayContains(cloudPlatforms, iaasPlatform) {
+			g.Skip("IAAS platform: " + iaasPlatform + " is not automated yet - skipping test")
+		}
+
+		tunedNodeNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker-tuning", "-ojsonpath={.items[*].metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if len(tunedNodeNames) == 0 {
+			g.Skip("No suitable worker node was found in : " + iaasPlatform + " - skipping test")
+		}
+		tunedNodeNameList := strings.Fields(tunedNodeNames)
+		if len(tunedNodeNameList) > 1 {
+			utils.Logf("Warning: multiple nodes matched label node-role.kubernetes.io/worker-tuning (%v); using first node %q", tunedNodeNames, tunedNodeNameList[0])
+		}
+		tunedNodeName := tunedNodeNameList[0]
+
+		var providerName string
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-tuning-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "tuning-pidmax", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			if providerName != "" {
+				_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "provider-"+providerName, "-n", ntoNamespace, "--ignore-not-found").Execute()
+			}
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.By("get cloud provider name")
+		providerName, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("profiles.tuned.openshift.io", tunedNodeName, "-n", ntoNamespace, "-ojsonpath={.spec.config.providerName}").Output()
+		o.Expect(providerName).NotTo(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert tuning-pidmax profile applied to nodes")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "tuning-pidmax", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("compare if the value kernel.pid_max on labeled node, should be 282828")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.pid_max", "282828")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		providerID, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.spec.providerID}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(providerID).NotTo(o.BeEmpty())
+		o.Expect(providerID).To(o.ContainSubstring(providerName))
+
+		g.By("apply cloud-provider profile")
+		err = utils.ApplyNsResourceFromTemplate(oc, ntoNamespace, "--ignore-unknown-parameters=true", "-f", fx.file("nto", "cloud-provider-profile.yaml"), "-p", "PROVIDER_NAME="+providerName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check provider + providerName profile should be automatically created")
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedNames).NotTo(o.BeEmpty())
+		o.Expect(tunedNames).To(o.ContainSubstring("provider-" + providerName))
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("check the value of vm.admin_reserve_kbytes on target nodes, the expected value is 16386")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "vm.admin_reserve_kbytes", "16386")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:74507][OTP]not log a same-priority warning for non-matching custom profiles with the same priority [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		var firstNodeName string
+		var secondNodeName string
+
+		SkipIsSNO(oc)
+
+		totalLinuxWorkerNode, err := utils.CountLinuxWorkerNodes(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		totalLinuxWorkerNodes := strconv.Itoa(totalLinuxWorkerNode)
+		if totalLinuxWorkerNode < 2 {
+			g.Skip("This test needs at least two worker nodes, have " + totalLinuxWorkerNodes + ". skipping test.")
+		}
+
+		firstNodeName, _, err = utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		secondNodeName, _, err = utils.GetLinuxWorkerNode(oc, 1)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", firstNodeName, "node-role.kubernetes.io/worker-tuning-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", secondNodeName, "node-role.kubernetes.io/worker-priority18-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "tuning-pidmax", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "tuning-pidmax2", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Get the tuned pod name in the same node that labeled node
+		ntoOperatorPodName, err := utils.GetNTOPodName(oc, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(ntoOperatorPodName).NotTo(o.BeEmpty())
+
+		g.By("pick two worker nodes to label as worker-tuning and worker-priority18")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", firstNodeName, "node-role.kubernetes.io/worker-tuning=").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", secondNodeName, "node-role.kubernetes.io/worker-priority18=").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		firstNTORes := utils.NtoResource{
+			Name:        "tuning-pidmax",
+			Namespace:   ntoNamespace,
+			Template:    fx.file("nto", "nto-sysctl-template.yaml"),
+			SysctlParam: "kernel.pid_max",
+			SysctlValue: "282828",
+			Label:       "node-role.kubernetes.io/worker-tuning",
+		}
+
+		// Setting "vm.dirty_ratio" via sysctl in tuned is deprecated now; using kernel.pid_max for the second node to make things simple.
+		secondNTORes := utils.NtoResource{
+			Name:        "tuning-pidmax2",
+			Namespace:   ntoNamespace,
+			Template:    fx.file("nto", "nto-sysctl-template.yaml"),
+			SysctlParam: "kernel.pid_max",
+			SysctlValue: "2097152",
+			Label:       "node-role.kubernetes.io/worker-priority18",
+		}
+
+		g.By("create tuning-pidmax profile")
+		err = firstNTORes.ApplyNTOTunedProfile(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create tuning-pidmax2 profile")
+		err = secondNTORes.ApplyNTOTunedProfile(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create tuning-pidmax profile and apply it to nodes")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, firstNodeName, "tuning-pidmax", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create tuning-pidmax2 profile and apply it to nodes")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, secondNodeName, "tuning-pidmax2", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By(fmt.Sprintf("check the value kernel.pid_max on %v is 282828", firstNodeName))
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, firstNodeName, "kernel.pid_max", "282828")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("check the value kernel.pid_max on %v is 2097152", secondNodeName))
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, secondNodeName, "kernel.pid_max", "2097152")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("make sure operator pod logs do not contain 'same priority' substring")
+		ntoOperatorPodLogs, err := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", ntoNamespace, ntoOperatorPodName, "--tail=50").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(ntoOperatorPodLogs).NotTo(o.BeEmpty())
+		o.Expect(ntoOperatorPodLogs).NotTo(o.ContainSubstring("same priority"))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:75555][OTP]start the tuned pod before workload pods on node reboot [Disruptive][Slow]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		tunedNodeName, pool, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		initialMachineCount, err := utils.GetPoolUpdatedMachineCount(ctx, oc, pool)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-pao-").Execute()
+			_ = utils.WaitForPoolUpdatedMachineCount(cleanupCtx, oc, pool, initialMachineCount)
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("performanceprofile", "pao-baseprofile", "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("mcp", "worker-pao", "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Get how many cpus on the specified worker node
+		g.By("get the number of CPU cores on the labeled worker node")
+		nodeCPUCores, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.capacity.cpu}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeCPUCores).NotTo(o.BeEmpty())
+
+		nodeCPUCoresInt, err := strconv.Atoi(nodeCPUCores)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if nodeCPUCoresInt <= 1 {
+			g.Skip("the worker node does not have enough cpus - skipping test")
+		}
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.By("label the node with node-role.kubernetes.io/worker-pao=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-pao=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		ocpArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.nodeInfo.architecture}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if (iaasPlatform == "aws" || iaasPlatform == "gcp") && ocpArch == "amd64" {
+			// Only GCP and AWS support realtime-kernel
+			g.By("apply pao-baseprofile performance profile")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-baseprofile.yaml"), "-p", "ISENABLED=true")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		} else if ocpArch == "ppc64le" {
+			g.By("apply pao-baseprofile performance profile for ppc64le")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-baseprofile-ppc64le.yaml"), "-p", "ISENABLED=false")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		} else {
+			g.By("apply pao-baseprofile performance profile")
+			err = utils.ApplyClusterResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", fx.file("pao", "pao-baseprofile.yaml"), "-p", "ISENABLED=false")
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		g.By("check Performance Profile pao-baseprofile was created automatically")
+		paoBasePerformanceProfile, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("performanceprofile").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(paoBasePerformanceProfile).NotTo(o.BeEmpty())
+		o.Expect(paoBasePerformanceProfile).To(o.ContainSubstring("pao-baseprofile"))
+
+		g.By("create machine config pool worker-pao")
+		err = utils.CreateOperatorResourceByYaml(oc, "", fx.file("pao", "pao-baseprofile-mcp.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("assert if machine config pool applied for worker nodes")
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-pao", 1200)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("verify PAO profile was applied correctly")
+		expectRT := (iaasPlatform == "aws" || iaasPlatform == "gcp") && ocpArch == "amd64"
+		err = utils.VerifyPAOProfile(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node-performance-pao-baseprofile", "pao-baseprofile", expectRT)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// $ systemctl status  ocp-tuned-one-shot.service
+		// ocp-tuned-one-shot.service - TuneD service from NTO image
+		// ..
+		// Active: inactive (dead) since Thu 2024-06-20 14:29:32 UTC; 5min ago
+		// notice the one-shot tuned service started and finished before kubelet
+		// Return an error when the systemctl status ocp-tuned-one-shot.service is inactive, so err for o.Expect as expected.
+		g.By("check if end time of ocp-tuned-one-shot.service prior to startup time of kubelet service")
+
+		// supported property name
+		// 0.InactiveExitTimestampMonotonic
+		// 1.ExecMainStartTimestampMonotonic
+		// 2.ActiveEnterTimestampMonotonic
+		// 3.StateChangeTimestampMonotonic
+		// 4.ActiveExitTimestampMonotonic
+		// 5.InactiveEnterTimestampMonotonic
+		// 6.ConditionTimestampMonotonic
+		// 7.AssertTimestampMonotonic
+		inactiveExitTimestampMonotonicOfOCPTunedOneShotService, err := utils.ShowSystemctlPropertyValueOfServiceUnitByName(oc, tunedNodeName, ntoNamespace, "ocp-tuned-one-shot.service", "InactiveExitTimestampMonotonic")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		ocpTunedOneShotServiceStatusInactiveExitTimestamp, err := utils.GetSystemctlServiceUnitTimestampByPropertyNameWithMonotonic(inactiveExitTimestampMonotonicOfOCPTunedOneShotService)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		execMainStartTimestampMonotonicOfKubelet, err := utils.ShowSystemctlPropertyValueOfServiceUnitByName(oc, tunedNodeName, ntoNamespace, "kubelet.service", "ExecMainStartTimestampMonotonic")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		kubeletServiceStatusExecMainStartTimestamp, err := utils.GetSystemctlServiceUnitTimestampByPropertyNameWithMonotonic(execMainStartTimestampMonotonicOfKubelet)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("ocpTunedOneShotServiceStatusInactiveExitTimestamp is: %v, kubeletServiceStatusActiveEnterTimestamp is: %v", ocpTunedOneShotServiceStatusInactiveExitTimestamp, kubeletServiceStatusExecMainStartTimestamp)
+
+		o.Expect(kubeletServiceStatusExecMainStartTimestamp).To(o.BeNumerically(">", ocpTunedOneShotServiceStatusInactiveExitTimestamp))
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:75435][OTP]defer profile updates until node reboot when the deferred annotation is set to update [Disruptive]", oteg.Informing(), g.NodeTimeout(15*time.Minute), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "deferred-update-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "deferred-update-profile", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			if tunedPodName != "" {
+				// This test will make other tests (e.g. 29789) fail, because it will not restart tuned.  This is a problem if tuned-main.conf
+				// file is changed because of configuration parameters such as 'reapply_sysctl' or 'debug'.  Ensure we restart tuned once we finish.
+				_ = oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", ntoNamespace, tunedPodName, "--", "pkill", "-F", "/run/tuned/tuned.pid").Execute()
+			}
+			_ = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(cleanupCtx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "4096")
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "deferred-update=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		deferredNTORes := utils.NtoResource{
+			Name:          "deferred-update-profile",
+			Namespace:     ntoNamespace,
+			Template:      fx.file("nto", "deferred-nto.yaml"),
+			SysctlParam:   "kernel.shmmni",
+			SysctlValue:   "8192",
+			Label:         "deferred-update",
+			DeferredValue: "update",
+		}
+
+		g.By("create deferred-update profile")
+		err = deferredNTORes.ApplyNTOTunedProfileWithDeferredAnnotation(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create deferred-update profile and apply it to nodes")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "deferred-update-profile", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		g.By("compare the value kernel.shmmni on labeled node, should be 8192")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "8192")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("patch tuned with new value of kernel.shmmni to 10240")
+		err = utils.PatchTunedProfile(oc, ntoNamespace, "deferred-update-profile", fx.file("nto", "deferred-nto-update-patch.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("patch the tuned profile with a new value, the new value takes effect after node reboot")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "deferred-update-profile", "False")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profile.tuned.openshift.io", tunedNodeName, `-ojsonpath={.status.conditions[0].message}`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).NotTo(o.BeEmpty())
+		o.Expect(output).To(o.ContainSubstring("The TuneD daemon profile is waiting for the next node restart"))
+
+		g.By("reboot the node with updated tuned profile")
+		err = oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", ntoNamespace, "-it", tunedPodName, "--", "reboot").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.WaitForTunedProfileAppliedWithTimeout(ctx, oc, ntoNamespace, tunedNodeName, "deferred-update-profile", 600*time.Second, "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("compare the value kernel.shmmni on labeled node, should be 10240")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "10240")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("removed deferred tuned custom profile and unlabel node")
+		err = deferredNTORes.Delete(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("compare the value kernel.shmmni on labeled node, it will roll back to 4096")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "4096")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: sahshah
+	g.It("[test_id:75434][OTP]defer all profile changes until node reboot when the deferred annotation is set to always [Disruptive]", oteg.Informing(), g.NodeTimeout(15*time.Minute), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "deferred-always-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "deferred-always-profile", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			if tunedPodName != "" {
+				// This test will make other tests (e.g. 29789) fail, because it will not restart tuned.  This is a problem if tuned-main.conf
+				// file is changed because of configuration parameters such as 'reapply_sysctl' or 'debug'.  Ensure we restart tuned once we finish.
+				_ = oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", ntoNamespace, tunedPodName, "--", "pkill", "-F", "/run/tuned/tuned.pid").Execute()
+			}
+			_ = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(cleanupCtx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "4096")
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("pick one worker node to label to deferred-always")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "deferred-always=").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		deferredNTORes := utils.NtoResource{
+			Name:          "deferred-always-profile",
+			Namespace:     ntoNamespace,
+			Template:      fx.file("nto", "deferred-nto.yaml"),
+			SysctlParam:   "kernel.shmmni",
+			SysctlValue:   "8192",
+			Label:         "deferred-always",
+			DeferredValue: "always",
+		}
+
+		g.By("create deferred-always profile")
+		err = deferredNTORes.ApplyNTOTunedProfileWithDeferredAnnotation(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create deferred-always profile and apply it to nodes")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "openshift-node", "False")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profile.tuned.openshift.io", tunedNodeName, `-ojsonpath={.status.conditions[0].message}`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).NotTo(o.BeEmpty())
+		o.Expect(output).To(o.ContainSubstring("The TuneD daemon profile is waiting for the next node restart"))
+
+		g.By("compare the value kernel.shmmni on labeled node, should be 4096")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "4096")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("reboot the node with updated tuned profile")
+		err = oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", ntoNamespace, "-it", tunedPodName, "--", "reboot").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.WaitForTunedProfileAppliedWithTimeout(ctx, oc, ntoNamespace, tunedNodeName, "deferred-always-profile", 600*time.Second, "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check the value kernel.shmmni on labeled node, should be 8192")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "8192")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("removed deferred tuned custom profile and unlabel node")
+		err = deferredNTORes.Delete(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check the value kernel.shmmni on labeled node, it will roll back to 4096")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "4096")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:77764][OTP]allow kubelet to start when the NTO image cannot be pulled [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		proxyStdOut, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("proxy", "cluster", "-ojsonpath={.spec.httpsProxy}").Output()
+		utils.Logf("proxyStdOut is %v", proxyStdOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if len(proxyStdOut) == 0 {
+			g.Skip("No proxy in the cluster - skipping test")
+		}
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// numaNode = 0 hard coded in NTO requires a switch to a custom yaml
+		ocpArch, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.nodeInfo.architecture}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		disableHttpsPPFile := fx.file("nto", "disable-https-pp.yaml")
+		if ocpArch == "ppc64le" {
+			disableHttpsPPFile = fx.file("nto", "disable-https-pp-ppc64le.yaml")
+		}
+
+		// Get how many cpus on the specified worker node
+		g.By("get the number of CPU cores on the labeled worker node")
+		nodeCPUCores, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.capacity.cpu}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeCPUCores).NotTo(o.BeEmpty())
+
+		nodeCPUCoresInt, err := strconv.Atoi(nodeCPUCores)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if nodeCPUCoresInt <= 1 {
+			g.Skip("the worker node does not have enough cpus - skipping test")
+		}
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-nohttps-").Execute()
+			_ = utils.WaitForMCPUpdate(cleanupCtx, oc, "worker", 720)
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("mcp", "worker-nohttps", "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("PerformanceProfile", "performance", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.By("label the node with node-role.kubernetes.io/worker-nohttps=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-nohttps=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "disable-https-mcp.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("remove NTO image on label node")
+		stdOut, err := utils.DebugNodeRetryWithOptionsAndChroot(ctx, oc, tunedNodeName, []string{"-q"}, 3*time.Minute, "/bin/bash", "-c", ". /var/lib/ocp-tuned/image.env;podman rmi $NTO_IMAGE --force")
+		utils.Logf("removed NTO image is %v", stdOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("apply pao performance profile")
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, disableHttpsPPFile)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.WaitForMCPUpdate(ctx, oc, "worker-nohttps", 720)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		// Inactive status mean error in systemctl status ocp-tuned-one-shot.service, that's expected
+		g.By("check systemctl status ocp-tuned-one-shot.service, Active: inactive is expected")
+		stdOut, _ = utils.DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "systemctl", "status", "ocp-tuned-one-shot.service")
+		o.Expect(stdOut).To(o.ContainSubstring("ocp-tuned-one-shot.service: Deactivated successfully"))
+
+		g.By("check systemctl status kubelet, Active: active (running) is expected")
+		stdOut, err = utils.DebugNodeRetryWithOptionsAndChroot(ctx, oc, tunedNodeName, []string{"-q"}, 3*time.Minute, "systemctl", "status", "kubelet")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(stdOut).To(o.ContainSubstring("Active: active (running)"))
+
+		g.By("remove NTO image on label node and delete tuned pod, the image can pull successfully")
+		stdOut, err = utils.DebugNodeRetryWithOptionsAndChroot(ctx, oc, tunedNodeName, []string{"-q"}, 3*time.Minute, "/bin/bash", "-c", ". /var/lib/ocp-tuned/image.env;podman rmi $NTO_IMAGE --force")
+		utils.Logf("removed NTO image is %v", stdOut)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ntoNamespace, "pod", tunedPodName).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node again
+		tunedPodName, err = utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.AssertPodToBeReady(ctx, oc, tunedPodName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		podDescOutput, err := oc.AsAdmin().WithoutNamespace().Run("describe").Args("-n", ntoNamespace, "pod", tunedPodName).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(podDescOutput).To(o.ContainSubstring("Successfully pulled image"))
+	})
+
+	// author: sahshah
+	g.It("[test_id:76674][OTP]apply profile changes immediately when the deferred annotation is set to never [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "deferred-never-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "deferred-never-profile", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_ = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(cleanupCtx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "4096")
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		g.By("label the node with deferred-never=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "deferred-never=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		deferredNTORes := utils.NtoResource{
+			Name:          "deferred-never-profile",
+			Namespace:     ntoNamespace,
+			Template:      fx.file("nto", "deferred-nto.yaml"),
+			SysctlParam:   "kernel.shmmni",
+			SysctlValue:   "8192",
+			Label:         "deferred-never",
+			DeferredValue: "never",
+		}
+
+		g.By("compare the value kernel.shmmni on labeled node, should be 4096")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "4096")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create deferred-never profile")
+		err = deferredNTORes.ApplyNTOTunedProfileWithDeferredAnnotation(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("create deferred-never profile and apply it to nodes")
+		err = utils.WaitForTunedProfileApplied(ctx, oc, ntoNamespace, tunedNodeName, "deferred-never-profile", "True")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("check current profile for each node")
+		utils.LogCurrentProfiles(oc, ntoNamespace)
+
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profile.tuned.openshift.io", tunedNodeName, `-ojsonpath={.status.conditions[0].message}`).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).NotTo(o.BeEmpty())
+		o.Expect(output).To(o.ContainSubstring("TuneD profile applied"))
+
+		g.By("compare the value kernel.shmmni on labeled node, should be 8192")
+		err = utils.CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx, oc, ntoNamespace, tunedNodeName, "kernel.shmmni", "8192")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	// author: liqcui@redhat.com
+	g.It("[test_id:80233][OTP]detect and report duplicate TuneD profiles with conflicting content [Disruptive]", oteg.Informing(), func(ctx context.Context) {
+		SkipIsSNO(oc)
+
+		tunedNodeName, _, err := utils.GetLinuxWorkerNode(oc, 0)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.DeferCleanup(func(cleanupCtx context.Context) {
+			_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-dup-").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-profile-dup1", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("tuned", "openshift-profile-dup2", "-n", ntoNamespace, "--ignore-not-found").Execute()
+			utils.WaitForDefaultProfiles(cleanupCtx, oc, ntoNamespace)
+		})
+
+		g.By("label the node with node-role.kubernetes.io/worker-dup=")
+		err = oc.AsAdmin().WithoutNamespace().Run("label").Args("node", tunedNodeName, "node-role.kubernetes.io/worker-dup=", "--overwrite").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Get the tuned pod name in the same node that labeled node
+		tunedPodName, err := utils.GetTunedPodNameByNodeName(oc, tunedNodeName, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(tunedPodName).NotTo(o.BeEmpty())
+
+		ntoOperatorPod, err := utils.GetNTOPodName(oc, ntoNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("the tuned operator pod name is: \n%v", ntoOperatorPod)
+
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "nto-same-profile-diff-content1.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = utils.CreateOperatorResourceByYaml(oc, ntoNamespace, fx.file("nto", "nto-same-profile-diff-content2.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// The conflicting duplicate profile "openshift-profile-dup" is intentionally
+		// never applied to the node.  Wait for the operator to report the conflict
+		// in the Tuned CR status before asserting on it.
+		g.By("wait for the operator to detect and report the conflicting duplicate TuneD profiles")
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(_ context.Context) (bool, error) {
+			customizedTunedStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned/openshift-profile-dup1", "-ojsonpath={.status}").Output()
+			if err != nil {
+				utils.Logf("failed to get status of tuned/openshift-profile-dup1: %v", err)
+				return false, nil
+			}
+			return strings.Contains(customizedTunedStatus, "Duplicate TuneD profile") && strings.Contains(customizedTunedStatus, "conflicting content"), nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		TunedStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("current tuned list: \n%v", TunedStatus)
+
+		ProfileStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profile").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		utils.Logf("current profile of each nodes: \n%v", ProfileStatus)
+
+		// The status show Duplicate TuneD profile \"openshift-profile\" with conflicting content
+		customizedTunedStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned/openshift-profile-dup1", "-ojsonpath={.status}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(customizedTunedStatus).To(o.And(
+			o.ContainSubstring("Duplicate TuneD profile"),
+			o.ContainSubstring("conflicting content")))
+
+		customizedTunedStatus, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "tuned/openshift-profile-dup2", "-ojsonpath={.status}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(customizedTunedStatus).To(o.And(
+			o.ContainSubstring("Duplicate TuneD profile"),
+			o.ContainSubstring("conflicting content")))
+
+		err = utils.AssertNTOPodLogsLastLines(ctx, oc, ntoNamespace, ntoOperatorPod, "15", 60, "duplicate TuneD profile openshift-profile-dup with conflicting content detected")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
 })

--- a/test/extended/testdata/nto/cgroup-scheduler-besteffort-pod.yaml
+++ b/test/extended/testdata/nto/cgroup-scheduler-besteffort-pod.yaml
@@ -1,0 +1,28 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ocp-istream-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: app-web
+    spec:
+      nodeSelector:
+        tuned-scheduler-node: ""
+      containers:
+        - name: app-web
+          image: ${IMAGE_NAME}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+parameters:
+  - name: IMAGE_NAME

--- a/test/extended/testdata/nto/cgroup-scheduler-blacklist.yaml
+++ b/test/extended/testdata/nto/cgroup-scheduler-blacklist.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nto-cgroup-blacklist-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: ${PROFILE_NAME}
+      namespace: openshift-cluster-node-tuning-operator
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Custom OpenShift profile
+            include=openshift-node
+            [scheduler]
+            isolated_cores=1
+            cgroup_ps_blacklist=${CGROUP_BLACKLIST}
+          name: ${PROFILE_NAME}
+      recommend:
+        - match:
+            - label: tuned-scheduler-node
+          priority: 18
+          profile: ${PROFILE_NAME}
+          operand:
+            debug: false
+parameters:
+  - name: PROFILE_NAME
+  - name: CGROUP_BLACKLIST

--- a/test/extended/testdata/nto/cloud-provider-profile.yaml
+++ b/test/extended/testdata/nto/cloud-provider-profile.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nto-tuned-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: provider-${PROVIDER_NAME}
+      namespace: openshift-cluster-node-tuning-operator
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Cloud provider-specific profile
+            # Your tuning for Cloud provider goes here.
+            [sysctl]
+            vm.admin_reserve_kbytes=16386
+          name: provider-${PROVIDER_NAME}
+parameters:
+  - name: PROVIDER_NAME

--- a/test/extended/testdata/nto/custom-tuned-profiles-node.yaml
+++ b/test/extended/testdata/nto/custom-tuned-profiles-node.yaml
@@ -1,0 +1,29 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nto-tuned-node-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: ${TUNED_NAME}
+      namespace: openshift-cluster-node-tuning-operator
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Test if user can apply custom tuning: sysctl ${SYSCTLPARM}
+            include=openshift-node
+
+            [sysctl]
+            ${SYSCTLPARM}=${SYSCTLVALUE}
+          name: ${TUNED_NAME}
+      recommend:
+        - match:
+            - label: tuned.openshift.io/elasticsearch
+          priority: 15
+          profile: ${TUNED_NAME}
+parameters:
+  - name: TUNED_NAME
+  - name: SYSCTLPARM
+  - name: SYSCTLVALUE

--- a/test/extended/testdata/nto/default-irq-smp-affinity.yaml
+++ b/test/extended/testdata/nto/default-irq-smp-affinity.yaml
@@ -9,23 +9,23 @@ objects:
       name: ${TUNED_NAME}
     spec:
       profile:
-      - data: |
-          [main]
-          summary=An OpenShift profile to test [scheduler] default_irq_smp_affinity option
-          include=openshift-node
-          [scheduler]
-          # isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7
-          isolated_cores=1
-          # the cpulist in 'default_irq_smp_affinity' is unpacked and written directly to /proc/irq/default_smp_affinity
-          # default_irq_smp_affinity=1
-          ${SYSCTLPARM}=${SYSCTLVALUE}
-        name: ${TUNED_NAME}
+        - data: |
+            [main]
+            summary=An OpenShift profile to test [scheduler] default_irq_smp_affinity option
+            include=openshift-node
+            [scheduler]
+            # isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7
+            isolated_cores=1
+            # the cpulist in 'default_irq_smp_affinity' is unpacked and written directly to /proc/irq/default_smp_affinity
+            # default_irq_smp_affinity=1
+            ${SYSCTLPARM}=${SYSCTLVALUE}
+          name: ${TUNED_NAME}
       recommend:
-      - match:
-        - label: tuned.openshift.io/default-irq-smp-affinity
-        priority: 18
-        profile: ${TUNED_NAME}
+        - match:
+            - label: tuned.openshift.io/default-irq-smp-affinity
+          priority: 18
+          profile: ${TUNED_NAME}
 parameters:
-- name: TUNED_NAME
-- name: SYSCTLPARM
-- name: SYSCTLVALUE
+  - name: TUNED_NAME
+  - name: SYSCTLPARM
+  - name: SYSCTLVALUE

--- a/test/extended/testdata/nto/deferred-nto-update-patch.yaml
+++ b/test/extended/testdata/nto/deferred-nto-update-patch.yaml
@@ -1,0 +1,9 @@
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Custom OpenShift profile
+        include=openshift-node
+        [sysctl]
+        kernel.shmmni=10240
+      name: deferred-update-profile

--- a/test/extended/testdata/nto/deferred-nto.yaml
+++ b/test/extended/testdata/nto/deferred-nto.yaml
@@ -1,0 +1,32 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nto-tuned-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: ${TUNED_PROFILE}
+      namespace: openshift-cluster-node-tuning-operator
+      annotations:
+        tuned.openshift.io/deferred: "${DEFERRED_VALUE}"
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Custom OpenShift profile
+            include=openshift-node
+            [sysctl]
+            ${SYSCTL_NAME}=${SYSCTL_VALUE}
+          name: ${TUNED_PROFILE}
+      recommend:
+        - match:
+            - label: ${LABEL_NAME}
+          priority: 20
+          profile: ${TUNED_PROFILE}
+parameters:
+  - name: TUNED_PROFILE
+  - name: SYSCTL_NAME
+  - name: SYSCTL_VALUE
+  - name: LABEL_NAME
+  - name: DEFERRED_VALUE

--- a/test/extended/testdata/nto/disable-https-mcp.yaml
+++ b/test/extended/testdata/nto/disable-https-mcp.yaml
@@ -1,0 +1,13 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-nohttps
+  labels:
+    worker-nohttps: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker, worker-nohttps]}
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-nohttps: ""

--- a/test/extended/testdata/nto/disable-https-pp-ppc64le.yaml
+++ b/test/extended/testdata/nto/disable-https-pp-ppc64le.yaml
@@ -1,0 +1,16 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: "2-3"
+    reserved: "0-1"
+  globallyDisableIrqLoadBalancing: false
+  net:
+    userLevelNetworking: true
+    devices: []
+  nodeSelector:
+    node-role.kubernetes.io/worker-nohttps: ""
+  realTimeKernel:
+    enabled: false

--- a/test/extended/testdata/nto/disable-https-pp.yaml
+++ b/test/extended/testdata/nto/disable-https-pp.yaml
@@ -1,0 +1,18 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: "2-3"
+    reserved: "0-1"
+  globallyDisableIrqLoadBalancing: false
+  net:
+    userLevelNetworking: true
+    devices: []
+  nodeSelector:
+    node-role.kubernetes.io/worker-nohttps: ""
+  numa:
+    topologyPolicy: "single-numa-node"
+  realTimeKernel:
+    enabled: false

--- a/test/extended/testdata/nto/hp-performanceprofile-patch.yaml
+++ b/test/extended/testdata/nto/hp-performanceprofile-patch.yaml
@@ -1,0 +1,6 @@
+spec:
+  recommend:
+    - machineConfigLabels:
+        machineconfiguration.openshift.io/role: "master"
+      priority: 18
+      profile: openshift-node-performance-hp-performanceprofile

--- a/test/extended/testdata/nto/hp-performanceprofile.yaml
+++ b/test/extended/testdata/nto/hp-performanceprofile.yaml
@@ -1,0 +1,58 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: hp-performanceprofile-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: openshift-node-performance-hp-performanceprofile
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Openshift node optimized for deterministic performance at the cost of increased power consumption, focused on low latency network performance. Based on Tuned 2.11 and Cluster node tuning (oc 4.5)
+            include=openshift-node,cpu-partitioning
+            [variables]
+            isolated_cores=1
+            not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+            [cpu]
+            force_latency=cstate.id:1|3
+            governor=performance
+            energy_perf_bias=performance
+            min_perf_pct=100
+            [vm]
+            transparent_hugepages=never
+            [sysctl]
+            kernel.hung_task_timeout_secs = 600
+            kernel.nmi_watchdog = 0
+            kernel.sched_rt_runtime_us = -1
+            kernel.timer_migration = 0
+            kernel.numa_balancing=0
+            net.core.busy_read=50
+            net.core.busy_poll=50
+            net.ipv4.tcp_fastopen=3
+            vm.stat_interval = 10
+            kernel.sched_min_granularity_ns=10000000
+            vm.dirty_ratio=10
+            vm.dirty_background_ratio=3
+            vm.swappiness=10
+            kernel.sched_migration_cost_ns=5000000
+            [selinux]
+            avc_cache_threshold=8192
+            [net]
+            nf_conntrack_hashsize=131072
+            [bootloader]
+            initrd_remove_dir=
+            initrd_dst_img=
+            initrd_add_dir=
+            cmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=disable nosoftlockup
+            cmdline_realtime=+tsc=nowatchdog intel_iommu=on iommu=pt isolcpus=managed_irq,${isolated_cores} systemd.cpu_affinity=${not_isolated_cores_expanded}
+            cmdline_hugepages=+ default_hugepagesz=2M
+            cmdline_additionalArg=+
+          name: openshift-node-performance-hp-performanceprofile
+      recommend:
+        - machineConfigLabels:
+            machineconfiguration.openshift.io/role: "master"
+          priority: 30
+          profile: openshift-node-performance-hp-performanceprofile

--- a/test/extended/testdata/nto/hugepage-100m-pod.yaml
+++ b/test/extended/testdata/nto/hugepage-100m-pod.yaml
@@ -1,0 +1,58 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ocp-istream-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: hugepages-app
+      labels:
+        app: hugepages-example
+    spec:
+      containers:
+        - securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          image: ${IMAGENAME}
+          command:
+            - sleep
+            - inf
+          name: example
+          volumeMounts:
+            - mountPath: /dev/hugepages
+              name: hugepage
+            - mountPath: /etc/podinfo
+              name: podinfo
+          resources:
+            limits:
+              hugepages-2Mi: 100Mi
+              memory: "1Gi"
+              cpu: "100m"
+            requests:
+              hugepages-2Mi: 100Mi
+          env:
+            - name: REQUESTS_HUGEPAGES_2Mi
+              valueFrom:
+                resourceFieldRef:
+                  containerName: example
+                  resource: requests.hugepages-2Mi
+      volumes:
+        - name: hugepage
+          emptyDir:
+            medium: HugePages
+        - name: podinfo
+          downwardAPI:
+            items:
+              - path: "hugepages_2M_request"
+                resourceFieldRef:
+                  containerName: example
+                  resource: requests.hugepages-2Mi
+                  divisor: 1M
+parameters:
+  - name: IMAGENAME

--- a/test/extended/testdata/nto/hugepage-mcp.yaml
+++ b/test/extended/testdata/nto/hugepage-mcp.yaml
@@ -1,0 +1,13 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-hp
+  labels:
+    worker-hp: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker, worker-hp]}
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-hp: ""

--- a/test/extended/testdata/nto/hugepage-tuned-boottime.yaml
+++ b/test/extended/testdata/nto/hugepage-tuned-boottime.yaml
@@ -1,0 +1,19 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: hugepages
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Boot time configuration for hugepages
+        include=openshift-node
+        [bootloader]
+        cmdline_openshift_node_hugepages=hugepagesz=2M hugepages=50
+      name: openshift-node-hugepages
+  recommend:
+    - machineConfigLabels:
+        machineconfiguration.openshift.io/role: "worker-hp"
+      priority: 18
+      profile: openshift-node-hugepages

--- a/test/extended/testdata/nto/ips.yaml
+++ b/test/extended/testdata/nto/ips.yaml
@@ -1,0 +1,37 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ips-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: ips
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=A custom OpenShift IPS host profile
+            [sysctl]
+            kernel.msgmni=4096
+            ${SYSCTLPARM1}=${SYSCTLVALUE1}
+            kernel.shmmax=180000000
+            kernel.sem="128 1048576 32 32768"
+            net.core.rmem_default=>33554431
+            net.core.rmem_max=>33554431
+            fs.file-max=>240000
+            vm.dirty_background_ratio=64
+            vm.dirty_ratio=72
+            ${SYSCTLPARM2}=${SYSCTLVALUE2}
+          name: ips-host
+      recommend:
+        - match:
+            - label: tuned
+              value: ips
+          priority: 18
+          profile: ips-host
+parameters:
+  - name: SYSCTLPARM1
+  - name: SYSCTLVALUE1
+  - name: SYSCTLPARM2
+  - name: SYSCTLVALUE2

--- a/test/extended/testdata/nto/machine-config-pool.yaml
+++ b/test/extended/testdata/nto/machine-config-pool.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nto-mcp-template
+objects:
+  - apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    metadata:
+      name: ${MCP_NAME}
+      labels:
+        worker-rt: ""
+    spec:
+      machineConfigSelector:
+        matchExpressions:
+          - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker, worker-rt]}
+      nodeSelector:
+        matchLabels:
+          node-role.kubernetes.io/worker-rt: ""
+parameters:
+  - name: MCP_NAME

--- a/test/extended/testdata/nto/net-plugin-tuned-node.yaml
+++ b/test/extended/testdata/nto/net-plugin-tuned-node.yaml
@@ -1,0 +1,18 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: net-plugin
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Net Plugin Test Case
+        include=openshift-node
+        [net]
+        channels=combined 1
+      name: net-plugin
+  recommend:
+    - match:
+        - label: node-role.kubernetes.io/netplugin
+      priority: 5
+      profile: net-plugin

--- a/test/extended/testdata/nto/node-diffcpus-mcp.yaml
+++ b/test/extended/testdata/nto/node-diffcpus-mcp.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nto-mcp-template
+objects:
+  - apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    metadata:
+      name: ${MCP_NAME}
+      labels:
+        worker-diffcpus: ""
+    spec:
+      machineConfigSelector:
+        matchExpressions:
+          - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker, worker-diffcpus]}
+      nodeSelector:
+        matchLabels:
+          node-role.kubernetes.io/worker-diffcpus: ""
+parameters:
+  - name: MCP_NAME

--- a/test/extended/testdata/nto/node-diffcpus-tuned-bootloader.yaml
+++ b/test/extended/testdata/nto/node-diffcpus-tuned-bootloader.yaml
@@ -1,0 +1,18 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-bootcmdline-cpu
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Custom OpenShift profile
+        [bootloader]
+        cmdline=+cpus=${f:exec:/usr/bin/bash:-c:nproc|tr -d '\n'}
+      name: openshift-bootcmdline-cpu
+  recommend:
+    - machineConfigLabels:
+        machineconfiguration.openshift.io/role: "worker-diffcpus"
+      priority: 18
+      profile: openshift-bootcmdline-cpu

--- a/test/extended/testdata/nto/nto-same-profile-diff-content1.yaml
+++ b/test/extended/testdata/nto/nto-same-profile-diff-content1.yaml
@@ -1,0 +1,19 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-profile-dup1
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Custom OpenShift profile
+        include=openshift-node
+        [sysctl]
+        kernel.shmmni=8192
+      name: openshift-profile-dup
+  recommend:
+    - match:
+        - label: node-role.kubernetes.io/worker-dup
+      priority: 20
+      profile: openshift-profile-dup

--- a/test/extended/testdata/nto/nto-same-profile-diff-content2.yaml
+++ b/test/extended/testdata/nto/nto-same-profile-diff-content2.yaml
@@ -1,0 +1,19 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-profile-dup2
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Custom OpenShift profile
+        include=openshift-node
+        [sysctl]
+        kernel.shmmni=8191
+      name: openshift-profile-dup
+  recommend:
+    - match:
+        - label: node-role.kubernetes.io/worker-dup
+      priority: 20
+      profile: openshift-profile-dup

--- a/test/extended/testdata/nto/nto-sysctl-pod.yaml
+++ b/test/extended/testdata/nto/nto-sysctl-pod.yaml
@@ -1,0 +1,31 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: pod_test-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: sysctlpod
+      labels:
+        app: sysctlpod
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker-tuning: ""
+      containers:
+        - name: sysctlpod
+          securityContext:
+            runAsNonRoot: ${{RUNASNONROOT}}
+            seccompProfile:
+              type: RuntimeDefault
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          image: ${IMAGE_NAME}
+          command: ["/bin/bash"]
+          args: ["-c", "sysctl kernel.pid_max;while true;do pidmax=`sysctl kernel.pid_max`; if [[ $pidmax != *181818 ]];then echo kernel.pid_max not equal 181818; fi;done"]
+          imagePullPolicy: Always
+parameters:
+  - name: IMAGE_NAME
+  - name: RUNASNONROOT

--- a/test/extended/testdata/nto/nto-sysctl-template.yaml
+++ b/test/extended/testdata/nto/nto-sysctl-template.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: pod_test-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: ${TUNED_PROFILE}
+      namespace: openshift-cluster-node-tuning-operator
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Custom OpenShift PidMax profile
+            include=openshift-node
+            [sysctl]
+            ${SYSCTL_NAME} = ${SYSCTL_VALUE}
+          name: ${TUNED_PROFILE}
+      recommend:
+        - match:
+            - label: ${LABEL_NAME}
+              value: ""
+          priority: 18
+          profile: ${TUNED_PROFILE}
+parameters:
+  - name: TUNED_PROFILE
+  - name: SYSCTL_NAME
+  - name: SYSCTL_VALUE
+  - name: LABEL_NAME

--- a/test/extended/testdata/nto/nto-tuned-debug-node.yaml
+++ b/test/extended/testdata/nto/nto-tuned-debug-node.yaml
@@ -1,0 +1,33 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nto-tuned-debug-node-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: ${TUNED_NAME}
+      namespace: openshift-cluster-node-tuning-operator
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Test change sysctl ${SYSCTLPARM}
+            include=openshift-control-plane
+
+            [sysctl]
+            ${SYSCTLPARM}=${SYSCTLVALUE}
+          name: ${TUNED_NAME}
+      recommend:
+        - match:
+            - label: tuned.openshift.io/elasticsearch
+          priority: 5
+          profile: ${TUNED_NAME}
+          operand:
+            debug: ${{ISDEBUG}}
+            #Using ${{ISDEBUG}} to support boolean
+parameters:
+  - name: TUNED_NAME
+  - name: SYSCTLPARM
+  - name: SYSCTLVALUE
+  - name: ISDEBUG

--- a/test/extended/testdata/nto/nto-tuned-pidmax.yaml
+++ b/test/extended/testdata/nto/nto-tuned-pidmax.yaml
@@ -1,0 +1,20 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: tuning-pidmax
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Custom OpenShift PidMax profile
+        include=openshift-node
+        [sysctl]
+        kernel.pid_max = 181818
+      name: tuning-pidmax
+  recommend:
+    - match:
+        - label: node-role.kubernetes.io/worker-tuning
+          value: ""
+      priority: 18
+      profile: tuning-pidmax

--- a/test/extended/testdata/nto/nto-unknown-profile.yaml
+++ b/test/extended/testdata/nto/nto-unknown-profile.yaml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nto-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Profile
+    metadata:
+      name: worker-does-not-exist-openshift-node
+    spec:
+      config:
+        debug: true
+        providerName: "${PROVIDER_NAME}"
+        tunedConfig: {}
+        tunedProfile: openshift-node
+parameters:
+  - name: PROVIDER_NAME

--- a/test/extended/testdata/nto/openshift-node-postgresql.yaml
+++ b/test/extended/testdata/nto/openshift-node-postgresql.yaml
@@ -1,0 +1,16 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-node-postgresql
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Custom OpenShift node profile for PostgreSQL server
+        include=openshift-node,postgresql
+      name: openshift-node-postgresql
+  recommend:
+    - match:
+        - label: tuned.openshift.io/openshift-node-postgresql
+      priority: 18
+      profile: openshift-node-postgresql

--- a/test/extended/testdata/nto/override.yaml
+++ b/test/extended/testdata/nto/override.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: override-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: override
+      namespace: openshift-cluster-node-tuning-operator
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Testing no-override of /etc/sysctl.d/*.conf parameters
+            [sysctl]
+            kernel.pid_max=1048576
+            fs.inotify.max_user_watches=163840
+          name: override
+      recommend:
+        - match:
+            - label: tuned.openshift.io/override
+          priority: 18
+          profile: override
+          operand:
+            tunedConfig:
+              reapply_sysctl: ${{REAPPLY_SYSCTL}}
+            debug: false
+parameters:
+  - name: REAPPLY_SYSCTL

--- a/test/extended/testdata/nto/realtime.yaml
+++ b/test/extended/testdata/nto/realtime.yaml
@@ -1,0 +1,26 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: ocp-istream-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: openshift-realtime
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Custom OpenShift realtime profile
+            #include=openshift-node,realtime
+            include=${INCLUDE}
+            [variables]
+            isolated_cores=1
+          name: openshift-realtime
+      recommend:
+        - machineConfigLabels:
+            machineconfiguration.openshift.io/role: "worker-rt"
+          priority: 18
+          profile: openshift-realtime
+parameters:
+  - name: INCLUDE

--- a/test/extended/testdata/nto/stalld-tuned.yaml
+++ b/test/extended/testdata/nto/stalld-tuned.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nto-tuned-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: openshift-stalld
+      namespace: openshift-cluster-node-tuning-operator
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Custom OpenShift profile
+            include=openshift-node,realtime
+            [sysctl]
+            kernel.sched_rt_runtime_us = -1
+
+            [service]
+            service.stalld=${STALLD_STATUS}
+            #STALLD_STATUS is stop,disable or start,enable
+          name: openshift-stalld
+      recommend:
+        - match:
+            - label: node-role.kubernetes.io/worker-stalld
+          priority: 18
+          profile: openshift-stalld
+parameters:
+  - name: STALLD_STATUS

--- a/test/extended/testdata/nto/tuned-nf-conntrack-max-node.yaml
+++ b/test/extended/testdata/nto/tuned-nf-conntrack-max-node.yaml
@@ -1,0 +1,25 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: tuned-nf-conntrack-max-node-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: nf-conntrack-max
+      namespace: openshift-cluster-node-tuning-operator
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Test if user can apply custom tuning: sysctl net.netfilter.nf_conntrack_max
+            include=openshift-node
+
+            [sysctl]
+            net.netfilter.nf_conntrack_max=1048578
+          name: nf-conntrack-max
+      recommend:
+        - match:
+            - label: tuned.openshift.io/elasticsearch
+          priority: 15
+          profile: nf-conntrack-max

--- a/test/extended/testdata/nto/tuning-maxpid.yaml
+++ b/test/extended/testdata/nto/tuning-maxpid.yaml
@@ -1,0 +1,20 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: tuning-maxpid
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Custom OpenShift PidMax profile
+        include=openshift-node
+        [sysctl]
+        kernel.pid_max = 181818
+      name: tuning-maxpid
+  recommend:
+    - match:
+        - label: node-role.kubernetes.io/worker-tuning
+          value: ""
+      priority: 20
+      profile: tuning-maxpid

--- a/test/extended/testdata/nto/worker-stuck-tuned.yaml
+++ b/test/extended/testdata/nto/worker-stuck-tuned.yaml
@@ -1,0 +1,17 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-profile-stuck
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=OpenShift profile stuck
+        [variables]
+        v=${f:exec:sleep:72}
+      name: openshift-profile-stuck
+  recommend:
+    - match:
+        - label: worker-stuck
+      priority: 18
+      profile: openshift-profile-stuck

--- a/test/extended/testdata/pao/pao-baseprofile-mcp.yaml
+++ b/test/extended/testdata/pao/pao-baseprofile-mcp.yaml
@@ -1,0 +1,13 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-pao
+  labels:
+    worker-pao: ""
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker, worker-pao]}
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-pao: ""

--- a/test/extended/testdata/pao/pao-baseprofile-ppc64le.yaml
+++ b/test/extended/testdata/pao/pao-baseprofile-ppc64le.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: pao-template
+objects:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    metadata:
+      name: pao-baseprofile
+    spec:
+      additionalKernelArgs:
+        - smt=4
+      cpu:
+        isolated: "1"
+        reserved: "0"
+      net:
+        userLevelNetworking: true
+      hugepages:
+        defaultHugepagesSize: 1G
+        pages:
+          - count: 1
+            size: 1G
+      realTimeKernel:
+        enabled: ${{ISENABLED}}
+      numa:
+        topologyPolicy: "best-effort"
+      nodeSelector:
+        node-role.kubernetes.io/worker-pao: ""
+parameters:
+  - name: ISENABLED

--- a/test/extended/testdata/pao/pao-baseprofile.yaml
+++ b/test/extended/testdata/pao/pao-baseprofile.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: pao-template
+objects:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    metadata:
+      name: pao-baseprofile
+    spec:
+      additionalKernelArgs:
+        - tsc=reliable
+      cpu:
+        isolated: "1"
+        reserved: "0"
+      net:
+        userLevelNetworking: true
+      hugepages:
+        defaultHugepagesSize: 1G
+        pages:
+          - count: 1
+            size: 1G
+      realTimeKernel:
+        enabled: ${{ISENABLED}}
+      numa:
+        topologyPolicy: "best-effort"
+      nodeSelector:
+        node-role.kubernetes.io/worker-pao: ""
+parameters:
+  - name: ISENABLED

--- a/test/extended/testdata/pao/pao-baseqos-pod.yaml
+++ b/test/extended/testdata/pao/pao-baseqos-pod.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: guaranteed-pod
+  annotations:
+    cpu-load-balancing.crio.io: "true"
+spec:
+  runtimeClassName: performance-pao-baseprofile
+  containers:
+    - name: guaranteed-pod
+      image: quay.io/openshifttest/nginx-alpine@sha256:04f316442d48ba60e3ea0b5a67eb89b0b667abf1c198a3d0056ca748736336a0
+      imagePullPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        limits:
+          memory: "100Mi"
+          cpu: 1
+        requests:
+          memory: "100Mi"
+          cpu: 1
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0

--- a/test/extended/testdata/pao/pao-include-performance-profile.yaml
+++ b/test/extended/testdata/pao/pao-include-performance-profile.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: pao-template
+objects:
+  - apiVersion: tuned.openshift.io/v1
+    kind: Tuned
+    metadata:
+      name: include-performance-profile
+    spec:
+      profile:
+        - data: |
+            [main]
+            summary=Configuration changes profile inherited from performance created tuned
+            include=openshift-node-performance-optimize
+            [bootloader]
+            cmdline_crash=nohz_full=0,2-4
+            [sysctl]
+            kernel.timer_migration=1
+            [service]
+            service.stalld=start,enable
+          name: include-performance-profile
+      recommend:
+        - machineConfigLabels:
+            #Role Name, master for SNO, worker-optimize for normal cluster
+            machineconfiguration.openshift.io/role: "${ROLENAME}"
+          priority: 19
+          profile: include-performance-profile
+parameters:
+  - name: ROLENAME

--- a/test/extended/testdata/pao/pao-performance-fixpatch.yaml
+++ b/test/extended/testdata/pao/pao-performance-fixpatch.yaml
@@ -1,0 +1,7 @@
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Configuration changes profile inherited from performance created tuned
+        include=openshift-node-performance-performance
+      name: performance-patch

--- a/test/extended/testdata/pao/pao-performance-optimize.yaml
+++ b/test/extended/testdata/pao/pao-performance-optimize.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: pao-template
+objects:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    metadata:
+      name: optimize
+    spec:
+      additionalKernelArgs:
+        - idle=poll
+      cpu:
+        isolated: 0,3
+        reserved: 1-2
+      globallyDisableIrqLoadBalancing: true
+      hugepages:
+        defaultHugepagesSize: 1G
+        pages:
+          - count: 2
+            size: 1G
+      nodeSelector:
+        #Role Name, master for SNO, worker-optimize for normal cluster
+        node-role.kubernetes.io/${ROLENAME}: ""
+      numa:
+        topologyPolicy: restricted
+      realTimeKernel:
+        enabled: false
+parameters:
+  - name: ROLENAME

--- a/test/extended/testdata/pao/pao-performance-patch.yaml
+++ b/test/extended/testdata/pao/pao-performance-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: performance-patch
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=Configuration changes profile inherited from performance created tuned
+        include=openshift-node-performance-example-performanceprofile
+        [service]
+        service.stalld=stop,disable
+      name: performance-patch
+  recommend:
+    - machineConfigLabels:
+        machineconfiguration.openshift.io/role: "worker-cnf"
+      priority: 19
+      profile: performance-patch

--- a/test/extended/testdata/pao/pao-performanceprofile.yaml
+++ b/test/extended/testdata/pao/pao-performanceprofile.yaml
@@ -1,0 +1,25 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: pao-template
+objects:
+  - apiVersion: performance.openshift.io/v2
+    kind: PerformanceProfile
+    metadata:
+      name: performance
+    spec:
+      cpu:
+        isolated: "1"
+        reserved: "0"
+      hugepages:
+        defaultHugepagesSize: "2M"
+        pages:
+          - size: "1G"
+            node: 0
+            count: 1
+      realTimeKernel:
+        enabled: ${{ISENABLED}}
+      nodeSelector:
+        node-role.kubernetes.io/worker-cnf: ""
+parameters:
+  - name: ISENABLED

--- a/test/extended/testdata/pao/pao-workercnf-mcp.yaml
+++ b/test/extended/testdata/pao/pao-workercnf-mcp.yaml
@@ -1,0 +1,14 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-cnf
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker, worker-cnf]}
+  paused: false
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-cnf: ""

--- a/test/extended/testdata/pao/pao-workeroptimize-mcp.yaml
+++ b/test/extended/testdata/pao/pao-workeroptimize-mcp.yaml
@@ -1,0 +1,14 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-optimize
+  labels:
+    machineconfiguration.openshift.io/role: worker-optimize
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker, worker-optimize]}
+  paused: false
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-optimize: ""

--- a/test/extended/utils/cli_wrapper.go
+++ b/test/extended/utils/cli_wrapper.go
@@ -1,7 +1,14 @@
+// cli_wrapper.go wraps the oc command-line tool to provide a simple interface
+// for test operations. It defines the CLI and Command structs with builder-pattern
+// methods for constructing and executing oc commands.
+
 package utils
 
 import (
+	"bufio"
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,8 +31,11 @@ type CLI struct {
 	verbose          bool
 }
 
+// defaultCommandTimeout is the maximum duration an oc command is allowed to run.
+const defaultCommandTimeout = 5 * time.Minute
+
 // NewCLIWithoutNamespace creates a new CLI instance without a default namespace
-func NewCLIWithoutNamespace(name string) *CLI {
+func NewCLIWithoutNamespace() *CLI {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {
 		kubeconfig = os.Getenv("HOME") + "/.kube/config"
@@ -162,7 +172,7 @@ func (c *CLI) SetupProject() error {
 	// Create the namespace
 	err := c.AsAdmin().WithoutNamespace().Run("create").Args("namespace", c.namespace).Execute()
 	if err != nil {
-		return fmt.Errorf("failed to create namespace %s: %v", c.namespace, err)
+		return fmt.Errorf("failed to create namespace %s: %w", c.namespace, err)
 	}
 
 	return nil
@@ -199,6 +209,8 @@ type Command struct {
 	verb     string
 	args     []string
 	inputStr string
+	timeout  time.Duration
+	ctx      context.Context
 }
 
 // Run starts building a command
@@ -220,6 +232,32 @@ func (cmd *Command) Args(args ...string) *Command {
 func (cmd *Command) InputString(input string) *Command {
 	cmd.inputStr = input
 	return cmd
+}
+
+// WithTimeout overrides defaultCommandTimeout for this command invocation. Use it for
+// commands that are expected to legitimately run longer than the default (e.g. a long
+// `oc wait`/`oc debug` call), so they aren't killed with a generic "context deadline
+// exceeded" indistinguishable from a genuine hang.
+func (cmd *Command) WithTimeout(timeout time.Duration) *Command {
+	cmd.timeout = timeout
+	return cmd
+}
+
+// WithCtx sets the context for the command. This allows callers to cancel in-flight
+// oc commands when the provided context is cancelled (e.g. test context or cleanup
+// context). If not set, context.Background() is used.
+func (cmd *Command) WithCtx(ctx context.Context) *Command {
+	cmd.ctx = ctx
+	return cmd
+}
+
+// timeoutOrDefault returns the per-call timeout if one was set via WithTimeout,
+// otherwise defaultCommandTimeout.
+func (cmd *Command) timeoutOrDefault() time.Duration {
+	if cmd.timeout > 0 {
+		return cmd.timeout
+	}
+	return defaultCommandTimeout
 }
 
 // Execute runs the command and returns an error if it fails
@@ -244,7 +282,8 @@ func (cmd *Command) buildCmdArgs() []string {
 	// Add verb
 	cmdArgs = append(cmdArgs, cmd.verb)
 
-	// Add namespace if set and not explicitly disabled
+	// Add namespace if set and not explicitly disabled. The `debug` verb does not
+	// accept `-n` in this position, so skip it to avoid command failures.
 	if !cmd.cli.withoutNamespace && cmd.cli.namespace != "" && cmd.verb != "debug" {
 		cmdArgs = append(cmdArgs, "-n", cmd.cli.namespace)
 	}
@@ -255,15 +294,28 @@ func (cmd *Command) buildCmdArgs() []string {
 	return cmdArgs
 }
 
-// Output runs the command and returns its output
-func (cmd *Command) Output() (string, error) {
-	cmdArgs := cmd.buildCmdArgs()
+// run builds and executes the underlying oc command, applying the shared logging,
+// timeout, and stdin/stdout/stderr plumbing used by both Output and Outputs. It
+// returns the trimmed stdout/stderr and the raw error from ocCmd.Run() (nil on
+// success), along with the resolved command-line args for callers that need them
+// (e.g. to build an ExitError). It does not itself log or wrap the error on
+// failure — callers are responsible for that, since Output and Outputs differ in
+// how they want to report failures.
+func (cmd *Command) run() (stdout, stderr string, cmdArgs []string, err error) {
+	cmdArgs = cmd.buildCmdArgs()
 
 	if cmd.cli.verbose {
-		fmt.Printf("DEBUG: %s %s\n", cmd.cli.execPath, strings.Join(cmdArgs, " "))
+		fmt.Fprintf(os.Stderr, "DEBUG: %s %s\n", cmd.cli.execPath, strings.Join(cmdArgs, " "))
 	}
 
-	ocCmd := exec.Command(cmd.cli.execPath, cmdArgs...)
+	parentCtx := cmd.ctx
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, cmd.timeoutOrDefault())
+	defer cancel()
+
+	ocCmd := exec.CommandContext(ctx, cmd.cli.execPath, cmdArgs...)
 
 	// Set up stdin if input string is provided
 	if cmd.inputStr != "" {
@@ -274,20 +326,29 @@ func (cmd *Command) Output() (string, error) {
 		Logf("running '%s %s'", cmd.cli.execPath, strings.Join(cmdArgs, " "))
 	}
 
-	var stdout, stderr bytes.Buffer
-	ocCmd.Stdout = &stdout
-	ocCmd.Stderr = &stderr
+	var stdoutBuf, stderrBuf bytes.Buffer
+	ocCmd.Stdout = &stdoutBuf
+	ocCmd.Stderr = &stderrBuf
 
-	err := ocCmd.Run()
-	trimmed := strings.TrimSpace(stdout.String())
+	err = ocCmd.Run()
+	stdout = strings.TrimSpace(stdoutBuf.String())
+	stderr = strings.TrimSpace(stderrBuf.String())
 
 	if err != nil {
-		stderrStr := strings.TrimSpace(stderr.String())
-		Logf("error running command: %v\nstdout: %s\nstderr: %s", err, trimmed, stderrStr)
-		return trimmed, fmt.Errorf("command failed: %v, stderr: %s", err, stderrStr)
+		Logf("error running command: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
 	}
 
-	return trimmed, nil
+	return stdout, stderr, cmdArgs, err
+}
+
+// Output runs the command and returns its output
+func (cmd *Command) Output() (string, error) {
+	stdout, stderr, _, err := cmd.run()
+	if err != nil {
+		return stdout, fmt.Errorf("command failed: %w, stderr: %s", err, stderr)
+	}
+
+	return stdout, nil
 }
 
 // ExitError represents an error from command execution
@@ -299,56 +360,104 @@ type ExitError struct {
 
 // Outputs runs the command and returns both stdout and stderr separately
 func (cmd *Command) Outputs() (string, string, error) {
+	stdout, stderr, cmdArgs, err := cmd.run()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return stdout, stderr, &ExitError{
+				ExitError: exitErr,
+				Cmd:       cmd.cli.execPath + " " + strings.Join(cmdArgs, " "),
+				StdErr:    stderr,
+			}
+		}
+		return stdout, stderr, fmt.Errorf("command failed: %w", err)
+	}
+
+	return stdout, stderr, nil
+}
+
+// FollowUntilContains runs a streaming command (e.g. "oc logs -f") and returns true as soon
+// as a line of its output contains keyword. It returns false if the command exits or ctx is
+// done before the keyword appears. The underlying process is always stopped before returning,
+// even if it would otherwise keep streaming forever.
+func (cmd *Command) FollowUntilContains(ctx context.Context, keyword string) bool {
+	// maxFollowedLineSize is the largest single line bufio.Scanner will accept while reading
+	// streamed command output. The default 64 KiB limit is too small for occasionally long
+	// container log lines.
+	const maxFollowedLineSize = 1024 * 1024
+
 	cmdArgs := cmd.buildCmdArgs()
-
-	if cmd.cli.verbose {
-		fmt.Printf("DEBUG: %s %s\n", cmd.cli.execPath, strings.Join(cmdArgs, " "))
-	}
-
-	ocCmd := exec.Command(cmd.cli.execPath, cmdArgs...)
-
-	// Set up stdin if input string is provided
-	if cmd.inputStr != "" {
-		ocCmd.Stdin = strings.NewReader(cmd.inputStr)
-	}
-
 	if cmd.cli.showInfo {
 		Logf("running '%s %s'", cmd.cli.execPath, strings.Join(cmdArgs, " "))
 	}
 
-	var stdout, stderr bytes.Buffer
-	ocCmd.Stdout = &stdout
-	ocCmd.Stderr = &stderr
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	err := ocCmd.Run()
-	stdoutStr := strings.TrimSpace(stdout.String())
-	stderrStr := strings.TrimSpace(stderr.String())
+	ocCmd := exec.CommandContext(ctx, cmd.cli.execPath, cmdArgs...)
+	// If WaitDelay is non-zero, the command's I/O pipes will be closed after
+	// WaitDelay has elapsed after either the command's process has exited or
+	// (if Context is non-nil) Context is done, whichever occurs first.
+	ocCmd.WaitDelay = 2 * time.Second
+	var stderrBuf bytes.Buffer
+	ocCmd.Stderr = &stderrBuf
 
+	stdout, err := ocCmd.StdoutPipe()
 	if err != nil {
-		Logf("error running command: %v\nstdout: %s\nstderr: %s", err, stdoutStr, stderrStr)
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return stdoutStr, stderrStr, &ExitError{
-				ExitError: exitErr,
-				Cmd:       cmd.cli.execPath + " " + strings.Join(cmdArgs, " "),
-				StdErr:    stderrStr,
+		Logf("FollowUntilContains: failed to create stdout pipe: %v", err)
+		return false
+	}
+	if err := ocCmd.Start(); err != nil {
+		Logf("FollowUntilContains: failed to start command: %v", err)
+		return false
+	}
+
+	// Scan the output on a separate goroutine so that we can stop waiting as soon as either
+	// the keyword shows up or ctx is done, without waiting for the command to exit on its own.
+	foundCh := make(chan bool, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 64*1024), maxFollowedLineSize)
+
+		found := false
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), keyword) {
+				found = true
+				break
 			}
 		}
-		return stdoutStr, stderrStr, fmt.Errorf("command failed: %v", err)
+		if err := scanner.Err(); err != nil && !errors.Is(err, os.ErrClosed) {
+			Logf("FollowUntilContains: error reading command output: %v", err)
+		}
+		foundCh <- found
+	}()
+
+	var found bool
+	select {
+	case found = <-foundCh:
+	case <-ctx.Done():
+		// The child may not release its stdout write end promptly (e.g. a subprocess
+		// that inherited the descriptor outlives it, or the process is slow to die),
+		// so the pipe would never EOF on its own. Close our read end to guarantee the
+		// scanner goroutine unblocks and cannot leak; the caller must still wait for it
+		// so that Wait() below is not called while stdout is still being read.
+		if err := stdout.Close(); err != nil && cmd.cli.verbose {
+			Logf("FollowUntilContains: failed to close stdout pipe: %v", err)
+		}
+		found = <-foundCh // block until the scanner goroutine stops reading stdout
 	}
 
-	return stdoutStr, stderrStr, nil
-}
-
-// OutputToFile executes the command and stores output to a file
-func (cmd *Command) OutputToFile(filename string) (string, error) {
-	_, err := cmd.Output()
-	if err != nil {
-		return "", err
+	// Cancel unconditionally: a match may have been found while the command is still
+	// streaming, in which case it would otherwise never exit on its own.
+	// Wait must only be called once stdout has stopped being read, which is guaranteed
+	// here since the scanner goroutine has already returned by this point.
+	cancel()
+	if err := ocCmd.Wait(); err != nil && cmd.cli.verbose {
+		Logf("FollowUntilContains: command exited: %v", err)
 	}
-	return filename, nil // Simplified version, full implementation would write to file
-}
 
-// FatalErr exits the test in case a fatal error has occurred
-func FatalErr(msg interface{}) {
-	panic(fmt.Sprintf("%v", msg))
+	if !found && stderrBuf.Len() > 0 {
+		Logf("FollowUntilContains: keyword %q not found; stderr:\n%s", keyword, strings.TrimSpace(stderrBuf.String()))
+	}
+
+	return found
 }

--- a/test/extended/utils/cluster_helpers.go
+++ b/test/extended/utils/cluster_helpers.go
@@ -1,0 +1,203 @@
+// cluster_helpers.go provides cluster topology detection and node discovery
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ClusterTopology represents the cluster topology type.
+type ClusterTopology int
+
+const (
+	// TopologyUnknown represents an unknown or unsupported cluster topology.
+	TopologyUnknown ClusterTopology = iota
+	// TopologySNO represents a Single Node OpenShift cluster (1 node, both master and worker).
+	TopologySNO
+	// TopologyCompact represents a compact cluster (3 nodes, all are both master and worker).
+	TopologyCompact
+	// TopologyStandard represents a standard cluster with dedicated master and worker nodes.
+	TopologyStandard
+)
+
+// countSliceMatches returns the number of elements in b that also appear in a.
+func countSliceMatches(a, b []string) int {
+	set := make(map[string]struct{}, len(a))
+	for _, v := range a {
+		set[v] = struct{}{}
+	}
+	count := 0
+	for _, v := range b {
+		if _, ok := set[v]; ok {
+			count++
+		}
+	}
+	return count
+}
+
+// Is3MasterNoDedicatedWorkerNode returns true when all three nodes are both master and worker (compact topology).
+func Is3MasterNoDedicatedWorkerNode(oc *CLI) bool {
+	return GetClusterTopology(oc) == TopologyCompact
+}
+
+// GetClusterTopology detects and returns the cluster topology.
+func GetClusterTopology(oc *CLI) ClusterTopology {
+	masterNodes, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/control-plane=", "-o=jsonpath={.items[*].metadata.name}").Output()
+	if err != nil {
+		return TopologyUnknown
+	}
+	workerNodes, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker=", "-o=jsonpath={.items[*].metadata.name}").Output()
+	if err != nil {
+		return TopologyUnknown
+	}
+	masters := strings.Fields(masterNodes)
+	workers := strings.Fields(workerNodes)
+
+	if len(masters) == 1 && len(workers) == 1 && masters[0] == workers[0] {
+		return TopologySNO
+	}
+
+	if len(masters) == 3 && len(workers) == 3 && countSliceMatches(masters, workers) == 3 {
+		return TopologyCompact
+	}
+
+	if len(masters) >= 1 && len(workers) >= 1 {
+		return TopologyStandard
+	}
+
+	return TopologyUnknown
+}
+
+// IsSNOOrCompact returns true for SNO or compact (3-master) clusters.
+func IsSNOOrCompact(oc *CLI) bool {
+	topo := GetClusterTopology(oc)
+	return topo == TopologySNO || topo == TopologyCompact
+}
+
+// IsSNOCluster returns true when the cluster has one node that is both master and worker.
+func IsSNOCluster(oc *CLI) bool {
+	return GetClusterTopology(oc) == TopologySNO
+}
+
+// IsSingleMasterCluster returns true when the cluster has exactly one control-plane node.
+// This is distinct from IsSNOCluster: a non-HA cluster may have a single control-plane
+// node alongside dedicated worker nodes, in which case IsSingleMasterCluster is true
+// but IsSNOCluster is false. Use this when a test must skip any cluster with only one
+// master (e.g. tests that reboot a master node), regardless of worker topology.
+func IsSingleMasterCluster(oc *CLI) (bool, error) {
+	masterNodes, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/control-plane=", "-o=jsonpath={.items[*].metadata.name}").Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to list control-plane nodes: %w", err)
+	}
+	masters := strings.Fields(masterNodes)
+	return len(masters) == 1, nil
+}
+
+// GetLinuxWorkerNode returns the n'th Linux node (0-indexed) and its pool name.
+// On regular clusters it returns a worker node with pool "worker".
+// On SNO and 3-master compact clusters it returns a master node with pool "master".
+func GetLinuxWorkerNode(oc *CLI, n int) (string, string, error) {
+	masterNodesStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/control-plane=", "-o=jsonpath={.items[*].metadata.name}").Output()
+	if err != nil {
+		return "", "", err
+	}
+	masters := strings.Fields(strings.TrimSpace(masterNodesStr))
+
+	workerNodesStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker=,kubernetes.io/os=linux", "-o=jsonpath={.items[*].metadata.name}").Output()
+	if err != nil {
+		return "", "", err
+	}
+	workers := strings.Fields(strings.TrimSpace(workerNodesStr))
+
+	isSNO := len(masters) == 1 && len(workers) == 1 && masters[0] == workers[0]
+	isCompact := Is3MasterNoDedicatedWorkerNode(oc)
+
+	if isSNO || isCompact {
+		if n < 0 || n >= len(masters) {
+			return "", "", fmt.Errorf("index %d out of range for %d master nodes", n, len(masters))
+		}
+		return masters[n], "master", nil
+	}
+
+	if n < 0 || n >= len(workers) {
+		return "", "", fmt.Errorf("index %d out of range for %d worker nodes", n, len(workers))
+	}
+	return workers[n], "worker", nil
+}
+
+// IsHyperShiftHostedCluster returns true when the cluster's control plane topology is External.
+func IsHyperShiftHostedCluster(oc *CLI) bool {
+	topology, err := oc.WithoutNamespace().AsAdmin().Run("get").Args("infrastructures.config.openshift.io", "cluster", "-o=jsonpath={.status.controlPlaneTopology}").Output()
+	if err != nil {
+		Logf("IsHyperShiftHostedCluster: failed to get infrastructure topology: %v", err)
+		return false
+	}
+	Logf("IsHyperShiftHostedCluster: topology is %s", topology)
+	if topology == "" {
+		status, statusErr := oc.WithoutNamespace().AsAdmin().Run("get").Args("infrastructures.config.openshift.io", "cluster", "-o=jsonpath={.status}").Output()
+		if statusErr != nil {
+			Logf("IsHyperShiftHostedCluster: failed to get cluster status: %v", statusErr)
+		}
+		Logf("IsHyperShiftHostedCluster: cluster status: %s", status)
+		Logf("IsHyperShiftHostedCluster: failure: topology is empty")
+		return false
+	}
+	return topology == "External"
+}
+
+// IsROSAHostedCluster returns true when the cluster is a ROSA hosted cluster,
+// detected by reading the cluster-type file from the SHARED_DIR environment variable.
+func IsROSAHostedCluster(oc *CLI) bool {
+	var clusterType string
+	sharedDir := os.Getenv("SHARED_DIR")
+	if len(sharedDir) != 0 {
+		fmt.Fprintln(os.Stderr, "SHARED_DIR was found")
+		byteArray, err := os.ReadFile(sharedDir + "/cluster-type")
+		if err != nil {
+			if !os.IsNotExist(err) {
+				Logf("failed to read cluster-type file: %v", err)
+			}
+			clusterType = ""
+		} else {
+			clusterType = string(byteArray)
+			clusterType = strings.ToLower(clusterType)
+		}
+	}
+	return strings.Contains(clusterType, "rosa")
+}
+
+// GetFirstMasterNodeName returns the name of the first master node.
+func GetFirstMasterNodeName(oc *CLI) (string, error) {
+	masterNodeNamesStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/control-plane=", "-oname").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to list master nodes: %w", err)
+	}
+	if masterNodeNamesStr == "" {
+		return "", fmt.Errorf("no master nodes found")
+	}
+	masterNodeNamesArray := strings.Split(masterNodeNamesStr, "\n")
+
+	if len(masterNodeNamesArray) > 0 {
+		firstMasterNodeNameArr := strings.Split(masterNodeNamesArray[0], "/")
+		if len(firstMasterNodeNameArr) > 1 {
+			return firstMasterNodeNameArr[1], nil
+		}
+	}
+	return "", fmt.Errorf("failed to parse master node name from: %q", masterNodeNamesArray[0])
+}
+
+// GetDefaultProfileNameOnMaster returns the default tuned profile name on the master node.
+func GetDefaultProfileNameOnMaster(oc *CLI, masterNodeName string) (string, error) {
+	defaultProfileName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-cluster-node-tuning-operator", "profiles.tuned.openshift.io", masterNodeName, "-ojsonpath={.status.tunedProfile}").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get tuned profile for node %s: %w", masterNodeName, err)
+	}
+	if defaultProfileName == "" {
+		return "", fmt.Errorf("tuned profile name is empty for node %s", masterNodeName)
+	}
+
+	Logf("defaultProfileName is %v on %v ", defaultProfileName, masterNodeName)
+	return defaultProfileName, nil
+}

--- a/test/extended/utils/debug_helpers.go
+++ b/test/extended/utils/debug_helpers.go
@@ -1,0 +1,268 @@
+// debug_helpers.go provides debug node operations
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// stringsSliceElementsHasPrefix checks if any element in the slice has the given prefix
+func stringsSliceElementsHasPrefix(slice []string, prefix string, caseSensitive bool) (bool, int) {
+	for i, s := range slice {
+		if caseSensitive {
+			if strings.HasPrefix(s, prefix) {
+				return true, i
+			}
+		} else {
+			if strings.HasPrefix(strings.ToLower(s), strings.ToLower(prefix)) {
+				return true, i
+			}
+		}
+	}
+	return false, -1
+}
+
+// resourceMetadata is the subset of an object's metadata needed for label/annotation lookups.
+type resourceMetadata struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+// getResourceMetadata fetches a single resource and decodes its labels/annotations from JSON,
+// avoiding the fragile `%v` map serialization produced by `-o=jsonpath={.metadata.labels}`.
+func getResourceMetadata(oc *CLI, resource, namespace, name string) (resourceMetadata, error) {
+	args := []string{resource}
+	if namespace != "" {
+		args = append(args, "-n", namespace)
+	}
+	if name != "" {
+		args = append(args, name)
+	}
+	args = append(args, "-o=json")
+	out, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(args...).Output()
+	if err != nil {
+		return resourceMetadata{}, err
+	}
+	var obj struct {
+		Metadata resourceMetadata `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(out), &obj); err != nil {
+		return resourceMetadata{}, err
+	}
+	return obj.Metadata, nil
+}
+
+// isNamespacePrivileged checks if a namespace has privileged security context constraints
+func isNamespacePrivileged(oc *CLI, namespace string) (bool, error) {
+	meta, err := getResourceMetadata(oc, "namespace", "", namespace)
+	if err != nil {
+		return false, err
+	}
+	return meta.Labels["pod-security.kubernetes.io/enforce"] == "privileged" ||
+		meta.Labels["security.openshift.io/scc.podSecurityLabelSync"] == "false", nil
+}
+
+// setNamespacePrivileged sets privileged labels on a namespace
+func setNamespacePrivileged(oc *CLI, namespace string) error {
+	err := oc.AsAdmin().WithoutNamespace().Run("label").Args("namespace", namespace, "pod-security.kubernetes.io/enforce=privileged", "pod-security.kubernetes.io/audit=privileged", "pod-security.kubernetes.io/warn=privileged", "security.openshift.io/scc.podSecurityLabelSync=false", "--overwrite").Execute()
+	return err
+}
+
+// recoverNamespaceRestricted recovers namespace to restricted labels
+func recoverNamespaceRestricted(oc *CLI, namespace string) {
+	err := oc.AsAdmin().WithoutNamespace().Run("label").Args("namespace", namespace, "pod-security.kubernetes.io/enforce-", "pod-security.kubernetes.io/audit-", "pod-security.kubernetes.io/warn-", "security.openshift.io/scc.podSecurityLabelSync-").Execute()
+	if err != nil {
+		Logf("recoverNamespaceRestricted: failed to remove labels from namespace %s: %v", namespace, err)
+	}
+}
+
+// isDefaultNodeSelectorEnabled checks if default node selector is enabled
+func isDefaultNodeSelectorEnabled(oc *CLI) bool {
+	selector, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("scheduler", "cluster", "-o=jsonpath={.spec.defaultNodeSelector}").Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(selector) != ""
+}
+
+// isWorkerNode checks if a node has the worker role
+func isWorkerNode(oc *CLI, nodeName string) bool {
+	meta, err := getResourceMetadata(oc, "node", "", nodeName)
+	if err != nil {
+		return false
+	}
+	_, ok := meta.Labels["node-role.kubernetes.io/worker"]
+	return ok
+}
+
+// isSpecifiedAnnotationKeyExist checks if a specific annotation key exists on a resource
+func isSpecifiedAnnotationKeyExist(oc *CLI, resource, namespace, annotationKey string) bool {
+	meta, err := getResourceMetadata(oc, resource, namespace, "")
+	if err != nil {
+		return false
+	}
+	_, ok := meta.Annotations[annotationKey]
+	return ok
+}
+
+// addAnnotationsToSpecificResource adds annotations to a specific resource
+func addAnnotationsToSpecificResource(oc *CLI, resource, namespace, annotation string) error {
+	args := []string{resource}
+	if namespace != "" {
+		args = append(args, "-n", namespace)
+	}
+	args = append(args, annotation, "--overwrite")
+	return oc.AsAdmin().WithoutNamespace().Run("annotate").Args(args...).Execute()
+}
+
+// removeAnnotationFromSpecificResource removes an annotation from a specific resource
+func removeAnnotationFromSpecificResource(oc *CLI, resource, namespace, annotationKey string) error {
+	args := []string{resource}
+	if namespace != "" {
+		args = append(args, "-n", namespace)
+	}
+	args = append(args, annotationKey+"-")
+	return oc.AsAdmin().WithoutNamespace().Run("annotate").Args(args...).Execute()
+}
+
+// ensureNamespacePrivilegedForDebug checks if the namespace needs privileged labels for debug node
+// and applies them if necessary. Returns a cleanup function that, when called, restores the
+// namespace to its previous state (only if labels were modified).
+func ensureNamespacePrivilegedForDebug(oc *CLI, namespace string, recoverLabels bool) (cleanup func(), err error) {
+	cleanup = func() {} // no-op default
+
+	if strings.HasPrefix(namespace, "openshift-") {
+		return cleanup, nil
+	}
+
+	isPrivileged, checkErr := isNamespacePrivileged(oc, namespace)
+	if checkErr != nil {
+		return cleanup, checkErr
+	}
+	if isPrivileged {
+		return cleanup, nil
+	}
+
+	if recoverLabels {
+		cleanup = func() { recoverNamespaceRestricted(oc, namespace) }
+	}
+
+	if err := setNamespacePrivileged(oc, namespace); err != nil {
+		return cleanup, fmt.Errorf("failed to set privileged labels on namespace %s: %w", namespace, err)
+	}
+
+	return cleanup, nil
+}
+
+// ensureAnnotationForDefaultNodeSelector adds the openshift.io/node-selector annotation to the
+// namespace if default nodeSelector is enabled and the target is not a worker node.
+// Returns a cleanup function that removes the annotation.
+func ensureAnnotationForDefaultNodeSelector(oc *CLI, namespace string, nodeName string) func() {
+	if !isDefaultNodeSelectorEnabled(oc) || isWorkerNode(oc, nodeName) || isSpecifiedAnnotationKeyExist(oc, "ns/"+namespace, "", `openshift.io/node-selector`) {
+		return func() {}
+	}
+
+	if err := addAnnotationsToSpecificResource(oc, "ns/"+namespace, "", `openshift.io/node-selector=`); err != nil {
+		Logf("warning: failed to add annotation: %v", err)
+	}
+
+	return func() {
+		if err := removeAnnotationFromSpecificResource(oc, "ns/"+namespace, "", `openshift.io/node-selector`); err != nil {
+			Logf("warning: failed to remove annotation: %v", err)
+		}
+	}
+}
+
+// debugNode is the core function for launching debug containers
+func debugNode(oc *CLI, nodeName string, cmdOptions []string, needChroot bool, recoverNsLabels bool, cmd ...string) (string, string, error) {
+	cargs := []string{"node/" + nodeName}
+
+	// Enhance for debug node namespace used logic
+	// if "--to-namespace=" option is used, then uses the input options' namespace, otherwise use oc.Namespace()
+	// if oc.Namespace() is empty, uses "default" namespace instead
+	hasToNamespaceInCmdOptions, index := stringsSliceElementsHasPrefix(cmdOptions, "--to-namespace=", false)
+	debugNodeNamespace := "default"
+	if hasToNamespaceInCmdOptions {
+		debugNodeNamespace = strings.TrimPrefix(cmdOptions[index], "--to-namespace=")
+	} else if ns := oc.Namespace(); ns != "" {
+		debugNodeNamespace = ns
+	}
+
+	// Ensure namespace has privileged labels for debug node on 4.12+ clusters.
+	// Register cleanup BEFORE the side-effect so it runs even if subsequent steps fail.
+	nsCleanup, err := ensureNamespacePrivilegedForDebug(oc, debugNodeNamespace, recoverNsLabels)
+	if err != nil {
+		return "", "", err
+	}
+	defer nsCleanup()
+
+	// Ensure annotation to prevent scheduler from overwriting the debug pod's nodeSelector.
+	annotationCleanup := ensureAnnotationForDefaultNodeSelector(oc, debugNodeNamespace, nodeName)
+	defer annotationCleanup()
+
+	if len(cmdOptions) > 0 {
+		cargs = append(cargs, cmdOptions...)
+	}
+	if !hasToNamespaceInCmdOptions {
+		cargs = append(cargs, "--to-namespace="+debugNodeNamespace)
+	}
+	if needChroot {
+		cargs = append(cargs, "--", "chroot", "/host")
+	} else {
+		cargs = append(cargs, "--")
+	}
+	cargs = append(cargs, cmd...)
+
+	return oc.AsAdmin().WithoutNamespace().Run("debug").Args(cargs...).Outputs()
+}
+
+// DebugNodeWithOptionsAndChrootWithStdErr executes a command on a node with options and chroot,
+// returning both stdout and stderr separately.
+func DebugNodeWithOptionsAndChrootWithStdErr(oc *CLI, nodeName string, options []string, command ...string) (string, string, error) {
+	stdout, stderr, err := debugNode(oc, nodeName, options, true, true, command...)
+	return stdout, stderr, err
+}
+
+// DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel launches debug container using chroot and with options e.g. --image
+// WithoutRecoverNsLabel which will not recover the labels that added for debug node container adapt the podSecurity changed on 4.12+ test clusters
+// "security.openshift.io/scc.podSecurityLabelSync=false" And "pod-security.kubernetes.io/enforce=privileged"
+func DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc *CLI, nodeName string, options []string, cmd ...string) (stdOut string, stdErr string, err error) {
+	return debugNode(oc, nodeName, options, true, false, cmd...)
+}
+
+// DebugNodeWithChroot executes a command on a node with chroot
+func DebugNodeWithChroot(oc *CLI, nodeName string, cmd ...string) (string, error) {
+	stdout, _, err := debugNode(oc, nodeName, nil, true, true, cmd...)
+	return stdout, err
+}
+
+// DebugNodeWithOptionsAndChroot executes a command on a node with options and chroot
+func DebugNodeWithOptionsAndChroot(oc *CLI, nodeName string, options []string, cmd ...string) (string, error) {
+	stdout, _, err := debugNode(oc, nodeName, options, true, true, cmd...)
+	return stdout, err
+}
+
+// DebugNodeRetryWithOptionsAndChroot executes a command on a node with retry, options and chroot
+func DebugNodeRetryWithOptionsAndChroot(ctx context.Context, oc *CLI, nodeName string, options []string, timeout time.Duration, cmd ...string) (string, error) {
+	var output string
+	var err error
+
+	pollErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, false, func(_ context.Context) (bool, error) {
+		output, err = DebugNodeWithOptionsAndChroot(oc, nodeName, options, cmd...)
+		return err == nil, nil
+	})
+
+	if pollErr != nil {
+		if err != nil {
+			return "", fmt.Errorf("DebugNodeRetryWithOptionsAndChroot timed out after %s: %w (last error: %v)", timeout, pollErr, err)
+		}
+		return "", fmt.Errorf("DebugNodeRetryWithOptionsAndChroot timed out after %s: %w", timeout, pollErr)
+	}
+	return output, nil
+}

--- a/test/extended/utils/helpers.go
+++ b/test/extended/utils/helpers.go
@@ -1,0 +1,838 @@
+// helpers.go provides general-purpose test helpers that are framework-agnostic with
+// no Ginkgo/Gomega dependencies! It replaces functions from
+// github.com/openshift/origin/test/extended/util/compat_otp.
+// Contents: template/resource helpers, pod/log operations, MachineSet lifecycle,
+// systemctl helpers, and base64/string utilities.
+
+package utils
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	machineAPINamespace = "openshift-machine-api"
+	mapiMachineset      = "machinesets.machine.openshift.io"
+	mapiMachine         = "machines.machine.openshift.io"
+)
+
+// Sentinel errors for WaitForMachinesRunning so callers can decide to skip.
+var (
+	ErrInsufficientInstanceCapacity        = fmt.Errorf("insufficient instance capacity")
+	ErrInsufficientResources               = fmt.Errorf("insufficient resources")
+	ErrPGClusterPlacementGroupNotSupported = fmt.Errorf("pgcluster placement group zone is not supported")
+)
+
+// newResourceFromTemplate processes a template and applies resources in a namespace.
+func newResourceFromTemplate(oc *CLI, namespace string, args ...string) error {
+	processArgs := []string{"process"}
+	applyArgs := []string{}
+	if len(namespace) != 0 {
+		processArgs = append(processArgs, "-n", namespace)
+		applyArgs = append(applyArgs, "-n", namespace)
+	} else {
+		// Cluster-scoped resources have no namespace to pass. Without "-n",
+		// "oc process" falls back to contacting the server using the current
+		// kubeconfig context's namespace, which may not exist on the target
+		// cluster. "--local" avoids the server round-trip entirely.
+		processArgs = append(processArgs, "--local=true")
+	}
+	processArgs = append(processArgs, args...)
+	applyArgs = append(applyArgs, "-f", "-")
+	processedTemplate, err := oc.AsAdmin().WithoutNamespace().Run(processArgs[0]).Args(processArgs[1:]...).Output()
+	if err != nil {
+		return fmt.Errorf("failed to process template: %w", err)
+	}
+
+	err = oc.AsAdmin().WithoutNamespace().Run("apply").Args(applyArgs...).InputString(processedTemplate).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to apply resource: %w", err)
+	}
+	return nil
+}
+
+// ApplyNsResourceFromTemplate processes a template and applies resources in a namespace.
+func ApplyNsResourceFromTemplate(oc *CLI, namespace string, args ...string) error {
+	return newResourceFromTemplate(oc, namespace, args...)
+}
+
+// ApplyClusterResourceFromTemplate processes a template and creates cluster-scoped resources.
+func ApplyClusterResourceFromTemplate(oc *CLI, args ...string) error {
+	return newResourceFromTemplate(oc, "", args...)
+}
+
+// CreateOperatorResourceByYaml creates a non-template YAML resource. When namespace is empty, creates cluster-scoped resources.
+func CreateOperatorResourceByYaml(oc *CLI, namespace string, yamlFile string) error {
+	var err error
+	if len(namespace) == 0 {
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", yamlFile).Execute()
+	} else {
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", yamlFile, "-n", namespace).Execute()
+	}
+	return err
+}
+
+// AssertPodToBeReady waits for a pod to be Running with the Ready condition True.
+func AssertPodToBeReady(ctx context.Context, oc *CLI, podName string, namespace string) error {
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, false, func(_ context.Context) (bool, error) {
+		podStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", podName, "-n", namespace, "-o=jsonpath={.status.phase}").Output()
+		if err != nil {
+			Logf("error getting status for pod %s/%s: %v, retrying", namespace, podName, err)
+			return false, nil
+		}
+		if podStatus != "Running" {
+			return false, nil
+		}
+		readyStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", podName, "-n", namespace, `-ojsonpath={.status.conditions[?(@.type=="Ready")].status}`).Output()
+		if err != nil {
+			Logf("error getting Ready condition for pod %s/%s: %v, retrying", namespace, podName, err)
+			return false, nil
+		}
+		return strings.TrimSpace(readyStatus) == "True", nil
+	})
+	if err != nil {
+		return fmt.Errorf("pod %s/%s did not become Ready within timeout: %w", namespace, podName, err)
+	}
+	return nil
+}
+
+// GetPodNodeName gets the node name where a pod is running
+func GetPodNodeName(oc *CLI, namespace string, podName string) (string, error) {
+	nodeName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", podName, "-n", namespace, "-o=jsonpath={.spec.nodeName}").Output()
+	return nodeName, err
+}
+
+// LabelPod adds or removes a label from a pod
+func LabelPod(oc *CLI, namespace string, podName string, label string) error {
+	return oc.AsAdmin().WithoutNamespace().Run("label").Args("pod", podName, "-n", namespace, label, "--overwrite").Execute()
+}
+
+// RemoteShPod executes a command in a pod
+func RemoteShPod(oc *CLI, namespace string, podName string, cmd ...string) (string, error) {
+	if len(cmd) == 0 {
+		return "", fmt.Errorf("RemoteShPod: no command provided for pod %s/%s", namespace, podName)
+	}
+	args := []string{"exec", podName, "-n", namespace, "--"}
+	args = append(args, cmd...)
+	output, err := oc.AsAdmin().WithoutNamespace().Run(args[0]).Args(args[1:]...).Output()
+	return output, err
+}
+
+// GetClusterVersion returns the cluster version as string value (Ex: 4.8) and cluster build (Ex: 4.8.0-0.nightly-2021-09-28-165247)
+func GetClusterVersion(oc *CLI) (string, string, error) {
+	clusterBuild, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterversion", "-o", "jsonpath={..desired.version}").Output()
+	if err != nil {
+		return "", "", err
+	}
+	splitValues := strings.Split(clusterBuild, ".")
+	if len(splitValues) < 2 {
+		return "", clusterBuild, fmt.Errorf("unexpected cluster version format: %q", clusterBuild)
+	}
+	clusterVersion := splitValues[0] + "." + splitValues[1]
+	return clusterVersion, clusterBuild, nil
+}
+
+// WaitForMCPUpdate waits until a MachineConfigPool reports fully updated machine counts.
+func WaitForMCPUpdate(ctx context.Context, oc *CLI, mcpName string, timeDurationSec int) error {
+	// Poll at ~1/10 of the total timeout, but never faster than 5s to avoid busy-waiting
+	// when timeDurationSec is small (e.g. < 10).
+	pollInterval := time.Duration(timeDurationSec/10) * time.Second
+	if pollInterval < 5*time.Second {
+		pollInterval = 5 * time.Second
+	}
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, time.Duration(timeDurationSec)*time.Second, false, func(_ context.Context) (bool, error) {
+		var (
+			mcpMachineCount         string
+			mcpReadyMachineCount    string
+			mcpUpdatedMachineCount  string
+			mcpDegradedMachineCount string
+			mcpUpdatingStatus       string
+			mcpUpdatedStatus        string
+			err                     error
+		)
+
+		mcpUpdatingStatus, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("mcp", mcpName, `-ojsonpath={.status.conditions[?(@.type=="Updating")].status}`).Output()
+		if err != nil {
+			Logf("MachineConfigPool [%v] failed to get updating status: %v", mcpName, err)
+			return false, nil
+		}
+		if mcpUpdatingStatus == "" {
+			Logf("MachineConfigPool [%v] updating status is empty, retrying", mcpName)
+			return false, nil
+		}
+		mcpUpdatedStatus, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("mcp", mcpName, `-ojsonpath={.status.conditions[?(@.type=="Updated")].status}`).Output()
+		if err != nil {
+			Logf("MachineConfigPool [%v] failed to get updated status: %v", mcpName, err)
+			return false, nil
+		}
+		if mcpUpdatedStatus == "" {
+			Logf("MachineConfigPool [%v] updated status is empty, retrying", mcpName)
+			return false, nil
+		}
+
+		// On SNO the API server may be temporarily unreachable during node reboot;
+		// treat any failure here as a retry rather than a hard error.
+		mcpMachineCount, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("mcp", mcpName, "-o=jsonpath={.status.machineCount}").Output()
+		if err != nil {
+			Logf("MachineConfigPool [%v] failed to get machineCount: %v", mcpName, err)
+			return false, nil
+		}
+		mcpReadyMachineCount, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("mcp", mcpName, "-o=jsonpath={.status.readyMachineCount}").Output()
+		if err != nil {
+			Logf("MachineConfigPool [%v] failed to get readyMachineCount: %v", mcpName, err)
+			return false, nil
+		}
+		mcpUpdatedMachineCount, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("mcp", mcpName, "-o=jsonpath={.status.updatedMachineCount}").Output()
+		if err != nil {
+			Logf("MachineConfigPool [%v] failed to get updatedMachineCount: %v", mcpName, err)
+			return false, nil
+		}
+		mcpDegradedMachineCount, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("mcp", mcpName, "-o=jsonpath={.status.degradedMachineCount}").Output()
+		if err != nil {
+			Logf("MachineConfigPool [%v] failed to get degradedMachineCount: %v", mcpName, err)
+			return false, nil
+		}
+		if mcpUpdatingStatus == "False" && mcpUpdatedStatus == "True" && mcpMachineCount == mcpReadyMachineCount && mcpMachineCount == mcpUpdatedMachineCount && mcpDegradedMachineCount == "0" {
+			Logf("MachineConfigPool [%v] checks succeeded!", mcpName)
+			return true, nil
+		}
+
+		Logf("MachineConfigPool [%v] checks failed, the following values were found:\nmachineCount: %v (ready=%v, updated=%v, degraded=%v)\nmcpUpdatingStatus: %v (expected: False)\nmcpUpdatedStatus: %v (expected: True)\nRetrying", mcpName, mcpMachineCount, mcpReadyMachineCount, mcpUpdatedMachineCount, mcpDegradedMachineCount, mcpUpdatingStatus, mcpUpdatedStatus)
+		return false, nil
+	})
+	return err
+}
+
+// WaitForMCPUpdateStarted waits until a MachineConfigPool has started (or is
+// in the middle of) an update cycle, i.e. its Updating condition is True.
+// Unlike WaitForMCPUpdate it does not require the pool to fully converge.  On
+// pools where applying a new configuration requires sequential node reboots
+// (e.g. the master pool), full convergence routinely outlives the time a
+// single test case is allowed to run; tests that only need to verify that the
+// pool picked up a new configuration should use this instead of
+// WaitForMCPUpdate and await the full convergence in their cleanup.
+func WaitForMCPUpdateStarted(ctx context.Context, oc *CLI, mcpName string, timeDurationSec int) error {
+	pollInterval := time.Duration(timeDurationSec/10) * time.Second
+	if pollInterval < 5*time.Second {
+		pollInterval = 5 * time.Second
+	}
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, time.Duration(timeDurationSec)*time.Second, false, func(_ context.Context) (bool, error) {
+		mcpUpdatingStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("mcp", mcpName, `-ojsonpath={.status.conditions[?(@.type=="Updating")].status}`).Output()
+		if err != nil {
+			Logf("MachineConfigPool [%v] failed to get updating status: %v, retrying", mcpName, err)
+			return false, nil
+		}
+		if mcpUpdatingStatus == "True" {
+			Logf("MachineConfigPool [%v] update cycle started", mcpName)
+			return true, nil
+		}
+		Logf("MachineConfigPool [%v] updating status is %q, waiting for the update cycle to start", mcpName, mcpUpdatingStatus)
+		return false, nil
+	})
+	return err
+}
+
+// WaitForNoPodsAvailableByKind used for checking no pods in a certain namespace
+func WaitForNoPodsAvailableByKind(ctx context.Context, oc *CLI, kind string, name string, namespace string) error {
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 180*time.Second, false, func(_ context.Context) (bool, error) {
+		kindNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(kind, name, "-n", namespace, "-oname").Output()
+		if err != nil {
+			if strings.Contains(err.Error(), "NotFound") {
+				Logf("resource %s/%s not found in %s", kind, name, namespace)
+				return true, nil
+			}
+			Logf("error getting %s/%s in %s: %v, retrying", kind, name, namespace, err)
+			return false, nil
+		}
+		if strings.Contains(kindNames, "NotFound") || strings.Contains(kindNames, "No resources") || len(kindNames) == 0 {
+			Logf("all resources of kind %s have been terminated", kind)
+			return true, nil
+		}
+		Logf("the pod is still terminating, waiting for a while: \n%v", kindNames)
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for %s/%s to disappear in %s: %w", kind, name, namespace, err)
+	}
+	return nil
+}
+
+func getPodLogs(oc *CLI, podName, namespace string) (string, error) {
+	return oc.AsAdmin().WithoutNamespace().Run("logs").Args(podName, "-n", namespace).Output()
+}
+
+func followPodLogsForKeyword(oc *CLI, podName, namespace, keyword string, durationSeconds int) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(durationSeconds)*time.Second)
+	defer cancel()
+
+	found := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-f", podName, "-n", namespace).FollowUntilContains(ctx, keyword)
+	if found {
+		Logf("found keyword %q in pod %s/%s logs", keyword, namespace, podName)
+		return true
+	}
+	Logf("keyword %q not found in pod %s/%s logs within %d seconds", keyword, namespace, podName, durationSeconds)
+	return false
+}
+
+// AssertPodLogsContain checks if pod logs contain a specific keyword.
+func AssertPodLogsContain(oc *CLI, podName, namespace, keyword string) (bool, error) {
+	logs, err := getPodLogs(oc, podName, namespace)
+	if err != nil {
+		return false, fmt.Errorf("failed to get pod logs for %s/%s: %w", namespace, podName, err)
+	}
+	return strings.Contains(logs, keyword), nil
+}
+
+// StreamPodLogsForKeyword follows pod logs (oc logs -f) and returns a channel that
+// receives true as soon as keyword appears, or false on timeout. Start this before triggering
+// the action that produces the expected log line.
+func StreamPodLogsForKeyword(oc *CLI, podName, namespace, keyword string, durationSeconds int) <-chan bool {
+	ch := make(chan bool, 1)
+	go func() {
+		ch <- followPodLogsForKeyword(oc, podName, namespace, keyword, durationSeconds)
+	}()
+	return ch
+}
+
+// MachineSetsExist checks if MachineSet resources exist in the cluster
+func MachineSetsExist(oc *CLI) (bool, error) {
+	items, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machinesets", "-A", "-o=jsonpath={.items}").Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to list machinesets: %w", err)
+	}
+	items = strings.TrimSpace(items)
+	return items != "" && items != "[]", nil
+}
+
+// RemoteShPodWithBash executes a bash command in a pod
+func RemoteShPodWithBash(oc *CLI, namespace string, podName string, bashCmd string) (string, error) {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("exec").Args(podName, "-n", namespace, "--", "bash", "-c", bashCmd).Output()
+	return output, err
+}
+
+// StringToBASE64 converts a string to base64
+func StringToBASE64(input string) string {
+	return base64.StdEncoding.EncodeToString([]byte(input))
+}
+
+// BASE64DecodeStr decodes a base64-encoded string
+func BASE64DecodeStr(src string) (string, error) {
+	plaintext, err := base64.StdEncoding.DecodeString(src)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode base64 string: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+// ImplStringArrayContains checks if a string array contains a specific value
+func ImplStringArrayContains(arr []string, str string) bool {
+	for _, a := range arr {
+		if a == str {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckPlatform returns the cluster's IaaS platform name.
+func CheckPlatform(oc *CLI) (string, error) {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platformStatus.type}").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get cluster platform: %w", err)
+	}
+	return strings.ToLower(output), nil
+}
+
+// GetFirstLinuxMachineSets returns the first non-windows, non-edge machineset name.
+func GetFirstLinuxMachineSets(oc *CLI) (string, error) {
+	machinesets, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachineset, "-o=jsonpath={.items[*].metadata.name}", "-n", machineAPINamespace).Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to list machinesets: %w", err)
+	}
+
+	var regularMachineset []string
+	for _, machineset := range strings.Fields(machinesets) {
+		if strings.Contains(machineset, "windows") || strings.Contains(machineset, "edge") {
+			continue
+		}
+		regularMachineset = append(regularMachineset, machineset)
+	}
+	if len(regularMachineset) == 0 {
+		return "", fmt.Errorf("no linux machinesets found")
+	}
+	return regularMachineset[0], nil
+}
+
+// GetMachineSetInstanceType returns the instance type of the first linux machineset.
+func GetMachineSetInstanceType(oc *CLI) (string, error) {
+	firstMachinesetName, err := GetFirstLinuxMachineSets(oc)
+	if err != nil {
+		return "", err
+	}
+	Logf("got %v from machineset list", firstMachinesetName)
+
+	iaasPlatform, err := CheckPlatform(oc)
+	if err != nil {
+		return "", err
+	}
+	var instanceType string
+	switch iaasPlatform {
+	case "aws":
+		instanceType, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", firstMachinesetName, "-n", machineAPINamespace, "-ojsonpath={.spec.template.spec.providerSpec.value.instanceType}").Output()
+	case "azure":
+		instanceType, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", firstMachinesetName, "-n", machineAPINamespace, "-ojsonpath={.spec.template.spec.providerSpec.value.vmSize}").Output()
+	case "gcp":
+		instanceType, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", firstMachinesetName, "-n", machineAPINamespace, "-ojsonpath={.spec.template.spec.providerSpec.value.machineType}").Output()
+	case "ibmcloud":
+		instanceType, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", firstMachinesetName, "-n", machineAPINamespace, "-ojsonpath={.spec.template.spec.providerSpec.value.profile}").Output()
+	case "alibabacloud":
+		instanceType, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", firstMachinesetName, "-n", machineAPINamespace, "-ojsonpath={.spec.template.spec.providerSpec.value.instanceType}").Output()
+	default:
+		return "", fmt.Errorf("unsupported platform %q", iaasPlatform)
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get instance type for machineset %s: %w", firstMachinesetName, err)
+	}
+	if instanceType == "" {
+		return "", fmt.Errorf("instance type is empty for machineset %s on platform %s", firstMachinesetName, iaasPlatform)
+	}
+	return instanceType, nil
+}
+
+// hasTokenSuffix reports whether s ends with sub as a whole size token, i.e.
+// sub is the entire string or is preceded by a "." "-" or "_" separator.
+func hasTokenSuffix(s, sub string) bool {
+	if s == sub {
+		return true
+	}
+	if !strings.HasSuffix(s, sub) {
+		return false
+	}
+	sepIdx := len(s) - len(sub) - 1
+	if sepIdx < 0 {
+		return false
+	}
+	switch s[sepIdx] {
+	case '.', '-', '_':
+		return true
+	default:
+		return false
+	}
+}
+
+func converseInstanceType(currentInstanceType, sSubString, tSubString string) string {
+	if hasTokenSuffix(currentInstanceType, sSubString) {
+		return strings.ReplaceAll(currentInstanceType, sSubString, tSubString)
+	}
+	if hasTokenSuffix(currentInstanceType, tSubString) {
+		return strings.ReplaceAll(currentInstanceType, tSubString, sSubString)
+	}
+	Logf("converseInstanceType: instance type %q does not contain %q or %q, returning empty", currentInstanceType, sSubString, tSubString)
+	return ""
+}
+
+// SpecifyMachinesetWithDifferentInstanceType used for specify cpu type that different from default one.
+func SpecifyMachinesetWithDifferentInstanceType(oc *CLI) (string, error) {
+	var expectedInstanceType string
+	// Check cloud provider name
+	iaasPlatform, err := CheckPlatform(oc)
+	if err != nil {
+		return "", err
+	}
+
+	// Get instance type of the first machineset
+	currentInstanceType, err := GetMachineSetInstanceType(oc)
+	if err != nil {
+		return "", err
+	}
+
+	switch iaasPlatform {
+	case "aws":
+		// we use m6i.2xlarge as default instance type, if current machineset instanceType is "m6i.2xlarge", we use "m6i.xlarge"
+		expectedInstanceType = converseInstanceType(currentInstanceType, "2xlarge", "xlarge")
+		if len(expectedInstanceType) == 0 {
+			expectedInstanceType = "m6i.xlarge"
+		}
+	case "azure":
+		// we use Standard_DS3_v2 as default instance type, if current machineset instanceType is "Standard_DS3_v2", we use "Standard_DS2_v2"
+		expectedInstanceType = converseInstanceType(currentInstanceType, "DS3_v2", "DS2_v2")
+		if len(expectedInstanceType) == 0 {
+			expectedInstanceType = "Standard_DS2_v2"
+		}
+	case "gcp":
+		// we use n1-standard-4 as default instance type, if current machineset instanceType is "n1-standard-4", we use "n1-standard-2"
+		expectedInstanceType = converseInstanceType(currentInstanceType, "standard-4", "standard-2")
+		if len(expectedInstanceType) == 0 {
+			expectedInstanceType = "n1-standard-2"
+		}
+
+	case "ibmcloud":
+		// we use bx2-4x16 as default instance type, if current machineset instanceType is "bx2-4x16", we use "bx2d-2x8"
+		expectedInstanceType = converseInstanceType(currentInstanceType, "4x16", "2x8")
+		if len(expectedInstanceType) == 0 {
+			expectedInstanceType = "bx2d-2x8"
+		}
+	case "alibabacloud":
+		// we use ecs.g6.xlarge as default instance type, if current machineset instanceType is "ecs.g6.xlarge", we use "ecs.g6.large"
+		expectedInstanceType = converseInstanceType(currentInstanceType, "xlarge", "large")
+		if len(expectedInstanceType) == 0 {
+			expectedInstanceType = "ecs.g6.large"
+		}
+	default:
+		return "", fmt.Errorf("unsupported cloud provider %q", iaasPlatform)
+	}
+	return expectedInstanceType, nil
+}
+
+// replaceYAMLLineValue replaces the value of the (first) "key:" occurrence on every
+// line of yaml that contains "key:", preserving any leading whitespace.
+func replaceYAMLLineValue(yaml, key, value string) string {
+	needle := key + ":"
+	lines := strings.Split(yaml, "\n")
+	for i, line := range lines {
+		if idx := strings.Index(line, needle); idx >= 0 {
+			lines[i] = line[:idx] + needle + " " + value
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// CreateMachinesetByInstanceType creates a machineset with the specified name and instance type.
+func CreateMachinesetByInstanceType(oc *CLI, machinesetName string, instanceType string) error {
+	ocGetMachineset, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachineset, "-n", machineAPINamespace, "-oname").Output()
+	if err != nil {
+		return fmt.Errorf("failed to list machinesets: %w", err)
+	}
+	if ocGetMachineset == "" {
+		return fmt.Errorf("no machinesets found")
+	}
+	Logf("existing machinesets:\n%v", ocGetMachineset)
+
+	firstMachinesetName, err := GetFirstLinuxMachineSets(oc)
+	if err != nil {
+		return err
+	}
+	Logf("got %v from machineset list", firstMachinesetName)
+
+	machinesetYamlOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachineset, firstMachinesetName, "-n", machineAPINamespace, "-oyaml").Output()
+	if err != nil {
+		return fmt.Errorf("failed to get machineset %s: %w", firstMachinesetName, err)
+	}
+	if machinesetYamlOutput == "" {
+		return fmt.Errorf("machineset %s YAML output is empty", firstMachinesetName)
+	}
+
+	obj := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal([]byte(machinesetYamlOutput), &obj.Object); err != nil {
+		return fmt.Errorf("failed to parse machineset %s YAML: %w", firstMachinesetName, err)
+	}
+
+	// Strip server-managed metadata and status so the fetched machineset can be
+	// recreated under a new name; ownerReferences are intentionally preserved.
+	unstructured.RemoveNestedField(obj.Object, "metadata", "resourceVersion")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "uid")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "generation")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "selfLink")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
+	unstructured.RemoveNestedField(obj.Object, "status")
+
+	obj.SetName(machinesetName)
+	// The machineset-name label must match metadata.name for the machineset
+	// controller to adopt the machines it creates.
+	if err := unstructured.SetNestedField(obj.Object, machinesetName, "spec", "selector", "matchLabels", "machine.openshift.io/cluster-api-machineset"); err != nil {
+		return fmt.Errorf("failed to set selector label for machineset %s: %w", machinesetName, err)
+	}
+	if err := unstructured.SetNestedField(obj.Object, machinesetName, "spec", "template", "metadata", "labels", "machine.openshift.io/cluster-api-machineset"); err != nil {
+		return fmt.Errorf("failed to set template label for machineset %s: %w", machinesetName, err)
+	}
+
+	sanitizedYamlOutput, err := yaml.Marshal(obj.Object)
+	if err != nil {
+		return fmt.Errorf("failed to serialize machineset %s: %w", machinesetName, err)
+	}
+	newMachinesetYaml := string(sanitizedYamlOutput)
+
+	iaasPlatform, err := CheckPlatform(oc)
+	if err != nil {
+		return err
+	}
+	switch iaasPlatform {
+	case "aws", "alibabacloud":
+		Logf("instanceType is %v inside CreateMachinesetByInstanceType", instanceType)
+		newMachinesetYaml = replaceYAMLLineValue(newMachinesetYaml, "instanceType", instanceType)
+	case "gcp":
+		Logf("machineType is %v inside CreateMachinesetByInstanceType", instanceType)
+		newMachinesetYaml = replaceYAMLLineValue(newMachinesetYaml, "machineType", instanceType)
+	case "azure":
+		Logf("vmSize is %v inside CreateMachinesetByInstanceType", instanceType)
+		newMachinesetYaml = replaceYAMLLineValue(newMachinesetYaml, "vmSize", instanceType)
+	case "ibmcloud":
+		Logf("profile is %v inside CreateMachinesetByInstanceType", instanceType)
+		newMachinesetYaml = replaceYAMLLineValue(newMachinesetYaml, "profile", instanceType)
+	default:
+		Logf("unsupported instance: %v", instanceType)
+	}
+
+	newMachinesetYaml = replaceYAMLLineValue(newMachinesetYaml, "replicas", "1")
+
+	return oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", "-", "-n", machineAPINamespace).InputString(newMachinesetYaml).Execute()
+}
+
+func getMachineSetReplicas(oc *CLI, machineSetName string) (int, error) {
+	replicasVal, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachineset, machineSetName, "-o=jsonpath={.spec.replicas}", "-n", machineAPINamespace).Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get replicas for machineset %s: %w", machineSetName, err)
+	}
+	replicas, err := strconv.Atoi(replicasVal)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse replicas %q for machineset %s: %w", replicasVal, machineSetName, err)
+	}
+	return replicas, nil
+}
+
+func getNodeNamesFromMachineSet(oc *CLI, machineSetName string) ([]string, error) {
+	nodeNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachine, "-o=jsonpath={.items[*].status.nodeRef.name}", "-l", "machine.openshift.io/cluster-api-machineset="+machineSetName, "-n", machineAPINamespace).Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nodes for machineset %s: %w", machineSetName, err)
+	}
+	if nodeNames == "" {
+		return nil, nil
+	}
+	return strings.Fields(nodeNames), nil
+}
+
+func waitForNodesReady(ctx context.Context, oc *CLI, machineSetName string) error {
+	machineNumber, err := getMachineSetReplicas(oc, machineSetName)
+	if err != nil {
+		return err
+	}
+	if machineNumber < 1 {
+		return nil
+	}
+
+	Logf("wait nodes ready then check nodes haven't uninitialized taints")
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 180*time.Second, false, func(ctx context.Context) (bool, error) {
+		nodeNames, nodeErr := getNodeNamesFromMachineSet(oc, machineSetName)
+		if nodeErr != nil {
+			Logf("error getting node names for machineset %s: %v, retrying", machineSetName, nodeErr)
+			return false, nil
+		}
+		if len(nodeNames) == 0 {
+			Logf("no nodes bound yet for machineset %s (expected %d), retrying", machineSetName, machineNumber)
+			return false, nil
+		}
+		for _, nodeName := range nodeNames {
+			readyStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", nodeName, "-o=jsonpath={.status.conditions[?(@.type==\"Ready\")].status}").Output()
+			if err != nil {
+				if strings.Contains(err.Error(), "NotFound") {
+					Logf("node %s does not exist, skipping", nodeName)
+					continue
+				}
+				Logf("error getting ready status for node %s: %v, retrying", nodeName, err)
+				return false, nil
+			}
+			Logf("node %s readyStatus: %s", nodeName, readyStatus)
+			if readyStatus != "True" {
+				return false, nil
+			}
+			taints, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", nodeName, "-o=jsonpath={.spec.taints}").Output()
+			if err != nil {
+				Logf("error getting taints for node %s: %v, retrying", nodeName, err)
+				return false, nil
+			}
+			if strings.Contains(taints, "uninitialized") {
+				Logf("node %s has uninitialized taint %s, retrying", nodeName, taints)
+				return false, nil
+			}
+		}
+		Logf("all nodes are ready and haven't uninitialized taints")
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("some nodes are not ready in 3 minutes for machineset %s: %w", machineSetName, err)
+	}
+	return nil
+}
+
+// WaitForMachinesRunning waits for machines in a machineset to be running.
+func WaitForMachinesRunning(ctx context.Context, oc *CLI, machineNumber int, machineSetName string) error {
+	Logf("waiting for the machines Running")
+
+	pollErr := wait.PollUntilContextTimeout(ctx, 60*time.Second, 1200*time.Second, false, func(_ context.Context) (bool, error) {
+		msg, getErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachineset, machineSetName, "-o=jsonpath={.status.readyReplicas}", "-n", machineAPINamespace).Output()
+		if getErr != nil {
+			Logf("error getting readyReplicas for machineset %s: %v, retrying", machineSetName, getErr)
+			return false, nil
+		}
+		if strings.TrimSpace(msg) == "" {
+			Logf("readyReplicas for machineset %s is not set yet, retrying", machineSetName)
+			return false, nil
+		}
+		machinesRunning, convErr := strconv.Atoi(msg)
+		if convErr != nil {
+			Logf("failed to parse readyReplicas %q for machineset %s: %v, retrying", msg, machineSetName, convErr)
+			return false, nil
+		}
+		if machinesRunning != machineNumber {
+			phase, getPhaseErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachine, "-n", machineAPINamespace, "-l", "machine.openshift.io/cluster-api-machineset="+machineSetName, "-o=jsonpath={.items[*].status.phase}").Output()
+			if getPhaseErr != nil {
+				Logf("error getting machine phases for machineset %s: %v, retrying", machineSetName, getPhaseErr)
+				return false, nil
+			}
+			if strings.Contains(phase, "Failed") {
+				output, dumpErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachine, "-n", machineAPINamespace, "-l", "machine.openshift.io/cluster-api-machineset="+machineSetName, "-o=yaml").Output()
+				if dumpErr != nil {
+					Logf("error dumping machine YAML for machineset %s: %v", machineSetName, dumpErr)
+				}
+				Logf("%v", output)
+				if strings.Contains(output, "error launching instance: Instances in the pgcluster Placement Group") {
+					return false, ErrPGClusterPlacementGroupNotSupported
+				}
+				return false, fmt.Errorf("some machine go into Failed phase")
+			}
+			if strings.Contains(phase, "Provisioning") {
+				output, dumpErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachine, "-n", machineAPINamespace, "-l", "machine.openshift.io/cluster-api-machineset="+machineSetName, "-o=yaml").Output()
+				if dumpErr != nil {
+					Logf("error dumping machine YAML for machineset %s: %v", machineSetName, dumpErr)
+				}
+				if strings.Contains(output, "InsufficientInstanceCapacity") || strings.Contains(output, "InsufficientCapacityOnOutpost") {
+					Logf("%v", output)
+					return false, ErrInsufficientInstanceCapacity
+				}
+				if strings.Contains(output, "InsufficientResources") {
+					Logf("%v", output)
+					return false, ErrInsufficientResources
+				}
+			}
+			Logf("expected %v machine are not Running yet and waiting up to 1 minutes", machineNumber)
+			return false, nil
+		}
+		Logf("expected %v machines are Running", machineNumber)
+		return true, nil
+	})
+
+	if pollErr != nil {
+		switch {
+		case errors.Is(pollErr, ErrInsufficientInstanceCapacity):
+			return ErrInsufficientInstanceCapacity
+		case errors.Is(pollErr, ErrInsufficientResources):
+			return ErrInsufficientResources
+		case errors.Is(pollErr, ErrPGClusterPlacementGroupNotSupported):
+			return ErrPGClusterPlacementGroupNotSupported
+		default:
+			output, dumpErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachine, "-n", machineAPINamespace, "-l", "machine.openshift.io/cluster-api-machineset="+machineSetName, "-o=yaml").Output()
+			if dumpErr != nil {
+				Logf("error dumping machine YAML for machineset %s: %v", machineSetName, dumpErr)
+			}
+			Logf("%v", output)
+			return fmt.Errorf("expected %d machines are not Running after waiting up to 20 minutes: %w", machineNumber, pollErr)
+		}
+	}
+
+	Logf("all machines are Running")
+	if machineNumber >= 1 {
+		if err := waitForNodesReady(ctx, oc, machineSetName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetNodeNameByMachineset returns the node name for the first machine in a machineset.
+func GetNodeNameByMachineset(oc *CLI, machinesetName string) (string, error) {
+	machinesetLabels, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachineset, machinesetName, "-n", machineAPINamespace, "-ojsonpath={.spec.selector.matchLabels.machine\\.openshift\\.io/cluster-api-machineset}").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get machineset labels for %s: %w", machinesetName, err)
+	}
+	if machinesetLabels == "" {
+		return "", fmt.Errorf("machineset labels are empty for %s", machinesetName)
+	}
+
+	machineNameStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(mapiMachine, "-l", "machine.openshift.io/cluster-api-machineset="+machinesetLabels, "-n", machineAPINamespace, "-oname").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get machines for machineset %s: %w", machinesetName, err)
+	}
+	if machineNameStr == "" {
+		return "", fmt.Errorf("no machines found for machineset %s", machinesetName)
+	}
+
+	machineNames := strings.Fields(machineNameStr)
+	if len(machineNames) == 0 {
+		return "", fmt.Errorf("no machine names parsed from output for machineset %s", machinesetName)
+	}
+	machineName := machineNames[0]
+	Logf("machineName is %v in GetNodeNameByMachineset", machineName)
+
+	nodeName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(machineName, "-n", machineAPINamespace, "-ojsonpath={.status.nodeRef.name}").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get node name for machine %s: %w", machineName, err)
+	}
+	if nodeName == "" {
+		return "", fmt.Errorf("node name is empty for machine %s", machineName)
+	}
+	return nodeName, nil
+}
+
+// CountLinuxWorkerNodes counts Linux worker nodes
+func CountLinuxWorkerNodes(oc *CLI) (int, error) {
+	nodeList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker=,kubernetes.io/os=linux", "-o=jsonpath={.items[*].metadata.name}").Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to list Linux worker nodes: %w", err)
+	}
+	nodes := strings.Fields(nodeList)
+	return len(nodes), nil
+}
+
+// ShowSystemctlPropertyValueOfServiceUnitByName returns a systemctl show property value for a service unit.
+func ShowSystemctlPropertyValueOfServiceUnitByName(oc *CLI, tunedNodeName string, ntoNamespace string, serviceUnit string, propertyName string) (string, error) {
+	debugOptions := []string{"-q", "--to-namespace=" + ntoNamespace}
+	allProperties, err := DebugNodeWithOptionsAndChroot(oc, tunedNodeName, debugOptions, "systemctl", "show", serviceUnit)
+	if err != nil {
+		return "", fmt.Errorf("failed to get properties for service %s on node %s: %w", serviceUnit, tunedNodeName, err)
+	}
+
+	var propertyValue string
+	if strings.Contains(allProperties, propertyName) {
+		propertyValue, err = DebugNodeWithOptionsAndChroot(oc, tunedNodeName, debugOptions, "systemctl", "show", "-p", propertyName, serviceUnit)
+		if err != nil {
+			return "", fmt.Errorf("failed to get property %s for service %s on node %s: %w", propertyName, serviceUnit, tunedNodeName, err)
+		}
+	} else {
+		return "", fmt.Errorf("property %s not found in output for service %s on node %s", propertyName, serviceUnit, tunedNodeName)
+	}
+	return strings.TrimSpace(propertyValue), nil
+}
+
+// GetSystemctlServiceUnitTimestampByPropertyNameWithMonotonic extracts a monotonic timestamp from a systemctl property value.
+func GetSystemctlServiceUnitTimestampByPropertyNameWithMonotonic(propertyValue string) (int, error) {
+	if !strings.Contains(propertyValue, "=") {
+		return 0, fmt.Errorf("property value %q does not contain '=' separator", propertyValue)
+	}
+	if !strings.Contains(propertyValue, "Monotonic") {
+		return 0, fmt.Errorf("property value %q does not contain 'Monotonic'", propertyValue)
+	}
+	serviceUnitTimestampArr := strings.Split(propertyValue, "=")
+	if len(serviceUnitTimestampArr) < 2 {
+		return 0, fmt.Errorf("property value %q has no value after '=' separator", propertyValue)
+	}
+	serviceUnitTimestamp, err := strconv.Atoi(serviceUnitTimestampArr[1])
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse timestamp from %q: %w", propertyValue, err)
+	}
+	if serviceUnitTimestamp == 0 {
+		return 0, fmt.Errorf("timestamp is 0 for property value %q — service may have never started", propertyValue)
+	}
+	Logf("the serviceUnitTimestamp is [ %v ]", serviceUnitTimestamp)
+	return serviceUnitTimestamp, nil
+}

--- a/test/extended/utils/log_helpers.go
+++ b/test/extended/utils/log_helpers.go
@@ -1,0 +1,19 @@
+// log_helpers.go provides the Logf logging utility used across the package.
+
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+// Logf is a simple logging function to replace e2e.Logf.
+// It writes a single line to stderr. stderr is intentionally used (not
+// GinkgoWriter or stdout) so the message is emitted exactly once: it is
+// neither captured into Ginkgo's GinkgoWriter output nor copied into the
+// run-test result report. GinkgoWriter output is echoed twice by OTE
+// (live to stderr + captured into the stdout report), which would
+// duplicate every log line using something like `2>&1 | tee file.log`.
+func Logf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+}

--- a/test/extended/utils/nto_util.go
+++ b/test/extended/utils/nto_util.go
@@ -9,6 +9,7 @@ import (
 
 	extendedbindata "github.com/openshift/cluster-node-tuning-operator/test/extended/bindata"
 
+	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 )
 
@@ -77,6 +78,13 @@ func IsNTOPodInstalled(oc *CLI, namespace string) bool {
 	}
 	Logf("deployment %v found in namespace %s!", ntoDeployment, namespace)
 	return true
+}
+
+func SkipNoNTO(oc *CLI, namespace string) {
+	// test requires NTO to be installed
+	if !IsNTOPodInstalled(oc, namespace) {
+		g.Skip("NTO is not installed - skipping test ...")
+	}
 }
 
 func GetDefaultSMPAffinityBitMaskbyCPUCores(oc *CLI, workerNodeName string) string {
@@ -492,6 +500,17 @@ func IsSNOCluster(oc *CLI) bool {
 		return false
 	}
 	return len(strings.Split(strings.TrimSpace(nodeCount), "\n")) == 1
+}
+
+// IsRosaCluster determines whether the cluster is a Red Hat OpenShift Service on AWS (ROSA) cluster
+// Parameters:
+//   - oc: CLI client for interacting with the OpenShift cluster
+//
+// Returns:
+//   - bool: true if cluster is ROSA, false otherwise
+func IsRosaCluster(oc *CLI) bool {
+	product, _ := oc.WithoutNamespace().AsAdmin().Run("get").Args("clusterclaims/product.open-cluster-management.io", "-o=jsonpath={.spec.value}").Output()
+	return strings.Compare(product, "ROSA") == 0
 }
 
 func DebugNodeRetryWithOptionsAndChrootWithStdErr(oc *CLI, nodeName string, options []string, command ...string) (string, string, error) {

--- a/test/extended/utils/nto_util.go
+++ b/test/extended/utils/nto_util.go
@@ -1,25 +1,37 @@
+// nto_util.go provides NTO-specific utilities: NtoResource CRUD operations,
+// sysctl comparison and parsing, tuned profile management, NTO-specific wait
+// helpers and assertions, certificate comparison, PAO profile verification,
+// and sysctl comparison helpers.
+
 package utils
 
 import (
+	"bytes"
+	"context"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	extendedbindata "github.com/openshift/cluster-node-tuning-operator/test/extended/bindata"
 
-	o "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-type FixtureTB interface {
-	Helper()
-	TempDir() string
-}
-
-// Logf is a simple logging function to replace e2e.Logf
-func Logf(format string, args ...interface{}) {
-	fmt.Printf(format+"\n", args...)
+// NtoResource holds the fields needed to create and manage NTO test resources.
+type NtoResource struct {
+	Name          string
+	Namespace     string
+	Template      string
+	SysctlParam   string
+	SysctlValue   string
+	DeferredValue string
+	Label         string
 }
 
 // bindataAssetKey returns the go-bindata asset name (paths under the testdata tree; see Makefile -prefix).
@@ -31,117 +43,134 @@ func bindataAssetKey(elem []string) string {
 	return strings.TrimPrefix(key, "testdata/")
 }
 
-func materializeTestdataFixture(tb FixtureTB, rel string, data []byte) string {
-	tb.Helper()
-	base := tb.TempDir()
-	dest := filepath.Join(base, filepath.FromSlash(rel))
-	if err := os.MkdirAll(filepath.Dir(dest), 0750); err != nil {
-		panic(fmt.Sprintf("TestdataFixturePath: mkdir: %v", err))
-	}
-	if err := os.WriteFile(dest, data, 0644); err != nil {
-		panic(fmt.Sprintf("TestdataFixturePath: write %q: %v", dest, err))
-	}
-	p, err := filepath.Abs(dest)
-	if err != nil {
-		panic(err)
-	}
-	return p
-}
-
-// TestdataFixturePath materializes a manifest from go-bindata into a file under tb.TempDir()
-// and returns its absolute path for use with oc -f.  The directory is removed when the test
-// completes.
-func TestdataFixturePath(tb FixtureTB, elem ...string) string {
-	tb.Helper()
+// TestdataFixturePathBase materializes a manifest from go-bindata into a file under the given
+// base directory.  The caller is responsible for cleaning up baseDir.
+func TestdataFixturePathBase(baseDir string, elem ...string) (string, error) {
 	if len(elem) == 0 {
-		panic("must specify path")
+		return "", fmt.Errorf("must specify path")
 	}
 	key := bindataAssetKey(elem)
 	data, err := extendedbindata.Asset(key)
 	if err != nil {
-		panic(fmt.Sprintf("TestdataFixturePath: unknown asset %q (from %v): %v", key, elem, err))
+		return "", fmt.Errorf("TestdataFixturePathBase: unknown asset %q (from %v): %v", key, elem, err)
 	}
-	return materializeTestdataFixture(tb, key, data)
+	dest := filepath.Join(baseDir, filepath.FromSlash(key))
+	if existing, statErr := os.ReadFile(dest); statErr == nil && bytes.Equal(existing, data) {
+		// file already materialized with current content — reuse it
+		p, absErr := filepath.Abs(dest)
+		if absErr != nil {
+			return "", absErr
+		}
+		return p, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0750); err != nil {
+		return "", fmt.Errorf("TestdataFixturePathBase: mkdir: %v", err)
+	}
+	if err := os.WriteFile(dest, data, 0644); err != nil {
+		return "", fmt.Errorf("TestdataFixturePathBase: write %q: %v", dest, err)
+	}
+	p, absErr := filepath.Abs(dest)
+	if absErr != nil {
+		return "", absErr
+	}
+	return p, nil
 }
 
-// IsNTOPodInstalled will return true if any pod is found in the given namespace, and false otherwise
-func IsNTOPodInstalled(oc *CLI, namespace string) bool {
-	Logf("checking if pod is found in namespace %s...", namespace)
-
-	ntoDeployment, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployment", "-n", namespace, "-ojsonpath={.items[*].metadata.name}").Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	if len(ntoDeployment) == 0 {
-		Logf("no deployment cluster-node-tuning-operator found in namespace %s :(", namespace)
-		return false
+// IsNTOInstalled reports whether the NTO operator deployment exists in the given namespace
+// and has at least one ready replica. A deployment can exist but be in a Terminating or
+// unavailable state; this check ensures it is actually functional before tests proceed.
+func IsNTOInstalled(oc *CLI, namespace string) (bool, error) {
+	const ntoDeploymentName = "cluster-node-tuning-operator"
+	ntoDeployment, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployment", ntoDeploymentName, "-n", namespace, "-ojsonpath={.metadata.name}").Output()
+	if err != nil {
+		return false, err
 	}
-	Logf("deployment %v found in namespace %s!", ntoDeployment, namespace)
-	return true
+	if ntoDeployment != ntoDeploymentName {
+		return false, nil
+	}
+	readyReplicas, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployment", ntoDeploymentName, "-n", namespace, "-ojsonpath={.status.readyReplicas}").Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to get ready replicas for deployment %s: %w", ntoDeploymentName, err)
+	}
+	ready, err := strconv.Atoi(readyReplicas)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse readyReplicas for deployment %s: %w", ntoDeploymentName, err)
+	}
+	return ready > 0, nil
 }
 
-func GetDefaultSMPAffinityBitMaskbyCPUCores(oc *CLI, workerNodeName string) string {
-	// Get CPU number in specified worker nodes
+// GetDefaultSMPAffinityBitMaskByCPUCores computes a hexadecimal CPU bitmask
+// string with bits 0..cpuCores-1 set, representing the default SMP affinity
+// for a worker node with the given number of CPU cores.
+func GetDefaultSMPAffinityBitMaskByCPUCores(oc *CLI, workerNodeName string) (string, error) {
 	cpuCoresStdOut, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", workerNodeName, "-ojsonpath={.status.capacity.cpu}").Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-	o.Expect(cpuCoresStdOut).NotTo(o.BeEmpty())
+	if err != nil {
+		return "", fmt.Errorf("failed to get CPU cores for node %s: %w", workerNodeName, err)
+	}
+	if cpuCoresStdOut == "" {
+		return "", fmt.Errorf("CPU cores output is empty for node %s", workerNodeName)
+	}
 
 	cpuCores, err := strconv.Atoi(cpuCoresStdOut)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	o.Expect(cpuCoresStdOut).NotTo(o.BeEmpty())
-
-	cpuHexMask := make([]byte, 0, 2)
-	if cpuCores%4 != 0 {
-		modCPUCoresby4 := cpuCores % 4
-		var cpuCoresMask int
-		switch modCPUCoresby4 {
-		case 3:
-			cpuCoresMask = 7
-		case 2:
-			cpuCoresMask = 3
-		case 1:
-			cpuCoresMask = 1
-		}
-		cpuHexMask = append(cpuHexMask, byte(cpuCoresMask))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse CPU cores %q for node %s: %w", cpuCoresStdOut, workerNodeName, err)
+	}
+	if cpuCores < 1 {
+		return "", fmt.Errorf("invalid CPU cores %d for node %s: must be at least 1", cpuCores, workerNodeName)
 	}
 
-	for i := 0; i < cpuCores/4; i++ {
-		cpuHexMask = append(cpuHexMask, 15)
-	}
+	// Build a bitmask with bits 0..cpuCores-1 all set, then format as hex.
+	// Use big.Int to support CPU counts >= 64 without overflow.
+	mask := new(big.Int).Lsh(big.NewInt(1), uint(cpuCores))
+	mask.Sub(mask, big.NewInt(1))
+	cpuHexMaskFmt := strings.TrimLeft(mask.Text(16), "0")
+	Logf("there are %d cores on worker node %s, the hex mask is %s", cpuCores, workerNodeName, cpuHexMaskFmt)
 
-	cpuHexMaskStr := fmt.Sprintf("%x", cpuHexMask)
-	cpuHexMaskFmt := strings.ReplaceAll(cpuHexMaskStr, "0", "")
-	Logf("There are %d cores on worker node %s, the hex mask is %s", cpuCores, workerNodeName, cpuHexMaskFmt)
-
-	return cpuHexMaskFmt
+	return cpuHexMaskFmt, nil
 }
 
-func ConvertCPUBitMaskToByte(cpuHexMask string) []byte {
-	cpuHexMaskChars := []rune(cpuHexMask)
-	cpuBitsMask := make([]byte, 0)
-	cpuNum := 0
-	for i := 0; i < len(cpuHexMaskChars); i++ {
-		switch cpuHexMaskChars[i] {
-		case 'f':
-			cpuBitsMask = append(cpuBitsMask, 15)
-			cpuNum = cpuNum + 4
-		case '7':
-			cpuBitsMask = append(cpuBitsMask, 7)
-			cpuNum = cpuNum + 3
-		case '3':
-			cpuBitsMask = append(cpuBitsMask, 3)
-			cpuNum = cpuNum + 2
-		case '1':
-			cpuBitsMask = append(cpuBitsMask, 1)
-			cpuNum = cpuNum + 1
+// ConvertCPUBitMaskToByte converts a hexadecimal CPU bitmask string to a byte slice
+// where each byte represents the decimal value of the corresponding hex character.
+// For example, "f" becomes []byte{15} and "ff" becomes []byte{15, 15}.
+// The input is case-insensitive and validated for valid hex characters (0-9, a-f).
+func ConvertCPUBitMaskToByte(cpuHexMask string) ([]byte, error) {
+	if cpuHexMask == "" {
+		return nil, fmt.Errorf("empty hex mask")
+	}
+
+	cpuHexMask = strings.ToLower(cpuHexMask)
+
+	for _, c := range cpuHexMask {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return nil, fmt.Errorf("invalid hex character: %c", c)
 		}
 	}
-	Logf("The total CPU number is %v\nThe CPU HexMask is:\n%s\nThe CPU BitsMask is:\n%b\n", cpuNum, cpuHexMask, cpuBitsMask)
-	return cpuBitsMask
+
+	cpuBitsMask := make([]byte, 0, len(cpuHexMask))
+	for i := 0; i < len(cpuHexMask); i++ {
+		c := cpuHexMask[i]
+		var value byte
+		switch {
+		case c >= '0' && c <= '9':
+			value = c - '0'
+		case c >= 'a' && c <= 'f':
+			value = c - 'a' + 10
+		}
+		cpuBitsMask = append(cpuBitsMask, value)
+	}
+	var bitsMaskStr strings.Builder
+	for _, b := range cpuBitsMask {
+		fmt.Fprintf(&bitsMaskStr, "%04b", b)
+	}
+	Logf("The CPU HexMask is:\n%s\nThe CPU BitsMask is:\n%s\n", cpuHexMask, bitsMaskStr.String())
+	return cpuBitsMask, nil
 }
 
-func ConvertIsolatedCPURange2CPUList(isolatedCPURange string) []byte {
+// ConvertIsolatedCPURange2CPUList converts a sysctl-style CPU range string
+// into a flat list of individual CPU indices.
+func ConvertIsolatedCPURange2CPUList(isolatedCPURange string) ([]int, error) {
 	// Get a separated cpu number list
-	cpuList := make([]byte, 0, 8)
+	cpuList := make([]int, 0, 8)
 	// From [1,2,4-5,12-17,24-28,30-32]
 	// To   [1 2 4 5 12 13 14 15 16 17 24 25 26 27 28 30 31 32]
 	cpuRangeList := strings.Split(isolatedCPURange, ",")
@@ -157,27 +186,56 @@ func ConvertIsolatedCPURange2CPUList(isolatedCPURange string) []byte {
 			// endCPU is 17
 			// the CPU range must be two numbers
 			cpuRange := strings.Split(cpuRangeList[i], "-")
-			endCPU, _ := strconv.Atoi(cpuRange[1])
-			startCPU, _ := strconv.Atoi(cpuRange[0])
-			for i := 0; i <= endCPU-startCPU; i++ {
-				cpus := startCPU + i
-				cpuList = append(cpuList, byte(cpus))
+			if len(cpuRange) != 2 {
+				return nil, fmt.Errorf("invalid CPU range %q: expected exactly two elements", cpuRangeList[i])
+			}
+			startCPU, err := strconv.Atoi(cpuRange[0])
+			if err != nil {
+				return nil, fmt.Errorf("invalid start CPU %q in range %q: %w", cpuRange[0], cpuRangeList[i], err)
+			}
+			endCPU, err := strconv.Atoi(cpuRange[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid end CPU %q in range %q: %w", cpuRange[1], cpuRangeList[i], err)
+			}
+			if endCPU < startCPU {
+				return nil, fmt.Errorf("invalid CPU range %q: end CPU %d is less than start CPU %d", cpuRangeList[i], endCPU, startCPU)
+			}
+			for j := 0; j <= endCPU-startCPU; j++ {
+				cpus := startCPU + j
+				cpuList = append(cpuList, cpus)
 			}
 		} else {
-			cpus, _ := strconv.Atoi(cpuRangeList[i])
-			// Ignore 1,2,<no number>
-			if len(cpuRangeList[i]) != 0 {
-				cpuList = append(cpuList, byte(cpus))
+			cpus, err := strconv.Atoi(cpuRangeList[i])
+			if err != nil {
+				return nil, fmt.Errorf("invalid CPU %q: %w", cpuRangeList[i], err)
 			}
+			cpuList = append(cpuList, cpus)
 		}
 	}
-	return cpuList
+	return cpuList, nil
 }
 
-func AssertIsolateCPUCoresAffectedBitMask(cpuBitsMask []byte, isolatedCPU []byte) string {
+// normalizeAffinityMask strips whitespace and leading zeros from a CPU
+// affinity bitmask string, collapsing an all-zero value to "0" so that
+// trimming never produces an empty string that could spuriously match an
+// unrelated mask.
+func normalizeAffinityMask(mask string) string {
+	mask = strings.TrimSpace(mask)
+	mask = strings.TrimLeft(mask, "0")
+	if mask == "" {
+		mask = "0"
+	}
+	return mask
+}
+
+// AssertIsolateCPUCoresAffectedBitMask checks whether the actual IRQ SMP
+// affinity mask on a worker node matches the affinity mask that results from
+// isolating the given CPUs from the full CPU bitmask. Returns true if the
+// values match, false otherwise.
+func AssertIsolateCPUCoresAffectedBitMask(cpuBitsMask []byte, isolatedCPU []int, actualSMPAffinity string) (bool, error) {
 	// Isolated CPU Range, 0,1,3-4,11-16,23-27
 	//           27 26 25 24 ---------------------------------3 2 1 0
-	//           27%6=3
+	//           27%4=3
 	// [1111     1111         1111 1111 1111 1111 1111         1111] cpuBitMask
 	// [0000     1111         1000 0001 1111 1000 0001         1011] isolatedCPU
 	// --------------------------------------------------------------
@@ -189,47 +247,55 @@ func AssertIsolateCPUCoresAffectedBitMask(cpuBitsMask []byte, isolatedCPU []byte
 	totalCPUBitMaskGroups := len(cpuBitsMask)
 	totalIsolatedCPUNum := len(isolatedCPU)
 
-	Logf("The total isolated CPUs is: %v\n", totalIsolatedCPUNum)
-	Logf("The max CPU that isolated is : %v\n", int(isolatedCPU[totalIsolatedCPUNum-1]))
+	Logf("the total isolated CPUs is: %v\n", totalIsolatedCPUNum)
+	if totalIsolatedCPUNum == 0 {
+		return false, fmt.Errorf("no isolated CPUs provided, cannot compute affinity mask")
+	}
+	Logf("the max CPU that isolated is : %v\n", isolatedCPU[totalIsolatedCPUNum-1])
+
+	// Work on a copy to avoid mutating the caller's slice.
+	workingMask := make([]byte, totalCPUBitMaskGroups)
+	copy(workingMask, cpuBitsMask)
 
 	// The max CPU number is 27, Index is 15
-	maxValueOfIsolatedCPUIndex := int(isolatedCPU[totalIsolatedCPUNum-1]) / 4
+	maxValueOfIsolatedCPUIndex := isolatedCPU[totalIsolatedCPUNum-1] / 4
 	Logf("totalCPUGroupNum is: %v\nmaxCPUGroupIndex is: %v\n", totalCPUBitMaskGroups, maxValueOfIsolatedCPUIndex)
 	maxValueOfCPUBitMaskGroupsIndex := totalCPUBitMaskGroups - 1
 	for i := totalIsolatedCPUNum - 1; i >= 0; i-- {
-		isolatedCPUIndex := int(isolatedCPU[i]) / 4
+		isolatedCPUIndex := isolatedCPU[i] / 4
 
 		cpuBitsMaskIndex := maxValueOfCPUBitMaskGroupsIndex - isolatedCPUIndex
-		// 3 => 1000 2=>0100 1=>0010 0=>0000
-		modIsolatedCPUby4 := int(isolatedCPU[i] % 4)
-		var isolatedCPUMask int
-		switch modIsolatedCPUby4 {
-		case 3:
-			isolatedCPUMask = 8
-		case 2:
-			isolatedCPUMask = 4
-		case 1:
-			isolatedCPUMask = 2
-		case 0:
-			isolatedCPUMask = 1
-		}
+		// modIsolatedCPUby4 is 0-3; the corresponding bit mask is 1<<modIsolatedCPUby4
+		// (0=>0001, 1=>0010, 2=>0100, 3=>1000)
+		modIsolatedCPUby4 := isolatedCPU[i] % 4
+		isolatedCPUMask := 1 << modIsolatedCPUby4
 
-		valueOfCPUBitsMaskOnIndex := int(cpuBitsMask[cpuBitsMaskIndex]) ^ isolatedCPUMask
-		Logf("%04b ^ %04b = %04b\n", cpuBitsMask[cpuBitsMaskIndex], isolatedCPUMask, valueOfCPUBitsMaskOnIndex)
-		cpuBitsMask[cpuBitsMaskIndex] = byte(valueOfCPUBitsMaskOnIndex)
+		valueOfCPUBitsMaskOnIndex := int(workingMask[cpuBitsMaskIndex]) ^ isolatedCPUMask
+		Logf("%04b ^ %04b = %04b\n", workingMask[cpuBitsMaskIndex], isolatedCPUMask, valueOfCPUBitsMaskOnIndex)
+		workingMask[cpuBitsMaskIndex] = byte(valueOfCPUBitsMaskOnIndex)
 	}
-	cpuBitsMaskStr := fmt.Sprintf("%x", cpuBitsMask)
-	affinityCPUMask = strings.ReplaceAll(cpuBitsMaskStr, "0", "")
-	Logf("affinityCPUMask is: %s\n", affinityCPUMask)
-	return affinityCPUMask
+	cpuBitsMaskStr := fmt.Sprintf("%x", workingMask)
+	// Each byte of workingMask holds a nibble (0-15), but %x renders it as two
+	// hex chars (e.g., 0x0f -> "0f"). Take the lower nibble of each byte and
+	// strip leading zeros to match the kernel's compact hex representation.
+	cpuBitsMaskRune := []rune(cpuBitsMaskStr)
+	bitsMaskChars := make([]byte, 0, len(cpuBitsMaskRune)/2)
+	for i := 1; i < len(cpuBitsMaskRune); i = i + 2 {
+		bitsMaskChars = append(bitsMaskChars, byte(cpuBitsMaskRune[i]))
+	}
+	affinityCPUMask = normalizeAffinityMask(string(bitsMaskChars))
+	actualSMPAffinity = normalizeAffinityMask(actualSMPAffinity)
+	Logf("affinityCPUMask is: -%s-, actualSMPAffinity is -%s-\n", affinityCPUMask, actualSMPAffinity)
+	return affinityCPUMask == actualSMPAffinity, nil
 }
 
-func AssertDefaultIRQSMPAffinityAffectedBitMask(cpuBitsMask []byte, isolatedCPU []byte, defaultIRQSMPAffinity string) bool {
-	defaultIRQSMPAffinity = strings.ReplaceAll(defaultIRQSMPAffinity, "\n", "")
-
+// AssertDefaultIRQSMPAffinityAffectedBitMask checks whether the default IRQ
+// SMP affinity on worker nodes matches the affinity mask derived from the
+// isolated CPUs. Returns true if the values match, false otherwise.
+func AssertDefaultIRQSMPAffinityAffectedBitMask(cpuBitsMask []byte, isolatedCPU []int, defaultIRQSMPAffinity string) (bool, error) {
 	// Isolated CPU Range, 0,1,3-4,11-16,23-27
 	//           27 26 25 24 ---------------------------------3 2 1 0
-	//           27%6=3
+	//           27%4=3
 	// [1111     1111         1111 1111 1111 1111 1111         1111] cpuBitMask
 	// [0000     1111         1000 0001 1111 1000 0001         1011] isolatedCPU
 	// --------------------------------------------------------------
@@ -239,424 +305,1502 @@ func AssertDefaultIRQSMPAffinityAffectedBitMask(cpuBitsMask []byte, isolatedCPU 
 	//     maxValueOfIsolatedCPUIndex
 
 	var affinityCPUMask string
-	var isMatch bool
 	totalCPUBitMaskGroups := len(cpuBitsMask)
 	totalIsolatedCPUNum := len(isolatedCPU)
 
-	Logf("The total isolated CPUs is: %v\n", totalIsolatedCPUNum)
-	Logf("The max CPU that isolated is : %v\n", int(isolatedCPU[totalIsolatedCPUNum-1]))
+	Logf("the total isolated CPUs is: %v\n", totalIsolatedCPUNum)
+	if totalIsolatedCPUNum == 0 {
+		return false, fmt.Errorf("no isolated CPUs provided, cannot compute affinity mask")
+	}
+	Logf("the max CPU that isolated is : %v\n", isolatedCPU[totalIsolatedCPUNum-1])
+	// Initialize all bits to zero of isolatedCPUMask first.
 	isolatedCPUMaskGroup := make([]byte, totalCPUBitMaskGroups)
 
-	Logf("The initial isolatedCPUMask is %04b\n", isolatedCPUMaskGroup)
+	Logf("the initial isolatedCPUMask is %04b\n", isolatedCPUMaskGroup)
 
 	maxValueOfCPUBitMaskGroupsIndex := totalCPUBitMaskGroups - 1
 	for i := totalIsolatedCPUNum - 1; i >= 0; i-- {
-		isolatedCPUIndex := int(isolatedCPU[i]) / 4
+		isolatedCPUIndex := isolatedCPU[i] / 4
 
 		cpuBitsMaskIndex := maxValueOfCPUBitMaskGroupsIndex - isolatedCPUIndex
 
-		// 3 => 1000 2=>0100 1=>0010 0=>0000
-		modIsolatedCPUby4 := int(isolatedCPU[i] % 4)
-		var isolatedCPUMask int
-		switch modIsolatedCPUby4 {
-		case 3:
-			isolatedCPUMask = 8
-		case 2:
-			isolatedCPUMask = 4
-		case 1:
-			isolatedCPUMask = 2
-		case 0:
-			isolatedCPUMask = 1
-		}
+		// modIsolatedCPUby4 is 0-3; the corresponding bit mask is 1<<modIsolatedCPUby4
+		// (0=>0001, 1=>0010, 2=>0100, 3=>1000)
+		modIsolatedCPUby4 := isolatedCPU[i] % 4
+		isolatedCPUMask := 1 << modIsolatedCPUby4
 
 		Logf("%04b | %04b = %04b\n", isolatedCPUMaskGroup[cpuBitsMaskIndex], isolatedCPUMask, int(isolatedCPUMaskGroup[cpuBitsMaskIndex])|isolatedCPUMask)
 		valueOfCPUBitsMaskOnIndex := int(isolatedCPUMaskGroup[cpuBitsMaskIndex]) | isolatedCPUMask
 		isolatedCPUMaskGroup[cpuBitsMaskIndex] = byte(valueOfCPUBitsMaskOnIndex)
 	}
-	// Remove additional 0 in the isolatedCPUMaskGroup
+	// Convert the byte slice to a hex string, then extract the second character
+	// of each two-character hex pair. Each byte produces two hex chars (e.g., 0xAB -> "ab");
+	// taking the odd-indexed characters (1, 3, 5, ...) yields the lower nibble of each byte,
+	// which corresponds to the bits affected by isolated CPUs (positions 0,1,2,3 within each group of 4).
 	Logf("cpuBitsMask is: %04b\n", isolatedCPUMaskGroup)
 	cpuBitsMaskStr := fmt.Sprintf("%x", isolatedCPUMaskGroup)
 	cpuBitsMaskRune := []rune(cpuBitsMaskStr)
-	bitsMaskChars := make([]byte, 0, 2)
+	bitsMaskChars := make([]byte, 0, len(cpuBitsMaskRune)/2)
 
 	for i := 1; i < len(cpuBitsMaskRune); i = i + 2 {
 		bitsMaskChars = append(bitsMaskChars, byte(cpuBitsMaskRune[i]))
 	}
-	affinityCPUMask = string(bitsMaskChars)
-	// If defaultIRQSMPAffinity start with 0, ie, 00020, remove 000 and change to 20
-	if strings.HasPrefix(defaultIRQSMPAffinity, "0") || strings.HasPrefix(affinityCPUMask, "0") {
-		defaultIRQSMPAffinity = strings.TrimLeft(defaultIRQSMPAffinity, "0")
-		affinityCPUMask = strings.TrimLeft(affinityCPUMask, "0")
-	}
+	// Normalize leading zeros independently on each side so that different-length
+	// hex representations of the same value (e.g. "0010" vs "00010") compare equal.
+	defaultIRQSMPAffinity = normalizeAffinityMask(defaultIRQSMPAffinity)
+	affinityCPUMask = normalizeAffinityMask(string(bitsMaskChars))
 
 	Logf("affinityCPUMask is: -%s-, defaultIRQSMPAffinity is -%s-\n", affinityCPUMask, defaultIRQSMPAffinity)
+	var isMatch bool
 	if affinityCPUMask == defaultIRQSMPAffinity {
 		isMatch = true
 	}
-	return isMatch
+	return isMatch, nil
 }
 
-type NtoResource struct {
-	Name        string
-	Namespace   string
-	Template    string
-	Sysctlparm  string
-	Sysctlvalue string
-}
-
-func (ntoRes *NtoResource) CreateIRQSMPAffinityProfileIfNotExist(oc *CLI) {
-	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", ntoRes.Name, "-n", ntoRes.Namespace).Output()
-	if strings.Contains(output, "NotFound") || strings.Contains(output, "No resources") || err != nil {
-		Logf("no tuned in project: %s, create one: %s", ntoRes.Namespace, ntoRes.Name)
-		processedTemplate, err := oc.AsAdmin().WithoutNamespace().Run("process").Args("-n", ntoRes.Namespace, "--ignore-unknown-parameters=true", "-f", ntoRes.Template, "-p", "TUNED_NAME="+ntoRes.Name, "-p", "SYSCTLPARM="+ntoRes.Sysctlparm, "-p", "SYSCTLVALUE="+ntoRes.Sysctlvalue, "-o", "yaml").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		Logf("Processed template:\n%s", processedTemplate)
-		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-n", ntoRes.Namespace, "-f", "-").InputString(processedTemplate).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		Logf("Successfully created tuned resource: %s in namespace: %s", ntoRes.Name, ntoRes.Namespace)
-
-		// Wait for the Tuned resource to be created and ready
-		o.Eventually(func() bool {
-			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", ntoRes.Name, "-n", ntoRes.Namespace).Output()
-			if err != nil || strings.Contains(output, "NotFound") {
-				Logf("Tuned resource not yet available: %v", err)
-				return false
-			}
-			Logf("Tuned resource %s is now available", ntoRes.Name)
-			return true
-		}, "30s", "5s").Should(o.BeTrue(), "Tuned resource should be created")
-	} else {
-		Logf("already exist %v in project: %s", ntoRes.Name, ntoRes.Namespace)
+// CreateIRQSMPAffinityProfile processes the NtoResource template and creates
+// an IRQ SMP affinity Tuned resource in the cluster.
+func (ntoRes *NtoResource) CreateIRQSMPAffinityProfile(oc *CLI) error {
+	processedTemplate, err := oc.AsAdmin().WithoutNamespace().Run("process").Args("-n", ntoRes.Namespace, "--ignore-unknown-parameters=true", "-f", ntoRes.Template, "-p", "TUNED_NAME="+ntoRes.Name, "-p", "SYSCTLPARM="+ntoRes.SysctlParam, "-p", "SYSCTLVALUE="+ntoRes.SysctlValue, "-o", "yaml").Output()
+	if err != nil {
+		return fmt.Errorf("failed to process template for IRQ SMP affinity profile %s: %w", ntoRes.Name, err)
 	}
-}
-
-func (ntoRes *NtoResource) Delete(oc *CLI) {
-	_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ntoRes.Namespace, "tuned", ntoRes.Name, "--ignore-not-found").Execute()
-}
-
-// AssertIfTunedProfileApplied checks the logs for a given tuned pod in a given namespace to see if the expected profile was applied
-func (ntoRes *NtoResource) AssertIfTunedProfileApplied(oc *CLI, namespace string, tunedNodeName string, tunedName string, expectedAppliedStatus string) {
-	Logf("Checking if tuned profile %s is applied to node %s", tunedName, tunedNodeName)
-
-	// First check if the Profile resource exists
-	o.Eventually(func() bool {
-		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "profiles.tuned.openshift.io", tunedNodeName).Output()
-		if err != nil || strings.Contains(output, "NotFound") {
-			Logf("Profile resource %s not found yet in namespace %s: %v", tunedNodeName, namespace, err)
-			return false
-		}
-		Logf("Profile resource %s found in namespace %s", tunedNodeName, namespace)
-		return true
-	}, "60s", "5s").Should(o.BeTrue(), "Profile resource should exist for node "+tunedNodeName)
-
-	// Then check if the profile is applied with the correct status
-	o.Eventually(func() bool {
-		appliedStatus, err1 := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "profiles.tuned.openshift.io", tunedNodeName, `-ojsonpath='{.status.conditions[?(@.type=="Applied")].status}'`).Output()
-		tunedProfile, err2 := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "profiles.tuned.openshift.io", tunedNodeName, "-ojsonpath={.status.tunedProfile}").Output()
-
-		Logf("Checking profile status: appliedStatus=%s (err=%v), tunedProfile=%s (err=%v), expectedStatus=%s, expectedProfile=%s",
-			appliedStatus, err1, tunedProfile, err2, expectedAppliedStatus, tunedName)
-
-		if err1 != nil || err2 != nil {
-			Logf("Error getting profile status: err1=%v, err2=%v", err1, err2)
-			return false
-		}
-
-		if !strings.Contains(appliedStatus, expectedAppliedStatus) || strings.Contains(appliedStatus, "Unknown") {
-			Logf("Applied status not matching: got %s, want %s", appliedStatus, expectedAppliedStatus)
-			return false
-		}
-
-		if tunedProfile != tunedName {
-			Logf("Tuned profile name not matching: got %s, want %s", tunedProfile, tunedName)
-			return false
-		}
-
-		Logf("Profile %s successfully applied to node %s with status %s", tunedName, tunedNodeName, appliedStatus)
-		return true
-	}, "180s", "5s").Should(o.BeTrue(), fmt.Sprintf("Profile %s should be applied to node %s", tunedName, tunedNodeName))
-}
-
-func ChoseOneWorkerNodeToRunCase(oc *CLI, choseBy int) string {
-	// Prior to choose worker nodes with machineset
-	var tunedNodeName string
-	machinesetOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", "-n", "openshift-machine-api", "-o=jsonpath={.items[*].metadata.name}").Output()
-	machineSetExists := (err == nil && len(machinesetOutput) > 0)
-
-	if machineSetExists {
-		machinesetName := GetWorkerMachinesetName(oc, choseBy)
-		Logf("machinesetName is %v in ChoseOneWorkerNodeToRunCase", machinesetName)
-
-		if len(machinesetName) != 0 {
-			machinesetReplicas, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("machineset", "-n", "openshift-machine-api", machinesetName, "-o=jsonpath={.spec.replicas}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			if !strings.Contains(machinesetReplicas, "0") {
-				// First check if any nodes exist with this machineset label
-				nodeNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "machine.openshift.io/cluster-api-machineset="+machinesetName, "-o=jsonpath={.items[*].metadata.name}").Output()
-				o.Expect(err).NotTo(o.HaveOccurred())
-				if len(strings.TrimSpace(nodeNames)) > 0 {
-					// Get the first node name
-					nodeList := strings.Fields(nodeNames)
-					tunedNodeName = nodeList[0]
-					o.Expect(tunedNodeName).NotTo(o.BeEmpty())
-				} else {
-					Logf("No nodes found for machineset %s, falling back to node selection without machineset", machinesetName)
-					tunedNodeName = ChoseOneWorkerNodeNotByMachineset(oc, choseBy)
-				}
-			} else {
-				tunedNodeName = ChoseOneWorkerNodeNotByMachineset(oc, choseBy)
-			}
-		} else {
-			tunedNodeName = ChoseOneWorkerNodeNotByMachineset(oc, choseBy)
-		}
-	} else {
-		tunedNodeName = ChoseOneWorkerNodeNotByMachineset(oc, choseBy)
-		Logf("the tunedNodeName that we get inside ChoseOneWorkerNodeToRunCase when choseBy %v is %v ", choseBy, tunedNodeName)
+	err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-n", ntoRes.Namespace, "-f", "-").InputString(processedTemplate).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to create IRQ SMP affinity profile %s: %w", ntoRes.Name, err)
 	}
-	return tunedNodeName
+	return nil
 }
 
-// GetLinuxWorkerMachinesets returns a list of Linux worker machinesets, filtering out Windows and edge nodes
-func GetLinuxWorkerMachinesets(oc *CLI) []string {
-	machinesetList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-machine-api", "machineset", "-ojsonpath={.items[*].metadata.name}").Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	workerMachineSets := strings.Split(machinesetList, " ")
-	Logf("workerMachineSets is %v", workerMachineSets)
-
-	linuxMachineset := make([]string, 0, len(workerMachineSets))
-	for _, machineset := range workerMachineSets {
-		// Skip windows and edge nodes
-		if strings.Contains(machineset, "windows") || strings.Contains(machineset, "edge") {
-			Logf("skip windows or edge node [ %v ]", machineset)
-		} else if len(machineset) > 0 {
-			linuxMachineset = append(linuxMachineset, machineset)
-		}
-	}
-	Logf("linuxMachineset is %v", linuxMachineset)
-	return linuxMachineset
-}
-
-func GetWorkerMachinesetName(oc *CLI, machineseetSN int) string {
-	linuxMachineset := GetLinuxWorkerMachinesets(oc)
-
-	var machinesetName string
-	if machineseetSN < len(linuxMachineset) {
-		machinesetName = linuxMachineset[machineseetSN]
-	}
-
-	Logf("machinesetName is %v in GetWorkerMachinesetName", machinesetName)
-	return machinesetName
-}
-
-func ChoseOneWorkerNodeNotByMachineset(oc *CLI, choseBy int) string {
-	var tunedNodeName string
-	workerNodesStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker=,kubernetes.io/os=linux", "-o=jsonpath={.items[*].metadata.name}").Output()
-	o.Expect(err).NotTo(o.HaveOccurred())
-	workerNodes := strings.Fields(workerNodesStr)
-	o.Expect(len(workerNodes)).To(o.BeNumerically(">", 0), "No worker nodes found")
-
-	switch choseBy {
-	// 0 means the first worker node, 1 means the last worker node
-	case 0:
-		tunedNodeName = workerNodes[0]
-		Logf("the tunedNodeName that we get inside ChoseOneWorkerNodeNotByMachineset when choseBy 0 is %v ", tunedNodeName)
-		o.Expect(tunedNodeName).NotTo(o.BeEmpty())
-	case 1:
-		tunedNodeName = workerNodes[len(workerNodes)-1]
-		Logf("the tunedNodeName that we get inside ChoseOneWorkerNodeNotByMachineset when choseBy 1 is %v ", tunedNodeName)
-		o.Expect(tunedNodeName).NotTo(o.BeEmpty())
-	default:
-		Logf("Invalid parameter for choseBy is %v ", choseBy)
-	}
-	return tunedNodeName
+// Delete removes the NtoResource Tuned object from the cluster.
+func (ntoRes *NtoResource) Delete(oc *CLI) error {
+	return oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ntoRes.Namespace, "tuned", ntoRes.Name, "--ignore-not-found").Execute()
 }
 
 // Helper functions for NTO extended tests (from nto_helpers.go)
 
-func GetFirstLinuxWorkerNode(oc *CLI) (string, error) {
-	workerNodesStr, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker=,kubernetes.io/os=linux", "-o=jsonpath={.items[*].metadata.name}").Output()
+// GetNTOPodName checks all pods in a given namespace and returns the first NTO pod name found
+func GetNTOPodName(oc *CLI, namespace string) (string, error) {
+	podName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "pods", "-lname=cluster-node-tuning-operator", "-ojsonpath={.items[*].metadata.name}").Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get NTO operator pod: %w", err)
 	}
-	nodes := strings.Fields(strings.TrimSpace(workerNodesStr))
-	if len(nodes) == 0 {
-		return "", fmt.Errorf("no Linux worker nodes found")
+	if podName == "" {
+		return "", fmt.Errorf("NTO operator pod was not found in namespace %s", namespace)
 	}
-	return nodes[0], nil
+	return podName, nil
 }
 
-func IsSNOCluster(oc *CLI) bool {
-	nodeCount, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "--no-headers").Output()
+// GetTunedState returns a string representation of the spec.managementState of the specified tuned in a given namespace
+func GetTunedState(oc *CLI, namespace string, tunedName string) (string, error) {
+	return oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", tunedName, "-n", namespace, "-o=jsonpath={.spec.managementState}").Output()
+}
+
+// PatchTunedState will patch the state of the specified tuned to that specified if supported, will throw an error if patch fails or state unsupported
+func PatchTunedState(oc *CLI, namespace string, tunedName string, state string) error {
+	state = strings.ToLower(state)
+	switch state {
+	case "unmanaged":
+		return oc.AsAdmin().WithoutNamespace().Run("patch").Args("tuned", tunedName, "-p", `{"spec":{"managementState":"Unmanaged"}}`, "--type", "merge", "-n", namespace).Execute()
+	case "managed":
+		return oc.AsAdmin().WithoutNamespace().Run("patch").Args("tuned", tunedName, "-p", `{"spec":{"managementState":"Managed"}}`, "--type", "merge", "-n", namespace).Execute()
+	case "removed":
+		return oc.AsAdmin().WithoutNamespace().Run("patch").Args("tuned", tunedName, "-p", `{"spec":{"managementState":"Removed"}}`, "--type", "merge", "-n", namespace).Execute()
+	default:
+		return fmt.Errorf("specified state %s is unsupported", state)
+	}
+}
+
+// GetTunedPriority returns a string representation of the spec.recommend.priority of the specified tuned in a given namespace
+func GetTunedPriority(oc *CLI, namespace string, tunedName string) (string, error) {
+	return oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", tunedName, "-n", namespace, "-o=jsonpath={.spec.recommend[*].priority}").Output()
+}
+
+// PatchTunedProfile will patch the priority of the specified tuned to that specified in a given YAML or JSON file.
+// We cannot directly patch the value since it is nested within a list, thus the need for a patch file for this function.
+func PatchTunedProfile(oc *CLI, namespace string, tunedName string, patchFile string) error {
+	return oc.AsAdmin().WithoutNamespace().Run("patch").Args("tuned", tunedName, "--patch-file="+patchFile, "--type", "merge", "-n", namespace).Execute()
+}
+
+// GetTunedProfile returns a string representation of the status.tunedProfile of the given node in the given namespace
+func GetTunedProfile(oc *CLI, namespace string, tunedNodeName string) (string, error) {
+	return oc.AsAdmin().WithoutNamespace().Run("get").Args("profiles.tuned.openshift.io", tunedNodeName, "-n", namespace, "-o=jsonpath={.status.tunedProfile}").Output()
+}
+
+// GetTunedPodNameByNodeName returns the tuned pod name for a given node
+func GetTunedPodNameByNodeName(oc *CLI, tunedNodeName, namespace string) (string, error) {
+	podName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-n", namespace, "-l", "name=tuned", "--field-selector=spec.nodeName="+tunedNodeName, "-o=jsonpath={.items[0].metadata.name}").Output()
 	if err != nil {
-		return false
+		return "", fmt.Errorf("failed to get tuned pod for node %s: %w", tunedNodeName, err)
 	}
-	return len(strings.Split(strings.TrimSpace(nodeCount), "\n")) == 1
+	if podName == "" {
+		return "", fmt.Errorf("no tuned pod found for node %s", tunedNodeName)
+	}
+	Logf("the Tuned Pod Name is: %v", podName)
+	return podName, nil
 }
 
-func DebugNodeRetryWithOptionsAndChrootWithStdErr(oc *CLI, nodeName string, options []string, command ...string) (string, string, error) {
-	stdout, stderr, err := DebugNode(oc, nodeName, options, true, true, command...)
-	return stdout, stderr, err
+// CreateCustomTunedProfile processes the NtoResource template and creates a
+// custom Tuned resource in the cluster.
+func (ntoRes *NtoResource) CreateCustomTunedProfile(oc *CLI) error {
+	processedTemplate, err := oc.AsAdmin().WithoutNamespace().Run("process").Args("-n", ntoRes.Namespace, "--ignore-unknown-parameters=true", "-f", ntoRes.Template, "-p", "TUNED_NAME="+ntoRes.Name, "-p", "SYSCTLPARM="+ntoRes.SysctlParam, "-p", "SYSCTLVALUE="+ntoRes.SysctlValue, "-o", "yaml").Output()
+	if err != nil {
+		return fmt.Errorf("failed to process template for tuned profile %s: %w", ntoRes.Name, err)
+	}
+	err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-n", ntoRes.Namespace, "-f", "-").InputString(processedTemplate).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to create tuned profile %s: %w", ntoRes.Name, err)
+	}
+	return nil
 }
 
-// StringsSliceElementsHasPrefix checks if any element in the slice has the given prefix
-func StringsSliceElementsHasPrefix(slice []string, prefix string, caseSensitive bool) (bool, int) {
-	for i, s := range slice {
-		if caseSensitive {
-			if strings.HasPrefix(s, prefix) {
-				return true, i
-			}
-		} else {
-			if strings.HasPrefix(strings.ToLower(s), strings.ToLower(prefix)) {
-				return true, i
-			}
+// CreateDebugTunedProfile processes the NtoResource template and creates a
+// Tuned resource in the cluster with debugging optionally turned on.
+func (ntoRes *NtoResource) CreateDebugTunedProfile(oc *CLI, isDebug bool) error {
+	processedTemplate, err := oc.AsAdmin().WithoutNamespace().Run("process").Args("-n", ntoRes.Namespace, "--ignore-unknown-parameters=true", "-f", ntoRes.Template, "-p", "TUNED_NAME="+ntoRes.Name, "-p", "SYSCTLPARM="+ntoRes.SysctlParam, "-p", "SYSCTLVALUE="+ntoRes.SysctlValue, "-p", "ISDEBUG="+strconv.FormatBool(isDebug), "-o", "yaml").Output()
+	if err != nil {
+		return fmt.Errorf("failed to process template for debug tuned profile %s: %w", ntoRes.Name, err)
+	}
+	err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-n", ntoRes.Namespace, "-f", "-").InputString(processedTemplate).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to create debug tuned profile %s: %w", ntoRes.Name, err)
+	}
+	return nil
+}
+
+// ApplyNTOTunedProfile processes the NtoResource template and applies a Tuned
+// resource to the cluster.
+func (ntoRes *NtoResource) ApplyNTOTunedProfile(oc *CLI) error {
+	processedTemplate, err := oc.AsAdmin().WithoutNamespace().Run("process").Args("-n", ntoRes.Namespace, "--ignore-unknown-parameters=true", "-f", ntoRes.Template, "-p", "TUNED_PROFILE="+ntoRes.Name, "-p", "SYSCTL_NAME="+ntoRes.SysctlParam, "-p", "SYSCTL_VALUE="+ntoRes.SysctlValue, "-p", "LABEL_NAME="+ntoRes.Label, "-o", "yaml").Output()
+	if err != nil {
+		return fmt.Errorf("failed to process template for NTO tuned profile %s: %w", ntoRes.Name, err)
+	}
+	err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-n", ntoRes.Namespace, "-f", "-").InputString(processedTemplate).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to apply NTO tuned profile %s: %w", ntoRes.Name, err)
+	}
+	return nil
+}
+
+// ApplyNTOTunedProfileWithDeferredAnnotation processes the NtoResource template
+// and applies a Tuned resource with a deferred annotation to the cluster.
+func (ntoRes *NtoResource) ApplyNTOTunedProfileWithDeferredAnnotation(oc *CLI) error {
+	processedTemplate, err := oc.AsAdmin().WithoutNamespace().Run("process").Args("-n", ntoRes.Namespace, "--ignore-unknown-parameters=true", "-f", ntoRes.Template, "-p", "TUNED_PROFILE="+ntoRes.Name, "-p", "SYSCTL_NAME="+ntoRes.SysctlParam, "-p", "SYSCTL_VALUE="+ntoRes.SysctlValue, "-p", "LABEL_NAME="+ntoRes.Label, "-p", "DEFERRED_VALUE="+ntoRes.DeferredValue, "-o", "yaml").Output()
+	if err != nil {
+		return fmt.Errorf("failed to process template for NTO tuned profile with deferred annotation %s: %w", ntoRes.Name, err)
+	}
+	err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-n", ntoRes.Namespace, "-f", "-").InputString(processedTemplate).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to apply NTO tuned profile with deferred annotation %s: %w", ntoRes.Name, err)
+	}
+	return nil
+}
+
+// Parsing functions
+
+// sysctlNumericValue extracts the leading integer value of the sysctl key from
+// sysctl-style output (e.g. "kernel.pid_max = 4194304").
+func sysctlNumericValue(input, key string) (string, error) {
+	for _, line := range strings.Split(input, "\n") {
+		idx := strings.Index(line, key)
+		if idx < 0 {
+			continue
+		}
+		rest := strings.TrimLeft(line[idx+len(key):], " \t")
+		if !strings.HasPrefix(rest, "=") {
+			continue
+		}
+		rest = strings.TrimLeft(rest[1:], " \t")
+		end := 0
+		for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+			end++
+		}
+		if end > 0 {
+			return rest[:end], nil
 		}
 	}
-	return false, -1
+	return "", fmt.Errorf("%s not found in input", key)
 }
 
-// IsNamespacePrivileged checks if a namespace has privileged security context constraints
-func IsNamespacePrivileged(oc *CLI, namespace string) (bool, error) {
-	labels, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("namespace", namespace, "-o=jsonpath={.metadata.labels}").Output()
+// GetMaxUserWatchesValue parses out the value determining max_user_watches in inotify.conf.
+func GetMaxUserWatchesValue(inotify string) (string, error) {
+	return sysctlNumericValue(inotify, "fs.inotify.max_user_watches")
+}
+
+// GetMaxUserInstancesValue parses out the value determining max_user_instances in inotify.conf.
+func GetMaxUserInstancesValue(inotify string) (string, error) {
+	return sysctlNumericValue(inotify, "fs.inotify.max_user_instances")
+}
+
+// GetKernelPidMaxValue parses out the value determining pid_max in the kernel.
+func GetKernelPidMaxValue(kernel string) (string, error) {
+	return sysctlNumericValue(kernel, "kernel.pid_max")
+}
+
+// GetValueOfSysctlByName parses out the sysctl value from the kernel on a given node.
+func GetValueOfSysctlByName(oc *CLI, tunedNodeName, sysctlparm string) (string, error) {
+	sysctlValue, _, err := debugNode(oc, tunedNodeName, []string{"--quiet=true"}, false, true, "sysctl", "-n", sysctlparm)
 	if err != nil {
-		return false, err
+		return "", fmt.Errorf("failed to get sysctl %s on node %s: %w", sysctlparm, tunedNodeName, err)
 	}
-	return strings.Contains(labels, "pod-security.kubernetes.io/enforce:privileged") ||
-		strings.Contains(labels, "security.openshift.io/scc.podSecurityLabelSync:false"), nil
+	if sysctlValue == "" {
+		return "", fmt.Errorf("sysctl output is empty for %s on node %s", sysctlparm, tunedNodeName)
+	}
+	return strings.TrimSpace(sysctlValue), nil
 }
 
-// SetNamespacePrivileged sets privileged labels on a namespace
-func SetNamespacePrivileged(oc *CLI, namespace string) error {
-	err := oc.AsAdmin().WithoutNamespace().Run("label").Args("namespace", namespace, "pod-security.kubernetes.io/enforce=privileged", "pod-security.kubernetes.io/audit=privileged", "pod-security.kubernetes.io/warn=privileged", "security.openshift.io/scc.podSecurityLabelSync=false", "--overwrite").Execute()
+// Sysctl comparison functions
+
+// getSysctlValue reads the sysctl value from a node using oc debug.
+func getSysctlValue(oc *CLI, nodeName, sysctlparm string, options ...string) (string, error) {
+	stdOut, _, err := DebugNodeWithOptionsAndChrootWithStdErr(oc, nodeName, append([]string{"--quiet=true"}, options...), "sysctl", "-n", sysctlparm)
+	if err != nil {
+		return "", fmt.Errorf("failed to get sysctl %s on %s: %w", sysctlparm, nodeName, err)
+	}
+	return stdOut, nil
+}
+
+// sysctlSearch builds the "sysctlparm = value" string used for display/logging.
+func sysctlSearch(sysctlparm, value string) string {
+	return sysctlparm + " = " + value
+}
+
+// CompareSpecifiedValueByNameOnLabelNode checks if the sysctl parameter equals the specified value on a labeled node.
+// It retries on transient failures (e.g., oc debug command failing during node reboots or on SNO)
+// with 15-second intervals up to 180 seconds, consistent with CompareSpecifiedValueByNameOnLabelNodeWithRetry.
+func CompareSpecifiedValueByNameOnLabelNode(ctx context.Context, oc *CLI, labelNodeName, sysctlparm, specifiedvalue string) error {
+	err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 180*time.Second, false, func(_ context.Context) (bool, error) {
+		stdOut, getErr := getSysctlValue(oc, labelNodeName, sysctlparm)
+		if getErr != nil {
+			Logf("failed to get sysctl %s on node %s: %v, retrying", sysctlparm, labelNodeName, getErr)
+			return false, nil
+		}
+		Logf("the value on %v is: %v", labelNodeName, strings.TrimSpace(stdOut))
+		if strings.TrimSpace(stdOut) != specifiedvalue {
+			Logf("sysctl %s on node %v does not equal expected value %q: got %q, retrying", sysctlparm, labelNodeName, specifiedvalue, strings.TrimSpace(stdOut))
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("sysctl %s on node %s did not converge to expected value %q within timeout: %w", sysctlparm, labelNodeName, specifiedvalue, err)
+	}
+	return nil
+}
+
+// CompareSysctlDifferentFromSpecifiedValueByNameWithRetry polls all worker nodes and asserts
+// that the sysctl parameter does not equal the specified value. It retries every 15 seconds
+// for up to 3 minutes to allow NTO time to reconcile after pod deletion or label removal.
+func CompareSysctlDifferentFromSpecifiedValueByNameWithRetry(ctx context.Context, oc *CLI, sysctlparm, specifiedvalue string) error {
+	err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 180*time.Second, false, func(_ context.Context) (bool, error) {
+		nodeList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker=", "-o=jsonpath={.items[*].metadata.name}").Output()
+		if err != nil {
+			Logf("error listing worker nodes: %v, retrying", err)
+			return false, nil
+		}
+		nodes := strings.Fields(nodeList)
+		if len(nodes) == 0 {
+			return false, fmt.Errorf("no worker nodes found")
+		}
+
+		for _, node := range nodes {
+			stdOut, err := getSysctlValue(oc, node, sysctlparm)
+			if err != nil {
+				Logf("error checking sysctl on %v: %v", node, err)
+				return false, nil
+			}
+			Logf("the value is [ %v ] on %v", strings.TrimSpace(stdOut), node)
+			if strings.TrimSpace(stdOut) == specifiedvalue {
+				Logf("sysctl %v still equals %v on %v, retrying", sysctlparm, specifiedvalue, node)
+				return false, nil
+			}
+		}
+		Logf("sysctl %v is different from %v on all worker nodes", sysctlparm, specifiedvalue)
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("sysctl value did not change within timeout: %w", err)
+	}
+	return nil
+}
+
+// CompareSysctlValueOnAllWorkerNodesWithRetry polls all worker nodes and validates
+// sysctl values across the cluster:
+// - Checks that the tuned node has the expected sysctl value
+// - Verifies that other worker nodes do NOT have the specified value
+// - If defaultvalue is provided, ensures non-tuned nodes have the defaultvalue
+// It retries every 15 seconds for up to 3 minutes to allow NTO time to reconcile.
+func CompareSysctlValueOnAllWorkerNodesWithRetry(ctx context.Context, oc *CLI, tunedNodeName, sysctlparm, defaultvalue, specifiedvalue string) error {
+	err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 180*time.Second, false, func(_ context.Context) (bool, error) {
+		nodeList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker=", "-o=jsonpath={.items[*].metadata.name}").Output()
+		if err != nil {
+			Logf("error listing worker nodes: %v, retrying", err)
+			return false, nil
+		}
+		nodes := strings.Fields(nodeList)
+		if len(nodes) == 0 {
+			return false, fmt.Errorf("no worker nodes found")
+		}
+
+		// Ensure the tuned node is in the worker node list; if not, it cannot be validated.
+		tunedNodeFound := false
+		for _, node := range nodes {
+			if node == tunedNodeName {
+				tunedNodeFound = true
+				break
+			}
+		}
+		if !tunedNodeFound {
+			Logf("tuned node %v not found in worker node list %v, retrying", tunedNodeName, nodes)
+			return false, nil
+		}
+
+		for _, node := range nodes {
+			stdOut, err := getSysctlValue(oc, node, sysctlparm)
+			if err != nil {
+				Logf("error checking sysctl on %v: %v", node, err)
+				return false, nil
+			}
+			Logf("the actual value is %v on %v", strings.TrimSpace(stdOut), node)
+			if node == tunedNodeName {
+				Logf("the expected value of %v should be %v on %v", sysctlparm, specifiedvalue, node)
+				if strings.TrimSpace(stdOut) != specifiedvalue {
+					Logf("sysctl %v not yet %v on %v, retrying", sysctlparm, specifiedvalue, node)
+					return false, nil
+				}
+			} else {
+				Logf("the expected value of %v shouldn't be %v on %v", sysctlparm, specifiedvalue, node)
+				if strings.TrimSpace(stdOut) == specifiedvalue {
+					Logf("sysctl %v still equals %v on %v, retrying", sysctlparm, specifiedvalue, node)
+					return false, nil
+				}
+				if len(defaultvalue) > 0 {
+					Logf("the expected default value of %v should be %v on %v", sysctlparm, defaultvalue, node)
+					if strings.TrimSpace(stdOut) != defaultvalue {
+						Logf("sysctl %v not yet default %v on %v, retrying", sysctlparm, defaultvalue, node)
+						return false, nil
+					}
+				}
+			}
+		}
+		Logf("sysctl %v is %v on %v and not on other worker nodes", sysctlparm, specifiedvalue, tunedNodeName)
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("sysctl value did not converge within timeout: %w", err)
+	}
+	return nil
+}
+
+// CompareSpecifiedValueByNameOnLabelNodeWithRetry polls the given node's sysctl parameter
+// and asserts it matches the expected value.  It retries every 15 seconds for up to 3 minutes.
+func CompareSpecifiedValueByNameOnLabelNodeWithRetry(ctx context.Context, oc *CLI, ntoNamespace, nodeName, sysctlparm, specifiedvalue string) error {
+	search := sysctlSearch(sysctlparm, specifiedvalue)
+
+	err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 180*time.Second, false, func(_ context.Context) (bool, error) {
+		sysctlOutput, _, err := DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, nodeName, []string{"--quiet=true", "--to-namespace=" + ntoNamespace}, "sysctl", "-n", sysctlparm)
+		Logf("the actual value is [ %v ] on %v", sysctlOutput, nodeName)
+		if err != nil {
+			Logf("failed to get sysctl value on %v: %v, retrying", nodeName, err)
+			return false, nil
+		}
+
+		if strings.TrimSpace(sysctlOutput) == specifiedvalue {
+			Logf("matched '%s' on %s", search, nodeName)
+			return true, nil
+		}
+		Logf("no match for '%s' on %s", search, nodeName)
+		return false, nil
+	})
 	return err
 }
 
-// RecoverNamespaceRestricted recovers namespace to restricted labels
-func RecoverNamespaceRestricted(oc *CLI, namespace string) {
-	_ = oc.AsAdmin().WithoutNamespace().Run("label").Args("namespace", namespace, "pod-security.kubernetes.io/enforce-", "pod-security.kubernetes.io/audit-", "pod-security.kubernetes.io/warn-", "security.openshift.io/scc.podSecurityLabelSync-").Execute()
-}
+// Assertion functions
 
-// IsDefaultNodeSelectorEnabled checks if default node selector is enabled
-func IsDefaultNodeSelectorEnabled(oc *CLI) bool {
-	selector, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("scheduler", "cluster", "-o=jsonpath={.spec.defaultNodeSelector}").Output()
+// WaitForSchedulingDisabledNode waits until a node with 'SchedulingDisabled' or 'NotReady' status appears.
+// If nodeLabelSelector is not empty, only nodes matching the selector are considered.
+func WaitForSchedulingDisabledNode(ctx context.Context, oc *CLI, nodeLabelSelector string) (string, error) {
+	var nodeNames []string
+	var labelArgs []string
+	if nodeLabelSelector != "" {
+		labelArgs = []string{"-l", nodeLabelSelector}
+	}
+	err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 3*time.Minute, false, func(_ context.Context) (bool, error) {
+		// Get nodes with SchedulingDisabled (unschedulable) via jsonpath
+		unschedulableArgs := append(append([]string{"nodes"}, labelArgs...), "-o=jsonpath={.items[?(@.spec.unschedulable==true)].metadata.name}")
+		unschedulableNodes, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(unschedulableArgs...).Output()
+		if err != nil {
+			Logf("failed to get unschedulable nodes: %v, retrying", err)
+			return false, nil
+		}
+		unschedulableList := strings.Fields(strings.TrimSpace(unschedulableNodes))
+		if len(unschedulableList) > 0 {
+			Logf("'SchedulingDisabled' status found on nodes: %v", unschedulableList)
+			nodeNames = unschedulableList
+			return true, nil
+		}
+
+		nodesText, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(append([]string{"nodes"}, labelArgs...)...).Output()
+		if err != nil {
+			Logf("failed to get nodes: %v, retrying", err)
+			return false, nil
+		}
+		for _, line := range strings.Split(nodesText, "\n") {
+			if strings.Contains(line, "NotReady") {
+				fields := strings.Fields(line)
+				if len(fields) > 0 {
+					Logf("'NotReady' status found on node: %v", fields[0])
+					nodeNames = []string{fields[0]}
+					return true, nil
+				}
+			}
+		}
+
+		Logf("no node with 'SchedulingDisabled' or 'NotReady' status found - retrying")
+		return false, nil
+	})
 	if err != nil {
-		return false
+		return "", fmt.Errorf("no node was found with 'SchedulingDisabled' status within timeout limit (3 minutes): %w", err)
 	}
-	return strings.TrimSpace(selector) != ""
+	Logf("node Name is %v", nodeNames[0])
+	return nodeNames[0], nil
 }
 
-// IsWorkerNode checks if a node has the worker role
-func IsWorkerNode(oc *CLI, nodeName string) bool {
-	labels, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", nodeName, "-o=jsonpath={.metadata.labels}").Output()
+// WaitForMasterNodeChanges waits until 'default_hugepagesz=2M' is present in /proc/cmdline on the master node.
+// The node must be rebooted to pick up the new kernel arguments; the 8 minute
+// timeout covers the drain, reboot and rejoin of a single master.
+func WaitForMasterNodeChanges(ctx context.Context, oc *CLI, masterNodeName string) error {
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Minute, 8*time.Minute, false, func(_ context.Context) (bool, error) {
+		output, _, err := debugNode(oc, masterNodeName, []string{"--quiet=true"}, true, true, "cat", "/proc/cmdline")
+		if err != nil {
+			Logf("failed to get /proc/cmdline on %v: %v, retrying", masterNodeName, err)
+			return false, nil
+		}
+
+		isMasterNodeChanged := strings.Contains(output, "default_hugepagesz=2M")
+		if isMasterNodeChanged {
+			Logf("node %v has expected changes:\n%v", masterNodeName, output)
+			return true, nil
+		}
+		Logf("node %v does not have expected changes - retrying", masterNodeName)
+		return false, nil
+	})
 	if err != nil {
-		return false
+		return fmt.Errorf("node %s did not have expected changes within timeout limit: %w", masterNodeName, err)
 	}
-	return strings.Contains(labels, "node-role.kubernetes.io/worker")
+	return nil
 }
 
-// IsSpecifiedAnnotationKeyExist checks if a specific annotation key exists on a resource
-func IsSpecifiedAnnotationKeyExist(oc *CLI, resource, namespace, annotationKey string) bool {
-	args := []string{resource}
-	if namespace != "" {
-		args = append(args, "-n", namespace)
-	}
-	args = append(args, "-o=jsonpath={.metadata.annotations}")
-	annotations, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(args...).Output()
+// AssertDebugSettings checks whether the debug setting on a tuned profile
+// matches the expected value "true" or "false".
+func AssertDebugSettings(oc *CLI, tunedNodeName string, ntoNamespace string, isDebug string) (bool, error) {
+	nodeProfile, err := oc.AsAdmin().WithoutNamespace().Run("describe").Args("profiles.tuned.openshift.io", tunedNodeName, "-n", ntoNamespace).Output()
 	if err != nil {
-		return false
+		return false, fmt.Errorf("failed to describe profile: %w", err)
 	}
-	return strings.Contains(annotations, annotationKey)
+
+	isMatch := false
+	debugPrefix := "Debug:"
+	for _, line := range strings.Split(nodeProfile, "\n") {
+		if idx := strings.Index(line, debugPrefix); idx >= 0 && strings.TrimSpace(line[idx+len(debugPrefix):]) == isDebug {
+			isMatch = true
+			Logf("the result is: %v", line)
+			break
+		}
+	}
+	return isMatch, nil
 }
 
-// AddAnnotationsToSpecificResource adds annotations to a specific resource
-func AddAnnotationsToSpecificResource(oc *CLI, resource, namespace, annotation string) error {
-	args := []string{resource}
-	if namespace != "" {
-		args = append(args, "-n", namespace)
+// AssertNTOCustomProfileStatus returns whether the node profile matches the expected profile and condition statuses.
+func AssertNTOCustomProfileStatus(oc *CLI, ntoNamespace string, tunedNodeName string, expectedProfile string, expectedAppliedStatus string, expectedDegradedStatus string) (bool, error) {
+	currentProfile, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io", tunedNodeName, `-ojsonpath={.status.tunedProfile}`).Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to get current profile: %w", err)
 	}
-	args = append(args, annotation, "--overwrite")
-	return oc.AsAdmin().WithoutNamespace().Run("annotate").Args(args...).Execute()
+	if currentProfile == "" {
+		return false, fmt.Errorf("current profile is empty")
+	}
+	Logf("currentProfile is %v", currentProfile)
+
+	appliedStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io", tunedNodeName, `-ojsonpath={.status.conditions[?(@.type=="Applied")].status}`).Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to get applied status: %w", err)
+	}
+	if appliedStatus == "" {
+		return false, fmt.Errorf("applied status is empty")
+	}
+	Logf("appliedStatus is %v", appliedStatus)
+
+	degradedStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "profiles.tuned.openshift.io", tunedNodeName, `-ojsonpath={.status.conditions[?(@.type=="Degraded")].status}`).Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to get degraded status: %w", err)
+	}
+	if degradedStatus == "" {
+		return false, fmt.Errorf("degraded status is empty")
+	}
+	Logf("degradedStatus is %v", degradedStatus)
+
+	return appliedStatus == expectedAppliedStatus && degradedStatus == expectedDegradedStatus && currentProfile == expectedProfile, nil
 }
 
-// RemoveAnnotationFromSpecificResource removes an annotation from a specific resource
-func RemoveAnnotationFromSpecificResource(oc *CLI, resource, namespace, annotationKey string) error {
-	args := []string{resource}
-	if namespace != "" {
-		args = append(args, "-n", namespace)
+// AssertNTOPodLogsLastLines polls the NTO pod logs until they contain the
+// given filter keyword, or times out after timeDurationSec seconds.
+// When lineN is "-1", search the full log.
+func AssertNTOPodLogsLastLines(ctx context.Context, oc *CLI, namespace string, ntoPod string, lineN string, timeDurationSec int, filter string) error {
+	regNTOPodLogs, err := regexp.Compile(".*" + filter + ".*")
+	if err != nil {
+		return fmt.Errorf("failed to compile regex for filter %q: %w", filter, err)
 	}
-	args = append(args, annotationKey+"-")
-	return oc.AsAdmin().WithoutNamespace().Run("annotate").Args(args...).Execute()
+
+	timeout := time.Duration(timeDurationSec) * time.Second
+	if timeout < 15*time.Second {
+		timeout = 15 * time.Second
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, 15*time.Second, timeout, false, func(_ context.Context) (bool, error) {
+		// Do not assert on log fetch errors: on SNO the API server may be temporarily unreachable during master node restart or certificate rotation.
+		ntoPodLogs, logErr := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", namespace, ntoPod, "--tail="+lineN).Output()
+		if logErr != nil {
+			Logf("error fetching logs for pod %s/%s: %v, retrying", namespace, ntoPod, logErr)
+			return false, nil
+		}
+
+		isMatch := regNTOPodLogs.MatchString(ntoPodLogs)
+		if isMatch {
+			loglines := regNTOPodLogs.FindAllString(ntoPodLogs, -1)
+			Logf("the logs of nto pod %v is: \n%v", ntoPod, loglines[0])
+			return true, nil
+		}
+		Logf("the keywords of nto pod isn't found, try next")
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("the tuned pod's log doesn't contain the keywords, please check: %w", err)
+	}
+	return nil
 }
 
-// DebugNode is the core function for launching debug containers
-func DebugNode(oc *CLI, nodeName string, cmdOptions []string, needChroot bool, recoverNsLabels bool, cmd ...string) (stdOut string, stdErr string, err error) {
+// WaitForCOStatusWithKeywords polls the clusteroperator status until it contains the given keywords.
+func WaitForCOStatusWithKeywords(ctx context.Context, oc *CLI, timeout time.Duration, keywords string) error {
+	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, false, func(_ context.Context) (bool, error) {
+		coStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("co").Output()
+		if err != nil {
+			Logf("error getting clusteroperator status: %v, retrying", err)
+			return false, nil
+		}
+		if !strings.Contains(coStatus, keywords) {
+			Logf("keywords %q not found in co status, retrying", keywords)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("keywords %q not found in clusteroperator status within timeout: %w", keywords, err)
+	}
+	return nil
+}
+
+// WaitForCONodeTuningStatusClear waits until warning messages disappear from co/node-tuning; they can clear with delay.
+func WaitForCONodeTuningStatusClear(ctx context.Context, oc *CLI, timeDurationSec int, filter string) error {
+	pollInterval := time.Duration(timeDurationSec/10) * time.Second
+	if pollInterval < 5*time.Second {
+		pollInterval = 5 * time.Second
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, time.Duration(timeDurationSec)*time.Second, false, func(_ context.Context) (bool, error) {
+		coNodeTuningStdOut, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("co/node-tuning").Output()
+		if err != nil {
+			Logf("error getting co/node-tuning: %v, retrying", err)
+			return false, nil
+		}
+
+		if !strings.Contains(coNodeTuningStdOut, filter) {
+			return true, nil
+		}
+		for _, line := range strings.Split(coNodeTuningStdOut, "\n") {
+			if strings.Contains(line, filter) {
+				Logf("the status of co/node-tuning is:%v \n%v\n", coNodeTuningStdOut, line)
+				break
+			}
+		}
+		Logf("the keywords of co/node-tuning still found, try next")
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("the checking of co/node-tuning met with unexpected error, please check: %w", err)
+	}
+	return nil
+}
+
+// MachineConfig and node validation functions
+
+// GetPoolUpdatedMachineCount returns the UpdatedMachineCount for MCP 'pool'.
+func GetPoolUpdatedMachineCount(ctx context.Context, oc *CLI, pool string) (int32, error) {
 	var (
-		debugNodeNamespace string
-		isNsPrivileged     bool
-		cargs              []string
-		outputError        error
+		explain error
+		count   int32
 	)
 
-	cargs = []string{"node/" + nodeName}
+	startTime := time.Now()
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		updatedMachineCount, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("mcp", pool, "-o=jsonpath={.status.updatedMachineCount}").Output()
+		if err != nil {
+			explain = err
+			return false, nil
+		}
+		updated, err := strconv.ParseInt(strings.TrimSpace(updatedMachineCount), 10, 32)
+		if err != nil {
+			explain = err
+			return false, nil
+		}
+		count = int32(updated)
+		return true, nil
+	}); err != nil {
+		if explain != nil {
+			return 0, fmt.Errorf("failed to get pool %s UpdatedMachineCount (waited %s): last error: %v: %w", pool, time.Since(startTime), explain, err)
+		}
+		return 0, fmt.Errorf("failed to get pool %s UpdatedMachineCount (waited %s): %w", pool, time.Since(startTime), err)
+	}
+	return count, nil
+}
 
-	// Enhance for debug node namespace used logic
-	// if "--to-namespace=" option is used, then uses the input options' namespace, otherwise use oc.Namespace()
-	// if oc.Namespace() is empty, uses "default" namespace instead
-	hasToNamespaceInCmdOptions, index := StringsSliceElementsHasPrefix(cmdOptions, "--to-namespace=", false)
-	if hasToNamespaceInCmdOptions {
-		debugNodeNamespace = strings.TrimPrefix(cmdOptions[index], "--to-namespace=")
-	} else {
-		debugNodeNamespace = oc.Namespace()
-		if debugNodeNamespace == "" {
-			debugNodeNamespace = "default"
+// WaitForPoolUpdatedMachineCount polls a pool until its UpdatedMachineCount equals to 'count'.
+func WaitForPoolUpdatedMachineCount(ctx context.Context, oc *CLI, pool string, count int32) error {
+	var explain error
+
+	startTime := time.Now()
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
+		updatedMachineCount, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("mcp", pool, "-o=jsonpath={.status.updatedMachineCount}").Output()
+		if err != nil {
+			// This is not fatal.  On SNO, API server will be unavailable during reboots.
+			explain = err
+			return false, nil
+		}
+		updated, err := strconv.ParseInt(strings.TrimSpace(updatedMachineCount), 10, 32)
+		if err != nil {
+			explain = err
+			return false, nil
+		}
+		if int32(updated) == count {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		if explain != nil {
+			return fmt.Errorf("pool %s UpdatedMachineCount != %d (waited %s): last error: %v: %w", pool, count, time.Since(startTime), explain, err)
+		}
+		return fmt.Errorf("pool %s UpdatedMachineCount != %d (waited %s): %w", pool, count, time.Since(startTime), err)
+	}
+	return nil
+}
+
+// AssertTunedAppliedMC checks if a custom tuned profile was applied via MachineConfigPool.
+func AssertTunedAppliedMC(oc *CLI, mcNameSubstring string, filter string) error {
+	mcNameList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("mc", "--no-headers", "-oname").Output()
+	if err != nil {
+		return fmt.Errorf("failed to list MachineConfigs: %w", err)
+	}
+	Logf("the name of mcName is: %v", mcNameList)
+
+	// Find MachineConfig names that contain the substring mcNameSubstring.
+	var mcName []string
+	for _, line := range strings.Split(mcNameList, "\n") {
+		if strings.Contains(line, mcNameSubstring) {
+			mcName = append(mcName, line)
 		}
 	}
+	Logf("the expected names of mcName is: %v", mcName)
+	if len(mcName) == 0 {
+		return fmt.Errorf("no MachineConfig found matching substring %q", mcNameSubstring)
+	}
+	if len(mcName) > 1 {
+		return fmt.Errorf("expected exactly one MachineConfig matching %q, found %d: %v", mcNameSubstring, len(mcName), mcName)
+	}
 
-	// Running oc debug node command in normal projects
-	// (normal projects mean projects that are not clusters default projects like: "openshift-xxx" et al)
-	// need extra configuration on 4.12+ ocp test clusters
-	// https://github.com/openshift/oc/blob/master/pkg/helpers/cmd/errors.go#L24-L29
-	if !strings.HasPrefix(debugNodeNamespace, "openshift-") {
-		isNsPrivileged, outputError = IsNamespacePrivileged(oc, debugNodeNamespace)
-		if outputError != nil {
-			return "", "", outputError
+	mcOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(mcName[0], "-oyaml").Output()
+	if err != nil {
+		return fmt.Errorf("failed to get MachineConfig %s: %w", mcName[0], err)
+	}
+	if !strings.Contains(mcOutput, filter) {
+		return fmt.Errorf("MachineConfig %s does not contain expected filter %q", mcName[0], filter)
+	}
+
+	// Print machineconfig content by filter
+	for _, line := range strings.Split(mcOutput, "\n") {
+		if strings.Contains(line, filter) {
+			Logf("the result is: %v", line)
+			break
 		}
-		if !isNsPrivileged {
-			if recoverNsLabels {
-				defer RecoverNamespaceRestricted(oc, debugNodeNamespace)
+	}
+	return nil
+}
+
+// WaitForMachineConfigWithKernelArg polls until a MachineConfig with the given
+// name exists and its spec.kernelArguments (a list of "key=value" strings)
+// contain the expected name/value pair.
+func WaitForMachineConfigWithKernelArg(ctx context.Context, oc *CLI, mcName, kernelArgName, kernelArgValue string, timeDurationSec int) error {
+	pollInterval := time.Duration(timeDurationSec/10) * time.Second
+	if pollInterval < 5*time.Second {
+		pollInterval = 5 * time.Second
+	}
+	kernelArg := kernelArgName + "=" + kernelArgValue
+	explain := ""
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, time.Duration(timeDurationSec)*time.Second, false, func(_ context.Context) (bool, error) {
+		kernelArgsOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("mc", mcName, "-o=jsonpath={.spec.kernelArguments[*]}").Output()
+		if err != nil {
+			explain = fmt.Sprintf("MachineConfig %s does not exist (yet): %v", mcName, err)
+			Logf("%s, retrying", explain)
+			return false, nil
+		}
+		for _, arg := range strings.Fields(kernelArgsOutput) {
+			if arg == kernelArg {
+				Logf("MachineConfig [%v] has kernel argument [%v] as expected", mcName, kernelArg)
+				return true, nil
 			}
-			outputError = SetNamespacePrivileged(oc, debugNodeNamespace)
-			if outputError != nil {
-				return "", "", outputError
+		}
+		explain = fmt.Sprintf("MachineConfig %s kernel arguments %q do not contain %q", mcName, kernelArgsOutput, kernelArg)
+		Logf("%s, retrying", explain)
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("MachineConfig %s did not contain kernel argument %s within timeout: %s", mcName, kernelArg, explain)
+	}
+	return nil
+}
+
+// AssertTunedAppliedToNode checks if a custom tuned profile was applied to a given node.
+func AssertTunedAppliedToNode(oc *CLI, tunedNodeName string, filter string) (bool, error) {
+	cmdLineOutput, _, err := DebugNodeWithOptionsAndChrootWithoutRecoverNsLabel(oc, tunedNodeName, []string{"--quiet=true"}, "cat", "/proc/cmdline")
+	if err != nil {
+		return false, fmt.Errorf("failed to read /proc/cmdline on node %s: %w", tunedNodeName, err)
+	}
+	if strings.Contains(cmdLineOutput, filter) {
+		// /proc/cmdline is a single line; print it for diagnostics. This replaces
+		// the former regexp.MustCompile(".*"+...QuoteMeta(filter)...+".*").FindAllString.
+		Logf("the result is: %v", cmdLineOutput)
+		return true, nil
+	}
+	Logf("the result mismatched the filter: %v", filter)
+	return false, nil
+}
+
+// AssertIOTimeoutAndMaxRetries verifies that the NVMe io_timeout parameter
+// is set to 4294967295 on all worker nodes that have the NVMe module loaded.
+func AssertIOTimeoutAndMaxRetries(ctx context.Context, oc *CLI) error {
+	nodeList, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker=", "-o=jsonpath={.items[*].metadata.name}").Output()
+	if err != nil {
+		return fmt.Errorf("failed to list worker nodes: %w", err)
+	}
+	nodes := strings.Fields(nodeList)
+	if len(nodes) == 0 {
+		return fmt.Errorf("no worker nodes found")
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 3*time.Minute, false, func(_ context.Context) (bool, error) {
+		checked := false
+		for _, node := range nodes {
+			checkOutput, checkStderr, checkErr := debugNode(oc, node, []string{"--quiet=true"}, true, true, "ls", "/sys/module/nvme_core/parameters/io_timeout")
+			if checkErr != nil {
+				if strings.Contains(checkStderr, "cannot access") || strings.Contains(checkStderr, "No such file") {
+					Logf("node %s does not have NVMe module loaded, skipping", node)
+					continue
+				}
+				Logf("failed to check NVMe module on node %s: %v, retrying", node, checkErr)
+				return false, nil
+			}
+			if checkOutput == "" {
+				Logf("node %s does not have NVMe module loaded, skipping", node)
+				continue
+			}
+			checked = true
+			timeoutOutput, _, err := debugNode(oc, node, []string{"--quiet=true"}, true, true, "cat", "/sys/module/nvme_core/parameters/io_timeout")
+			if err != nil {
+				Logf("failed to read io_timeout on node %s: %v, retrying", node, err)
+				return false, nil
+			}
+			Logf("the value of io_timeout is : %v on node %v", timeoutOutput, node)
+			if !strings.Contains(timeoutOutput, "4294967295") {
+				Logf("io_timeout on node %s does not contain expected value 4294967295: got %q, retrying", node, timeoutOutput)
+				return false, nil
+			}
+		}
+		if !checked {
+			return false, fmt.Errorf("no node exposed nvme_core io_timeout parameter; nothing was verified")
+		}
+		return true, nil
+	})
+	return err
+}
+
+// Certificate and service functions
+var endpointRE = regexp.MustCompile(`^((\d{1,3}\.){3}\d{1,3}|[0-9a-fA-F:]+):\d+$`)
+
+// GetServiceEndpoint returns the IP:port endpoint of the node-tuning-operator
+// service in the given namespace.
+func GetServiceEndpoint(oc *CLI, namespace string) (string, error) {
+	endpointAddresses, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "endpoints/node-tuning-operator", "-ojsonpath={.subsets[*].addresses[*].ip}").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get endpoint addresses: %w", err)
+	}
+	if endpointAddresses == "" {
+		return "", fmt.Errorf("endpoint addresses are empty")
+	}
+
+	endpointPorts, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "endpoints/node-tuning-operator", "-ojsonpath={.subsets[*].ports[*].port}").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get endpoint ports: %w", err)
+	}
+	if endpointPorts == "" {
+		return "", fmt.Errorf("endpoint ports are empty")
+	}
+
+	addresses := strings.Split(strings.TrimSpace(endpointAddresses), " ")
+	ports := strings.Split(strings.TrimSpace(endpointPorts), " ")
+	if len(addresses) == 0 || len(ports) == 0 {
+		return "", fmt.Errorf("no endpoint addresses or ports found")
+	}
+
+	endpoint := addresses[0] + ":" + ports[0]
+	if !endpointRE.MatchString(endpoint) {
+		return "", fmt.Errorf("endpoint %q does not match expected IP:port format", endpoint)
+	}
+	return endpoint, nil
+}
+
+// certsEqual compares two PEM-encoded certificates by decoding their first PEM
+// block and comparing the DER bytes. This checks content equality only and does
+// not validate certificate properties such as expiration dates or chain of trust.
+func certsEqual(pemCert1, pemCert2 string) (bool, error) {
+	block1, _ := pem.Decode([]byte(pemCert1))
+	if block1 == nil {
+		return false, fmt.Errorf("failed to parse PEM certificate from first input")
+	}
+	block2, _ := pem.Decode([]byte(pemCert2))
+	if block2 == nil {
+		return false, fmt.Errorf("failed to parse PEM certificate from second input")
+	}
+	return bytes.Equal(block1.Bytes, block2.Bytes), nil
+}
+
+// fetchOpenSSLCertificateFromNode connects to metricEndpoint via openssl
+// s_client from tunedNodeName (chrooted debug pod) and pipes the output
+// through pipeCmd (e.g. "openssl x509" to normalize, or a sed extraction of
+// the raw PEM block). Both certificate-rotation polls below share this single
+// command builder so a pod-spawn/exec failure is reported identically and
+// distinguishably from a genuine certificate mismatch.
+func fetchOpenSSLCertificateFromNode(oc *CLI, tunedNodeName, metricEndpoint string, recoverNsLabels bool, pipeCmd string) (string, error) {
+	cmd := "/usr/bin/openssl s_client -connect " + metricEndpoint + " 2>/dev/null </dev/null | " + pipeCmd
+	stdout, _, err := debugNode(oc, tunedNodeName, []string{"--quiet=true"}, true, recoverNsLabels, "/bin/bash", "-c", cmd)
+	return stdout, err
+}
+
+// CompareCertificateBetweenOpenSSLandTLSSecret compares the certificate
+// obtained via OpenSSL from the NTO service endpoint with the tls.crt stored
+// in the node-tuning-operator-tls secret. Returns an error if they differ.
+func CompareCertificateBetweenOpenSSLandTLSSecret(ctx context.Context, oc *CLI, ntoNamespace string, tunedNodeName string) error {
+	metricEndpoint, err := GetServiceEndpoint(oc, ntoNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to get service endpoint: %w", err)
+	}
+	var lastReason string
+	err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 180*time.Second, false, func(_ context.Context) (bool, error) {
+		// Extract certificate from openssl that nto operator service endpoint
+		openSSLOutputAfter, err := fetchOpenSSLCertificateFromNode(oc, tunedNodeName, metricEndpoint, true, `sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'`)
+		if err != nil {
+			lastReason = fmt.Sprintf("failed to get openssl certificate from node %s (endpoint unreachable or debug pod failed): %v", tunedNodeName, err)
+			Logf("%s, retrying", lastReason)
+			return false, nil
+		}
+
+		// Extract tls.crt from secret node-tuning-operator-tls
+		encodeBase64tlsCertOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ntoNamespace, "secret", "node-tuning-operator-tls", `-ojsonpath={.data.tls\.crt}`).Output()
+		if err != nil {
+			lastReason = fmt.Sprintf("failed to get tls.crt from secret: %v", err)
+			Logf("%s, retrying", lastReason)
+			return false, nil
+		}
+		tlsCertOutput, err := BASE64DecodeStr(encodeBase64tlsCertOutput)
+		if err != nil {
+			lastReason = fmt.Sprintf("failed to decode tls.crt from secret: %v", err)
+			Logf("%s, retrying", lastReason)
+			return false, nil
+		}
+
+		isSame, err := certsEqual(openSSLOutputAfter, tlsCertOutput)
+		if err != nil {
+			lastReason = fmt.Sprintf("failed to compare certificates: %v", err)
+			Logf("%s, retrying", lastReason)
+			return false, nil
+		}
+		if isSame {
+			Logf("the certificate is the same")
+			return true, nil
+		}
+		lastReason = "the certificate served by the endpoint still differs from the tls.crt secret"
+		Logf("%s, try next round", lastReason)
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("certificate served by node %s never matched tls.crt secret (last reason: %s): %w", tunedNodeName, lastReason, err)
+	}
+	return nil
+}
+
+// WaitForNTOCertificateRotation waits until the NTO metrics server certificate has been rotated.
+func WaitForNTOCertificateRotation(ctx context.Context, oc *CLI, ntoNamespace string, tunedNodeName string, encodeBase64CertificateBefore string) error {
+	metricEndpoint, err := GetServiceEndpoint(oc, ntoNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to get service endpoint: %w", err)
+	}
+	var lastReason string
+	err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 300*time.Second, false, func(_ context.Context) (bool, error) {
+		certificateAfter, err := fetchOpenSSLCertificateFromNode(oc, tunedNodeName, metricEndpoint, false, "/usr/bin/openssl x509")
+		if err != nil {
+			lastReason = fmt.Sprintf("failed to get certificate from node %s (endpoint unreachable or debug pod failed): %v", tunedNodeName, err)
+			Logf("%s, retrying", lastReason)
+			return false, nil
+		}
+
+		encodeBase64CertificateAfter := StringToBASE64(certificateAfter)
+
+		if encodeBase64CertificateBefore != encodeBase64CertificateAfter {
+			Logf("the certificate has been updated")
+			return true, nil
+		}
+		lastReason = "the certificate served by the endpoint still matches the pre-rotation certificate"
+		Logf("%s, try next round", lastReason)
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("NTO certificate on node %s was not rotated within timeout (last reason: %s): %w", tunedNodeName, lastReason, err)
+	}
+	return nil
+}
+
+// AssertNetworkChannelQueuesStatus checks if network channel queues are configured correctly.
+func AssertNetworkChannelQueuesStatus(oc *CLI, namespace string, tunedNodeName string) (bool, error) {
+	var isMatch bool
+	findStr := `find /sys/class/net -type l -not -lname '*virtual*' -a -not -name 'enP*' -printf '%f\n'`
+	ifNameList, _, err := DebugNodeWithOptionsAndChrootWithStdErr(oc, tunedNodeName, []string{"--quiet=true", "--to-namespace=" + namespace}, "bash", "-c", findStr)
+	if err != nil {
+		return false, fmt.Errorf("failed to list physical network interfaces on node %s: %w", tunedNodeName, err)
+	}
+	Logf("physical network list is: %v", ifNameList)
+	if ifNameList == "" {
+		return false, fmt.Errorf("no physical network interfaces found on node %s", tunedNodeName)
+	}
+
+	// Remove double quotes
+	ifNameStr := strings.ReplaceAll(ifNameList, "\"", "")
+	if ifNameStr == "" {
+		return false, fmt.Errorf("physical network interface list is empty on node %s", tunedNodeName)
+	}
+	// Check all physical nic
+	ifNames := strings.Split(ifNameStr, "\n")
+	Logf("ifNames is: %v", ifNames)
+	if len(ifNames) == 0 {
+		return false, fmt.Errorf("no physical network interfaces parsed on node %s", tunedNodeName)
+	}
+
+	for _, ifName := range ifNames {
+		if len(ifName) > 0 {
+			ethToolsOutput, _, err := DebugNodeWithOptionsAndChrootWithStdErr(oc, tunedNodeName, []string{"--quiet=true", "--to-namespace=" + namespace}, "ethtool", "-l", ifName)
+			if err != nil {
+				return false, fmt.Errorf("failed to run ethtool on %s for interface %s: %w", tunedNodeName, ifName, err)
+			}
+			if ethToolsOutput == "" {
+				return false, fmt.Errorf("ethtool output is empty for interface %s on node %s", ifName, tunedNodeName)
+			}
+			Logf("ethtool -l %v:, \n%v", ifName, ethToolsOutput)
+
+			// Check whether any "Combined:" line carries a "1" value.
+			for _, line := range strings.Split(ethToolsOutput, "\n") {
+				if idx := strings.Index(line, "Combined:"); idx >= 0 {
+					value := strings.TrimSpace(line[idx+len("Combined:"):])
+					if value == "1" {
+						isMatch = true
+						break
+					}
+				}
+			}
+			if isMatch {
+				break
 			}
 		}
 	}
+	return isMatch, nil
+}
 
-	// For default nodeSelector enabled test clusters we need to add the extra annotation to avoid the debug pod's
-	// nodeSelector overwritten by the scheduler
-	if IsDefaultNodeSelectorEnabled(oc) && !IsWorkerNode(oc, nodeName) && !IsSpecifiedAnnotationKeyExist(oc, "ns/"+debugNodeNamespace, "", `openshift.io/node-selector`) {
-		if err := AddAnnotationsToSpecificResource(oc, "ns/"+debugNodeNamespace, "", `openshift.io/node-selector=`); err != nil {
-			Logf("Warning: failed to add annotation: %v", err)
+// validateProcessFilter validates that the processFilter only contains safe characters
+// to prevent shell command injection. Only alphanumeric characters, hyphens,
+// underscores, and dots are allowed.
+func validateProcessFilter(processFilter string) error {
+	matched, err := regexp.MatchString(`^[a-zA-Z0-9_.-]+$`, processFilter)
+	if err != nil {
+		return fmt.Errorf("failed to validate process filter: %w", err)
+	}
+	if !matched {
+		return fmt.Errorf("invalid process filter: %q contains disallowed characters", processFilter)
+	}
+	return nil
+}
+
+// cpusAllowedListValue extracts the value following "Cpus_allowed_list:" from the
+// output of `grep ^Cpus_allowed_list /proc/<pid>/status`. It returns the trimmed
+// value, or "" if the field is absent.
+func cpusAllowedListValue(status string) string {
+	for _, line := range strings.Split(status, "\n") {
+		if idx := strings.Index(line, "Cpus_allowed_list:"); idx >= 0 {
+			return strings.TrimSpace(line[idx+len("Cpus_allowed_list:"):])
 		}
-		defer func() {
-			if err := RemoveAnnotationFromSpecificResource(oc, "ns/"+debugNodeNamespace, "", `openshift.io/node-selector`); err != nil {
-				Logf("Warning: failed to remove annotation: %v", err)
+	}
+	return ""
+}
+
+// AssertProcessExcludedFromCgroupScheduler checks that a process is excluded from the cgroup scheduler.
+func AssertProcessExcludedFromCgroupScheduler(oc *CLI, tunedNodeName string, namespace string, processFilter string, nodeCPUCores int) (bool, error) {
+	if err := validateProcessFilter(processFilter); err != nil {
+		return false, err
+	}
+	if nodeCPUCores < 2 {
+		return false, fmt.Errorf("node %s has insufficient CPU cores (%d) for cgroup scheduler exclusion check; need at least 2", tunedNodeName, nodeCPUCores)
+	}
+
+	pIDCpusAllowedList, err := DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"-n", namespace, "--quiet=true", "--to-namespace=" + namespace}, "/bin/bash", "-c", "grep ^Cpus_allowed_list /proc/$(pgrep "+processFilter+" | tail -1)/status")
+	if err != nil {
+		return false, fmt.Errorf("failed to get Cpus_allowed_list for process %s on node %s: %w", processFilter, tunedNodeName, err)
+	}
+	Logf("actually Process's Cpus_allowed_list in /proc/$PID/status on worker nodes is: \n%v", pIDCpusAllowedList)
+
+	// CPU = 2:
+	//   In cgroup blacklist: 0-1 (N is CPU cores - 1)
+	//   Not in cgroup blacklist: 0
+	// CPU > 2:
+	//   In cgroup blacklist: 0-N (N is CPU cores - 1)
+	//   Not in cgroup blacklist: 0,2-N (N is CPU cores - 1)
+	var expected string
+	switch nodeCPUCores {
+	case 2:
+		expected = "0"
+	case 3:
+		// Kernel collapses single-element ranges: "2-2" → "2"
+		expected = "0,2"
+	default:
+		expected = "0,2-" + strconv.Itoa(nodeCPUCores-1)
+	}
+
+	Logf("expected Process's Cpus_allowed_list in /proc/$PID/status on worker nodes is: \n%v", "Cpus_allowed_list:	"+expected)
+
+	// Compare the entire value following "Cpus_allowed_list:" so a blacklist range such
+	// as "0-10" (which ends in "0") is not mistakenly reported as the excluded value "0".
+	isMatch := cpusAllowedListValue(pIDCpusAllowedList) == expected
+
+	Logf("match cgroup Cpus_allowed_list for process %v is: %v", processFilter, isMatch)
+	return isMatch, nil
+}
+
+// AssertProcessInCgroupSchedulerBlacklist checks that a process is present
+// in the cgroup scheduler blacklist (Cpus_allowed_list = "0-N" where N is
+// nodeCPUCores - 1), meaning it is excluded from all CPUs.
+func AssertProcessInCgroupSchedulerBlacklist(oc *CLI, tunedNodeName string, namespace string, processFilter string, nodeCPUCores int) (bool, error) {
+	if err := validateProcessFilter(processFilter); err != nil {
+		return false, err
+	}
+	if nodeCPUCores < 2 {
+		return false, fmt.Errorf("node %s has insufficient CPU cores (%d) for cgroup scheduler blacklist check; need at least 2", tunedNodeName, nodeCPUCores)
+	}
+
+	pIDCpusAllowedList, err := DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"-n", namespace, "--quiet=true", "--to-namespace=" + namespace}, "/bin/bash", "-c", "grep ^Cpus_allowed_list /proc/$(pgrep "+processFilter+" | tail -1)/status")
+	if err != nil {
+		return false, fmt.Errorf("failed to get Cpus_allowed_list for process %s on node %s: %w", processFilter, tunedNodeName, err)
+	}
+	Logf("actually Process's Cpus_allowed_list in /proc/$PID/status on worker nodes is: \n%v", pIDCpusAllowedList)
+
+	// CPU = 2:
+	//   In cgroup blacklist: 0-1
+	//   Not in cgroup blacklist: 0
+	// CPU > 2:
+	//   In cgroup blacklist: 0-N (N is CPU cores - 1)
+	//   Not in cgroup blacklist: 0,2-N (N is CPU cores - 1)
+
+	expectedBlacklist := "0-" + strconv.Itoa(nodeCPUCores-1)
+	Logf("expected Process's Cpus_allowed_list in /proc/$PID/status on worker nodes is: \n%v", "Cpus_allowed_list:	"+expectedBlacklist)
+	// Compare the entire value following "Cpus_allowed_list:" (see comment in the
+	// sibling function for why an exact value comparison is required).
+	isMatch := cpusAllowedListValue(pIDCpusAllowedList) == expectedBlacklist
+
+	Logf("match cgroup Cpus_allowed_list for process %v is: %v", processFilter, isMatch)
+	return isMatch, nil
+}
+
+// ConfirmedTunedReady polls until the tuned resource with the given name
+// appears in the namespace, indicating the tuned daemon has applied it.
+func ConfirmedTunedReady(ctx context.Context, oc *CLI, ntoNamespace string, tunedName string, timeDurationSec int) error {
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, time.Duration(timeDurationSec)*time.Second, false, func(_ context.Context) (bool, error) {
+		tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("tuned", "-n", ntoNamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
+		if err != nil {
+			Logf("failed to get tuned status in %v: %v, retrying", ntoNamespace, err)
+			return false, nil
+		}
+
+		for _, name := range strings.Fields(tunedNames) {
+			if name == tunedName {
+				return true, nil
 			}
-		}()
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("tuned %s is not ready: %w", tunedName, err)
+	}
+	return nil
+}
+
+// SwitchThrottlectlOnOff runs throttlectl with the given state ("on" or "off")
+// on the tuned node and verifies the change by polling /proc/sys/kernel/sched_rt_runtime_us.
+// "off" disables RT throttling and sets sched_rt_runtime_us to -1 (unlimited),
+// while "on" re-enables it with a finite runtime value.
+func SwitchThrottlectlOnOff(ctx context.Context, oc *CLI, ntoNamespace, tunedNodeName string, throttlectlState string, timeDurationSec int) error {
+	switch throttlectlState {
+	case "on", "off":
+	default:
+		return fmt.Errorf("unexpected throttlectl state: %s, must be \"on\" or \"off\"", throttlectlState)
 	}
 
-	if len(cmdOptions) > 0 {
-		cargs = append(cargs, cmdOptions...)
+	_, err := DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "/usr/bin/throttlectl", throttlectlState)
+	if err != nil {
+		return fmt.Errorf("failed to run throttlectl %v on %v: %w", throttlectlState, tunedNodeName, err)
 	}
-	if !hasToNamespaceInCmdOptions {
-		cargs = append(cargs, "--to-namespace="+debugNodeNamespace)
-	}
-	if needChroot {
-		cargs = append(cargs, "--", "chroot", "/host")
-	} else {
-		cargs = append(cargs, "--")
-	}
-	cargs = append(cargs, cmd...)
 
-	return oc.AsAdmin().WithoutNamespace().Run("debug").Args(cargs...).Outputs()
+	// Poll only the status check to verify the change took effect.
+	err = wait.PollUntilContextTimeout(ctx, 10*time.Second, time.Duration(timeDurationSec)*time.Second, false, func(_ context.Context) (bool, error) {
+		schedRTRuntimeStatus, err := DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "cat", "/proc/sys/kernel/sched_rt_runtime_us")
+		if err != nil {
+			Logf("failed to get sched_rt_runtime_us from %v: %v, retrying", tunedNodeName, err)
+			return false, nil
+		}
+
+		// When throttling is disabled the runtime is unlimited (-1); when enabled
+		// it is a finite value (e.g. 950000).
+		throttlingOff := strings.Contains(schedRTRuntimeStatus, "-1")
+		if (throttlectlState == "off" && throttlingOff) || (throttlectlState == "on" && !throttlingOff) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("throttlectl status isn't correct: %w", err)
+	}
+	return nil
+}
+
+// WaitForTunedProfileApplied waits until a tuned profile is applied to a node.
+// It first checks if the Profile resource exists, then verifies the profile is applied with the expected status.
+// WaitForTunedProfileApplied waits for the tuned Profile resource for tunedNodeName
+// to be applied with the expected status (default "True") and to reference tunedName.
+func WaitForTunedProfileApplied(ctx context.Context, oc *CLI, namespace string, tunedNodeName string, tunedName string, expectedAppliedStatus ...string) error {
+	return WaitForTunedProfileAppliedWithTimeout(ctx, oc, namespace, tunedNodeName, tunedName, 180*time.Second, expectedAppliedStatus...)
+}
+
+// WaitForTunedProfileAppliedWithTimeout is like WaitForTunedProfileApplied but
+// allows the caller to specify the total timeout for the entire operation
+// (profile-existence check plus applied-status poll).
+// This is needed after events such as a node reboot that may take several minutes
+// before tuned starts and applies the deferred profile.
+func WaitForTunedProfileAppliedWithTimeout(ctx context.Context, oc *CLI, namespace string, tunedNodeName string, tunedName string, timeout time.Duration, expectedAppliedStatus ...string) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	status := "True"
+	if len(expectedAppliedStatus) > 0 {
+		status = expectedAppliedStatus[0]
+	}
+
+	// First check if the Profile resource exists
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, false, func(_ context.Context) (bool, error) {
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "profiles.tuned.openshift.io", tunedNodeName).Output()
+		if err != nil || strings.Contains(output, "NotFound") {
+			Logf("Profile resource %s not found yet in namespace %s: %v", tunedNodeName, namespace, err)
+			return false, nil
+		}
+		Logf("Profile resource %s found in namespace %s", tunedNodeName, namespace)
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("Profile resource should exist for node %s: %w", tunedNodeName, err)
+	}
+
+	// Then check if the profile is applied with the correct status
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, false, func(_ context.Context) (bool, error) {
+		appliedStatus, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "profiles.tuned.openshift.io", tunedNodeName, `-ojsonpath={.status.conditions[?(@.type=="Applied")].status}`).Output()
+		if err != nil {
+			Logf("error getting profile status for %s: %v, retrying", tunedNodeName, err)
+			return false, nil
+		}
+
+		tunedProfile, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "profiles.tuned.openshift.io", tunedNodeName, "-ojsonpath={.status.tunedProfile}").Output()
+		if err != nil {
+			Logf("error getting profile status for %s: %v, retrying", tunedNodeName, err)
+			return false, nil
+		}
+
+		if !strings.Contains(appliedStatus, status) || strings.Contains(appliedStatus, "Unknown") {
+			Logf("applied status not matching: got %s, want %s", appliedStatus, status)
+			return false, nil
+		}
+
+		if tunedProfile != tunedName {
+			Logf("Tuned profile name not matching: got %s, want %s", tunedProfile, tunedName)
+			return false, nil
+		}
+
+		Logf("Profile %s successfully applied to node %s with status %s", tunedName, tunedNodeName, appliedStatus)
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("Profile %s should be applied to node %s: %w", tunedName, tunedNodeName, err)
+	}
+	return nil
+}
+
+// WaitForDefaultProfiles waits for the default tuned profiles to be applied across
+// the cluster. Master/control-plane nodes should have "openshift-control-plane" and
+// worker nodes should have "openshift-node". On SNO/compact clusters all nodes are
+// expected to have "openshift-control-plane".
+func WaitForDefaultProfiles(ctx context.Context, oc *CLI, namespace string) {
+	const (
+		expectedMasterProfile = "openshift-control-plane"
+		expectedWorkerProfile = "openshift-node"
+		pollInterval          = 10 * time.Second
+		timeout               = 5 * time.Minute
+	)
+
+	masterNodes, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/control-plane=", "-o=jsonpath={.items[*].metadata.name}").Output()
+	if err != nil {
+		Logf("WaitForDefaultProfiles: failed to list master nodes: %v", err)
+		return
+	}
+
+	workerNodes, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker=", "-o=jsonpath={.items[*].metadata.name}").Output()
+	if err != nil {
+		Logf("WaitForDefaultProfiles: failed to list worker nodes: %v", err)
+		return
+	}
+
+	err = wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(_ context.Context) (bool, error) {
+		allOk := true
+
+		for _, node := range strings.Fields(masterNodes) {
+			profile, err := GetTunedProfile(oc, namespace, node)
+			if err != nil || profile != expectedMasterProfile {
+				Logf("WaitForDefaultProfiles: node %q has profile %q, expected %q", node, profile, expectedMasterProfile)
+				allOk = false
+			}
+		}
+
+		for _, node := range strings.Fields(workerNodes) {
+			// Skip nodes that also have the control-plane label (SNO/compact).
+			roleLabels, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node/"+node, "-o", "jsonpath={.metadata.labels}").Output()
+			if err != nil {
+				Logf("WaitForDefaultProfiles: failed to get labels for node %s: %v", node, err)
+				allOk = false
+				continue
+			}
+			if strings.Contains(roleLabels, "node-role.kubernetes.io/control-plane") {
+				continue
+			}
+			profile, err := GetTunedProfile(oc, namespace, node)
+			if err != nil || profile != expectedWorkerProfile {
+				Logf("WaitForDefaultProfiles: node %q has profile %q, expected %q", node, profile, expectedWorkerProfile)
+				allOk = false
+			}
+		}
+
+		return allOk, nil
+	})
+	if err != nil {
+		Logf("WaitForDefaultProfiles: timed out waiting for default profiles: %v", err)
+	}
+}
+
+// LogCurrentProfiles retrieves and logs the current tuned profile for each node.
+func LogCurrentProfiles(oc *CLI, namespace string) string {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "profiles.tuned.openshift.io").Output()
+	if err != nil {
+		Logf("failed to get current profiles: %v", err)
+		return ""
+	}
+	Logf("current profile for each node: \n%v", output)
+	return output
+}
+
+// extractKubeletConfValue extracts the value assigned to key in a kubelet.conf
+// line of the form `"key": "value",` (grep output), returning "" if key is
+// absent or has no value, rather than only reporting whether key appears.
+func extractKubeletConfValue(kubeletConfOutput, key string) string {
+	for _, line := range strings.Split(kubeletConfOutput, "\n") {
+		if !strings.Contains(line, key) {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		value := strings.TrimSpace(parts[1])
+		value = strings.TrimSuffix(value, ",")
+		value = strings.Trim(value, `"`)
+		return value
+	}
+	return ""
+}
+
+// VerifyPAOProfile verifies that a PAO performance profile was applied correctly.
+// It checks: tuned profile creation, profile application, hugepages, CPU Manager settings,
+// Topology Manager settings, real-time kernel (conditional), and runtimeClass.
+func VerifyPAOProfile(ctx context.Context, oc *CLI, namespace string, tunedNodeName string, profileName, runtimeClass string, expectRT bool) error {
+	// Check tuned profile was created
+	tunedNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "tuned").Output()
+	if err != nil {
+		return fmt.Errorf("failed to list tuned profiles: %w", err)
+	}
+	if !strings.Contains(tunedNames, profileName) {
+		return fmt.Errorf("tuned profile %s not found: got %s", profileName, tunedNames)
+	}
+
+	// Check current profiles
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "profiles.tuned.openshift.io").Output()
+	if err != nil {
+		return fmt.Errorf("failed to list profiles: %w", err)
+	}
+	Logf("current profile for each node: \n%v", output)
+
+	// Wait for tuned profile applied
+	err = WaitForTunedProfileApplied(ctx, oc, namespace, tunedNodeName, profileName)
+	if err != nil {
+		return fmt.Errorf("profile %s not applied on node %s: %w", profileName, tunedNodeName, err)
+	}
+
+	// Verify post-application settings with retry. The kubelet may not have
+	// restarted with the new configuration yet, so transient failures should
+	// log and retry rather than failing the test immediately.
+	const (
+		pollInterval = 15 * time.Second
+		timeout      = 5 * time.Minute
+	)
+	err = wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(_ context.Context) (bool, error) {
+		// Check profile name on node
+		nodeProfileName, err := GetTunedProfile(oc, namespace, tunedNodeName)
+		if err != nil {
+			Logf("failed to get tuned profile on node %s: %v, retrying", tunedNodeName, err)
+			return false, nil
+		}
+		if !strings.Contains(nodeProfileName, profileName) {
+			Logf("profile on node %s is %q, expected %q, retrying", tunedNodeName, nodeProfileName, profileName)
+			return false, nil
+		}
+
+		// Check hugepages-1Gi
+		nodeHugePagesOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.allocatable.hugepages-1Gi}").Output()
+		if err != nil {
+			Logf("failed to get hugepages-1Gi on node %s: %v, retrying", tunedNodeName, err)
+			return false, nil
+		}
+		if !strings.Contains(nodeHugePagesOutput, "1Gi") {
+			Logf("hugepages-1Gi on node %s is %q, expected 1Gi, retrying", tunedNodeName, nodeHugePagesOutput)
+			return false, nil
+		}
+
+		// Check CPU Manager policy
+		cpuManagerConfOutput, err := DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "/bin/bash", "-c", "cat /etc/kubernetes/kubelet.conf | grep cpuManager")
+		if err != nil {
+			Logf("failed to get CPU Manager policy on node %s: %v, retrying", tunedNodeName, err)
+			return false, nil
+		}
+		if cpuManagerConfOutput == "" {
+			Logf("CPU Manager policy output is empty on node %s, retrying", tunedNodeName)
+			return false, nil
+		}
+		cpuManagerPolicy := extractKubeletConfValue(cpuManagerConfOutput, "cpuManagerPolicy")
+		cpuManagerReconcilePeriod := extractKubeletConfValue(cpuManagerConfOutput, "cpuManagerReconcilePeriod")
+		if cpuManagerPolicy == "" || cpuManagerReconcilePeriod == "" {
+			Logf("CPU Manager policy on node %s has empty value(s): got %q, retrying", tunedNodeName, cpuManagerConfOutput)
+			return false, nil
+		}
+		Logf("the settings of CPU Manager Policy on labeled nodes: cpuManagerPolicy=%s cpuManagerReconcilePeriod=%s", cpuManagerPolicy, cpuManagerReconcilePeriod)
+
+		// Check CPU Manager reservedSystemCPUs
+		cpuManagerConfOutput, err = DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "/bin/bash", "-c", "cat /etc/kubernetes/kubelet.conf | grep reservedSystemCPUs")
+		if err != nil {
+			Logf("failed to get reservedSystemCPUs on node %s: %v, retrying", tunedNodeName, err)
+			return false, nil
+		}
+		if cpuManagerConfOutput == "" {
+			Logf("reservedSystemCPUs output is empty on node %s, retrying", tunedNodeName)
+			return false, nil
+		}
+		reservedSystemCPUs := extractKubeletConfValue(cpuManagerConfOutput, "reservedSystemCPUs")
+		if reservedSystemCPUs == "" {
+			Logf("reservedSystemCPUs on node %s has empty value: got %q, retrying", tunedNodeName, cpuManagerConfOutput)
+			return false, nil
+		}
+		Logf("the settings of CPU Manager reservedSystemCPUs on labeled nodes: reservedSystemCPUs=%s", reservedSystemCPUs)
+
+		// Check Topology Manager topologyManagerPolicy
+		topologyManagerConfOutput, err := DebugNodeWithOptionsAndChroot(oc, tunedNodeName, []string{"--quiet=true"}, "/bin/bash", "-c", "cat /etc/kubernetes/kubelet.conf | grep topologyManagerPolicy")
+		if err != nil {
+			Logf("failed to get topologyManagerPolicy on node %s: %v, retrying", tunedNodeName, err)
+			return false, nil
+		}
+		if topologyManagerConfOutput == "" {
+			Logf("topologyManagerPolicy output is empty on node %s, retrying", tunedNodeName)
+			return false, nil
+		}
+		topologyManagerPolicy := extractKubeletConfValue(topologyManagerConfOutput, "topologyManagerPolicy")
+		if topologyManagerPolicy == "" {
+			Logf("topologyManagerPolicy on node %s has empty value: got %q, retrying", tunedNodeName, topologyManagerConfOutput)
+			return false, nil
+		}
+		Logf("the settings of CPU Manager topologyManagerPolicy on labeled nodes: topologyManagerPolicy=%s", topologyManagerPolicy)
+
+		// Check realTime kernel (conditional). The kernel is a boot-time property
+		// that will not change with retries, so a mismatch is a terminal error.
+		kernelVersion, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", tunedNodeName, "-ojsonpath={.status.nodeInfo.kernelVersion}").Output()
+		if err != nil {
+			Logf("failed to get kernel version on node %s: %v, retrying", tunedNodeName, err)
+			return false, nil
+		}
+		if kernelVersion == "" {
+			Logf("kernel version on node %s is empty, retrying", tunedNodeName)
+			return false, nil
+		}
+		if expectRT && !strings.Contains(kernelVersion, "rt") {
+			return false, fmt.Errorf("expected real-time kernel on node %s but got kernel version: %q", tunedNodeName, kernelVersion)
+		}
+		if !expectRT && strings.Contains(kernelVersion, "rt") {
+			return false, fmt.Errorf("did not expect real-time kernel on node %s but got kernel version: %q", tunedNodeName, kernelVersion)
+		}
+
+		// Check runtimeClass
+		runtimeClassOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("performanceprofile", runtimeClass, "-ojsonpath={.status.runtimeClass}").Output()
+		if err != nil {
+			Logf("failed to get runtimeClass for performance profile %s: %v, retrying", runtimeClass, err)
+			return false, nil
+		}
+		if runtimeClassOutput == "" {
+			Logf("runtimeClass output is empty for performance profile %s, retrying", runtimeClass)
+			return false, nil
+		}
+		if !strings.Contains(runtimeClassOutput, "performance-"+runtimeClass) {
+			Logf("runtimeClass for performance profile %s is %q, expected performance-%s, retrying", runtimeClass, runtimeClassOutput, runtimeClass)
+			return false, nil
+		}
+		Logf("the settings of runtimeClass on labeled nodes: \n%v", runtimeClassOutput)
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to verify PAO profile on node %s: %w", tunedNodeName, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add all the remaining NTO tests from openshift-tests-private repository,
apart from HyperShift tests.  HyperShift tests will be added as a follow-up PR.

This also fixes numerous race conditions and issues previously present in
tests and utility functions in openshift-tests-private.

Remove the ReleaseGate label from all tests. The gating mechanism is no
longer used.  Instead, the Informing label should be dropped once a test is
considered mature.

Refactor nto_util.go: replace FixtureTB interface with proper error
returns, add NtoResource struct, introduce TestdataFixturePathBase with
lazy fixture materialization, and add IsNTOInstalled deployment check.

Add new utility modules (cluster_helpers, debug_helpers, helpers,
log_helpers) and spec helpers (hypernto, helpers). Add AGENTS.md and
README.md documentation.

As pod-level labelling is deprecated, move tests to node-level labelling
where possible:
  * rewritten:
    * test_id:33237
    * test_id:33238
    * test_id:27491
    * test_id:37125
    * test_id:49705
  * removed:
    * test_id:23959 already deprecated in Polarion
    * test_id:23958 already deprecated in Polarion



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded validation for NTO tuning, performance profiles, hugepages, sysctl settings, and hosted ROSA HyperShift clusters.
  * Added reusable test fixtures and broader coverage for cluster topologies, node discovery, debugging, and resource management.
  * Added more reliable command execution with timeouts and cancellable streaming checks.

* **Bug Fixes**
  * Tests now skip cleanly when NTO is unavailable or unsupported cluster types are detected.
  * Corrected test data formatting and streamlined suite qualification.

* **Documentation**
  * Added comprehensive guidance for developing, running, and maintaining extended tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->