### PR TITLE
OCPBUGS-86541: Enable timer migrations for all use-cases

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -120,6 +120,15 @@ vm.swappiness=10
 #> rps configuration
 # net.core.rps_default_mask=${not_isolated_cpumask}
 
+# cpu-partitioning for RHEL disables it (= 0)
+# OCP is too dynamic when partitioning and needs to evacuate
+# scheduled timers when starting a guaranteed workload (= 1)
+# This has an unfortunate side-effect that HRTIMERs break
+# and cyclictest results will be affected, but there is no
+# way around that. Not enabling this breaks cpu pinned
+# workload isolation for example when any TCP timeout
+# and keep alive timers are present.
+kernel.timer_migration=1
 
 [selinux]
 #> Custom (atomic host)

--- a/assets/performanceprofile/tuned/openshift-node-performance-rt
+++ b/assets/performanceprofile/tuned/openshift-node-performance-rt
@@ -7,10 +7,3 @@ summary=Real time profile to override unsupported settings
 #Therefore, if the real time kernel is detected they will be dropped, meaning won't be applied.
 drop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll
 
-{{if .RealTimeHint}}
-# cpu-partitioning and RealTimeHint for RHEL disable it (= 0)
-# OCP is too dynamic when partitioning and needs to evacuate
-# scheduled timers when starting a guaranteed workload (= 1)
-# But only when kernel-rt is in use or HRTIMERs break
-kernel.timer_migration=1
-{{end}}

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -362,8 +362,6 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 
 	Context("Tuned kernel parameters", Label(string(label.Tier0)), func() {
 		It("[test_id:28466][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Should contain configuration injected through openshift-node-performance profile", func() {
-			profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
-			Expect(err).ToNot(HaveOccurred(), "Unable to fetch latest profile")
 			sysctlMap := map[string]string{
 				"kernel.hung_task_timeout_secs": "600",
 				"kernel.nmi_watchdog":           "0",
@@ -371,16 +369,13 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				"vm.stat_interval":              "10",
 				"kernel.timer_migration":        "1",
 			}
-			if !*profile.Spec.RealTimeKernel.Enabled {
-				sysctlMap["kernel.timer_migration"] = "0"
-			}
 
 			key := types.NamespacedName{
 				Name:      components.GetComponentName(testutils.PerformanceProfileName, components.ProfileNamePerformance),
 				Namespace: components.NamespaceNodeTuningOperator,
 			}
 			tuned := &tunedv1.Tuned{}
-			err = testclient.ControlPlaneClient.Get(context.TODO(), key, tuned)
+			err := testclient.ControlPlaneClient.Get(context.TODO(), key, tuned)
 			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator object "+key.String())
 			validateTunedActiveProfile(context.TODO(), workerRTNodes)
 			execSysctlOnWorkers(context.TODO(), workerRTNodes, sysctlMap)

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -47,9 +47,15 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n#
-      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
+      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
+      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      results will be affected, but there is no\n# way around that. Not enabling this
+      breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
+      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
+      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
@@ -59,10 +65,7 @@ spec:
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
-      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n\n#
-      cpu-partitioning and RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic
-      when partitioning and needs to evacuate\n# scheduled timers when starting a
-      guaranteed workload (= 1)\n# But only when kernel-rt is in use or HRTIMERs break\nkernel.timer_migration=1\n\n"
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n"
     name: openshift-node-performance-rt-openshift-bootstrap-master
   - data: |+
       [main]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -47,9 +47,15 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n#
-      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
+      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
+      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      results will be affected, but there is no\n# way around that. Not enabling this
+      breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
+      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
+      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
@@ -59,10 +65,7 @@ spec:
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
-      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n\n#
-      cpu-partitioning and RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic
-      when partitioning and needs to evacuate\n# scheduled timers when starting a
-      guaranteed workload (= 1)\n# But only when kernel-rt is in use or HRTIMERs break\nkernel.timer_migration=1\n\n"
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n"
     name: openshift-node-performance-rt-openshift-bootstrap-worker
   - data: |+
       [main]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -47,9 +47,15 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n#
-      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
+      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
+      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      results will be affected, but there is no\n# way around that. Not enabling this
+      breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
+      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
+      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
@@ -59,10 +65,7 @@ spec:
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
-      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n\n#
-      cpu-partitioning and RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic
-      when partitioning and needs to evacuate\n# scheduled timers when starting a
-      guaranteed workload (= 1)\n# But only when kernel-rt is in use or HRTIMERs break\nkernel.timer_migration=1\n\n"
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n"
     name: openshift-node-performance-rt-openshift-bootstrap-master
   - data: |+
       [main]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -47,9 +47,15 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n#
-      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
+      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
+      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      results will be affected, but there is no\n# way around that. Not enabling this
+      breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
+      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
+      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
@@ -59,10 +65,7 @@ spec:
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
-      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n\n#
-      cpu-partitioning and RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic
-      when partitioning and needs to evacuate\n# scheduled timers when starting a
-      guaranteed workload (= 1)\n# But only when kernel-rt is in use or HRTIMERs break\nkernel.timer_migration=1\n\n"
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n"
     name: openshift-node-performance-rt-openshift-bootstrap-worker
   - data: |+
       [main]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_tuned.yaml
@@ -45,9 +45,15 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n#
-      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
+      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
+      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      results will be affected, but there is no\n# way around that. Not enabling this
+      breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
+      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
+      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
@@ -58,10 +64,7 @@ spec:
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
-      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n\n#
-      cpu-partitioning and RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic
-      when partitioning and needs to evacuate\n# scheduled timers when starting a
-      guaranteed workload (= 1)\n# But only when kernel-rt is in use or HRTIMERs break\nkernel.timer_migration=1\n\n"
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n"
     name: openshift-node-performance-rt-manual
   - data: |+
       [main]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -45,9 +45,15 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n#
-      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
+      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
+      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      results will be affected, but there is no\n# way around that. Not enabling this
+      breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
+      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
+      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
@@ -59,10 +65,7 @@ spec:
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
-      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n\n#
-      cpu-partitioning and RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic
-      when partitioning and needs to evacuate\n# scheduled timers when starting a
-      guaranteed workload (= 1)\n# But only when kernel-rt is in use or HRTIMERs break\nkernel.timer_migration=1\n\n"
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n"
     name: openshift-node-performance-rt-manual
   - data: |+
       [main]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -47,9 +47,15 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n#
-      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
+      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
+      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      results will be affected, but there is no\n# way around that. Not enabling this
+      breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
+      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
+      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
@@ -60,10 +66,7 @@ spec:
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
-      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n\n#
-      cpu-partitioning and RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic
-      when partitioning and needs to evacuate\n# scheduled timers when starting a
-      guaranteed workload (= 1)\n# But only when kernel-rt is in use or HRTIMERs break\nkernel.timer_migration=1\n\n"
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n"
     name: openshift-node-performance-rt-manual
   - data: |+
       [main]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_tuned.yaml
@@ -47,9 +47,15 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n#
-      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
+      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
+      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      results will be affected, but there is no\n# way around that. Not enabling this
+      breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
+      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
+      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
@@ -60,10 +66,7 @@ spec:
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
-      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n\n#
-      cpu-partitioning and RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic
-      when partitioning and needs to evacuate\n# scheduled timers when starting a
-      guaranteed workload (= 1)\n# But only when kernel-rt is in use or HRTIMERs break\nkernel.timer_migration=1\n\n"
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n"
     name: openshift-node-performance-rt-manual
   - data: |+
       [main]

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -45,9 +45,15 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n#
-      !! The names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
+      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
+      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
+      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      results will be affected, but there is no\n# way around that. Not enabling this
+      breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
+      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
+      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
@@ -58,10 +64,7 @@ spec:
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
       profile inherits these kernel parameters from the network-latency profile. \n#Therefore,
-      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n\n#
-      cpu-partitioning and RealTimeHint for RHEL disable it (= 0)\n# OCP is too dynamic
-      when partitioning and needs to evacuate\n# scheduled timers when starting a
-      guaranteed workload (= 1)\n# But only when kernel-rt is in use or HRTIMERs break\nkernel.timer_migration=1\n\n"
+      if the real time kernel is detected they will be dropped, meaning won't be applied.\ndrop=kernel.numa_balancing,net.core.busy_read,net.core.busy_poll\n\n"
     name: openshift-node-performance-rt-manual
   - data: |+
       [main]


### PR DESCRIPTION
This has an unfortunate side-effect that HRTIMERs break and cyclictest results will be affected, but there is no way around that. Not enabling this breaks cpu pinned workload isolation for example when any TCP timeout and keep alive timers are present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized kernel timer-migration setting across tuned performance profiles so timer behavior is consistent between regular and real-time configurations.

* **Tests**
  * Updated performance tests and test data to expect the new, consistent timer-migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->