### PR TITLE
OCPBUGS-112336:apis: add missing fields to apis v1

### DIFF
--- a/docs/performanceprofile/performance_profile.md
+++ b/docs/performanceprofile/performance_profile.md
@@ -3,7 +3,7 @@
 
 This document documents the PerformanceProfile API introduced by the Performance controller.
 
-> This document is generated from code comments on the `PerformanceProfile` struct.  
+> This document is generated from code comments on the `PerformanceProfile` struct.
 > When contributing a change to this document please do so by changing those code comments.
 
 ## Table of Contents

--- a/manifests/20-performance-profile.crd.yaml
+++ b/manifests/20-performance-profile.crd.yaml
@@ -95,8 +95,21 @@ spec:
                     offlined:
                       description: Offline defines a set of CPUs that will be unused and set offline
                       type: string
+                    ovsDpdk:
+                      description: |-
+                        OvsDpdk defines a set of CPUs dedicated for OVS-DPDK PMD (Poll Mode Driver)
+                        threads, fully isolated from the operating system and Kubernetes scheduling.
+                        WorkloadPartitioning or --strict-cpu-reservation kubelet CPUManager policy
+                        option is a prerequisite for this feature.
+                      type: string
                     reserved:
                       description: Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet.
+                      type: string
+                    shared:
+                      description: |-
+                        Shared defines a set of CPUs that will be shared among guaranteed workloads
+                        that needs additional cpus which are not exclusive,
+                        alongside the isolated, exclusive resources that are being used already by those workloads.
                       type: string
                 globallyDisableIrqLoadBalancing:
                   description: |-
@@ -153,6 +166,10 @@ spec:
                           size:
                             description: Size defines huge page size, maps to the 'hugepagesz' kernel boot parameter.
                             type: string
+                kernelPageSize:
+                  description: KernelPageSize defines the kernel page size. 4k is the default, 64k is only supported on aarch64
+                  type: string
+                  default: 4k
                 machineConfigLabel:
                   description: |-
                     MachineConfigLabel defines the label to add to the MachineConfigs the operator creates. It has to be
@@ -234,10 +251,15 @@ spec:
                         HighPowerConsumption defines if the node should be configured in high power consumption mode.
                         The flag will affect the power consumption but will improve the CPUs latency.
                       type: boolean
+                    mixedCpus:
+                      description: |-
+                        MixedCpus enables the mixed-cpu-node-plugin on the node.
+                        Defaults to false.
+                      type: boolean
                     perPodPowerManagement:
                       description: |-
                         PerPodPowerManagement defines if the node should be configured in per pod power management.
-                        PerPodPowerManagement and HighPowerConsumption hints can not be enabled together.
+                        PerPodPowerManagement and HighPowerConsumption hints can not be enabled together. Defaults to false.
                       type: boolean
                     realTime:
                       description: RealTime defines if the node should be configured for the real time workload. Defaults to true.
@@ -509,13 +531,6 @@ spec:
                         offloads the complexity of cpu load balancing to the application.
                         Defaults to "true"
                       type: boolean
-                    ovsDpdk:
-                      description: |-
-                        OvsDpdk defines a set of CPUs reserved for OVS-DPDK PMD (Poll Mode Driver)
-                        threads, fully isolated from the operating system and Kubernetes scheduling.
-                        WorkloadPartitioning or --strict-cpu-reservation kubelet CPUManager policy
-                        option are a prerequisite for this feature.
-                      type: string
                     isolated:
                       description: |-
                         Isolated defines a set of CPUs that will be used to give to application threads the most execution time possible,
@@ -527,6 +542,13 @@ spec:
                       type: string
                     offlined:
                       description: Offline defines a set of CPUs that will be unused and set offline
+                      type: string
+                    ovsDpdk:
+                      description: |-
+                        OvsDpdk defines a set of CPUs dedicated for OVS-DPDK PMD (Poll Mode Driver)
+                        threads, fully isolated from the operating system and Kubernetes scheduling.
+                        WorkloadPartitioning or --strict-cpu-reservation kubelet CPUManager policy
+                        option is a prerequisite for this feature.
                       type: string
                     reserved:
                       description: Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet.

