### PR TITLE
OCPBUGS-86803: e2e: Remove unnecessary len(numa) < 2 skip gates

### DIFF
--- a/test/e2e/performanceprofile/functests/13_llc/llc.go
+++ b/test/e2e/performanceprofile/functests/13_llc/llc.go
@@ -301,9 +301,6 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				}
 				numaInfo, err := nodes.GetNumaNodes(ctx, &cnfnode)
 				Expect(err).ToNot(HaveOccurred(), "Unable to get numa information from the node")
-				if len(numaInfo) < 2 {
-					Skip(fmt.Sprintf("This test need 2 Numa nodes. The number of numa nodes on node %s < 2", cnfnode.Name))
-				}
 
 				getCCX = nodes.GetL3SharedCPUs(&cnfnode)
 				reserved, err = getCCX(0)
@@ -1090,9 +1087,6 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				}
 
 				nosmt = transformToNoSMT(coresiblings)
-				if len(numaInfo) < 2 {
-					Skip(fmt.Sprintf("This test need 2 Numa nodes. The number of numa nodes on node %s < 2", cnfnode.Name))
-				}
 				Expect(err).ToNot(HaveOccurred())
 			}
 			if !hasBaremetal {

--- a/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/updating_profile.go
@@ -777,9 +777,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		It("[test_id:50966]verify offlined parameter accepts multiple ranges of cpuid's", func() {
 			var reserved, isolated, offlined cpuset.CPUSet
 			numaTopology := copyNumaCoreSiblings(numaCoreSiblings)
-			if len(numaCoreSiblings) < 2 {
-				Skip(fmt.Sprintf("This test need 2 NUMA nodes, available only %d", len(numaCoreSiblings)))
-			}
 			if len(numaCoreSiblings[0]) < 20 {
 				Skip("This test needs systems with at least 20 cores per socket")
 			}
@@ -850,9 +847,6 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		It("[test_id:50968]verify cpus mentioned in reserved or isolated cannot be offline", func() {
 			var reserved, isolated, offlined cpuset.CPUSet
 			numaTopology := copyNumaCoreSiblings(numaCoreSiblings)
-			if len(numaCoreSiblings) < 2 {
-				Skip(fmt.Sprintf("This test need 2 NUMA nodes, available only %d", len(numaCoreSiblings)))
-			}
 			// Get reserved core siblings from 0, 1
 			for reservedCores := 0; reservedCores < 2; reservedCores++ {
 				// Get the cpu siblings from the selected core and delete the siblings
@@ -915,6 +909,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		It("[test_id:50970]Offline CPUID's from multiple numa nodes", func() {
 			var reserved, isolated, offlined cpuset.CPUSet
 			numaTopology := copyNumaCoreSiblings(numaCoreSiblings)
+			// Here we explicitly want to offline cpus from different numa nodes,
+			// hence this test requires systems with multiple numa nodes.
 			if len(numaCoreSiblings) < 2 {
 				Skip(fmt.Sprintf("This test need 2 NUMA nodes, available only %d", len(numaCoreSiblings)))
 			}


### PR DESCRIPTION
Allow tests to run on systems with single numa
These tests never needed 2 numa nodes 

Changes:

llc.go:
- BeforeAll (SMT Enabled) — removed len(numaInfo) < 2 skip. Affects: 77725, 77726, 81668, 77728, 77729, 77730, 81670, 81671, 87072, 87073, 87074
- BeforeAll (SMT Disabled) — removed len(numaInfo) < 2 skip. Affects: 81672, 81673

updating_profile.go:
- 50966 — removed NUMA check
- 50968 — removed NUMA check
- 50970 — added comment why numa check is required here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed NUMA-count gating from LLC-aware CPU-pinning tests so they run on more hardware configurations.
  * Relaxed NUMA-based skip logic in offline-CPU update tests so they proceed more often, increasing test coverage across platforms.
  * Preserved cores-per-socket and empty-topology checks where needed to avoid unreliable runs.
  * Added clarifying test notes about offlining CPUs across NUMA nodes for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->