### PR TITLE
CNF-26060: add optional --ovs-dpdk-cpu-count flag (default 0)

### DIFF
--- a/pkg/performanceprofile/profilecreator/cmd/root.go
+++ b/pkg/performanceprofile/profilecreator/cmd/root.go
@@ -86,6 +86,7 @@ type ProfileData struct {
 	isolatedCPUs              string
 	reservedCPUs              string
 	offlinedCPUs              string
+	ovsDpdkCPUs               string
 	nodeSelector              *metav1.LabelSelector
 	mcpSelector               map[string]string
 	performanceProfileName    string
@@ -315,17 +316,22 @@ func makeProfileDataFrom(nodeHandler *profilecreator.GHWHandler, args *ProfileCr
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute get system information: %v", err)
 	}
-	reservedCPUs, isolatedCPUs, offlinedCPUs, err := profilecreator.CalculateCPUSets(systemInfo, args.ReservedCPUCount, args.OfflinedCPUCount, args.SplitReservedCPUsAcrossNUMA, args.DisableHT, args.PowerConsumptionMode == ultraLowLatency)
+	cpuSets, err := profilecreator.CalculateCPUSets(systemInfo, args.ReservedCPUCount, args.OfflinedCPUCount, args.OvsDpdkCPUCount, args.SplitReservedCPUsAcrossNUMA, args.DisableHT, args.PowerConsumptionMode == ultraLowLatency)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute the reserved and isolated CPUs: %v", err)
 	}
+	reservedCPUs, isolatedCPUs, offlinedCPUs, ovsDpdkCPUs := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined, cpuSets.OvsDpdk
 	Alert("%d reserved CPUs allocated: %v ", reservedCPUs.Size(), reservedCPUs.String())
 	Alert("%d isolated CPUs allocated: %v", isolatedCPUs.Size(), isolatedCPUs.String())
