### PR TITLE
NO-JIRA: Fix CentOS Stream image build failing in dnf history undo

### DIFF
--- a/hack/dockerfile_install_support.sh
+++ b/hack/dockerfile_install_support.sh
@@ -29,7 +29,6 @@ if [[ "${ID}" == "centos" ]]; then
   dnf build-dep tuned.spec -y
   make rpm PYTHON=/usr/bin/python3
   rm -rf /root/rpmbuild/RPMS/noarch/{tuned-gtk*,tuned-utils*,tuned-profiles-compat*}
-  dnf --setopt=protected_packages= history -y undo 0  # Remove builddep
 
   cp -r /root/rpmbuild/RPMS/noarch /root/rpms
   dnf install --setopt=tsflags=nodocs -y ${INSTALL_PKGS}


### PR DESCRIPTION
The CentOS branch of hack/dockerfile_install_support.sh used
"dnf history undo 0" to clean up the tuned build dependencies.
That reverts every dnf transaction back to the base image state,
which requires re-downloading the old versions of the packages
that "dnf build-dep" upgraded (e.g. python3-3.9.25-2,
systemd-252-64).   As CentOS Stream 9 is a rolling release, those
old builds are no longer available in the repositories, so the
undo fails with "Cannot find rpm nevra" and the image build is
broken.

Drop the line.  The build dependencies do not need to be removed
right after the RPM build: the existing "dnf remove" of the build
tools and the final "dnf autoremove" already drop the build tools
and everything installed only as build dependencies, without
downgrading anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build and Packaging**
  - CentOS builds no longer automatically remove build dependencies after creating TuneD RPMs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->