### PR TITLE
OCPBUGS-105474: Prevent offlined CPUs from being re-onlined after reboot by udev hotplug rule

### DIFF
--- a/assets/performanceprofile/configs/40-redhat-hotplug.rules
+++ b/assets/performanceprofile/configs/40-redhat-hotplug.rules
@@ -1,0 +1,6 @@
+# Managed by the Node Tuning Operator. Do not edit.
+#
+# This file shadows the default read-only rule /usr/lib/udev/rules.d/40-redhat-hotplug.rules,
+# which re-onlines CPUs on udev "add" events and races NTO's set-cpus-offline
+# service, re-onlining CPUs the profile offlined. This empty file overrides that
+# rule and keeps the offlined CPUs offline. Written only when spec.cpu.offlined is set.

--- a/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/performanceprofile/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -65,6 +65,7 @@ const (
 
 	udevRulesDir         = "/etc/udev/rules.d"
 	udevPhysicalRpsRules = "99-netdev-physical-rps.rules"
+	udevHotplugRules     = "40-redhat-hotplug.rules"
 	// scripts
 	hugepagesAllocation       = "hugepages-allocation"
 	setCPUsOffline            = "set-cpus-offline"
@@ -341,6 +342,16 @@ func getIgnitionConfig(profile *performancev2.PerformanceProfile, opts *componen
 			Enabled:  ptr.To(true),
 			Name:     getSystemdService(setCPUsOffline),
 		})
+
+		// Shadow the vendor hotplug udev rule with a same-named file in /etc/udev/rules.d
+		// so udev ignores /usr/lib/udev/rules.d/ and does not re-online CPUs offlined by the profile.
+		// The file carries only a comment explaining the shadowing (see the asset for details).
+		udevHotplugRuleMode := 0644
+		udevHotplugRuleContent, err := assets.Configs.ReadFile(filepath.Join("configs", udevHotplugRules))
+		if err != nil {
+			return nil, err
+		}
+		addContent(ignitionConfig, udevHotplugRuleContent, filepath.Join(udevRulesDir, udevHotplugRules), &udevHotplugRuleMode)
 	}
 
 	irqBalanceOpts, err := getIRQBalanceBannedCPUsOptions(opts.OvsDpdkCPUs)

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/arm/manual_machineconfig.yaml
@@ -55,6 +55,13 @@ spec:
         path: /usr/local/bin/cpuset-configure.sh
         user: {}
       - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBNYW5hZ2VkIGJ5IHRoZSBOb2RlIFR1bmluZyBPcGVyYXRvci4gRG8gbm90IGVkaXQuCiMKIyBUaGlzIGZpbGUgc2hhZG93cyB0aGUgZGVmYXVsdCByZWFkLW9ubHkgcnVsZSAvdXNyL2xpYi91ZGV2L3J1bGVzLmQvNDAtcmVkaGF0LWhvdHBsdWcucnVsZXMsCiMgd2hpY2ggcmUtb25saW5lcyBDUFVzIG9uIHVkZXYgImFkZCIgZXZlbnRzIGFuZCByYWNlcyBOVE8ncyBzZXQtY3B1cy1vZmZsaW5lCiMgc2VydmljZSwgcmUtb25saW5pbmcgQ1BVcyB0aGUgcHJvZmlsZSBvZmZsaW5lZC4gVGhpcyBlbXB0eSBmaWxlIG92ZXJyaWRlcyB0aGF0CiMgcnVsZSBhbmQga2VlcHMgdGhlIG9mZmxpbmVkIENQVXMgb2ZmbGluZS4gV3JpdHRlbiBvbmx5IHdoZW4gc3BlYy5jcHUub2ZmbGluZWQgaXMgc2V0Lgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/40-redhat-hotplug.rules
+        user: {}
+      - contents:
           source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
           verification: {}
         group: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/manual_machineconfig.yaml
@@ -56,6 +56,13 @@ spec:
         path: /usr/local/bin/cpuset-configure.sh
         user: {}
       - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBNYW5hZ2VkIGJ5IHRoZSBOb2RlIFR1bmluZyBPcGVyYXRvci4gRG8gbm90IGVkaXQuCiMKIyBUaGlzIGZpbGUgc2hhZG93cyB0aGUgZGVmYXVsdCByZWFkLW9ubHkgcnVsZSAvdXNyL2xpYi91ZGV2L3J1bGVzLmQvNDAtcmVkaGF0LWhvdHBsdWcucnVsZXMsCiMgd2hpY2ggcmUtb25saW5lcyBDUFVzIG9uIHVkZXYgImFkZCIgZXZlbnRzIGFuZCByYWNlcyBOVE8ncyBzZXQtY3B1cy1vZmZsaW5lCiMgc2VydmljZSwgcmUtb25saW5pbmcgQ1BVcyB0aGUgcHJvZmlsZSBvZmZsaW5lZC4gVGhpcyBlbXB0eSBmaWxlIG92ZXJyaWRlcyB0aGF0CiMgcnVsZSBhbmQga2VlcHMgdGhlIG9mZmxpbmVkIENQVXMgb2ZmbGluZS4gV3JpdHRlbiBvbmx5IHdoZW4gc3BlYy5jcHUub2ZmbGluZWQgaXMgc2V0Lgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/40-redhat-hotplug.rules
