### PR TITLE
OCPBUGS-91745: e2e: fix: clear hugepages before switching kernelPageSize to 4k

### DIFF
--- a/test/e2e/performanceprofile/functests/14_arm/kernelpagesize.go
+++ b/test/e2e/performanceprofile/functests/14_arm/kernelpagesize.go
@@ -2,7 +2,6 @@ package __arm
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -18,7 +17,6 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/infrastructure"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/label"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodes"
-	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/poolname"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profilesupdate"
 )
@@ -34,7 +32,6 @@ var _ = Describe("[rfe_id:80342] kernelPageSize configuration validation on aarc
 	var (
 		workerRTNodes               []corev1.Node
 		perfProfile, initialProfile *performancev2.PerformanceProfile
-		poolName                    string
 		err                         error
 		ctx                         context.Context = context.Background()
 		isArm                       bool
@@ -50,10 +47,8 @@ var _ = Describe("[rfe_id:80342] kernelPageSize configuration validation on aarc
 		workerRTNode = workerRTNodes[0]
 
 		perfProfile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
-		initialProfile = perfProfile.DeepCopy()
-
-		poolName = poolname.GetByProfile(ctx, perfProfile)
 		Expect(err).ToNot(HaveOccurred())
+		initialProfile = perfProfile.DeepCopy()
 
 		isArm, err = infrastructure.IsARM(ctx, &workerRTNode)
 		Expect(err).ToNot(HaveOccurred())
@@ -61,33 +56,15 @@ var _ = Describe("[rfe_id:80342] kernelPageSize configuration validation on aarc
 			Skip("This test requires an aarch64 arm CPU")
 		}
 
-		By("Make sure that the performance profile starts the test suite with 4k kernelPageSize and real time kernel disabled")
-		currentKernelPageSize, err := getKernelPageSizeFromNode(ctx, workerRTNode)
-		Expect(err).ToNot(HaveOccurred())
-
-		var realTimeKernelEnabled bool
-		var validKernelPageSize bool
-
-		if perfProfile.Spec.RealTimeKernel != nil {
-			realTimeKernelEnabled = *perfProfile.Spec.RealTimeKernel.Enabled
+		By("Ensuring profile baseline: kernelPageSize=4k, no hugepages, RT disabled")
+		perfProfile.Spec.HugePages = nil
+		perfProfile.Spec.KernelPageSize = ptr.To(performancev2.KernelPageSize(kernelPageSize4k))
+		perfProfile.Spec.RealTimeKernel = &performancev2.RealTimeKernel{
+			Enabled: ptr.To(false),
 		}
 
-		if perfProfile.Spec.KernelPageSize != nil {
-			validKernelPageSize = currentKernelPageSize != kernelPageSizeBytes4k
-		}
-
-		if realTimeKernelEnabled || validKernelPageSize {
-			perfProfile.Spec.RealTimeKernel = &performancev2.RealTimeKernel{
-				Enabled: ptr.To(false),
-			}
-			*perfProfile.Spec.KernelPageSize = kernelPageSize4k
-			profiles.UpdateWithRetry(perfProfile)
-
-			By(fmt.Sprintf("Applying changes in performance profile and waiting until %s will start updating", poolName))
-			profilesupdate.WaitForTuningUpdating(ctx, perfProfile)
-
-			By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-			profilesupdate.WaitForTuningUpdated(ctx, perfProfile)
+		if !equality.Semantic.DeepEqual(perfProfile.Spec, initialProfile.Spec) {
+			profilesupdate.ApplyProfileAndWait(ctx, perfProfile)
 		}
 	})
 
@@ -96,18 +73,8 @@ var _ = Describe("[rfe_id:80342] kernelPageSize configuration validation on aarc
 		profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 
-		currentSpec, _ := json.Marshal(profile.Spec)
-		spec, _ := json.Marshal(initialProfile.Spec)
-
-		// revert only if the profile changes
-		if !equality.Semantic.DeepEqual(currentSpec, spec) {
-			profiles.UpdateWithRetry(initialProfile)
-
-			By(fmt.Sprintf("Applying changes in performance profile and waiting until %s will start updating", poolName))
-			profilesupdate.WaitForTuningUpdating(ctx, initialProfile)
-
-			By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-			profilesupdate.WaitForTuningUpdated(ctx, initialProfile)
+		if !equality.Semantic.DeepEqual(profile.Spec, initialProfile.Spec) {
+			profilesupdate.ApplyProfileAndWait(ctx, initialProfile)
 		}
 	})
 
@@ -118,18 +85,12 @@ var _ = Describe("[rfe_id:80342] kernelPageSize configuration validation on aarc
 					By(fmt.Sprintf("Modifying the profile to use %s", newKernelPageSize))
 					klog.Infof("Changing kernelPageSize to: %s from: %s", newKernelPageSize, *perfProfile.Spec.KernelPageSize)
 					perfProfile.Spec.KernelPageSize = ptr.To(performancev2.KernelPageSize(newKernelPageSize))
-					profiles.UpdateWithRetry(perfProfile)
-
-					By(fmt.Sprintf("Applying changes in performance profile and waiting until %s will start updating", poolName))
-					profilesupdate.WaitForTuningUpdating(ctx, perfProfile)
-
-					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
-					profilesupdate.WaitForTuningUpdated(ctx, perfProfile)
+					profilesupdate.ApplyProfileAndWait(ctx, perfProfile)
 
 					By(fmt.Sprintf("Verifying the kernelPageSize has changed to %s on the affected node", expectedKernelPageSize))
 					kernelPageSize, err := getKernelPageSizeFromNode(ctx, workerRTNode)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(kernelPageSize).To(Equal(expectedKernelPageSize))
+					Expect(kernelPageSize).To(Equal(expectedKernelPageSize), "kernel page size mismatch on node")
 				},
 				Entry("[test_id:80459] should accept 64k kernelPageSize", kernelPageSize64k, kernelPageSizeBytes64k),
 				Entry("[test_id:80461] should accept 4k kernelPageSize", kernelPageSize4k, kernelPageSizeBytes4k),

--- a/test/e2e/performanceprofile/functests/utils/profilesupdate/profile_update.go
+++ b/test/e2e/performanceprofile/functests/utils/profilesupdate/profile_update.go
@@ -22,6 +22,7 @@ import (
 	testlog "github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/log"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/mcps"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/nodepools"
+	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/poolname"
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profiles"
 )
 
@@ -127,4 +128,17 @@ func WaitForTuningUpdated(ctx context.Context, profile *performancev2.Performanc
 	testlog.Infof("wait for node pool %q transition into config ready state", client.ObjectKeyFromObject(np).String())
 	err = nodepools.WaitForConfigToBeReady(ctx, testclient.ControlPlaneClient, np.Name, np.Namespace)
 	Expect(err).ToNot(HaveOccurred())
+}
+
+// ApplyProfileAndWait updates the profile and waits for the MCP rollout (or nodepool on hypershift) to complete.
+// Replaces the common 3-step pattern: UpdateWithRetry + WaitForTuningUpdating + WaitForTuningUpdated.
+func ApplyProfileAndWait(ctx context.Context, profile *performancev2.PerformanceProfile) {
+	GinkgoHelper()
+	poolName := poolname.GetByProfile(ctx, profile)
+	By("Updating the performance profile")
+	profiles.UpdateWithRetry(profile)
+	By(fmt.Sprintf("Applying changes in performance profile and waiting until %s will start updating", poolName))
+	WaitForTuningUpdating(ctx, profile)
+	By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
+	WaitForTuningUpdated(ctx, profile)
 }


### PR DESCRIPTION
BeforeAll set kernelPageSize=4k without clearing hugepages (512M default
on arm CI cluster), causing the admission webhook to reject the
incompatible combination on aarch64.

- Declarative baseline in BeforeAll: set kernelPageSize=4k, clear
  hugepages, disable RT; apply only if spec differs (DeepEqual guard)
- Simplify AfterAll revert with same DeepEqual guard (drop JSON marshal)
- Fix Expect(err) ordering after GetByNodeLabels
- Extract 3-step update pattern into ApplyProfileAndWait helper (cosmetic)
- Remove unused imports (encoding/json, poolname) and poolName variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved ARM/aarch64 `kernelPageSize` end-to-end coverage by standardizing baseline preparation and making the test skip non-ARM nodes.
  * Refined performance profile rollout handling to apply updates only when the target spec differs, using a shared “apply and wait” flow to ensure tuning readiness/completion.
  * Simplified update/revert behavior and the kernel page size validation flow to apply each change, wait for tuning, then verify the observed setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->