+	if ovsDpdkCPUs.Size() > 0 {
+		Alert("%d ovs-dpdk CPUs allocated: %v", ovsDpdkCPUs.Size(), ovsDpdkCPUs.String())
+	}
 	kernelArgs := profilecreator.GetAdditionalKernelArgs(args.DisableHT)
 	profileData := &ProfileData{
 		reservedCPUs:              reservedCPUs.String(),
 		offlinedCPUs:              offlinedCPUs.String(),
 		isolatedCPUs:              isolatedCPUs.String(),
+		ovsDpdkCPUs:               ovsDpdkCPUs.String(),
 		performanceProfileName:    args.ProfileName,
 		topologyPolicy:            args.TMPolicy,
 		rtKernel:                  args.RTKernel,
@@ -409,6 +415,7 @@ type ProfileCreatorArgs struct {
 	ProfileName                 string `json:"profile-name"`
 	ReservedCPUCount            int    `json:"reserved-cpu-count"`
 	OfflinedCPUCount            int    `json:"offlined-cpu-count"`
+	OvsDpdkCPUCount             int    `json:"ovs-dpdk-cpu-count"`
 	SplitReservedCPUsAcrossNUMA bool   `json:"split-reserved-cpus-across-numa"`
 	DisableHT                   bool   `json:"disable-ht"`
 	RTKernel                    bool   `json:"rt-kernel"`
@@ -426,6 +433,7 @@ type ProfileCreatorArgs struct {
 func (pca *ProfileCreatorArgs) AddFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&pca.ReservedCPUCount, "reserved-cpu-count", 0, "Number of reserved CPUs (required)")
 	flags.IntVar(&pca.OfflinedCPUCount, "offlined-cpu-count", 0, "Number of offlined CPUs")
+	flags.IntVar(&pca.OvsDpdkCPUCount, "ovs-dpdk-cpu-count", 0, "Number of OVS-DPDK CPUs")
 	flags.BoolVar(&pca.SplitReservedCPUsAcrossNUMA, "split-reserved-cpus-across-numa", false, "Split the Reserved CPUs across NUMA nodes")
 	flags.StringVar(&pca.MCPName, "mcp-name", "", "MCP name corresponding to the target machines (required)")
 	flags.BoolVar(&pca.DisableHT, "disable-ht", false, "Disable Hyperthreading")
@@ -472,6 +480,11 @@ func makePerformanceProfileFrom(profileData ProfileData) (runtime.Object, error)
 	if len(profileData.offlinedCPUs) > 0 {
 		offlined := performancev2.CPUSet(profileData.offlinedCPUs)
 		profile.Spec.CPU.Offlined = &offlined
+	}
+
+	if len(profileData.ovsDpdkCPUs) > 0 {
+		ovsDpdk := performancev2.CPUSet(profileData.ovsDpdkCPUs)
+		profile.Spec.CPU.OvsDpdk = &ovsDpdk
 	}
 
 	if len(profileData.additionalKernelArgs) > 0 {

--- a/pkg/performanceprofile/profilecreator/profilecreator.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator.go
@@ -105,8 +105,17 @@ type systemInfo struct {
 	HtEnabled    bool
 }
 
-// Calculates the resevered, isolated and offlined cpuSets.
-func CalculateCPUSets(systemInfo *systemInfo, reservedCPUCount int, offlinedCPUCount int, splitReservedCPUsAcrossNUMA bool, disableHTFlag bool, highPowerConsumptionMode bool) (cpuset.CPUSet, cpuset.CPUSet, cpuset.CPUSet, error) {
+// PerformanceProfileCPUSets holds the reserved, isolated, offlined and ovs-dpdk
+// cpuSets computed for a performance profile.
+type PerformanceProfileCPUSets struct {
+	Reserved cpuset.CPUSet
+	Isolated cpuset.CPUSet
+	Offlined cpuset.CPUSet
+	OvsDpdk  cpuset.CPUSet
+}
+
+// Calculates the reserved, isolated, offlined and ovs-dpdk cpuSets.
+func CalculateCPUSets(systemInfo *systemInfo, reservedCPUCount int, offlinedCPUCount int, ovsDpdkCPUCount int, splitReservedCPUsAcrossNUMA bool, disableHTFlag bool, highPowerConsumptionMode bool) (PerformanceProfileCPUSets, error) {
 	topologyInfo := systemInfo.TopologyInfo
 	htEnabled := systemInfo.HtEnabled
 
@@ -114,54 +123,127 @@ func CalculateCPUSets(systemInfo *systemInfo, reservedCPUCount int, offlinedCPUC
 	// if user want to "disable" them in the kernel
 	updatedTopologyInfo, err := updateTopologyInfo(topologyInfo, disableHTFlag, systemInfo.HtEnabled)
 	if err != nil {
-		return cpuset.CPUSet{}, cpuset.CPUSet{}, cpuset.CPUSet{}, err
+		return PerformanceProfileCPUSets{}, err
 	}
 
 	updatedExtCPUInfo, err := updateExtendedCPUInfo(systemInfo.CpuInfo, cpuset.CPUSet{}, disableHTFlag, htEnabled)
 	if err != nil {
-		return cpuset.CPUSet{}, cpuset.CPUSet{}, cpuset.CPUSet{}, err
+		return PerformanceProfileCPUSets{}, err
 	}
 
 	cpuInfo := updatedExtCPUInfo.CpuInfo
 	// Check limits are in range
 	if reservedCPUCount <= 0 || reservedCPUCount >= int(cpuInfo.TotalThreads) {
-		return cpuset.CPUSet{}, cpuset.CPUSet{}, cpuset.CPUSet{}, fmt.Errorf("please specify the reserved CPU count in the range [1,%d]", cpuInfo.TotalThreads-1)
+		return PerformanceProfileCPUSets{}, fmt.Errorf("please specify the reserved CPU count in the range [1,%d]", cpuInfo.TotalThreads-1)
 	}
 
 	if offlinedCPUCount < 0 || offlinedCPUCount >= int(cpuInfo.TotalThreads) {
-		return cpuset.CPUSet{}, cpuset.CPUSet{}, cpuset.CPUSet{}, fmt.Errorf("please specify the offlined CPU count in the range [0,%d]", cpuInfo.TotalThreads-1)
+		return PerformanceProfileCPUSets{}, fmt.Errorf("please specify the offlined CPU count in the range [0,%d]", cpuInfo.TotalThreads-1)
 	}
 
-	if reservedCPUCount+offlinedCPUCount >= int(cpuInfo.TotalThreads) {
-		return cpuset.CPUSet{}, cpuset.CPUSet{}, cpuset.CPUSet{}, fmt.Errorf("please ensure that reserved-cpu-count plus offlined-cpu-count should be in the range [0,%d]", cpuInfo.TotalThreads-1)
+	if ovsDpdkCPUCount < 0 || ovsDpdkCPUCount >= int(cpuInfo.TotalThreads) {
+		return PerformanceProfileCPUSets{}, fmt.Errorf("please specify the ovs-dpdk CPU count in the range [0,%d]", cpuInfo.TotalThreads-1)
+	}
+
+	if reservedCPUCount+offlinedCPUCount+ovsDpdkCPUCount >= int(cpuInfo.TotalThreads) {
+		return PerformanceProfileCPUSets{}, fmt.Errorf("please ensure that reserved-cpu-count, offlined-cpu-count and ovs-dpdk-cpu-count are in range [0,%d]", cpuInfo.TotalThreads-1)
 	}
 
 	// Calculate reserved cpus.
 	reserved, err := getReservedCPUs(updatedTopologyInfo, reservedCPUCount, splitReservedCPUsAcrossNUMA, disableHTFlag, htEnabled)
 	if err != nil {
-		return cpuset.CPUSet{}, cpuset.CPUSet{}, cpuset.CPUSet{}, err
+		return PerformanceProfileCPUSets{}, err
 	}
 
 	updatedExtCPUInfo, err = updateExtendedCPUInfo(updatedExtCPUInfo, reserved, disableHTFlag, htEnabled)
 	if err != nil {
-		return cpuset.CPUSet{}, cpuset.CPUSet{}, cpuset.CPUSet{}, err
+		return PerformanceProfileCPUSets{}, err
 	}
 	//Calculate offlined cpus
 	// note this takes into account the reserved cpus from the step above
 	offlined, err := getOfflinedCPUs(updatedExtCPUInfo, offlinedCPUCount, disableHTFlag, htEnabled, highPowerConsumptionMode)
 	if err != nil {
-		return cpuset.CPUSet{}, cpuset.CPUSet{}, cpuset.CPUSet{}, err
+		return PerformanceProfileCPUSets{}, err
+	}
+
+	updatedExtCPUInfo, err = updateExtendedCPUInfo(updatedExtCPUInfo, offlined, disableHTFlag, htEnabled)
+	if err != nil {
+		return PerformanceProfileCPUSets{}, err
+	}
+
+	// Calculate OVS-DPDK cpus.
+	// note this takes into account the reserved and offlined cpus from the steps above
+	ovsDpdk, err := getOvsDpdkCPUs(updatedExtCPUInfo, ovsDpdkCPUCount, disableHTFlag, htEnabled)
+	if err != nil {
+		return PerformanceProfileCPUSets{}, err
 	}
 
 	// Calculate isolated cpus.
 	// Note that topology info could have been modified by "GetReservedCPUS" so
 	// to properly calculate isolated CPUS we need to use the updated topology information.
-	isolated, err := getIsolatedCPUs(updatedTopologyInfo.Nodes, reserved, offlined)
+	isolated, err := getIsolatedCPUs(updatedTopologyInfo.Nodes, reserved.Union(ovsDpdk), offlined)
 	if err != nil {
-		return cpuset.CPUSet{}, cpuset.CPUSet{}, cpuset.CPUSet{}, err
+		return PerformanceProfileCPUSets{}, err
 	}
 
-	return reserved, isolated, offlined, nil
+	return PerformanceProfileCPUSets{
+		Reserved: reserved,
+		Isolated: isolated,
+		Offlined: offlined,
+		OvsDpdk:  ovsDpdk,
+	}, nil
+}
+
+// getOvsDpdkCPUs selects logical processors for OVS-DPDK PMD threads from cores not already
+// claimed by reserved/offlined CPUs, mirroring getReservedCPUs HT rules:
+// HT on → even count, whole sibling groups; HT off / disable-ht → any count, one LP per core.
+func getOvsDpdkCPUs(extCpuInfo *extendedCPUInfo, ovsDpdkCPUCount int, disableHTFlag bool, htEnabled bool) (cpuset.CPUSet, error) {
+	if ovsDpdkCPUCount == 0 {
+		return cpuset.CPUSet{}, nil
+	}
+
+	if htEnabled && disableHTFlag {
+		Alert("currently hyperthreading is enabled and the performance profile will disable it")
+		htEnabled = false
+	}
+
+	if htEnabled && ovsDpdkCPUCount%2 != 0 {
+		return cpuset.CPUSet{}, fmt.Errorf("can't allocate odd number of CPUs when hyperthreading is enabled")
+	}
+
+	// coreFree reports whether a core can be claimed for OVS-DPDK: it must have at least one
+	// logical processor, none of them already used, and — with HT enabled — a whole sibling
+	// group so we never split a core (same rule as getReservedCPUs).
+	coreFree := func(core *cpu.ProcessorCore) bool {
+		if len(core.LogicalProcessors) == 0 || (htEnabled && len(core.LogicalProcessors) < 2) {
+			return false
+		}
+		for _, lp := range core.LogicalProcessors {
+			if IsLogicalProcessorUsed(extCpuInfo, lp) {
+				return false
+			}
+		}
+		return true
+	}
+
+	ovsDpdk := newCPUAccumulator()
+	for _, processor := range extCpuInfo.CpuInfo.Processors {
+		free := make([]*cpu.ProcessorCore, 0, len(processor.Cores))
+		for _, core := range processor.Cores {
+			if coreFree(core) {
+				free = append(free, core)
+			}
+		}
+		if _, err := ovsDpdk.AddCores(ovsDpdkCPUCount, free); err != nil {
+			return cpuset.CPUSet{}, err
+		}
+	}
+
+	result := ovsDpdk.Result()
+	if result.Size() < ovsDpdkCPUCount {
+		return cpuset.CPUSet{}, fmt.Errorf("could not allocate %d ovs-dpdk CPUs from unused cores (allocated %d)", ovsDpdkCPUCount, result.Size())
+	}
+	return result, nil
 }
 
 // Calculates Isolated cpuSet as the difference between all the cpus in the topology and those already chosen as reserved or offlined.
@@ -247,7 +329,7 @@ func updateTopologyInfo(topoInfo *topology.Info, disableHTFlag bool, htEnabled b
 	//currently HT is enabled on the system and the user wants to disable HT
 
 	if htEnabled && disableHTFlag {
-		Alert("Updating Topology info because currently hyperthreading is enabled and the performance profile will disable it")
+		Alert("updating Topology info because currently hyperthreading is enabled and the performance profile will disable it")
 		return topologyHTDisabled(topoInfo), nil
 	}
 	return topoInfo, nil
@@ -255,7 +337,7 @@ func updateTopologyInfo(topoInfo *topology.Info, disableHTFlag bool, htEnabled b
 
 func getReservedCPUs(topologyInfo *topology.Info, reservedCPUCount int, splitReservedCPUsAcrossNUMA bool, disableHTFlag bool, htEnabled bool) (cpuset.CPUSet, error) {
 	if htEnabled && disableHTFlag {
-		Alert("Currently hyperthreading is enabled and the performance profile will disable it")
+		Alert("currently hyperthreading is enabled and the performance profile will disable it")
 		htEnabled = false
 	}
 	Alert("NUMA cell(s): %d", len(topologyInfo.Nodes))

--- a/pkg/performanceprofile/profilecreator/profilecreator_test.go
+++ b/pkg/performanceprofile/profilecreator/profilecreator_test.go
@@ -599,7 +599,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			disableHT := false
 			highPowerConsumptionMode := false
 
-			reserved, isolated, offlined, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reserved, isolated, offlined := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			klog.Infof("Input:")
@@ -617,7 +618,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			Expect(offlined.Intersection(isolated).IsEmpty()).To(BeTrue())
 			Expect(offlined.Size()).To(Equal(offlinedCPUCount))
 
-			reservedNode1, isolatedNode1, offlinedNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSetsNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedNode1, isolatedNode1, offlinedNode1 := cpuSetsNode1.Reserved, cpuSetsNode1.Isolated, cpuSetsNode1.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			By("ensure that PPC calculated same sets on another nodes but different core IDs")
@@ -645,7 +647,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			disableHT := false
 			highPowerConsumptionMode := false
 
-			reserved, isolated, offlined, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reserved, isolated, offlined := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			klog.Infof("Input:")
@@ -663,7 +666,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			Expect(offlined.Intersection(isolated).IsEmpty()).To(BeTrue())
 			Expect(offlined.Size()).To(Equal(offlinedCPUCount))
 
-			reservedNode1, isolatedNode1, offlinedNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSetsNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedNode1, isolatedNode1, offlinedNode1 := cpuSetsNode1.Reserved, cpuSetsNode1.Isolated, cpuSetsNode1.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			By("ensure that PPC calculated same sets on another nodes but different core IDs")
@@ -686,7 +690,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			disableHT := false
 			highPowerConsumptionMode := true
 
-			reserved, isolated, offlined, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reserved, isolated, offlined := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			klog.Infof("Input:")
@@ -704,7 +709,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			Expect(offlined.Intersection(isolated).IsEmpty()).To(BeTrue())
 			Expect(offlined.Size()).To(Equal(offlinedCPUCount))
 
-			reservedNode1, isolatedNode1, offlinedNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSetsNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedNode1, isolatedNode1, offlinedNode1 := cpuSetsNode1.Reserved, cpuSetsNode1.Isolated, cpuSetsNode1.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			By("ensure that PPC calculated same sets on another nodes but different core IDs")
@@ -727,7 +733,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			disableHT := false
 			highPowerConsumptionMode := false
 
-			reserved, isolated, offlined, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reserved, isolated, offlined := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			klog.Infof("Input:")
@@ -745,7 +752,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			Expect(offlined.Intersection(isolated).IsEmpty()).To(BeTrue())
 			Expect(offlined.Size()).To(Equal(offlinedCPUCount))
 
-			reservedNode1, isolatedNode1, offlinedNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSetsNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedNode1, isolatedNode1, offlinedNode1 := cpuSetsNode1.Reserved, cpuSetsNode1.Isolated, cpuSetsNode1.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			By("ensure that PPC calculated same sets on another nodes but different core IDs")
@@ -768,7 +776,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			disableHT := false
 			highPowerConsumptionMode := false
 
-			reserved, isolated, offlined, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reserved, isolated, offlined := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			klog.Infof("Input:")
@@ -786,7 +795,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			Expect(offlined.Intersection(isolated).IsEmpty()).To(BeTrue())
 			Expect(offlined.Size()).To(Equal(offlinedCPUCount))
 
-			reservedNode1, isolatedNode1, offlinedNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSetsNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedNode1, isolatedNode1, offlinedNode1 := cpuSetsNode1.Reserved, cpuSetsNode1.Isolated, cpuSetsNode1.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			By("ensure that PPC calculated same sets on another nodes but different core IDs")
@@ -809,7 +819,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			disableHT := true
 			highPowerConsumptionMode := false
 
-			reserved, isolated, offlined, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(&sysInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reserved, isolated, offlined := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			klog.Infof("Input:")
@@ -827,7 +838,8 @@ var _ = Describe("Performance profile creator: test with a simple cpu architectu
 			Expect(offlined.Intersection(isolated).IsEmpty()).To(BeTrue())
 			Expect(offlined.Size()).To(Equal(offlinedCPUCount))
 
-			reservedNode1, isolatedNode1, offlinedNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSetsNode1, err := CalculateCPUSets(&sysInfoNode1, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedNode1, isolatedNode1, offlinedNode1 := cpuSetsNode1.Reserved, cpuSetsNode1.Isolated, cpuSetsNode1.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			By("ensure that PPC calculated same sets on another nodes but different core IDs")
@@ -875,7 +887,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reservedCPUSet.String()).To(Equal("0,2,4,6,8,10,12,14,16,18,40,42,44,46,48,50,52,54,56,58"))
 			Expect(isolatedCPUSet.String()).To(Equal("1,3,5,7,9,11,13,15,17,19-39,41,43,45,47,49,51,53,55,57,59-79"))
@@ -898,7 +911,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reservedCPUSet.String()).To(Equal("0-9,40-49"))
 			Expect(isolatedCPUSet.String()).To(Equal("10-39,50-79"))
@@ -921,7 +935,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
 			Expect(err).To(HaveOccurred())
 		})
 		It("Errors out in case specified reservedCPUCount is greater than the total CPUs present in the system and disableHT is disabled", func() {
@@ -935,7 +949,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
 			Expect(err).To(HaveOccurred())
 		})
 		It("Errors out in case hyperthreading is enabled, splitReservedCPUsAcrossNUMA is enabled, disableHT is disabled and number of reserved CPUs per number of NUMA nodes are odd", func() {
@@ -949,7 +963,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
 			Expect(err).To(HaveOccurred())
 		})
 		It("Errors out in case hyperthreading is enabled, splitReservedCPUsAcrossNUMA is disabled,, disableHT is disabled and number of reserved CPUs are odd", func() {
@@ -963,7 +977,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
 			Expect(err).To(HaveOccurred())
 		})
 		It("Ensure reserved CPUs populated are correctly when splitReservedCPUsAcrossNUMA is disabled, disableHT is enabled", func() {
@@ -977,7 +991,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reservedCPUSet.String()).To(Equal("0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38"))
 			Expect(isolatedCPUSet.String()).To(Equal("1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39"))
@@ -994,7 +1009,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reservedCPUSet.String()).To(Equal("0-19"))
 			Expect(isolatedCPUSet.String()).To(Equal("20-39"))
@@ -1011,7 +1027,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Do not error out in case hyperthreading is currently enabled, splitReservedCPUsAcrossNUMA is enabled, disableHT is enabled and number of reserved CPUs allocated from a NUMA node are odd", func() {
@@ -1025,7 +1041,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Do not error out in case of a system where hyperthreading is not enabled initially, splitReservedCPUsAcrossNUMA is disabled, disableHT is enabled and number of reserved CPUs allocated are odd", func() {
@@ -1040,7 +1056,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -1058,7 +1074,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("please specify the offlined CPU count in the range"))
 		})
@@ -1075,7 +1091,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("please specify the offlined CPU count in the range"))
 		})
@@ -1093,9 +1109,9 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("please ensure that reserved-cpu-count plus offlined-cpu-count should be in the range"))
+			Expect(err.Error()).To(ContainSubstring("please ensure that reserved-cpu-count, offlined-cpu-count and ovs-dpdk-cpu-count are in range"))
 		})
 		It("with disable-ht true siblings does NOT count: Errors out in case offlinedCPUCount plus reservedCPUCount specified is greater than the number of CPUs", func() {
 			reservedCPUCount = 20
@@ -1108,9 +1124,9 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("please ensure that reserved-cpu-count plus offlined-cpu-count should be in the range"))
+			Expect(err.Error()).To(ContainSubstring("please ensure that reserved-cpu-count, offlined-cpu-count and ovs-dpdk-cpu-count are in range"))
 		})
 		It("with disable-ht true siblings does NOT count: Errors out in case offlinedCPUCount specified is greater than the number of CPUs in system", func() {
 			reservedCPUCount = 10
@@ -1124,7 +1140,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("please specify the offlined CPU count in the range"))
 		})
