### PR TITLE
OCPBUGS-87132: E2E: Remove ovs-vswitchd from platform services

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
+++ b/test/e2e/performanceprofile/functests/1_performance/cpu_management.go
@@ -987,7 +987,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", Ordered, func() {
 			expectedCpuset, err = cpuset.Parse(reservedCpus)
 			Expect(err).ToNot(HaveOccurred(), "Unable to parse reserved CPU set %s", reservedCpus)
 
-			platformServices = []string{"systemd", "crio", "kubelet", "ovs-vswitchd"}
+			platformServices = []string{"systemd", "crio", "kubelet"}
 		})
 
 		It("[test_id: 83851] verify platform services are restricted to reserved cpus", Label(string(label.Tier0)), func() {


### PR DESCRIPTION
ovs-vswitchd will always use all the online cpus
and will not be restricted to reserved cpus even
on schedulabel control plane nodes with workload partition enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated control-plane scheduling test to refine platform services CPU affinity validation by excluding one service from the test scope while maintaining reserved CPU parsing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->