### PR TITLE
NO-JIRA: ci: disable smt alignment for ovsDpdk tests

### DIFF
--- a/test/e2e/performanceprofile/functests/2_performance_update/ovsdpdk.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/ovsdpdk.go
@@ -90,26 +90,11 @@ var _ = Describe("[performance] ovsDpdk CPUs", Ordered, Label(string(label.OvsDp
 		}
 		currentProfile.Annotations[performancev2.PerformanceProfileCPULoadBalancingOvsDpdkAnnotation] = "disable"
 
-		policyOptions := map[string]string{}
-		for _, node := range workerRTNodes {
-			numOfCores, _ := node.Status.Capacity.Cpu().AsInt64()
-			if numOfCores <= numberOfCoresThatRequiredCancelingSMTAlignment {
-				testlog.Infof("canceling SMT alignment: node %s has %d CPUs", node.Name, numOfCores)
-				policyOptions["full-pcpus-only"] = "false"
-				smtAlignmentDisabled = true
-				break
-			}
+		// we're working under the assumption that all worker RT nodes have the same number of CPUs
+		if numOfCores, _ := workerRTNodes[0].Status.Capacity.Cpu().AsInt64(); numOfCores <= numberOfCoresThatRequiredCancelingSMTAlignment {
+			smtAlignmentDisabled = true
 		}
-		if !isWPEnabled {
-			testlog.Infof("Workload partitioning not enabled, adding strict-cpu-reservation via experimental annotation")
-			policyOptions["strict-cpu-reservation"] = "true"
-		}
-		if len(policyOptions) > 0 {
-			optJSON, err := json.Marshal(map[string]interface{}{"cpuManagerPolicyOptions": policyOptions})
-			Expect(err).ToNot(HaveOccurred())
-			currentProfile.Annotations["kubeletconfig.experimental"] = string(optJSON)
-		}
-
+		setPolicyOptions(currentProfile, isWPEnabled, smtAlignmentDisabled)
 		profiles.UpdateWithRetry(currentProfile)
 
 		updatedProfile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
@@ -339,26 +324,11 @@ var _ = Describe("[performance] ovsDpdk CPUs default partition", Ordered, Label(
 			currentProfile.Annotations = make(map[string]string)
 		}
 
-		policyOptions := map[string]string{}
-		for _, node := range workerRTNodes {
-			numOfCores, _ := node.Status.Capacity.Cpu().AsInt64()
-			if numOfCores <= numberOfCoresThatRequiredCancelingSMTAlignment {
-				testlog.Infof("canceling SMT alignment: node %s has %d CPUs", node.Name, numOfCores)
-				policyOptions["full-pcpus-only"] = "false"
-				smtAlignmentDisabled = true
-				break
-			}
+		// we're working under the assumption that all worker RT nodes have the same number of CPUs
+		if numOfCores, _ := workerRTNodes[0].Status.Capacity.Cpu().AsInt64(); numOfCores <= numberOfCoresThatRequiredCancelingSMTAlignment {
+			smtAlignmentDisabled = true
 		}
-		if !isWPEnabled {
-			testlog.Infof("Workload partitioning not enabled, adding strict-cpu-reservation via experimental annotation")
-			policyOptions["strict-cpu-reservation"] = "true"
-		}
-		if len(policyOptions) > 0 {
-			optJSON, err := json.Marshal(map[string]interface{}{"cpuManagerPolicyOptions": policyOptions})
-			Expect(err).ToNot(HaveOccurred())
-			currentProfile.Annotations["kubeletconfig.experimental"] = string(optJSON)
-		}
-
+		setPolicyOptions(currentProfile, isWPEnabled, smtAlignmentDisabled)
 		profiles.UpdateWithRetry(currentProfile)
 
 		updatedProfile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
@@ -587,4 +557,24 @@ func getIRQBannedCPUSet(irqbalanceContent string) cpuset.CPUSet {
 		return banned
 	}
 	return cpuset.New()
+}
+
+func setPolicyOptions(profile *performancev2.PerformanceProfile, isWPEnabled bool, smtAlignmentDisabled bool) {
+	GinkgoHelper()
+	policyOptions := map[string]string{}
+	if smtAlignmentDisabled {
+		testlog.Infof("canceling SMT alignment, adding full-pcpus-only=false via experimental annotation")
+		policyOptions["full-pcpus-only"] = "false"
+	}
+
+	if !isWPEnabled {
+		testlog.Infof("Workload partitioning not enabled, adding strict-cpu-reservation via experimental annotation")
+		policyOptions["strict-cpu-reservation"] = "true"
+	}
+
+	if len(policyOptions) > 0 {
+		optJSON, err := json.Marshal(map[string]interface{}{"cpuManagerPolicyOptions": policyOptions})
+		Expect(err).ToNot(HaveOccurred())
+		profile.Annotations["kubeletconfig.experimental"] = string(optJSON)
+	}
 }

--- a/test/e2e/performanceprofile/functests/2_performance_update/ovsdpdk.go
+++ b/test/e2e/performanceprofile/functests/2_performance_update/ovsdpdk.go
@@ -28,15 +28,18 @@ import (
 	"github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/profilesupdate"
 )
 
+const numberOfCoresThatRequiredCancelingSMTAlignment = 4
+
 var _ = Describe("[performance] ovsDpdk CPUs", Ordered, Label(string(label.OvsDpdk), string(label.Slow), string(label.Tier2)), func() {
 	var (
 		workerRTNodes  []corev1.Node
 		profile        *performancev2.PerformanceProfile
 		initialProfile *performancev2.PerformanceProfile
 
-		reservedSet    cpuset.CPUSet
-		ovsDpdkSet     cpuset.CPUSet
-		newIsolatedSet cpuset.CPUSet
+		reservedSet          cpuset.CPUSet
+		ovsDpdkSet           cpuset.CPUSet
+		newIsolatedSet       cpuset.CPUSet
+		smtAlignmentDisabled bool
 	)
 
 	BeforeAll(func() {
@@ -88,9 +91,20 @@ var _ = Describe("[performance] ovsDpdk CPUs", Ordered, Label(string(label.OvsDp
 		currentProfile.Annotations[performancev2.PerformanceProfileCPULoadBalancingOvsDpdkAnnotation] = "disable"
 
 		policyOptions := map[string]string{}
+		for _, node := range workerRTNodes {
+			numOfCores, _ := node.Status.Capacity.Cpu().AsInt64()
+			if numOfCores <= numberOfCoresThatRequiredCancelingSMTAlignment {
+				testlog.Infof("canceling SMT alignment: node %s has %d CPUs", node.Name, numOfCores)
+				policyOptions["full-pcpus-only"] = "false"
+				smtAlignmentDisabled = true
+				break
+			}
+		}
 		if !isWPEnabled {
 			testlog.Infof("Workload partitioning not enabled, adding strict-cpu-reservation via experimental annotation")
 			policyOptions["strict-cpu-reservation"] = "true"
+		}
+		if len(policyOptions) > 0 {
 			optJSON, err := json.Marshal(map[string]interface{}{"cpuManagerPolicyOptions": policyOptions})
 			Expect(err).ToNot(HaveOccurred())
 			currentProfile.Annotations["kubeletconfig.experimental"] = string(optJSON)
@@ -266,7 +280,7 @@ var _ = Describe("[performance] ovsDpdk CPUs", Ordered, Label(string(label.OvsDp
 		})
 
 		It("should preserve ovsDpdk CPU IRQ banning across GU pod lifecycle", func() {
-			verifyOvsDpdkIRQBanningAcrossGUPodLifecycle(context.TODO(), &workerRTNodes[0], profile, ovsDpdkSet)
+			verifyOvsDpdkIRQBanningAcrossGUPodLifecycle(context.TODO(), &workerRTNodes[0], profile, ovsDpdkSet, smtAlignmentDisabled)
 		})
 	})
 })
@@ -277,7 +291,8 @@ var _ = Describe("[performance] ovsDpdk CPUs default partition", Ordered, Label(
 		profile        *performancev2.PerformanceProfile
 		initialProfile *performancev2.PerformanceProfile
 
-		ovsDpdkSet cpuset.CPUSet
+		ovsDpdkSet           cpuset.CPUSet
+		smtAlignmentDisabled bool
 	)
 
 	BeforeAll(func() {
@@ -324,11 +339,22 @@ var _ = Describe("[performance] ovsDpdk CPUs default partition", Ordered, Label(
 			currentProfile.Annotations = make(map[string]string)
 		}
 
+		policyOptions := map[string]string{}
+		for _, node := range workerRTNodes {
+			numOfCores, _ := node.Status.Capacity.Cpu().AsInt64()
+			if numOfCores <= numberOfCoresThatRequiredCancelingSMTAlignment {
+				testlog.Infof("canceling SMT alignment: node %s has %d CPUs", node.Name, numOfCores)
+				policyOptions["full-pcpus-only"] = "false"
+				smtAlignmentDisabled = true
+				break
+			}
+		}
 		if !isWPEnabled {
 			testlog.Infof("Workload partitioning not enabled, adding strict-cpu-reservation via experimental annotation")
-			optJSON, err := json.Marshal(map[string]interface{}{
-				"cpuManagerPolicyOptions": map[string]string{"strict-cpu-reservation": "true"},
-			})
+			policyOptions["strict-cpu-reservation"] = "true"
+		}
+		if len(policyOptions) > 0 {
+			optJSON, err := json.Marshal(map[string]interface{}{"cpuManagerPolicyOptions": policyOptions})
 			Expect(err).ToNot(HaveOccurred())
 			currentProfile.Annotations["kubeletconfig.experimental"] = string(optJSON)
 		}
@@ -416,12 +442,13 @@ var _ = Describe("[performance] ovsDpdk CPUs default partition", Ordered, Label(
 		})
 
 		It("should preserve ovsDpdk CPU IRQ banning across GU pod lifecycle", func() {
-			verifyOvsDpdkIRQBanningAcrossGUPodLifecycle(context.TODO(), &workerRTNodes[0], profile, ovsDpdkSet)
+			verifyOvsDpdkIRQBanningAcrossGUPodLifecycle(context.TODO(), &workerRTNodes[0], profile, ovsDpdkSet, smtAlignmentDisabled)
 		})
 	})
 })
 
-func verifyOvsDpdkIRQBanningAcrossGUPodLifecycle(ctx context.Context, node *corev1.Node, profile *performancev2.PerformanceProfile, ovsDpdkSet cpuset.CPUSet) {
+func verifyOvsDpdkIRQBanningAcrossGUPodLifecycle(ctx context.Context, node *corev1.Node, profile *performancev2.PerformanceProfile, ovsDpdkSet cpuset.CPUSet, smtAlignmentDisabled bool) {
+	GinkgoHelper()
 	testlog.Infof("Testing CRI-O IRQ interaction on node %s", node.Name)
 
 	By("Verifying default_smp_affinity has ovsDpdk CPU bits cleared before pod creation")
@@ -446,9 +473,17 @@ func verifyOvsDpdkIRQBanningAcrossGUPodLifecycle(ctx context.Context, node *core
 	testpod.Annotations = map[string]string{
 		"irq-load-balancing.crio.io": "disable",
 	}
+	var resourceCPULimit resource.Quantity
+
+	if smtAlignmentDisabled {
+		resourceCPULimit = resource.MustParse("1")
+	} else {
+		resourceCPULimit = resource.MustParse("2")
+	}
+
 	testpod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceCPU:    resourceCPULimit,
 			corev1.ResourceMemory: resource.MustParse("100Mi"),
 		},
 	}


### PR DESCRIPTION
Since CI downgraded from [6 to 4 CPUs workers](https://github.com/openshift/release/pull/82852), there's insufficient amount of CPUs for GU pod in ovsDpdk tests.
At the beginning of the test we are having the following PP CPUs:
1 `reserved`
2 `isolated`
1 `ovsDpdK`

setting a GU pod consuming exactly 2 full isolated cores is too tight (because there are some additional be/burstable pods on the system).

to overcome that we're disabling smt alignment in the beginning of the test and setting the GU pod requesting for a single CPU alone.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved OVS-DPDK performance test coverage for varying worker CPU counts and SMT alignment requirements.
  * Added validation for CPU alignment, workload partitioning, and strict CPU reservation settings.
  * Expanded IRQ lifecycle testing to cover workloads requiring one or two dedicated CPUs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->