### PR TITLE
CNF-20633: Enable nohz_full and skew_tick by default

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -148,6 +148,8 @@ initrd_add_dir=
 
 # overrides cpu-partitioning cmdline
 cmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}
+cmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}
+cmdline_cpu_tuning=+skew_tick=1
 
 # No default value but will be composed conditionally based on platform
 cmdline_iommu=
@@ -159,9 +161,8 @@ cmdline_isolation=+isolcpus=managed_irq,${isolated_cores}
 {{end}}
 
 {{if .RealTimeHint}}
-cmdline_realtime_nohzfull=+nohz_full=${isolated_cores}
 cmdline_realtime_nosoftlookup=+nosoftlockup
-cmdline_realtime_common=+skew_tick=1 rcutree.kthread_prio=11
+cmdline_realtime_common=+rcutree.kthread_prio=11
 {{end}}
 
 {{if .HighPowerConsumption}}

--- a/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
+++ b/assets/performanceprofile/tuned/openshift-node-performance-intel-x86
@@ -2,27 +2,6 @@
 summary=Platform specific tuning for Intel x86
 
 [bootloader]
-# DO NOT REMOVE THIS BLOCK
-# It makes sure the kernel arguments for Intel are applied
-# in the order compatible with OCP 4.17 which is important
-# for preventing an extra reboot during upgrade
-cmdline_cpu_part=
-cmdline_iommu_intel=
-cmdline_isolation=
-cmdline_realtime_nohzfull=
-cmdline_realtime_intel=
-cmdline_realtime_nosoftlookup=
-cmdline_realtime_intel_nmi=
-cmdline_realtime_common=
-cmdline_power_performance=
-cmdline_power_performance_intel=
-cmdline_idle_poll=
-cmdline_idle_poll_intel=
-cmdline_hugepages=
-cmdline_pstate=
-
-# Here comes the Intel specific tuning
-
 cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 {{if .RealTimeHint}}

--- a/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/tuned/tuned_test.go
@@ -35,9 +35,9 @@ var (
 	cmdlineIntelPstateAutomatic      = "intel_pstate=${f:intel_recommended_pstate}"
 	cmdlineIntelPstatePassive        = "intel_pstate=passive"
 	cmdlineMultipleHugePages         = "+ default_hugepagesz=1G   hugepagesz=1G hugepages=4 hugepagesz=2M hugepages=128"
-	cmdlineRealtimeNoHZFull          = "+nohz_full=${isolated_cores}"
+	cmdlineCPUPartNohzfull           = "+nohz_full=${isolated_cores}"
 	cmdlineRealtimeNosoftlookup      = "+nosoftlockup"
-	cmdlineRealtimeCommon            = "+skew_tick=1 rcutree.kthread_prio=11"
+	cmdlineRealtimeCommon            = "+rcutree.kthread_prio=11"
 	cmdlineWithoutStaticIsolation    = "+isolcpus=managed_irq,${isolated_cores}"
 	cmdlineWithStaticIsolation       = "+isolcpus=domain,managed_irq,${isolated_cores}"
 )
@@ -122,7 +122,7 @@ var _ = Describe("Tuned", func() {
 			Expect(bootLoaderSection.Key("cmdline_isolation").String()).To(Equal(cmdlineWithoutStaticIsolation))
 			Expect(bootLoaderSection.Key("cmdline_hugepages").String()).To(Equal(cmdlineHugepages))
 			Expect(bootLoaderSection.Key("cmdline_additionalArg").String()).To(Equal(cmdlineAdditionalArgs))
-			Expect(bootLoaderSection.Key("cmdline_realtime_nohzfull").String()).To(Equal(cmdlineRealtimeNoHZFull))
+			Expect(bootLoaderSection.Key("cmdline_cpu_part_nohzfull").String()).To(Equal(cmdlineCPUPartNohzfull))
 			Expect(bootLoaderSection.Key("cmdline_realtime_nosoftlookup").String()).To(Equal(cmdlineRealtimeNosoftlookup))
 			Expect(bootLoaderSection.Key("cmdline_realtime_common").String()).To(Equal(cmdlineRealtimeCommon))
 		})