--- a/pkg/apis/performanceprofile/v1/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v1/performanceprofile_types.go
@@ -61,6 +61,10 @@ type PerformanceProfileSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector"`
 	// RealTimeKernel defines a set of real time kernel related parameters. RT kernel won't be installed when not set.
 	RealTimeKernel *RealTimeKernel `json:"realTimeKernel,omitempty"`
+	// KernelPageSize defines the kernel page size. 4k is the default, 64k is only supported on aarch64
+	// +default="4k"
+	// +optional
+	KernelPageSize *KernelPageSize `json:"kernelPageSize,omitempty"`
 	// Additional kernel arguments.
 	// +optional
 	AdditionalKernelArgs []string `json:"additionalKernelArgs,omitempty"`
@@ -109,6 +113,17 @@ type CPU struct {
 	// Offline defines a set of CPUs that will be unused and set offline
 	// +optional
 	Offlined *CPUSet `json:"offlined,omitempty"`
+	// Shared defines a set of CPUs that will be shared among guaranteed workloads
+	// that needs additional cpus which are not exclusive,
+	// alongside the isolated, exclusive resources that are being used already by those workloads.
+	// +optional
+	Shared *CPUSet `json:"shared,omitempty"`
+	// OvsDpdk defines a set of CPUs dedicated for OVS-DPDK PMD (Poll Mode Driver)
+	// threads, fully isolated from the operating system and Kubernetes scheduling.
+	// WorkloadPartitioning or --strict-cpu-reservation kubelet CPUManager policy
+	// option is a prerequisite for this feature.
+	// +optional
+	OvsDpdk *CPUSet `json:"ovsDpdk,omitempty"`
 }
 
 // CPUfrequency defines cpu frequencies for isolated and reserved cpus
@@ -121,6 +136,12 @@ type HardwareTuning struct {
 	// ReservedCpuFreq defines a maximum frequency to be set across reserved cpus
 	ReservedCpuFreq *CPUfrequency `json:"reservedCpuFreq,omitempty"`
 }
+
+// KernelPageSize defines the size of the kernel pages.
+// The allowed values for this depend on CPU architecture
+// For x86/amd64, the only valid value is 4k.
+// For aarch64, the valid values are 4k, 64k.
+type KernelPageSize string
 
 // HugePageSize defines size of huge pages, can be 2M or 1G.
 type HugePageSize string
@@ -195,8 +216,12 @@ type WorkloadHints struct {
 	RealTime *bool `json:"realTime,omitempty"`
 	// +optional
 	// PerPodPowerManagement defines if the node should be configured in per pod power management.
-	// PerPodPowerManagement and HighPowerConsumption hints can not be enabled together.
+	// PerPodPowerManagement and HighPowerConsumption hints can not be enabled together. Defaults to false.
 	PerPodPowerManagement *bool `json:"perPodPowerManagement,omitempty"`
+	// +optional
+	// MixedCpus enables the mixed-cpu-node-plugin on the node.
+	// Defaults to false.
+	MixedCpus *bool `json:"mixedCpus,omitempty"`
 }
 
 // PerformanceProfileStatus defines the observed state of PerformanceProfile.

--- a/pkg/apis/performanceprofile/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/performanceprofile/v1/zz_generated.deepcopy.go
@@ -48,6 +48,16 @@ func (in *CPU) DeepCopyInto(out *CPU) {
 		*out = new(CPUSet)
 		**out = **in
 	}
+	if in.Shared != nil {
+		in, out := &in.Shared, &out.Shared
+		*out = new(CPUSet)
+		**out = **in
+	}
+	if in.OvsDpdk != nil {
+		in, out := &in.OvsDpdk, &out.OvsDpdk
+		*out = new(CPUSet)
+		**out = **in
+	}
 	return
 }
 