@@ -1142,7 +1158,7 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			_, _, _, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			_, err = CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("when splitReservedCPUsAcrossNUMA is disabled, disableHT is disabled and offlined-cpu-count is greater than number of cpus per socket then offline a complete socket", func() {
@@ -1158,7 +1174,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(offlinedCPUSet.Intersection(reservedCPUSet).IsEmpty()).To(BeTrue())
@@ -1198,7 +1215,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(offlinedCPUSet.Intersection(reservedCPUSet).IsEmpty()).To(BeTrue())
@@ -1234,7 +1252,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(offlinedCPUSet.Intersection(reservedCPUSet).IsEmpty()).To(BeTrue())
@@ -1270,7 +1289,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(offlinedCPUSet.Intersection(reservedCPUSet).IsEmpty()).To(BeTrue())
@@ -1306,7 +1326,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(offlinedCPUSet.Intersection(reservedCPUSet).IsEmpty()).To(BeTrue())
@@ -1341,7 +1362,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, highPowerConsumptionMode)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(offlinedCPUSet.Intersection(reservedCPUSet).IsEmpty()).To(BeTrue())
@@ -1371,7 +1393,8 @@ var _ = Describe("PerformanceProfileCreator: Populating Reserved and Isolated CP
 			Expect(err).ToNot(HaveOccurred())
 			systemInfo, err := handle.GatherSystemInfo()
 			Expect(err).ToNot(HaveOccurred())
-			reservedCPUSet, isolatedCPUSet, offlinedCPUSet, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, splitReservedCPUsAcrossNUMA, disableHT, false)
+			cpuSets, err := CalculateCPUSets(systemInfo, reservedCPUCount, offlinedCPUCount, 0, splitReservedCPUsAcrossNUMA, disableHT, false)
+			reservedCPUSet, isolatedCPUSet, offlinedCPUSet := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(offlinedCPUSet.Intersection(reservedCPUSet).IsEmpty()).To(BeTrue())
@@ -2007,6 +2030,120 @@ func GetTotalCPUSetFromGHW(handler *GHWHandler, disableHT bool) (cpuset.CPUSet, 
 	}
 	return totalCPUSet, nil
 }
