### PR TITLE
NO-JIRA: e2e: fix: restart tuned pod after irqbalance test to prevent cpuset pollution

### DIFF
--- a/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/irqbalance.go
@@ -223,6 +223,7 @@ var _ = Describe("[performance] IRQBalance", Ordered, func() {
 			err = testclient.DataPlaneClient.Create(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
+				GinkgoHelper()
 				if testpod != nil {
 					testlog.Infof("deleting pod %q", testpod.Name)
 					Expect(pods.DeleteAndSync(context.TODO(), testclient.DataPlaneClient, testpod)).To(Succeed())
@@ -236,6 +237,16 @@ var _ = Describe("[performance] IRQBalance", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred(), "failed to extract the default IRQ affinity from node %q", targetNode.Name)
 
 				testlog.Infof("IRQ Default affinity on %q when test ends: {%s}", targetNode.Name, irqAffBegin)
+
+				// Restart the tuned pod to restore clean CPU affinity.
+				// The tuned pod was restarted earlier while the guaranteed pod
+				// held exclusive CPUs, so its process affinity mask is permanently
+				// narrowed. A fresh start picks up the current (full) default cpuset.
+				By(fmt.Sprintf("restarting tuned pod on %s to restore clean CPU affinity", targetNode.Name))
+				tunedPod := nodes.TunedForNode(targetNode, RunningOnSingleNode)
+				Expect(pods.DeleteAndSync(context.TODO(), testclient.DataPlaneClient, tunedPod)).To(Succeed(), "failed to delete tuned pod on node %q", targetNode.Name)
+				nodes.TunedForNode(targetNode, RunningOnSingleNode)
+				testlog.Infof("tuned pod restarted on node %q with clean CPU affinity", targetNode.Name)
 			}()
 
 			testpod, err = pods.WaitForCondition(context.TODO(), client.ObjectKeyFromObject(testpod), corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)


### PR DESCRIPTION
The irqbalance test `Should not overwrite the banned CPU set on tuned restart` creates a guaranteed pod (exclusive CPUs), then restarts the tuned pod while that guaranteed pod is still running.
The new tuned process starts with a narrowed CPU affinity mask (missing the exclusive CPUs).
When the guaranteed pod is later cleaned up, the cgroup cpuset expands but the tuned process's sched_setaffinity mask stays narrow.

If the `cpu_management.go` `Ordered` block runs after `irqbalance.go`, test `test_id:87722` reads the tuned pod's stale process affinity via taskset and fails because it doesn't match the full online CPU set.

Fix: restart the tuned pod in the irqbalance test's defer cleanup after the guaranteed pod is deleted, so the tuned process picks up the current (full) default cpuset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance test cleanup by restoring CPU affinity and recreating the tuned pod after checks.
  * Added readiness validation for the replacement pod before continuing, improving test reliability and reducing failures caused by incomplete pod recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->