### PR TITLE
OCPBUGS-113651: Disable timer.migration on RHCOS 10

### DIFF
--- a/assets/performanceprofile/tuned/openshift-node-performance
+++ b/assets/performanceprofile/tuned/openshift-node-performance
@@ -122,14 +122,27 @@ vm.swappiness=10
 #> rps configuration
 # net.core.rps_default_mask=${not_isolated_cpumask}
 
-# cpu-partitioning for RHEL disables it (= 0)
-# OCP is too dynamic when partitioning and needs to evacuate
+[sysctl.timer-migration]
+type=sysctl
+# Match uname with kernel versions containing
+# .el9.x86_64 or .el9_<number>, but not .el91
+uname_regex=\.el9[ _.]
+# cpu-partitioning for RHEL disables timer.migration (= 0),
+# but OCP is too dynamic when partitioning and needs to evacuate
 # scheduled timers when starting a guaranteed workload (= 1)
+# 
 # This has an unfortunate side-effect that HRTIMERs break
 # and cyclictest results will be affected, but there is no
 # way around that. Not enabling this breaks cpu pinned
 # workload isolation for example when any TCP timeout
 # and keep alive timers are present.
+#
+# This is only needed for RHEL 9 based platforms.
+# RHEL 10 kernels reworked the timer management and are
+# no longer affected by this issue.
+#
+# This whole block can be removed when the RHEL 9
+# support is dropped.
 kernel.timer_migration=1
 
 [selinux]