@@ -321,6 +331,11 @@ func (in *PerformanceProfileSpec) DeepCopyInto(out *PerformanceProfileSpec) {
 		*out = new(RealTimeKernel)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.KernelPageSize != nil {
+		in, out := &in.KernelPageSize, &out.KernelPageSize
+		*out = new(KernelPageSize)
+		**out = **in
+	}
 	if in.AdditionalKernelArgs != nil {
 		in, out := &in.AdditionalKernelArgs, &out.AdditionalKernelArgs
 		*out = make([]string, len(*in))
@@ -428,6 +443,11 @@ func (in *WorkloadHints) DeepCopyInto(out *WorkloadHints) {
 	}
 	if in.PerPodPowerManagement != nil {
 		in, out := &in.PerPodPowerManagement, &out.PerPodPowerManagement
+		*out = new(bool)
+		**out = **in
+	}
+	if in.MixedCpus != nil {
+		in, out := &in.MixedCpus, &out.MixedCpus
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/performanceprofile/v2/performanceprofile_conversion.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_conversion.go
@@ -31,6 +31,14 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		if curr.Spec.CPU.BalanceIsolated != nil {
 			dst.Spec.CPU.BalanceIsolated = ptr.To(*curr.Spec.CPU.BalanceIsolated)
 		}
+		if curr.Spec.CPU.Shared != nil {
+			shared := v1.CPUSet(*curr.Spec.CPU.Shared)
+			dst.Spec.CPU.Shared = &shared
+		}
+		if curr.Spec.CPU.OvsDpdk != nil {
+			ovsDpdk := v1.CPUSet(*curr.Spec.CPU.OvsDpdk)
+			dst.Spec.CPU.OvsDpdk = &ovsDpdk
+		}
 	}
 
 	if curr.Spec.HardwareTuning != nil {
@@ -95,6 +103,11 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		}
 	}
 
+	if curr.Spec.KernelPageSize != nil {
+		kernelPageSize := v1.KernelPageSize(*curr.Spec.KernelPageSize)
+		dst.Spec.KernelPageSize = &kernelPageSize
+	}
+
 	if curr.Spec.AdditionalKernelArgs != nil {
 		dst.Spec.AdditionalKernelArgs = make([]string, len(curr.Spec.AdditionalKernelArgs))
 		copy(dst.Spec.AdditionalKernelArgs, curr.Spec.AdditionalKernelArgs)
@@ -143,6 +156,13 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.GloballyDisableIrqLoadBalancing = ptr.To(*curr.Spec.GloballyDisableIrqLoadBalancing)
 	}
 
+	if curr.Spec.WorkloadHints != nil {
+		dst.Spec.WorkloadHints = new(v1.WorkloadHints)
+		if curr.Spec.WorkloadHints.MixedCpus != nil {
+			dst.Spec.WorkloadHints.MixedCpus = ptr.To(*curr.Spec.WorkloadHints.MixedCpus)
+		}
+	}
+
 	// Status
 	if curr.Status.Conditions != nil {
 		dst.Status.Conditions = make([]conditionsv1.Condition, len(curr.Status.Conditions))
@@ -182,6 +202,14 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		}
 		if src.Spec.CPU.BalanceIsolated != nil {
 			curr.Spec.CPU.BalanceIsolated = ptr.To(*src.Spec.CPU.BalanceIsolated)
+		}
+		if src.Spec.CPU.Shared != nil {
+			shared := CPUSet(*src.Spec.CPU.Shared)
+			curr.Spec.CPU.Shared = &shared
+		}
+		if src.Spec.CPU.OvsDpdk != nil {
+			ovsDpdk := CPUSet(*src.Spec.CPU.OvsDpdk)
+			curr.Spec.CPU.OvsDpdk = &ovsDpdk
 		}
 	}
 
@@ -235,6 +263,11 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		}
 	}
 
+	if src.Spec.KernelPageSize != nil {
+		kernelPageSize := KernelPageSize(*src.Spec.KernelPageSize)
+		curr.Spec.KernelPageSize = &kernelPageSize
+	}
+
 	if src.Spec.AdditionalKernelArgs != nil {
 		curr.Spec.AdditionalKernelArgs = make([]string, len(src.Spec.AdditionalKernelArgs))
 		copy(curr.Spec.AdditionalKernelArgs, src.Spec.AdditionalKernelArgs)
@@ -283,6 +316,13 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		curr.Spec.GloballyDisableIrqLoadBalancing = ptr.To(*src.Spec.GloballyDisableIrqLoadBalancing)
 	} else { // set to true by default
 		curr.Spec.GloballyDisableIrqLoadBalancing = ptr.To(true)
+	}
+
+	if src.Spec.WorkloadHints != nil {
+		curr.Spec.WorkloadHints = new(WorkloadHints)
+		if src.Spec.WorkloadHints.MixedCpus != nil {
+			curr.Spec.WorkloadHints.MixedCpus = ptr.To(*src.Spec.WorkloadHints.MixedCpus)
+		}
 	}
 
 	// Status