@@ -154,17 +154,16 @@ var _ = Describe("Tuned", func() {
 			})
 
 			It("should have mandatory bootloader keys in tuned", func() {
-				tunedData := getTunedStructuredData(profile, components.ProfileNameIntelX86)
+				tunedData := getTunedStructuredData(profile, components.ProfileNamePerformance)
 				bootloader, err := tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(bootloader.HasKey("cmdline_cpu_part")).To(BeTrue())
+				Expect(bootloader.HasKey("cmdline_cpu_part_nohzfull")).To(BeTrue())
+				Expect(bootloader.HasKey("cmdline_cpu_tuning")).To(BeTrue())
 				Expect(bootloader.HasKey("cmdline_isolation")).To(BeTrue())
-				Expect(bootloader.HasKey("cmdline_realtime_nohzfull")).To(BeTrue())
 				Expect(bootloader.HasKey("cmdline_realtime_nosoftlookup")).To(BeTrue())
 				Expect(bootloader.HasKey("cmdline_realtime_common")).To(BeTrue())
-				Expect(bootloader.HasKey("cmdline_idle_poll")).To(BeTrue())
 				Expect(bootloader.HasKey("cmdline_hugepages")).To(BeTrue())
-				Expect(bootloader.HasKey("cmdline_pstate")).To(BeTrue())
 			})
 		})
 
@@ -187,7 +186,7 @@ var _ = Describe("Tuned", func() {
 
 				bootLoaderSection, err := tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bootLoaderSection.Key("cmdline_realtime_nohzfull").String()).ToNot(Equal(cmdlineRealtimeNoHZFull))
+				Expect(bootLoaderSection.Key("cmdline_cpu_part_nohzfull").String()).To(Equal(cmdlineCPUPartNohzfull))
 				Expect(bootLoaderSection.Key("cmdline_realtime_nosoftlookup").String()).ToNot(Equal(cmdlineRealtimeNosoftlookup))
 				Expect(bootLoaderSection.Key("cmdline_realtime_common").String()).ToNot(Equal(cmdlineRealtimeCommon))
 			})
@@ -206,7 +205,7 @@ var _ = Describe("Tuned", func() {
 				Expect(sysctl.Key("kernel.sched_rt_runtime_us").String()).To(Equal("-1"))
 				bootLoader, err := tunedData.GetSection("bootloader")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bootLoader.Key("cmdline_realtime_nohzfull").String()).To(Equal(cmdlineRealtimeNoHZFull))
+				Expect(bootLoader.Key("cmdline_cpu_part_nohzfull").String()).To(Equal(cmdlineCPUPartNohzfull))
 				Expect(bootLoader.Key("cmdline_realtime_nosoftlookup").String()).To(Equal(cmdlineRealtimeNosoftlookup))
 				Expect(bootLoader.Key("cmdline_realtime_common").String()).To(Equal(cmdlineRealtimeCommon))
 			})

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -58,9 +58,9 @@ spec:
       names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n
+      \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -100,27 +100,6 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
-      # DO NOT REMOVE THIS BLOCK
-      # It makes sure the kernel arguments for Intel are applied
-      # in the order compatible with OCP 4.17 which is important
-      # for preventing an extra reboot during upgrade
-      cmdline_cpu_part=
-      cmdline_iommu_intel=
-      cmdline_isolation=
-      cmdline_realtime_nohzfull=
-      cmdline_realtime_intel=
-      cmdline_realtime_nosoftlookup=
-      cmdline_realtime_intel_nmi=
-      cmdline_realtime_common=
-      cmdline_power_performance=
-      cmdline_power_performance_intel=
-      cmdline_idle_poll=
-      cmdline_idle_poll_intel=
-      cmdline_hugepages=
-      cmdline_pstate=
-
-      # Here comes the Intel specific tuning
-
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -58,9 +58,9 @@ spec:
       names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n
+      \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -100,27 +100,6 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
-      # DO NOT REMOVE THIS BLOCK
-      # It makes sure the kernel arguments for Intel are applied
-      # in the order compatible with OCP 4.17 which is important
-      # for preventing an extra reboot during upgrade
-      cmdline_cpu_part=
-      cmdline_iommu_intel=
-      cmdline_isolation=
-      cmdline_realtime_nohzfull=
-      cmdline_realtime_intel=
-      cmdline_realtime_nosoftlookup=
-      cmdline_realtime_intel_nmi=
-      cmdline_realtime_common=
-      cmdline_power_performance=
-      cmdline_power_performance_intel=
-      cmdline_idle_poll=
-      cmdline_idle_poll_intel=
-      cmdline_hugepages=
-      cmdline_pstate=
-
-      # Here comes the Intel specific tuning
-
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -58,9 +58,9 @@ spec:
       names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n