--- a/test/e2e/performanceprofile/functests/1_performance/performance.go
+++ b/test/e2e/performanceprofile/functests/1_performance/performance.go
@@ -400,7 +400,14 @@ var _ = Describe("[rfe_id:27368][performance]", Ordered, func() {
 				"kernel.nmi_watchdog":           "0",
 				"kernel.sched_rt_runtime_us":    "-1",
 				"vm.stat_interval":              "10",
-				"kernel.timer_migration":        "1",
+			}
+			// On RHEL 9 the profile forces timer_migration=1 for workload isolation.
+			// On RHEL 10 the kernel handles this correctly on its own, so the override
+			// is skipped and the default (0, from the network-latency parent) is expected.
+			if len(workerRTNodes) > 0 && strings.Contains(workerRTNodes[0].Status.NodeInfo.KernelVersion, ".el9") {
+				sysctlMap["kernel.timer_migration"] = "1"
+			} else {
+				sysctlMap["kernel.timer_migration"] = "0"
 			}
 
 			key := types.NamespacedName{

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-master_tuned.yaml
@@ -49,16 +49,21 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
-      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
-      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
-      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n[sysctl.timer-migration]\ntype=sysctl\n#
+      Match uname with kernel versions containing\n# .el9.x86_64 or .el9_<number>,
+      but not .el91\nuname_regex=\\.el9[ _.]\n# cpu-partitioning for RHEL disables
+      timer.migration (= 0),\n# but OCP is too dynamic when partitioning and needs
+      to evacuate\n# scheduled timers when starting a guaranteed workload (= 1)\n#
+      \n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
       results will be affected, but there is no\n# way around that. Not enabling this
       breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
-      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
-      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
-      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      and keep alive timers are present.\n#\n# This is only needed for RHEL 9 based
+      platforms.\n# RHEL 10 kernels reworked the timer management and are\n# no longer
+      affected by this issue.\n#\n# This whole block can be removed when the RHEL
+      9\n# support is dropped.\nkernel.timer_migration=1\n\n[selinux]\n#> Custom (atomic
+      host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The names are important
+      for Intel and are referenced in openshift-node-performance-intel-x86\n\n# set
+      empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/extra-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -49,16 +49,21 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
-      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
-      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
-      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n[sysctl.timer-migration]\ntype=sysctl\n#
+      Match uname with kernel versions containing\n# .el9.x86_64 or .el9_<number>,
+      but not .el91\nuname_regex=\\.el9[ _.]\n# cpu-partitioning for RHEL disables
+      timer.migration (= 0),\n# but OCP is too dynamic when partitioning and needs
+      to evacuate\n# scheduled timers when starting a guaranteed workload (= 1)\n#
+      \n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
       results will be affected, but there is no\n# way around that. Not enabling this
       breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
-      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
-      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
-      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      and keep alive timers are present.\n#\n# This is only needed for RHEL 9 based
+      platforms.\n# RHEL 10 kernels reworked the timer management and are\n# no longer
+      affected by this issue.\n#\n# This whole block can be removed when the RHEL
+      9\n# support is dropped.\nkernel.timer_migration=1\n\n[selinux]\n#> Custom (atomic
+      host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The names are important
+      for Intel and are referenced in openshift-node-performance-intel-x86\n\n# set
+      empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-master_tuned.yaml
@@ -49,16 +49,21 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
-      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
-      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
-      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n[sysctl.timer-migration]\ntype=sysctl\n#
+      Match uname with kernel versions containing\n# .el9.x86_64 or .el9_<number>,
+      but not .el91\nuname_regex=\\.el9[ _.]\n# cpu-partitioning for RHEL disables
+      timer.migration (= 0),\n# but OCP is too dynamic when partitioning and needs
+      to evacuate\n# scheduled timers when starting a guaranteed workload (= 1)\n#
+      \n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
       results will be affected, but there is no\n# way around that. Not enabling this
       breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
-      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
-      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
-      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      and keep alive timers are present.\n#\n# This is only needed for RHEL 9 based
+      platforms.\n# RHEL 10 kernels reworked the timer management and are\n# no longer
+      affected by this issue.\n#\n# This whole block can be removed when the RHEL
+      9\n# support is dropped.\nkernel.timer_migration=1\n\n[selinux]\n#> Custom (atomic
+      host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The names are important
+      for Intel and are referenced in openshift-node-performance-intel-x86\n\n# set
+      empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n

--- a/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/bootstrap/no-mcp/openshift-bootstrap-worker_tuned.yaml
@@ -49,16 +49,21 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
-      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
-      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
-      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n[sysctl.timer-migration]\ntype=sysctl\n#
+      Match uname with kernel versions containing\n# .el9.x86_64 or .el9_<number>,
+      but not .el91\nuname_regex=\\.el9[ _.]\n# cpu-partitioning for RHEL disables
+      timer.migration (= 0),\n# but OCP is too dynamic when partitioning and needs
+      to evacuate\n# scheduled timers when starting a guaranteed workload (= 1)\n#
+      \n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
       results will be affected, but there is no\n# way around that. Not enabling this
       breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
-      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
-      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
-      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      and keep alive timers are present.\n#\n# This is only needed for RHEL 9 based
+      platforms.\n# RHEL 10 kernels reworked the timer management and are\n# no longer
+      affected by this issue.\n#\n# This whole block can be removed when the RHEL
+      9\n# support is dropped.\nkernel.timer_migration=1\n\n[selinux]\n#> Custom (atomic
+      host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The names are important
+      for Intel and are referenced in openshift-node-performance-intel-x86\n\n# set
+      empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_tuned.yaml
@@ -47,16 +47,21 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
-      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
-      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
-      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n[sysctl.timer-migration]\ntype=sysctl\n#
+      Match uname with kernel versions containing\n# .el9.x86_64 or .el9_<number>,
+      but not .el91\nuname_regex=\\.el9[ _.]\n# cpu-partitioning for RHEL disables
+      timer.migration (= 0),\n# but OCP is too dynamic when partitioning and needs
+      to evacuate\n# scheduled timers when starting a guaranteed workload (= 1)\n#
+      \n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
       results will be affected, but there is no\n# way around that. Not enabling this
       breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
-      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
-      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
-      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      and keep alive timers are present.\n#\n# This is only needed for RHEL 9 based
+      platforms.\n# RHEL 10 kernels reworked the timer management and are\n# no longer
+      affected by this issue.\n#\n# This whole block can be removed when the RHEL
+      9\n# support is dropped.\nkernel.timer_migration=1\n\n[selinux]\n#> Custom (atomic
+      host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The names are important
+      for Intel and are referenced in openshift-node-performance-intel-x86\n\n# set
+      empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/cpuFrequency/manual_tuned.yaml
@@ -47,16 +47,21 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
-      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
-      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
-      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n[sysctl.timer-migration]\ntype=sysctl\n#
+      Match uname with kernel versions containing\n# .el9.x86_64 or .el9_<number>,
+      but not .el91\nuname_regex=\\.el9[ _.]\n# cpu-partitioning for RHEL disables
+      timer.migration (= 0),\n# but OCP is too dynamic when partitioning and needs
+      to evacuate\n# scheduled timers when starting a guaranteed workload (= 1)\n#
+      \n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
       results will be affected, but there is no\n# way around that. Not enabling this
       breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
-      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
-      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
-      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      and keep alive timers are present.\n#\n# This is only needed for RHEL 9 based
+      platforms.\n# RHEL 10 kernels reworked the timer management and are\n# no longer
+      affected by this issue.\n#\n# This whole block can be removed when the RHEL
+      9\n# support is dropped.\nkernel.timer_migration=1\n\n[selinux]\n#> Custom (atomic
+      host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The names are important
+      for Intel and are referenced in openshift-node-performance-intel-x86\n\n# set
+      empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_tuned.yaml
@@ -49,16 +49,21 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
-      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
-      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
-      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n[sysctl.timer-migration]\ntype=sysctl\n#
+      Match uname with kernel versions containing\n# .el9.x86_64 or .el9_<number>,
+      but not .el91\nuname_regex=\\.el9[ _.]\n# cpu-partitioning for RHEL disables
+      timer.migration (= 0),\n# but OCP is too dynamic when partitioning and needs
+      to evacuate\n# scheduled timers when starting a guaranteed workload (= 1)\n#
+      \n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
       results will be affected, but there is no\n# way around that. Not enabling this
       breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
-      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
-      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
-      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      and keep alive timers are present.\n#\n# This is only needed for RHEL 9 based
+      platforms.\n# RHEL 10 kernels reworked the timer management and are\n# no longer
+      affected by this issue.\n#\n# This whole block can be removed when the RHEL
+      9\n# support is dropped.\nkernel.timer_migration=1\n\n[selinux]\n#> Custom (atomic
+      host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The names are important
+      for Intel and are referenced in openshift-node-performance-intel-x86\n\n# set
+      empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_tuned.yaml
@@ -49,16 +49,21 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
-      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
-      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
-      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n[sysctl.timer-migration]\ntype=sysctl\n#
+      Match uname with kernel versions containing\n# .el9.x86_64 or .el9_<number>,
+      but not .el91\nuname_regex=\\.el9[ _.]\n# cpu-partitioning for RHEL disables
+      timer.migration (= 0),\n# but OCP is too dynamic when partitioning and needs
+      to evacuate\n# scheduled timers when starting a guaranteed workload (= 1)\n#
+      \n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
       results will be affected, but there is no\n# way around that. Not enabling this
       breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
-      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
-      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
-      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      and keep alive timers are present.\n#\n# This is only needed for RHEL 9 based
+      platforms.\n# RHEL 10 kernels reworked the timer management and are\n# no longer
+      affected by this issue.\n#\n# This whole block can be removed when the RHEL
+      9\n# support is dropped.\nkernel.timer_migration=1\n\n[selinux]\n#> Custom (atomic
+      host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The names are important
+      for Intel and are referenced in openshift-node-performance-intel-x86\n\n# set
+      empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_tuned.yaml
@@ -47,16 +47,21 @@ spec:
       move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# also
       configured via a sysctl.d file\n# placed here for documentation purposes and
       commented out due\n# to a tuned logging bug complaining about duplicate sysctl:\n#
-      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n#
-      cpu-partitioning for RHEL disables it (= 0)\n# OCP is too dynamic when partitioning
-      and needs to evacuate\n# scheduled timers when starting a guaranteed workload
-      (= 1)\n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
+      \  https://issues.redhat.com/browse/RHEL-18972\n#> rps configuration\n# net.core.rps_default_mask=${not_isolated_cpumask}\n\n[sysctl.timer-migration]\ntype=sysctl\n#
+      Match uname with kernel versions containing\n# .el9.x86_64 or .el9_<number>,
+      but not .el91\nuname_regex=\\.el9[ _.]\n# cpu-partitioning for RHEL disables
+      timer.migration (= 0),\n# but OCP is too dynamic when partitioning and needs
+      to evacuate\n# scheduled timers when starting a guaranteed workload (= 1)\n#
+      \n# This has an unfortunate side-effect that HRTIMERs break\n# and cyclictest
       results will be affected, but there is no\n# way around that. Not enabling this
       breaks cpu pinned\n# workload isolation for example when any TCP timeout\n#
-      and keep alive timers are present.\nkernel.timer_migration=1\n\n[selinux]\n#>
-      Custom (atomic host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The
-      names are important for Intel and are referenced in openshift-node-performance-intel-x86\n\n#
-      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
+      and keep alive timers are present.\n#\n# This is only needed for RHEL 9 based
+      platforms.\n# RHEL 10 kernels reworked the timer management and are\n# no longer
+      affected by this issue.\n#\n# This whole block can be removed when the RHEL
+      9\n# support is dropped.\nkernel.timer_migration=1\n\n[selinux]\n#> Custom (atomic
+      host)\navc_cache_threshold=8192\n\n\n\n[bootloader]\n# !! The names are important
+      for Intel and are referenced in openshift-node-performance-intel-x86\n\n# set
+      empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n\n#
       overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
       tuned.non_isolcpus=${not_isolated_cpumask} systemd.cpu_affinity=${not_isolated_cores_expanded}\ncmdline_cpu_part_nohzfull=+nohz_full=${isolated_cores}\ncmdline_cpu_tuning=+skew_tick=1\n\n#
       No default value but will be composed conditionally based on platform\ncmdline_iommu=\n\n\ncmdline_isolation=+isolcpus=managed_irq,${isolated_cores}\n\n\n\ncmdline_realtime_nosoftlookup=+nosoftlockup\ncmdline_realtime_common=+rcutree.kthread_prio=11\n\n\n\n\n\n\n\ncmdline_hugepages=+


### PR DESCRIPTION
The new timer management in RHEL 10 (timer wheel) makes the timer migration obsolete.

This solves two issue in one stroke - no latency for polling workloads and no issues with high resolution timers either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applied timer migration settings only on RHEL 9 systems.
  * Prevented the setting from being enabled by default on newer kernel versions, including RHEL 10.
  * Documented the setting’s scope and known timer-related effects.

* **Tests**
  * Updated performance profile validation and rendering expectations to reflect RHEL 9-specific behavior across supported profile variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->