--- a/pkg/apis/performanceprofile/v2/performanceprofile_conversion_test.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_conversion_test.go
@@ -1,0 +1,54 @@
+package v2
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("PerformanceProfile conversion", func() {
+	It("should preserve newly added v1 fields through a v2 -> v1 -> v2 round trip", func() {
+		shared := CPUSet("8-9")
+		ovsDpdk := CPUSet("10-11")
+		kernelPageSize := KernelPageSize("4k")
+
+		src := &PerformanceProfile{}
+		src.Spec.CPU = &CPU{
+			Reserved: ptr.To(ReservedCPUs),
+			Isolated: ptr.To(IsolatedCPUs),
+			Shared:   &shared,
+			OvsDpdk:  &ovsDpdk,
+		}
+		src.Spec.KernelPageSize = &kernelPageSize
+		src.Spec.WorkloadHints = &WorkloadHints{
+			MixedCpus: ptr.To(true),
+		}
+
+		hub := &v1.PerformanceProfile{}
+		Expect(src.ConvertTo(hub)).To(Succeed())
+
+		Expect(hub.Spec.CPU.Shared).NotTo(BeNil())
+		Expect(*hub.Spec.CPU.Shared).To(Equal(v1.CPUSet(shared)))
+		Expect(hub.Spec.CPU.OvsDpdk).NotTo(BeNil())
+		Expect(*hub.Spec.CPU.OvsDpdk).To(Equal(v1.CPUSet(ovsDpdk)))
+		Expect(hub.Spec.KernelPageSize).NotTo(BeNil())
+		Expect(*hub.Spec.KernelPageSize).To(Equal(v1.KernelPageSize(kernelPageSize)))
+		Expect(hub.Spec.WorkloadHints).NotTo(BeNil())
+		Expect(hub.Spec.WorkloadHints.MixedCpus).NotTo(BeNil())
+		Expect(*hub.Spec.WorkloadHints.MixedCpus).To(BeTrue())
+
+		dst := &PerformanceProfile{}
+		Expect(dst.ConvertFrom(hub)).To(Succeed())
+
+		Expect(dst.Spec.CPU.Shared).NotTo(BeNil())
+		Expect(*dst.Spec.CPU.Shared).To(Equal(shared))
+		Expect(dst.Spec.CPU.OvsDpdk).NotTo(BeNil())
+		Expect(*dst.Spec.CPU.OvsDpdk).To(Equal(ovsDpdk))
+		Expect(dst.Spec.KernelPageSize).NotTo(BeNil())
+		Expect(*dst.Spec.KernelPageSize).To(Equal(kernelPageSize))
+		Expect(dst.Spec.WorkloadHints).NotTo(BeNil())
+		Expect(dst.Spec.WorkloadHints.MixedCpus).NotTo(BeNil())
+		Expect(*dst.Spec.WorkloadHints.MixedCpus).To(BeTrue())
+	})
+})


### PR DESCRIPTION
PerformanceProfile API should support a full v1 <-> v2 support without data loss.

The fact we're having missing fields on v1 means that a conversion from v2 to v1 will result in missing data.

Adding those fields in order to fulfill the gap:
Fields in v2 but missing from v1:

  1. Shared *CPUSet 
  2. OvsDpdk *CPUSet 
  3. KernelPageSize *KernelPageSize 
  4. MixedCpus *bool 

The added fields has the exact same defaults behaviors, types, default values, and all of them are optional, so they'll be fully backward-compatible.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for kernel page size, defaulting to 4 KiB.
  * Added support for shared CPUs and CPUs dedicated to OVS-DPDK processing.
  * Added workload hints for mixed CPU allocation.
* **Compatibility**
  * Preserved new CPU, kernel page size, and workload hint settings when converting between profile versions.
* **Documentation**
  * Clarified that per-pod power management is disabled by default.
  * Updated generated documentation formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->