### PR TITLE
OCPBUGS-100115: E2E: LLC: Restore uncore cache annotation to true

### DIFF
--- a/test/e2e/performanceprofile/functests/13_llc/llc.go
+++ b/test/e2e/performanceprofile/functests/13_llc/llc.go
@@ -252,6 +252,22 @@ var _ = Describe("[rfe_id:77446] LLC-aware cpu pinning", Label(string(label.Open
 
 		When("align-cpus-by-uncorecache cpumanager policy option is disabled", func() {
 			It("[test_id:77724] cpumanager Policy option in kubelet is configured appropriately", func(ctx context.Context) {
+				DeferCleanup(func(cleanupCtx context.Context) {
+					By("Restoring prefer-align-cpus-by-uncorecache to true")
+					profileAnnotations["kubeletconfig.experimental"] = llcPolicy
+					perfProfile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+					Expect(err).ToNot(HaveOccurred())
+					perfProfile.Annotations = profileAnnotations
+
+					profiles.UpdateWithRetry(perfProfile)
+
+					By(fmt.Sprintf("Applying changes in performance profile and waiting until %s will start updating", poolName))
+					profilesupdate.WaitForTuningUpdating(cleanupCtx, perfProfile)
+
+					By(fmt.Sprintf("Waiting when %s finishes updates", poolName))
+					profilesupdate.WaitForTuningUpdated(cleanupCtx, perfProfile)
+				})
+
 				llcDisablePolicy := `{"cpuManagerPolicyOptions":{"prefer-align-cpus-by-uncorecache":"false", "full-pcpus-only":"true"}}`
 				profileAnnotations["kubeletconfig.experimental"] = llcDisablePolicy
 				perfProfile.Annotations = profileAnnotations


### PR DESCRIPTION
Earlier in test_id: 77724 we disaled prefer-align-cpus-by-uncorecache but never enabled it back causing further tests to always run with prefer-align-cpus-by-uncorecache disabled

Add a deferCleanup so that prefer-align-cpus-by-uncorecache is re-enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test cleanup to restore the cluster’s original CPU/performance configuration after the test completes.
  * Added additional checks during cleanup to ensure configuration updates complete successfully and the cluster returns to the prior tuning state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->