### PR TITLE
OCPBUGS-98915: E2E: LLC: Pass fresh ctx variable to DeferCleanup functions

### DIFF
--- a/test/e2e/performanceprofile/functests/13_llc/llc.go
+++ b/test/e2e/performanceprofile/functests/13_llc/llc.go
@@ -101,10 +101,9 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 		cgroupV2                    bool
 	)
 
-	BeforeAll(func() {
+	BeforeAll(func(ctx context.Context) {
 		var hasMachineData bool
 		profileAnnotations = make(map[string]string)
-		ctx := context.Background()
 
 		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
@@ -154,7 +153,7 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 		// required to enable align-cpus-by-uncorecache cpumanager policy
 
 		By("Enabling Uncore cache feature")
-		Expect(testclient.Client.Create(context.TODO(), mc)).To(Succeed(), "Unable to apply machine config for enabling uncore cache")
+		Expect(testclient.Client.Create(ctx, mc)).To(Succeed(), "Unable to apply machine config for enabling uncore cache")
 
 		Expect(err).ToNot(HaveOccurred(), "Unable to apply machine config for enabling uncore cache")
 
@@ -207,8 +206,7 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 
 	Context("Configuration Tests", func() {
 		When("align-cpus-by-uncorecache cpumanager policy option is enabled", func() {
-			It("[test_id:77722] kubelet is configured appropriately", func() {
-				ctx := context.Background()
+			It("[test_id:77722] kubelet is configured appropriately", func(ctx context.Context) {
 				for _, node := range workerRTNodes {
 					kubeletconfig, err := nodes.GetKubeletConfig(ctx, &node)
 					Expect(err).ToNot(HaveOccurred())
@@ -218,8 +216,7 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 		})
 
 		When("align-cpus-by-uncorecache annotations is removed", func() {
-			It("[test_id:77723] should disable align-cpus-by-uncorecache cpumanager policy option", func() {
-				ctx := context.Background()
+			It("[test_id:77723] should disable align-cpus-by-uncorecache cpumanager policy option", func(ctx context.Context) {
 				// Get latest profile
 				perfProfile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 				Expect(err).ToNot(HaveOccurred())
@@ -254,8 +251,7 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 		})
 
 		When("align-cpus-by-uncorecache cpumanager policy option is disabled", func() {
-			It("[test_id:77724] cpumanager Policy option in kubelet is configured appropriately", func() {
-				ctx := context.Background()
+			It("[test_id:77724] cpumanager Policy option in kubelet is configured appropriately", func(ctx context.Context) {
 				llcDisablePolicy := `{"cpuManagerPolicyOptions":{"prefer-align-cpus-by-uncorecache":"false", "full-pcpus-only":"true"}}`
 				profileAnnotations["kubeletconfig.experimental"] = llcDisablePolicy
 				perfProfile.Annotations = profileAnnotations
@@ -284,14 +280,13 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			totalOnlineCpus  cpuset.CPUSet
 			getCCX           func(cpuid int) (cpuset.CPUSet, error)
 		)
-		BeforeAll(func() {
+		BeforeAll(func(ctx context.Context) {
 			var (
 				reserved, isolated cpuset.CPUSet
 				policy             = "single-numa-node"
 			)
 			profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 			Expect(err).ToNot(HaveOccurred())
-			ctx := context.Background()
 			hasBaremetal := false
 			for _, cnfnode := range workerRTNodes {
 				isVM, err := infrastructure.IsVM(ctx, &cnfnode)
@@ -339,8 +334,8 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 
 			testNS := *namespaces.TestingNamespace
 			Expect(testclient.DataPlaneClient.Create(ctx, &testNS)).ToNot(HaveOccurred())
-			DeferCleanup(func() {
-				Expect(testclient.DataPlaneClient.Delete(ctx, &testNS)).ToNot(HaveOccurred())
+			DeferCleanup(func(cleanupCtx context.Context) {
+				Expect(testclient.DataPlaneClient.Delete(cleanupCtx, &testNS)).ToNot(HaveOccurred())
 				Expect(namespaces.WaitForDeletion(testutils.NamespaceTesting, 5*time.Minute)).ToNot(HaveOccurred())
 			})
 		})
@@ -359,12 +354,12 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			podLabel["test-app"] = "telco1"
 			dp, err := createDeployment(ctx, deploymentName, podLabel, &targetNode, rl)
 			Expect(err).ToNot(HaveOccurred())
-			defer func() {
+			DeferCleanup(func(cleanupCtx context.Context) {
 				testlog.TaggedInfof("Cleanup", "Deleting Deployment %v", deploymentName)
-				err := testclient.DataPlaneClient.Delete(ctx, dp)
+				err := testclient.DataPlaneClient.Delete(cleanupCtx, dp)
 				Expect(err).ToNot(HaveOccurred(), "Unable to delete deployment %v", deploymentName)
-				waitForDeploymentPodsDeletion(ctx, &targetNode, podLabel)
-			}()
+				waitForDeploymentPodsDeletion(cleanupCtx, &targetNode, podLabel)
+			})
 
 			podList := &corev1.PodList{}
 			listOptions := &client.ListOptions{Namespace: testutils.NamespaceTesting, LabelSelector: labels.SelectorFromSet(dp.Spec.Selector.MatchLabels)}
@@ -404,13 +399,13 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			dp, err := createDeployment(ctx, deploymentName, podLabel, &targetNode, rl)
 			Expect(err).ToNot(HaveOccurred())
 			testlog.TaggedInfof("Deployment", "Deployment %s created", deploymentName)
-			defer func() {
+			DeferCleanup(func(cleanupCtx context.Context) {
 				// delete deployment
 				testlog.TaggedInfof("Cleanup", "Deleting Deployment %s", deploymentName)
-				err := testclient.DataPlaneClient.Delete(ctx, dp)
+				err := testclient.DataPlaneClient.Delete(cleanupCtx, dp)
 				Expect(err).ToNot(HaveOccurred(), "Unable to delete deployment %v", deploymentName)
-				waitForDeploymentPodsDeletion(ctx, &targetNode, podLabel)
-			}()
+				waitForDeploymentPodsDeletion(cleanupCtx, &targetNode, podLabel)
+			})
 			podList := &corev1.PodList{}
 			listOptions := &client.ListOptions{Namespace: testutils.NamespaceTesting, LabelSelector: labels.SelectorFromSet(dp.Spec.Selector.MatchLabels)}
 			Eventually(func() bool {
@@ -488,13 +483,13 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			podLabel["test-app"] = "telco3"
 			dp, err := createDeployment(ctx, deploymentName, podLabel, &targetNode, rl)
 			Expect(err).ToNot(HaveOccurred())
-			defer func() {
+			DeferCleanup(func(cleanupCtx context.Context) {
 				// delete deployment
 				testlog.TaggedInfof("Cleanup", "Deleting Deployment %v", deploymentName)
-				err := testclient.DataPlaneClient.Delete(ctx, dp)
+				err := testclient.DataPlaneClient.Delete(cleanupCtx, dp)
 				Expect(err).ToNot(HaveOccurred(), "Unable to delete deployment %v", deploymentName)
-				waitForDeploymentPodsDeletion(ctx, &targetNode, podLabel)
-			}()
+				waitForDeploymentPodsDeletion(cleanupCtx, &targetNode, podLabel)
+			})
 			podList := &corev1.PodList{}
 			listOptions := &client.ListOptions{Namespace: testutils.NamespaceTesting, LabelSelector: labels.SelectorFromSet(dp.Spec.Selector.MatchLabels)}
 			Eventually(func() bool {
@@ -560,10 +555,10 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 		})
 
 		Context("With Multiple Pods", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx context.Context) {
 				hasBaremetal := false
 				for i := range workerRTNodes {
-					isVM, err := infrastructure.IsVM(context.Background(), &workerRTNodes[i])
+					isVM, err := infrastructure.IsVM(ctx, &workerRTNodes[i])
 					Expect(err).ToNot(HaveOccurred())
 					if !isVM {
 						hasBaremetal = true
@@ -581,9 +576,8 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				L3UncoreCacheShareUnequal L3UncoreCacheShareMode = "unequal"
 			)
 			DescribeTable("Align multiple Guaranteed pods",
-				func(mode L3UncoreCacheShareMode) {
+				func(ctx context.Context, mode L3UncoreCacheShareMode) {
 					var (
-						ctx                   = context.Background()
 						targetNode            = workerRTNodes[0]
 						cpusetCfg             = &controller.CpuSet{}
 						cpusetList            []cpuset.CPUSet
@@ -614,19 +608,19 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 						dpList = append(dpList, dp)
 					}
 
-					defer func() {
+					DeferCleanup(func(cleanupCtx context.Context) {
 						// delete deployment
 						for _, dp := range dpList {
 							testlog.TaggedInfof("Deployment", "Deleting Deployment %v", dp.Name)
 							key := client.ObjectKeyFromObject(dp)
-							err := testclient.Client.Get(ctx, key, dp)
+							err := testclient.Client.Get(cleanupCtx, key, dp)
 							Expect(err).ToNot(HaveOccurred(), "Unable to fetch podlabels")
 							podLabels := dp.Spec.Template.Labels
-							err = testclient.DataPlaneClient.Delete(ctx, dp)
+							err = testclient.DataPlaneClient.Delete(cleanupCtx, dp)
 							Expect(err).ToNot(HaveOccurred(), "Unable to delete deployment %v", dp.Name)
-							waitForDeploymentPodsDeletion(ctx, &targetNode, podLabels)
+							waitForDeploymentPodsDeletion(cleanupCtx, &targetNode, podLabels)
 						}
-					}()
+					})
 
 					for i := 0; i < 2; i++ {
 						podList := &corev1.PodList{}
@@ -672,10 +666,10 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 		})
 
 		Context("Multiple Containers", func() {
-			BeforeEach(func() {
+			BeforeEach(func(ctx context.Context) {
 				hasBaremetal := false
 				for i := range workerRTNodes {
-					isVM, err := infrastructure.IsVM(context.Background(), &workerRTNodes[i])
+					isVM, err := infrastructure.IsVM(ctx, &workerRTNodes[i])
 					Expect(err).ToNot(HaveOccurred())
 					if !isVM {
 						hasBaremetal = true
@@ -695,9 +689,8 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			)
 
 			DescribeTable("Verify CPU Alignment with multiple containers",
-				func(deploymentName string, alignmentType alignment, containerName []string) {
+				func(ctx context.Context, deploymentName string, alignmentType alignment, containerName []string) {
 					var (
-						ctx           = context.Background()
 						containerList []corev1.Container
 						cpuSize       int
 						cpusetCfg     = &controller.CpuSet{}
@@ -742,12 +735,12 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 					dp.Spec.Template.Spec.Containers = append(dp.Spec.Template.Spec.Containers, containerList...)
 					err = testclient.Client.Create(ctx, dp)
 					Expect(err).ToNot(HaveOccurred())
-					defer func() {
+					DeferCleanup(func(cleanupCtx context.Context) {
 						testlog.TaggedInfof("Cleanup", "Deleting Deployment %v", deploymentName)
-						err := testclient.DataPlaneClient.Delete(ctx, dp)
+						err := testclient.DataPlaneClient.Delete(cleanupCtx, dp)
 						Expect(err).ToNot(HaveOccurred())
-						waitForDeploymentPodsDeletion(ctx, &targetNode, podLabel)
-					}()
+						waitForDeploymentPodsDeletion(cleanupCtx, &targetNode, podLabel)
+					})
 					podList := &corev1.PodList{}
 					listOptions := &client.ListOptions{Namespace: testutils.NamespaceTesting, LabelSelector: labels.SelectorFromSet(dp.Spec.Selector.MatchLabels)}
 					Eventually(func() bool {
@@ -803,8 +796,7 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 		Context("Odd CPU Requests with SMT Enabled", func() {
 			var initialOddCPUProfile *performancev2.PerformanceProfile
 			var targetNode corev1.Node
-			BeforeAll(func() {
-				ctx := context.Background()
+			BeforeAll(func(ctx context.Context) {
 				// Check for baremetal nodes before proceeding
 				hasBaremetal := false
 				for i := range workerRTNodes {
@@ -845,8 +837,7 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				profilesupdate.WaitForTuningUpdated(ctx, perfProfile)
 			})
 
-			AfterAll(func() {
-				ctx := context.Background()
+			AfterAll(func(ctx context.Context) {
 				// Restore original policy with full-pcpus-only: true
 
 				By("Restoring original performance profile policy")
@@ -893,13 +884,12 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				deploymentName := "test-deployment-odd-3"
 				dp, err := createDeployment(ctx, deploymentName, podLabel, &targetNode, rl)
 				Expect(err).ToNot(HaveOccurred())
-				defer func() {
+				DeferCleanup(func(cleanupCtx context.Context) {
 					testlog.TaggedInfof("Cleanup", "Deleting Deployment %v", deploymentName)
-					err := testclient.DataPlaneClient.Delete(ctx, dp)
+					err := testclient.DataPlaneClient.Delete(cleanupCtx, dp)
 					Expect(err).ToNot(HaveOccurred(), "Unable to delete deployment %v", deploymentName)
-					waitForDeploymentPodsDeletion(ctx, &targetNode, podLabel)
-				}()
-
+					waitForDeploymentPodsDeletion(cleanupCtx, &targetNode, podLabel)
+				})
 				podList := &corev1.PodList{}
 				listOptions := &client.ListOptions{Namespace: testutils.NamespaceTesting, LabelSelector: labels.SelectorFromSet(dp.Spec.Selector.MatchLabels)}
 				Eventually(func() bool {
@@ -941,13 +931,12 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				deploymentName := "test-deployment-odd-large"
 				dp, err := createDeployment(ctx, deploymentName, podLabel, &targetNode, rl)
 				Expect(err).ToNot(HaveOccurred())
-				defer func() {
+				DeferCleanup(func(cleanupCtx context.Context) {
 					testlog.TaggedInfof("Cleanup", "Deleting Deployment %v", deploymentName)
-					err := testclient.DataPlaneClient.Delete(ctx, dp)
+					err := testclient.DataPlaneClient.Delete(cleanupCtx, dp)
 					Expect(err).ToNot(HaveOccurred(), "Unable to delete deployment %v", deploymentName)
-					waitForDeploymentPodsDeletion(ctx, &targetNode, podLabel)
-				}()
-
+					waitForDeploymentPodsDeletion(cleanupCtx, &targetNode, podLabel)
+				})
 				podList := &corev1.PodList{}
 				listOptions := &client.ListOptions{Namespace: testutils.NamespaceTesting, LabelSelector: labels.SelectorFromSet(dp.Spec.Selector.MatchLabels)}
 				Eventually(func() bool {
@@ -1004,13 +993,12 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				deploymentName := "test-deployment-even-avoid-odd"
 				dp, err := createDeployment(ctx, deploymentName, podLabel, &targetNode, rl)
 				Expect(err).ToNot(HaveOccurred())
-				defer func() {
+				DeferCleanup(func(cleanupCtx context.Context) {
 					testlog.TaggedInfof("Cleanup", "Deleting Deployment %v", deploymentName)
-					err := testclient.DataPlaneClient.Delete(ctx, dp)
+					err := testclient.DataPlaneClient.Delete(cleanupCtx, dp)
 					Expect(err).ToNot(HaveOccurred(), "Unable to delete deployment %v", deploymentName)
-					waitForDeploymentPodsDeletion(ctx, &targetNode, podLabel)
-				}()
-
+					waitForDeploymentPodsDeletion(cleanupCtx, &targetNode, podLabel)
+				})
 				podList := &corev1.PodList{}
 				listOptions := &client.ListOptions{Namespace: testutils.NamespaceTesting, LabelSelector: labels.SelectorFromSet(dp.Spec.Selector.MatchLabels)}
 				Eventually(func() bool {
@@ -1059,10 +1047,9 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			podCpuResourceEqualtoL3CacheSize  podCpuResourceSize = "equalto"
 			podCpuResourceLessthanL3CacheSize podCpuResourceSize = "lessthan"
 		)
-		BeforeAll(func() {
+		BeforeAll(func(ctx context.Context) {
 			profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 			Expect(err).ToNot(HaveOccurred())
-			ctx := context.Background()
 			hasBaremetal := false
 			for _, cnfnode := range workerRTNodes {
 				isVM, err := infrastructure.IsVM(ctx, &cnfnode)
@@ -1155,16 +1142,15 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 
 			testNS := *namespaces.TestingNamespace
 			Expect(testclient.DataPlaneClient.Create(ctx, &testNS)).ToNot(HaveOccurred())
-			DeferCleanup(func() {
-				Expect(testclient.DataPlaneClient.Delete(ctx, &testNS)).ToNot(HaveOccurred())
+			DeferCleanup(func(cleanupCtx context.Context) {
+				Expect(testclient.DataPlaneClient.Delete(cleanupCtx, &testNS)).ToNot(HaveOccurred())
 				Expect(namespaces.WaitForDeletion(testutils.NamespaceTesting, 5*time.Minute)).ToNot(HaveOccurred())
 			})
 		})
 		DescribeTable("Align Guaranteed pod",
-			func(deploymentName string, resourceSize podCpuResourceSize) {
+			func(ctx context.Context, deploymentName string, resourceSize podCpuResourceSize) {
 				var (
-					ctx = context.Background()
-					rl  *corev1.ResourceList
+					rl *corev1.ResourceList
 				)
 				podLabel := make(map[string]string)
 				targetNode := workerRTNodes[0]
@@ -1185,12 +1171,12 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 				podLabel["test-app"] = "telco1"
 				dp, err := createDeployment(ctx, deploymentName, podLabel, &targetNode, rl)
 				Expect(err).ToNot(HaveOccurred())
-				defer func() {
+				DeferCleanup(func(cleanupCtx context.Context) {
 					testlog.TaggedInfof("Cleanup", "Deleting Deployment %v", deploymentName)
-					err := testclient.DataPlaneClient.Delete(ctx, dp)
+					err := testclient.DataPlaneClient.Delete(cleanupCtx, dp)
 					Expect(err).ToNot(HaveOccurred(), "Unable to delete deployment %v", deploymentName)
-					waitForDeploymentPodsDeletion(ctx, &targetNode, podLabel)
-				}()
+					waitForDeploymentPodsDeletion(cleanupCtx, &targetNode, podLabel)
+				})
 
 				podList := &corev1.PodList{}
 				listOptions := &client.ListOptions{Namespace: testutils.NamespaceTesting, LabelSelector: labels.SelectorFromSet(dp.Spec.Selector.MatchLabels)}
@@ -1235,17 +1221,17 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 		BeforeAll(func(ctx context.Context) {
 			testNS := *namespaces.TestingNamespace
 			Expect(testclient.DataPlaneClient.Create(ctx, &testNS)).ToNot(HaveOccurred())
-			DeferCleanup(func() {
-				Expect(testclient.DataPlaneClient.Delete(ctx, &testNS)).ToNot(HaveOccurred())
+			DeferCleanup(func(cleanupCtx context.Context) {
+				Expect(testclient.DataPlaneClient.Delete(cleanupCtx, &testNS)).ToNot(HaveOccurred())
 				Expect(namespaces.WaitForDeletion(testutils.NamespaceTesting, 5*time.Minute)).ToNot(HaveOccurred())
 			})
 		})
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx context.Context) {
 			targetNodeName = ""
 			for i := range workerRTNodes {
 				workerRT := &workerRTNodes[i]
-				isVM, err := infrastructure.IsVM(context.TODO(), workerRT)
+				isVM, err := infrastructure.IsVM(ctx, workerRT)
 				Expect(err).ToNot(HaveOccurred())
 				if !isVM {
 					targetNodeName = workerRT.Name
@@ -1264,22 +1250,17 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			Expect(targetL3GroupSize).Should(BeNumerically(">", expectedMinL3GroupSize), "L3 Group size too small: %d", targetL3GroupSize)
 		})
 
-		// TODO move to DeferCleanup?
-		AfterEach(func() {
-			if testPod == nil {
-				return
-			}
-			ctx := context.Background()
-			testlog.Infof("deleting pod %q", testPod.Name)
-			Expect(pods.DeleteAndSync(ctx, testclient.DataPlaneClient, testPod)).To(Succeed())
-		})
-
 		It("[test_id:77727] should align containers which request less than a L3 group size exclusive CPUs", func(ctx context.Context) {
 			askingCPUs := expectedMinL3GroupSize
 
 			By(fmt.Sprintf("Creating a test pod asking for %d exclusive CPUs", askingCPUs))
 			testPod = makeLLCPod(targetNodeName, askingCPUs)
 			Expect(testclient.Client.Create(ctx, testPod)).To(Succeed())
+
+			DeferCleanup(func(cleanupCtx context.Context) {
+				testlog.Infof("deleting pod %q", testPod.Name)
+				Expect(pods.DeleteAndSync(cleanupCtx, testclient.DataPlaneClient, testPod)).To(Succeed())
+			})
 
 			By("Waiting for the guaranteed pod to be ready")
 			testPod, err = pods.WaitForCondition(ctx, client.ObjectKeyFromObject(testPod), corev1.PodReady, corev1.ConditionTrue, 5*time.Minute)
@@ -1302,6 +1283,10 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 			By(fmt.Sprintf("Creating a test pod asking for %d exclusive CPUs", askingCPUs))
 			testPod = makeLLCPod(targetNodeName, askingCPUs)
 			Expect(testclient.Client.Create(ctx, testPod)).To(Succeed())
+			DeferCleanup(func(cleanupCtx context.Context) {
+				testlog.Infof("deleting pod %q", testPod.Name)
+				Expect(pods.DeleteAndSync(cleanupCtx, testclient.DataPlaneClient, testPod)).To(Succeed())
+			})
 
 			By("Waiting for the guaranteed pod to be ready")
 			testPod, err = pods.WaitForCondition(ctx, client.ObjectKeyFromObject(testPod), corev1.PodReady, corev1.ConditionTrue, 5*time.Minute)


### PR DESCRIPTION
Earlier DeferCleanup closure carried ctx from BeforeAll and ginkgo cancels that context after BeforeAll node completes so by the time DeferCleanup runs, the context is already cancelled

Also replace defer with ginkgo's DeferCleanup and pass new context variable

Remove all explicit ctx variables and incorporate them in relevant ginkgo specs like It, BeforeAll etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by propagating execution context consistently across setup, validation, and cleanup steps.
  * Updated cleanup handling to use dedicated cleanup contexts, helping ensure resources are removed correctly after tests.
  * Existing performance profile, CPU alignment, kubelet configuration, and pod validation coverage remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->