+      \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-master
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -100,27 +100,6 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
-      # DO NOT REMOVE THIS BLOCK
-      # It makes sure the kernel arguments for Intel are applied
-      # in the order compatible with OCP 4.17 which is important
-      # for preventing an extra reboot during upgrade
-      cmdline_cpu_part=
-      cmdline_iommu_intel=
-      cmdline_isolation=
-      cmdline_realtime_nohzfull=
-      cmdline_realtime_intel=
-      cmdline_realtime_nosoftlookup=
-      cmdline_realtime_intel_nmi=
-      cmdline_realtime_common=
-      cmdline_power_performance=
-      cmdline_power_performance_intel=
-      cmdline_idle_poll=
-      cmdline_idle_poll_intel=
-      cmdline_hugepages=
-      cmdline_pstate=
-
-      # Here comes the Intel specific tuning
-
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -58,9 +58,9 @@ spec:
       names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n \n\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n
+      \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-openshift-bootstrap-worker
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -100,27 +100,6 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
-      # DO NOT REMOVE THIS BLOCK
-      # It makes sure the kernel arguments for Intel are applied
-      # in the order compatible with OCP 4.17 which is important
-      # for preventing an extra reboot during upgrade
-      cmdline_cpu_part=
-      cmdline_iommu_intel=
-      cmdline_isolation=
-      cmdline_realtime_nohzfull=
-      cmdline_realtime_intel=
-      cmdline_realtime_nosoftlookup=
-      cmdline_realtime_intel_nmi=
-      cmdline_realtime_common=
-      cmdline_power_performance=
-      cmdline_power_performance_intel=
-      cmdline_idle_poll=
-      cmdline_idle_poll_intel=
-      cmdline_hugepages=
-      cmdline_pstate=
-
-      # Here comes the Intel specific tuning
-
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_tuned.yaml
@@ -56,10 +56,9 @@ spec:
       names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=32M
-      \  hugepagesz=512M hugepages=1 \n\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=32M   hugepagesz=512M hugepages=1 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,27 +98,6 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
-      # DO NOT REMOVE THIS BLOCK
-      # It makes sure the kernel arguments for Intel are applied
-      # in the order compatible with OCP 4.17 which is important
-      # for preventing an extra reboot during upgrade
-      cmdline_cpu_part=
-      cmdline_iommu_intel=
-      cmdline_isolation=
-      cmdline_realtime_nohzfull=
-      cmdline_realtime_intel=
-      cmdline_realtime_nosoftlookup=
-      cmdline_realtime_intel_nmi=
-      cmdline_realtime_common=
-      cmdline_power_performance=
-      cmdline_power_performance_intel=
-      cmdline_idle_poll=
-      cmdline_idle_poll_intel=
-      cmdline_hugepages=
-      cmdline_pstate=
-
-      # Here comes the Intel specific tuning
-
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -56,11 +56,10 @@ spec:
       names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
-      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n[sysfs]\n# sets provided
-      frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n[sysfs]\n#
+      sets provided frequencies to isolated and reserved cpus\n\n/sys/devices/system/cpu/cpufreq/policy2/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq=2500000\n/sys/devices/system/cpu/cpufreq/policy0/scaling_max_freq=2800000\n/sys/devices/system/cpu/cpufreq/policy1/scaling_max_freq=2800000\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -100,27 +99,6 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
-      # DO NOT REMOVE THIS BLOCK
-      # It makes sure the kernel arguments for Intel are applied
-      # in the order compatible with OCP 4.17 which is important
-      # for preventing an extra reboot during upgrade
-      cmdline_cpu_part=
-      cmdline_iommu_intel=
-      cmdline_isolation=
-      cmdline_realtime_nohzfull=
-      cmdline_realtime_intel=
-      cmdline_realtime_nosoftlookup=
-      cmdline_realtime_intel_nmi=
-      cmdline_realtime_common=
-      cmdline_power_performance=
-      cmdline_power_performance_intel=
-      cmdline_idle_poll=
-      cmdline_idle_poll_intel=
-      cmdline_hugepages=
-      cmdline_pstate=
-
-      # Here comes the Intel specific tuning
-
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -58,10 +58,9 @@ spec:
       names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
