### PR TITLE
OCPBUGS-99461: Add missing annotations to NetworkPolicy manifests

### DIFF
--- a/manifests/55-network-policy.yaml
+++ b/manifests/55-network-policy.yaml
@@ -10,7 +10,14 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    capability.openshift.io/name: NodeTuning
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: default-deny-all
+  namespace: openshift-cluster-node-tuning-operator
 spec:
   podSelector: {}
   policyTypes:
@@ -22,6 +29,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    capability.openshift.io/name: NodeTuning
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: allow-egress-to-api-server
   namespace: openshift-cluster-node-tuning-operator
 spec:
@@ -40,6 +53,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    capability.openshift.io/name: NodeTuning
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: allow-metrics-traffic
   namespace: openshift-cluster-node-tuning-operator
 spec:
@@ -64,6 +83,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  annotations:
+    capability.openshift.io/name: NodeTuning
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: allow-webhook-traffic
   namespace: openshift-cluster-node-tuning-operator
 spec:


### PR DESCRIPTION
NTO NetworkPolicy manifests that were added as part of #1323 were missing Cluster Profile (https://github.com/openshift/enhancements/blob/master/enhancements/update/cluster-profiles.md) annotations.

Add the missing Cluster Profile annotations, so that CVO does not ignore the NetworkPolicy manifests.

    include.release.openshift.io/hypershift: "true"
    include.release.openshift.io/ibm-cloud-managed: "true"
    include.release.openshift.io/self-managed-high-availability: "true"
    include.release.openshift.io/single-node-developer: "true"

Resolves: OCPBUGS-99461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated network policy metadata to identify the OpenShift `NodeTuning` capability.
  * Enabled the affected policies for `hypershift`, `ibm-cloud-managed`, `self-managed-high-availability`, and `single-node-developer` release streams.
  * Explicitly associated the default deny policy with the Node Tuning Operator namespace.
  * Network traffic rules, ports, and security behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->