### PR TITLE
OCPBUGS-83863: Strip debug symbols from Go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ TESTDATA_OTE_DIR=test/extended/testdata
 TESTDATA_OTE=$(shell find $(TESTDATA_OTE_DIR) -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null)
 ASSETS=$(shell find assets -name \*.yaml)
 GO=GOARCH=$(GOARCH) GO111MODULE=on GOFLAGS=-mod=vendor go
-GO_BUILD_RECIPE=$(GO) build -o $(OUT_DIR)/$(PACKAGE_BIN) -ldflags '-X $(PACKAGE)/version.Version=$(REV)' $(PACKAGE_MAIN)
+GO_BUILD_RECIPE=$(GO) build -o $(OUT_DIR)/$(PACKAGE_BIN) -ldflags '-s -w -X $(PACKAGE)/version.Version=$(REV)' $(PACKAGE_MAIN)
 GOFMT_CHECK=$(shell find . -not \( \( -wholename './.*' -o -wholename '*/vendor/*' \) -prune \) -name '*.go' | sort -u | xargs gofmt -s -l)
 REV=$(shell git describe --long --tags --match='v*' --always --dirty)
 
@@ -270,8 +270,7 @@ cluster-clean-pao:
 .PHONY: build-performance-profile-creator
 build-performance-profile-creator:
 	@echo "Building Performance Profile Creator (PPC)"
-	LDFLAGS="-s -w -X ${PACKAGE}/cmd/performance-profile-creator/version.Version=${REV} "; \
-	$(GO) build  -v $(LDFLAGS) -o $(OUT_DIR)/performance-profile-creator ./cmd/performance-profile-creator
+	$(GO) build -v -ldflags "-s -w -X $(PACKAGE)/cmd/performance-profile-creator/version.Version=$(REV)" -o $(OUT_DIR)/performance-profile-creator ./cmd/performance-profile-creator
 
 .PHONY: arm-kernel-pagesize                                                                                                                                                                                                                                      
 arm-kernelpagesize: $(BINDATA)
@@ -287,8 +286,7 @@ performance-profile-creator-tests: build-performance-profile-creator
 .PHONY: build-gather-sysinfo
 build-gather-sysinfo:
 	@echo "Building gather-sysinfo"
-	LDFLAGS="-s -w -X ${PACKAGE}/cmd/gather-sysinfo/version.Version=${REV} "; \
-	$(GO) build -v $(LDFLAGS) -o $(OUT_DIR)/gather-sysinfo ./cmd/gather-sysinfo
+	$(GO) build -v -ldflags "-s -w -X $(PACKAGE)/cmd/gather-sysinfo/version.Version=$(REV)" -o $(OUT_DIR)/gather-sysinfo ./cmd/gather-sysinfo
 
 .PHONY: gather-sysinfo-tests
 gather-sysinfo-tests: build-gather-sysinfo

--- a/Makefile
+++ b/Makefile
@@ -318,4 +318,4 @@ pao-clean-e2e:
 .PHONY: cluster-node-tuning-operator-test-ext
 cluster-node-tuning-operator-test-ext: $(BINDATA_OTE)
 	@echo "Building cluster-node-tuning-operator-test-ext"
-	GO_COMPLIANCE_POLICY=exempt_all CGO_ENABLED=0 $(GO) build -mod=vendor -v -o $(OUT_DIR)/cluster-node-tuning-operator-test-ext ./cmd/cluster-node-tuning-operator-test-ext
+	GO_COMPLIANCE_POLICY=exempt_all CGO_ENABLED=0 $(GO) build -mod=vendor -v -ldflags "-s -w" -o $(OUT_DIR)/cluster-node-tuning-operator-test-ext ./cmd/cluster-node-tuning-operator-test-ext


### PR DESCRIPTION
## Summary
- Add `-s -w` to ldflags in `GO_BUILD_RECIPE` to strip DWARF debug info and symbol tables from the main operator binary
- Fix `build-gather-sysinfo` and `build-performance-profile-creator` targets which intended to strip but had a make-vs-shell variable expansion bug (`$(LDFLAGS)` is expanded by make before the shell runs, so the shell variable set on the previous line was never used)

## Impact
The cluster-node-tuning-operator image (617 MB) contains three unstripped Go binaries totaling 195 MB:
- `cluster-node-tuning-operator` (96.8 MB)
- `gather-sysinfo` (63.8 MB)
- `performance-profile-creator` (34.6 MB)

Stripping typically reduces Go binary size by 20-30%, reducing container image pull time during node scale-up.

## Test plan
- [ ] Verify image builds successfully
- [ ] Verify binaries are stripped (`file /usr/bin/cluster-node-tuning-operator` should show "stripped")
- [ ] Verify operator functions correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to reduce binary sizes and streamline compilation across multiple build targets.
  * Applied the same build optimizations to additional build and test targets to ensure consistent output and faster, smaller artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->