### PR TITLE
OCPBUGS-66217: PerformanceProfile and Tuned CRDs during bootstrap

### DIFF
--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/bootstrap-required: "true"
     service.beta.openshift.io/inject-cabundle: "true"
   name: performanceprofiles.performance.openshift.io
 spec:

--- a/manifests/20-tuned.crd.yaml
+++ b/manifests/20-tuned.crd.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: tuneds.tuned.openshift.io
 spec:
   group: tuned.openshift.io


### PR DESCRIPTION
Make sure both the main NTO CRDs are deployed early on bootstrap so day 0 rendering can rely on those two CRDs being available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated performance and node-tuning resource definitions to support required initialization during system setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->