-      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -101,27 +100,6 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
-      # DO NOT REMOVE THIS BLOCK
-      # It makes sure the kernel arguments for Intel are applied
-      # in the order compatible with OCP 4.17 which is important
-      # for preventing an extra reboot during upgrade
-      cmdline_cpu_part=
-      cmdline_iommu_intel=
-      cmdline_isolation=
-      cmdline_realtime_nohzfull=
-      cmdline_realtime_intel=
-      cmdline_realtime_nosoftlookup=
-      cmdline_realtime_intel_nmi=
-      cmdline_realtime_common=
-      cmdline_power_performance=
-      cmdline_power_performance_intel=
-      cmdline_idle_poll=
-      cmdline_idle_poll_intel=
-      cmdline_hugepages=
-      cmdline_pstate=
-
-      # Here comes the Intel specific tuning
-
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_tuned.yaml
@@ -58,10 +58,9 @@ spec:
       names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
-      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -101,27 +100,6 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
-      # DO NOT REMOVE THIS BLOCK
-      # It makes sure the kernel arguments for Intel are applied
-      # in the order compatible with OCP 4.17 which is important
-      # for preventing an extra reboot during upgrade
-      cmdline_cpu_part=
-      cmdline_iommu_intel=
-      cmdline_isolation=
-      cmdline_realtime_nohzfull=
-      cmdline_realtime_intel=
-      cmdline_realtime_nosoftlookup=
-      cmdline_realtime_intel_nmi=
-      cmdline_realtime_common=
-      cmdline_power_performance=
-      cmdline_power_performance_intel=
-      cmdline_idle_poll=
-      cmdline_idle_poll_intel=
-      cmdline_hugepages=
-      cmdline_pstate=
-
-      # Here comes the Intel specific tuning
-
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -56,10 +56,9 @@ spec:
       names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
       set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
-      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\n#
-      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nohzfull=+nohz_full=${isolated_cores}\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+skew_tick=1
-      rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+ default_hugepagesz=1G
-      \  hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
+      tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
+      No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \n\n\n\n[rtentsk]\n\n\n"
     name: openshift-node-performance-manual
   - data: "[main]\nsummary=Real time profile to override unsupported settings\n\n[sysctl]\n#Real
       time kernel doesn't support the following kernel parameters.\n#The openshift-node-performance
@@ -99,27 +98,6 @@ spec:
       summary=Platform specific tuning for Intel x86
 
       [bootloader]
-      # DO NOT REMOVE THIS BLOCK
-      # It makes sure the kernel arguments for Intel are applied
-      # in the order compatible with OCP 4.17 which is important
-      # for preventing an extra reboot during upgrade
-      cmdline_cpu_part=
-      cmdline_iommu_intel=
-      cmdline_isolation=
-      cmdline_realtime_nohzfull=
-      cmdline_realtime_intel=
-      cmdline_realtime_nosoftlookup=
-      cmdline_realtime_intel_nmi=
-      cmdline_realtime_common=
-      cmdline_power_performance=
-      cmdline_power_performance_intel=
-      cmdline_idle_poll=
-      cmdline_idle_poll_intel=
-      cmdline_hugepages=
-      cmdline_pstate=
-
-      # Here comes the Intel specific tuning
-
       cmdline_iommu_intel=intel_iommu=on iommu=pt
 
 


### PR DESCRIPTION
The nohz_full kernel arg makes sure no tick interrupts arrive to cpus with just a single schedulable process.
That is something we really want.

All the conditions from https://github.com/torvalds/linux/blob/5097cbc/Documentation/timers/no_hz.rst#omit-scheduling-clock-ticks-for-cpus-with-only-one-runnable-task are satisfied as well:

- There are reserved cpus with tick enabled
- The tuning sets rcu_nocbs

The kernel command line parameter skew_tick helps to smooth jitter on moderate to large systems with latency-sensitive applications running and this matches exactly our use case.

There is also a cleanup of the Intel overrides block that only made sure the kernel arguments stay in the same order. I renamed two tuned variables to the reboot protection is not going to matter and 5.0 major version is a good opportunity to get rid of this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined kernel boot parameters by separating CPU `nohz_full` partitioning and tick-skew settings.
  * Simplified real-time boot parameter composition and Intel x86 bootloader configuration.
* **Bug Fixes**
  * Updated generated tuned profiles and rendered outputs to reflect the revised boot parameters.
* **Tests**
  * Updated controller tests and end-to-end rendering expectations for the new configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->