+
+var _ = Describe("PerformanceProfileCreator: OVS-DPDK CPU allocation", func() {
+	var sysInfo *systemInfo
+
+	BeforeEach(func() {
+		core0 := &cpu.ProcessorCore{ID: 0, NumThreads: 2, LogicalProcessors: []int{0, 8}}
+		core1 := &cpu.ProcessorCore{ID: 1, NumThreads: 2, LogicalProcessors: []int{1, 9}}
+		core2 := &cpu.ProcessorCore{ID: 2, NumThreads: 2, LogicalProcessors: []int{2, 10}}
+		core3 := &cpu.ProcessorCore{ID: 3, NumThreads: 2, LogicalProcessors: []int{3, 11}}
+		processor := &cpu.Processor{
+			ID:         0,
+			NumCores:   4,
+			NumThreads: 8,
+			Cores:      []*cpu.ProcessorCore{core0, core1, core2, core3},
+		}
+		cpuInfo := &cpu.Info{
+			TotalCores:   4,
+			TotalThreads: 8,
+			Processors:   []*cpu.Processor{processor},
+		}
+		sysInfo = &systemInfo{
+			HtEnabled: true,
+			CpuInfo: &extendedCPUInfo{
+				CpuInfo:                  cpuInfo,
+				NumLogicalProcessorsUsed: make(map[int]int),
+				LogicalProcessorsUsed:    make(map[int]struct{}),
+			},
+			TopologyInfo: &topology.Info{
+				Nodes: []*topology.Node{{
+					ID:    0,
+					Cores: []*cpu.ProcessorCore{core0, core1, core2, core3},
+				}},
+			},
+		}
+	})
+
+	It("allocates whole hyperthread sibling pairs for an even ovs-dpdk-cpu-count", func() {
+		cpuSets, err := CalculateCPUSets(sysInfo, 2, 0, 2, false, false, false)
+		reserved, isolated, offlined, ovsDpdk := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined, cpuSets.OvsDpdk
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ovsDpdk.Size()).To(Equal(2))
+		Expect(getSiblingsListForCPUSet(*sysInfo, ovsDpdk)).To(Equal(ovsDpdk))
+		Expect(ovsDpdk.Intersection(reserved).IsEmpty()).To(BeTrue())
+		Expect(ovsDpdk.Intersection(offlined).IsEmpty()).To(BeTrue())
+		Expect(ovsDpdk.Intersection(isolated).IsEmpty()).To(BeTrue())
+		Expect(reserved.Union(isolated).Union(offlined).Union(ovsDpdk).Size()).To(Equal(8))
+	})
+
+	It("rejects an odd ovs-dpdk-cpu-count when hyperthreading is enabled", func() {
+		_, err := CalculateCPUSets(sysInfo, 2, 0, 1, false, false, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("can't allocate odd number of CPUs when hyperthreading is enabled"))
+	})
+
+	It("allocates single cores (odd count allowed) when disable-ht is set", func() {
+		cpuSets, err := CalculateCPUSets(sysInfo, 2, 0, 1, false, true, false)
+		reserved, isolated, offlined, ovsDpdk := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined, cpuSets.OvsDpdk
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ovsDpdk.Size()).To(Equal(1))
+		Expect(ovsDpdk.Intersection(reserved).IsEmpty()).To(BeTrue())
+		Expect(ovsDpdk.Intersection(offlined).IsEmpty()).To(BeTrue())
+		Expect(ovsDpdk.Intersection(isolated).IsEmpty()).To(BeTrue())
+	})
+
+	It("allows odd and even ovs-dpdk-cpu-count when hyperthreading is already disabled", func() {
+		sysInfo.HtEnabled = false
+		for _, core := range sysInfo.TopologyInfo.Nodes[0].Cores {
+			core.NumThreads = 1
+			core.LogicalProcessors = core.LogicalProcessors[:1]
+		}
+		sysInfo.CpuInfo.CpuInfo.TotalThreads = 4
+		sysInfo.CpuInfo.CpuInfo.Processors[0].NumThreads = 4
+		for _, core := range sysInfo.CpuInfo.CpuInfo.Processors[0].Cores {
+			core.NumThreads = 1
+			core.LogicalProcessors = core.LogicalProcessors[:1]
+		}
+
+		cpuSetsOdd, err := CalculateCPUSets(sysInfo, 1, 0, 1, false, false, false)
+		ovsOdd := cpuSetsOdd.OvsDpdk
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ovsOdd.Size()).To(Equal(1))
+
+		cpuSetsEven, err := CalculateCPUSets(sysInfo, 1, 0, 2, false, false, false)
+		ovsEven := cpuSetsEven.OvsDpdk
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ovsEven.Size()).To(Equal(2))
+	})
+
+	It("returns an empty ovs-dpdk set when ovs-dpdk-cpu-count is zero", func() {
+		cpuSets, err := CalculateCPUSets(sysInfo, 2, 0, 0, false, false, false)
+		reserved, isolated, offlined, ovsDpdk := cpuSets.Reserved, cpuSets.Isolated, cpuSets.Offlined, cpuSets.OvsDpdk
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ovsDpdk.IsEmpty()).To(BeTrue())
+		Expect(reserved.Union(isolated).Union(offlined).Size()).To(Equal(8))
+	})
+
+	It("rejects a negative ovs-dpdk-cpu-count", func() {
+		_, err := CalculateCPUSets(sysInfo, 2, 0, -1, false, false, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("please specify the ovs-dpdk CPU count in the range [0,7]"))
+	})
+
+	It("rejects an ovs-dpdk-cpu-count that is not smaller than the total number of CPUs", func() {
+		_, err := CalculateCPUSets(sysInfo, 2, 0, 8, false, false, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("please specify the ovs-dpdk CPU count in the range [0,7]"))
+	})
+
+	It("rejects reserved plus offlined plus ovs-dpdk that leaves no isolated CPUs", func() {
+		_, err := CalculateCPUSets(sysInfo, 4, 2, 2, false, false, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("reserved-cpu-count, offlined-cpu-count and ovs-dpdk-cpu-count"))
+	})
+})
 
 func getSiblingsListForCPUSet(sysinfo systemInfo, cpus cpuset.CPUSet) cpuset.CPUSet {
 	cpuInfo := sysinfo.CpuInfo.CpuInfo

--- a/test/e2e/performanceprofile/functests-performance-profile-creator/1_performance-profile_creator/ppc.go
+++ b/test/e2e/performanceprofile/functests-performance-profile-creator/1_performance-profile_creator/ppc.go
@@ -78,6 +78,9 @@ var _ = Describe("[rfe_id:OCP-38968][ppc] Performance Profile Creator", func() {
 			if args.OfflinedCPUCount > 0 {
 				cmdArgs = append(cmdArgs, fmt.Sprintf("--offlined-cpu-count=%d", args.OfflinedCPUCount))
 			}
+			if args.OvsDpdkCPUCount > 0 {
+				cmdArgs = append(cmdArgs, fmt.Sprintf("--ovs-dpdk-cpu-count=%d", args.OvsDpdkCPUCount))
+			}
 
 			out, err := testutils.ExecAndLogCommand(ppcPath, cmdArgs...)
 			Expect(err).To(BeNil(), "failed to run ppc for '%s': %v", expectedProfilePath, err)
@@ -209,7 +212,7 @@ var _ = Describe("[rfe_id:OCP-38968][ppc] Performance Profile Creator", func() {
 		cmdArgs := append(defaultArgs, ppcArgs...)
 		_, errData, _ := testutils.ExecAndLogCommandWithStderr(ppcPath, cmdArgs...)
 		ppcErrorString := errorStringParser(errData)
-		Expect(ppcErrorString).To(ContainSubstring("failed to compute the reserved and isolated CPUs: please ensure that reserved-cpu-count plus offlined-cpu-count should be in the range"))
+		Expect(ppcErrorString).To(ContainSubstring("failed to compute the reserved and isolated CPUs: please ensure that reserved-cpu-count, offlined-cpu-count and ovs-dpdk-cpu-count are in range"))
 	})
 
 	Context("Systems with Hyperthreading disabled", func() {

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2c.json
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2c.json
@@ -1,0 +1,9 @@
+{
+  "must-gather-dir-path": "must-gather.sno",
+  "mcp-name": "master",
+  "reserved-cpu-count": 1,
+  "ovs-dpdk-cpu-count": 2,
+  "rt-kernel": false,
+  "user-level-networking": false,
+  "power-consumption-mode": "default"
+}

--- a/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2c.yaml
+++ b/test/e2e/performanceprofile/testdata/ppc-expected-profiles/profile2c.yaml
@@ -1,0 +1,24 @@
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: 3-11
+    ovsDpdk: 1-2
+    reserved: 0
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/master: ""
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: false
+  workloadHints:
+    highPowerConsumption: false
+    perPodPowerManagement: false
+    realTime: false
+


### PR DESCRIPTION
Add a new performance-profile-creator flag, --ovs-dpdk-cpu-count, that
reserves a dedicated set of CPUs for OVS-DPDK PMD threads and populates
spec.cpu.ovsDpdk on the generated PerformanceProfile. It defaults to 0,
leaving existing behavior unchanged.
CalculateCPUSets now also returns the OVS-DPDK cpuset. Selection happens
 after reserved and offlined CPUs are chosen, drawing only from cores not
 already claimed, and the resulting CPUs are excluded from the isolated
 set. Allocation mirrors the reserved-CPU hyperthreading rules: with HT
 enabled it takes whole sibling groups and requires an even count; with
 HT off (or --disable-ht) it takes one logical processor per core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for assigning CPUs to OVS-DPDK when creating performance profiles.
  * Added a command-line option to configure the OVS-DPDK CPU count.
  * OVS-DPDK CPU assignments are included in generated performance profiles when configured.

* **Bug Fixes**
  * Added validation for CPU capacity, allocation limits, hyperthreading, and invalid OVS-DPDK counts.
  * Improved CPU allocation to preserve isolated CPUs and select suitable whole cores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->