+        user: {}
+      - contents:
           source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
           verification: {}
         group: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/default/pp-norps/manual_machineconfig.yaml
@@ -56,6 +56,13 @@ spec:
         path: /usr/local/bin/cpuset-configure.sh
         user: {}
       - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBNYW5hZ2VkIGJ5IHRoZSBOb2RlIFR1bmluZyBPcGVyYXRvci4gRG8gbm90IGVkaXQuCiMKIyBUaGlzIGZpbGUgc2hhZG93cyB0aGUgZGVmYXVsdCByZWFkLW9ubHkgcnVsZSAvdXNyL2xpYi91ZGV2L3J1bGVzLmQvNDAtcmVkaGF0LWhvdHBsdWcucnVsZXMsCiMgd2hpY2ggcmUtb25saW5lcyBDUFVzIG9uIHVkZXYgImFkZCIgZXZlbnRzIGFuZCByYWNlcyBOVE8ncyBzZXQtY3B1cy1vZmZsaW5lCiMgc2VydmljZSwgcmUtb25saW5pbmcgQ1BVcyB0aGUgcHJvZmlsZSBvZmZsaW5lZC4gVGhpcyBlbXB0eSBmaWxlIG92ZXJyaWRlcyB0aGF0CiMgcnVsZSBhbmQga2VlcHMgdGhlIG9mZmxpbmVkIENQVXMgb2ZmbGluZS4gV3JpdHRlbiBvbmx5IHdoZW4gc3BlYy5jcHUub2ZmbGluZWQgaXMgc2V0Lgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/40-redhat-hotplug.rules
+        user: {}
+      - contents:
           source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
           verification: {}
         group: {}

--- a/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
+++ b/test/e2e/performanceprofile/testdata/render-expected-output/no-ref/manual_machineconfig.yaml
@@ -55,6 +55,13 @@ spec:
         path: /usr/local/bin/cpuset-configure.sh
         user: {}
       - contents:
+          source: data:text/plain;charset=utf-8;base64,IyBNYW5hZ2VkIGJ5IHRoZSBOb2RlIFR1bmluZyBPcGVyYXRvci4gRG8gbm90IGVkaXQuCiMKIyBUaGlzIGZpbGUgc2hhZG93cyB0aGUgZGVmYXVsdCByZWFkLW9ubHkgcnVsZSAvdXNyL2xpYi91ZGV2L3J1bGVzLmQvNDAtcmVkaGF0LWhvdHBsdWcucnVsZXMsCiMgd2hpY2ggcmUtb25saW5lcyBDUFVzIG9uIHVkZXYgImFkZCIgZXZlbnRzIGFuZCByYWNlcyBOVE8ncyBzZXQtY3B1cy1vZmZsaW5lCiMgc2VydmljZSwgcmUtb25saW5pbmcgQ1BVcyB0aGUgcHJvZmlsZSBvZmZsaW5lZC4gVGhpcyBlbXB0eSBmaWxlIG92ZXJyaWRlcyB0aGF0CiMgcnVsZSBhbmQga2VlcHMgdGhlIG9mZmxpbmVkIENQVXMgb2ZmbGluZS4gV3JpdHRlbiBvbmx5IHdoZW4gc3BlYy5jcHUub2ZmbGluZWQgaXMgc2V0Lgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/40-redhat-hotplug.rules
+        user: {}
+      - contents:
           source: data:text/plain;charset=utf-8;base64,W1VuaXRdCkRlc2NyaXB0aW9uPVRvcCBsZXZlbCBzbGljZSB1c2VkIHRvIGdpdmUgb3BlbnZzd2l0Y2ggYWNjZXNzIHRvIGFuIHVucmVzdHJpY3RlZCBzZXQgb2YgY3B1cwoKW1NsaWNlXQo=
           verification: {}
         group: {}


### PR DESCRIPTION
CPUs that a PerformanceProfile marks as offline are sometimes coming back online after a reboot:

The RHCOS CPU hotplug rule, shipped read-only in
`/usr/lib/udev/rules.d/40-redhat-hotplug.rules` , re-onlines CPUs on udev
`"add"` events, which races with NTO's `set-cpus-offline.service`. When the
udev rule wins, the CPUs actually offlined on the node are only a subset
of those defined in the profile's `spec.cpu.offlined`.

Fix this by shadowing the existing rule with a same-named, empty file
under `/etc/udev/rules.d`, which udev prefers over `/usr/lib`, so the rule
no longer re-onlines the offlined CPUs.

Note: We are currently in contact with the RHCOS team to remove or modify this rule upstream. 
If they agree to drop the rule, this temporary workaround can be safely reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented system hotplug behavior from re-enabling CPUs configured as offlined.
  * Ensured configured-offline CPUs remain offline after device events.
  * Updated generated MachineConfigs consistently across supported performance profile configurations.
  * Simplified IRQ affinity handling by removing obsolete default SMP affinity adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->